### PR TITLE
[UI][CatalogPromotion] Reapply catalog promotions after editing their rules and actions

### DIFF
--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_actions.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_actions.feature
@@ -52,11 +52,9 @@ Feature: Reapplying catalog promotions after editing their actions
         Then this product variant price should be "$9.00"
         And this product original price should be "$20.00"
 
-    @api
+    @api @ui @javascript
     Scenario: Restoring original price after removing action from catalog promotion configuration
         When I modify a catalog promotion "Winter sale"
         And I remove its every action
         And I save my changes
-        And the visitor view "PHP T-Shirt" variant
-        Then the product variant price should be "$20.00"
-        And the product original price should be "$20.00"
+        Then the visitor should see that the "PHP T-Shirt" variant is not discounted

--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_rules.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_rules.feature
@@ -5,7 +5,7 @@ Feature: Reapplying catalog promotion after editing their rules
     I want to have catalog promotion reapplied in product catalog once the rule of catalog promotion changes
 
     Background:
-        Given the store operates on a channel identified by "Web-US" code
+        Given the store operates on a single channel in "United States"
         And the store has a "T-Shirt" configurable product
         And this product has "PHP T-Shirt" variant priced at "$20.00"
         And the store has a "Mug" configurable product
@@ -14,7 +14,7 @@ Feature: Reapplying catalog promotion after editing their rules
         And there is a catalog promotion "Summer sale" that reduces price by "50%" and applies on "PHP T-Shirt" variant
         And I am logged in as an administrator
 
-    @api
+    @api @ui @javascript
     Scenario: Reapplying catalog promotion after adding a new rule to it
         Given there is a catalog promotion with "mug_sale" code and "Mug sale" name
         When I modify a catalog promotion "Mug sale"
@@ -24,21 +24,21 @@ Feature: Reapplying catalog promotion after editing their rules
         Then the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Mug sale" promotion
         And the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Mug sale" promotion
 
-    @api
-    Scenario: Reapplying catalog promotion after adding another action
+    @api @ui @javascript
+    Scenario: Reapplying catalog promotion after adding another rule
         When I modify a catalog promotion "Summer sale"
         And I add another rule that applies on "PHP Mug" variant
         And I save my changes
         Then the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion
         And the visitor should still see that the "PHP T-Shirt" variant is discounted from "$20.00" to "$10.00" with "Summer sale" promotion
 
-    @api
+    @api @ui @javascript
     Scenario: Reapplying catalog promotion after editing its rule
         When I edit "Summer sale" catalog promotion to be applied on "Expensive Mug" variant
         Then the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
         And the visitor should see that the "PHP T-Shirt" variant is not discounted
 
-    @api
+    @api @ui @javascript
     Scenario: Reapplying catalog promotion after removing its rules
         When I modify a catalog promotion "Summer sale"
         And I remove its every rule

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -19,6 +19,7 @@ use Sylius\Behat\Page\Admin\CatalogPromotion\CreatePageInterface;
 use Sylius\Behat\Page\Admin\CatalogPromotion\UpdatePageInterface;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Webmozart\Assert\Assert;
@@ -146,6 +147,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I add(?:| another) rule that applies on ("[^"]+" variant)$/
      * @When /^I add rule that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
      * @When /^I add rule that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
      */
@@ -219,9 +221,16 @@ final class ManagingCatalogPromotionsContext implements Context
     {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
 
-        $this->formElement->addRule();
         $this->formElement->chooseLastRuleVariants([$productVariant->getCode()]);
         $this->updatePage->saveChanges();
+    }
+
+    /**
+     * @When I remove its every rule
+     */
+    public function iRemoveItsEveryRule(): void
+    {
+        $this->formElement->removeAllRules();
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -495,7 +495,6 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Then /^the visitor should see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see ("[^"]+" variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      * @Then /^I should see (this variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      */
@@ -510,6 +509,22 @@ final class ProductContext implements Context
         Assert::same($this->showPage->getCatalogPromotionName(), $promotionName);
         Assert::same($this->showPage->getPrice(), $price);
         Assert::same($this->showPage->getOriginalPrice(), $originalPrice);
+    }
+
+    /**
+     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
+     */
+    public function theVisitorShouldSeeThatTheVariantIsDiscountedFromToWithPromotion(
+        ProductVariantInterface $variant,
+        string $originalPrice,
+        string $price,
+        string $promotionName
+    ): void {
+        /** @var ProductInterface $product */
+        $product = $variant->getProduct();
+
+        $this->iOpenProductPage($product);
+        $this->iShouldSeeVariantIsDiscountedFromToWithPromotion($variant, $originalPrice, $price, $promotionName);
     }
 
     /**
@@ -808,6 +823,18 @@ final class ProductContext implements Context
     public function iShouldSeeThisVariantIsNotDiscounted(): void
     {
         Assert::null($this->showPage->getOriginalPrice());
+    }
+
+    /**
+     * @Then /^the visitor should see that the ("([^"]*)" variant) is not discounted$/
+     */
+    public function theVisitorShouldSeeThatTheVariantIsNotDiscounted(ProductVariantInterface $variant): void
+    {
+        /** @var ProductInterface $product */
+        $product = $variant->getProduct();
+
+        $this->iOpenProductPage($product);
+        $this->iShouldSeeThisVariantIsNotDiscounted();
     }
 
     /**

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
@@ -113,6 +113,15 @@ final class FormElement extends Element implements FormElementInterface
         }
     }
 
+    public function removeAllRules(): void
+    {
+        $deleteButtons = $this->getDocument()->findAll('css', '#rules [data-form-collection="delete"]');
+
+        foreach ($deleteButtons as $deleteButton) {
+            $deleteButton->click();
+        }
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElementInterface.php
@@ -44,4 +44,6 @@ interface FormElementInterface
     public function getValidationMessageForAction(): string;
 
     public function removeAllActions(): void;
+
+    public function removeAllRules(): void;
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -249,7 +249,11 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
 
     public function selectVariant(string $variantName): void
     {
-        $variantRadio = $this->getElement('variant_radio', ['%variantName%' => $variantName]);
+        try {
+            $variantRadio = $this->getElement('variant_radio', ['%variantName%' => $variantName]);
+        } catch (ElementNotFoundException $exception) {
+            return;
+        }
 
         $driver = $this->getDriver();
         if ($driver instanceof Selenium2Driver || $driver instanceof ChromeDriver) {
@@ -321,7 +325,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'association' => '[data-test-product-association="%associationName%"]',
             'attributes' => '[data-test-product-attributes]',
             'average_rating' => '[data-test-average-rating]',
-            'catalog_promotion' => '#sylius_catalog_promotion',
+            'catalog_promotion' => '#promotion_label',
             'current_variant_input' => '[data-test-product-variants] td input:checked',
             'details' => '[data-tab="details"]',
             'main_image' => '[data-test-main-image]',

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
@@ -28,7 +28,7 @@ final class CatalogPromotionEventListener
         $this->eventBus = $eventBus;
     }
 
-    public function update(GenericEvent $event): void
+    public function dispatchCatalogPromotionUpdatedEvent(GenericEvent $event): void
     {
         $catalogPromotion = $event->getSubject();
         Assert::isInstanceOf($catalogPromotion, CatalogPromotionInterface::class);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -93,8 +93,8 @@
 
         <service id="Sylius\Bundle\CoreBundle\EventListener\CatalogPromotionEventListener">
             <argument type="service" id="sylius.event_bus" />
-            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_create" method="update" />
-            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_update" method="update" />
+            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_create" method="dispatchCatalogPromotionUpdatedEvent" />
+            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_update" method="dispatchCatalogPromotionUpdatedEvent" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Listener\CatalogPromotionUpdateListener">

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
@@ -39,7 +39,7 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
         $message = new CatalogPromotionUpdated('SALE');
         $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
 
-        $this->update($event);
+        $this->dispatchCatalogPromotionUpdatedEvent($event);
     }
 
     function it_throws_an_exception_if_event_object_is_not_a_catalog_promotion(GenericEvent $event): void
@@ -48,7 +48,7 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('update', [$event])
+            ->during('dispatchCatalogPromotionUpdatedEvent', [$event])
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
