### PR TITLE
[API] Do not allow to address empty cart

### DIFF
--- a/features/checkout/addressing_order/order_address_validation.feature
+++ b/features/checkout/addressing_order/order_address_validation.feature
@@ -16,7 +16,7 @@ Feature: Order address validation
         When the visitor specify the email as "jon.snow@example.com"
         And the visitor try to specify the incorrect billing address as "Ankh Morpork", "Frost Alley", "90210", "United Russia" for "Jon Snow"
         And the visitor complete the addressing step
-        Then I should be notified that "United Russia" country does not exist
+        Then they should be notified that "United Russia" country does not exist
 
     @api
     Scenario: Trying to add address without country to the cart by the visitor
@@ -24,4 +24,12 @@ Feature: Order address validation
         When the visitor specify the email as "jon.snow@example.com"
         And the visitor try to specify the billing address without country as "Ankh Morpork", "Frost Alley", "90210" for "Jon Snow"
         And the visitor complete the addressing step
-        Then I should be notified that address without country cannot exist
+        Then they should be notified that address without country cannot exist
+
+    @api
+    Scenario: Trying to add address without any products in cart
+        Given the visitor picks up the cart
+        When the visitor specify the email as "jon.snow@example.com"
+        And the visitor specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And the visitor complete the addressing step
+        Then they should be notified that they cannot address an empty cart

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -146,6 +146,7 @@ final class CartContext implements Context
     /**
      * @When I pick up my cart (again)
      * @When I pick up cart in the :localeCode locale
+     * @When the visitor picks up the cart
      */
     public function iPickUpMyCart(?string $localeCode = null): void
     {

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -648,6 +648,7 @@ final class CheckoutContext implements Context
 
     /**
      * @Then I should be notified that :countryName country does not exist
+     * @Then they should be notified that :countryName country does not exist
      */
     public function iShouldBeNotifiedThatCountryDoesNotExist(string $countryName): void
     {

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -659,6 +659,7 @@ final class CheckoutContext implements Context
 
     /**
      * @Then I should be notified that address without country cannot exist
+     * @Then they should be notified that address without country cannot exist
      */
     public function iShouldBeNotifiedThatAddressWithoutCountryCannotExist(): void
     {
@@ -666,6 +667,17 @@ final class CheckoutContext implements Context
             $this->ordersClient->getLastResponse(),
             'The address without country cannot exist'
         );
+    }
+
+    /**
+     * @Then they should be notified that they cannot address an empty cart
+     */
+    public function theyShouldBeNotifiedThatTheyCannotAddressAnEmptyCart(): void
+    {
+        $response = $this->ordersClient->getLastResponse();
+
+        Assert::false($this->responseChecker->isUpdateSuccessful($response));
+        $this->responseChecker->hasViolationWithMessage($response, 'The empty cart cannot be addressed');
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/validation/AddressOrder.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/validation/AddressOrder.xml
@@ -16,6 +16,11 @@
                     xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
 
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder">
+        <constraint name="Sylius\Bundle\ApiBundle\Validator\Constraints\OrderNotEmpty">
+            <option name="groups">
+                <value>sylius</value>
+            </option>
+        </constraint>
         <property name="billingAddress">
             <constraint name="NotNull" />
             <constraint name="Valid" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

After addressing the empty cart and adding an item to it, there is a cart with some products but payment_skipped as payment state :dancer: *In theory*, it's not a problem, as after completion payment state is correct (awaiting payment), but if anything happens about payment before checkout completion, it can lead to some nasty errors. And, conceptually, addressing empty cart does not seems as something correct 🚀 