### PR TITLE
[Build][Hot-fix] Ignore PHPStan analysis for StringInflector

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,5 +35,7 @@ parameters:
         - 'src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/CircularDependencyBreakingExceptionListenerPassTest.php'
         - 'src/Sylius/Bundle/CoreBundle/Tests/Listener/CircularDependencyBreakingExceptionListenerTest.php'
 
+        # PHP 7.4-specific issues
+        - 'src/Sylius/Component/Core/Formatter/StringInflector.php'
     ignoreErrors:
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | the same as https://github.com/Sylius/Sylius/pull/13138, but for 1.10
| License         | MIT

It started to fail on 1.10 as well :/ I'm temporarily disabling the analysis and we need to figure out what is wrong with it 🖖 🔥 