### PR TITLE
Remove types in public and protected properties in not final classes

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
@@ -19,7 +19,8 @@ use Twig\TwigFilter;
 
 class ProvinceNamingExtension extends AbstractExtension
 {
-    private ProvinceNamingProviderInterface $provinceNamingProvider;
+    /** @var ProvinceNamingProviderInterface */
+    private $provinceNamingProvider;
 
     public function __construct(ProvinceNamingProviderInterface $provinceNamingProvider)
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -20,7 +20,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class ProvinceAddressConstraint extends Constraint
 {
-    public string $message = 'sylius.address.province.valid';
+    /** @var string */
+    public $message = 'sylius.address.province.valid';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 final class ZoneCannotContainItself extends Constraint
 {
-    public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
+    /** @var string */
+    public $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -17,8 +17,7 @@ use Symfony\Component\Validator\Constraint;
 
 final class ZoneCannotContainItself extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
+    public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Account/ChangePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Account/ChangePaymentMethod.php
@@ -19,17 +19,22 @@ use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 /** @experimental */
 class ChangePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $paymentId = null;
+    public $paymentId;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $paymentMethodCode;
+    public $paymentMethodCode;
 
     public function __construct(string $paymentMethodCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/AddProductReview.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/AddProductReview.php
@@ -18,28 +18,33 @@ class AddProductReview implements CommandAwareDataTransformerInterface
 {
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $title;
+    public $title;
 
     /**
      * @psalm-immutable
+     * @var int|null
      */
-    public ?int $rating;
+    public $rating;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $comment;
+    public $comment;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $productCode;
+    public $productCode;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $email;
+    public $email;
 
     public function __construct(
         ?string $title,

--- a/src/Sylius/Bundle/ApiBundle/Command/BlameCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/BlameCart.php
@@ -18,13 +18,15 @@ class BlameCart
 {
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $shopUserEmail;
+    public $shopUserEmail;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $orderTokenValue;
+    public $orderTokenValue;
 
     public function __construct(string $shopUserEmail, string $orderTokenValue)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/AddItemToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/AddItemToCart.php
@@ -18,17 +18,22 @@ use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 /** @experimental */
 class AddItemToCart implements OrderTokenValueAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $productVariantCode;
+    public $productVariantCode;
 
     /**
      * @psalm-immutable
+     * @var int
      */
-    public int $quantity;
+    public $quantity;
 
     public function __construct(string $productVariantCode, int $quantity)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/ApplyCouponToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/ApplyCouponToCart.php
@@ -18,9 +18,15 @@ use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 /** @experimental */
 class ApplyCouponToCart implements OrderTokenValueAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
-    public ?string $couponCode;
+    /**
+     * @var string|null
+     */
+    public $couponCode;
 
     public function __construct(?string $couponCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
@@ -19,14 +19,21 @@ use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 /** @experimental */
 class ChangeItemQuantityInCart implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
-    public ?string $orderItemId = null;
+    /**
+     * @var string|null
+     */
+    public $orderItemId;
 
     /**
      * @psalm-immutable
+     * @var int
      */
-    public int $quantity;
+    public $quantity;
 
     public function __construct(int $quantity)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/PickupCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/PickupCart.php
@@ -19,15 +19,20 @@ use Sylius\Bundle\ApiBundle\Command\ChannelCodeAwareInterface;
 class PickupCart implements ChannelCodeAwareInterface
 {
     /**
-     * @psalm-immutable */
-    public ?string $tokenValue;
+     * @psalm-immutable
+     * @var string|null */
+    public $tokenValue;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $localeCode;
+    public $localeCode;
 
-    private ?string $channelCode = null;
+    /**
+     * @var string|null
+     */
+    private $channelCode;
 
     public function __construct(?string $tokenValue = null, ?string $localeCode = null)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
@@ -18,12 +18,16 @@ use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 /** @experimental */
 class RemoveItemFromCart implements OrderTokenValueAwareInterface
 {
-    public ?string $orderTokenValue;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $itemId;
+    public $itemId;
 
     public function __construct(?string $orderTokenValue, string $itemId)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/ChangeShopUserPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ChangeShopUserPassword.php
@@ -21,18 +21,21 @@ class ChangeShopUserPassword implements ShopUserIdAwareInterface
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $newPassword;
+    public $newPassword;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $confirmNewPassword;
+    public $confirmNewPassword;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $currentPassword;
+    public $currentPassword;
 
     public function __construct(?string $newPassword, ?string $confirmNewPassword, ?string $currentPassword)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
@@ -19,22 +19,28 @@ use Sylius\Component\Addressing\Model\AddressInterface;
 /** @experimental */
 class AddressOrder implements OrderTokenValueAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $email;
+    public $email;
 
     /**
      * @psalm-immutable
+     * @var AddressInterface
      */
-    public AddressInterface $billingAddress;
+    public $billingAddress;
 
     /**
      * @psalm-immutable
+     * @var AddressInterface|null
      */
-    public ?AddressInterface $shippingAddress;
+    public $shippingAddress;
 
     public function __construct(?string $email, AddressInterface $billingAddress, ?AddressInterface $shippingAddress = null)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
@@ -20,17 +20,22 @@ use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 /** @experimental */
 class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface, PaymentMethodCodeAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $paymentId = null;
+    public $paymentId;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $paymentMethodCode;
+    public $paymentMethodCode;
 
     public function __construct(string $paymentMethodCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
@@ -19,14 +19,21 @@ use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 /** @experimental */
 class ChooseShippingMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
-    public ?string $shipmentId = null;
+    /**
+     * @var string|null
+     */
+    public $shipmentId;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $shippingMethodCode;
+    public $shippingMethodCode;
 
     public function __construct(string $shippingMethodCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/CompleteOrder.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/CompleteOrder.php
@@ -18,9 +18,15 @@ use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 /** @experimental */
 class CompleteOrder implements OrderTokenValueAwareInterface
 {
-    public ?string $orderTokenValue = null;
+    /**
+     * @var string|null
+     */
+    public $orderTokenValue;
 
-    public ?string $notes;
+    /**
+     * @var string|null
+     */
+    public $notes;
 
     public function __construct(?string $notes = null)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ShipShipment.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ShipShipment.php
@@ -18,9 +18,15 @@ use Sylius\Bundle\ApiBundle\Command\ShipmentIdAwareInterface;
 /** @experimental */
 class ShipShipment implements ShipmentIdAwareInterface
 {
-    public ?int $shipmentId = null;
+    /**
+     * @var int|null
+     */
+    public $shipmentId;
 
-    public ?string $trackingCode;
+    /**
+     * @var string|null
+     */
+    public $trackingCode;
 
     public function __construct(?string $trackingCode = null)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/RegisterShopUser.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/RegisterShopUser.php
@@ -20,37 +20,49 @@ class RegisterShopUser implements ChannelCodeAwareInterface, LocaleCodeAwareInte
 {
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $firstName;
+    public $firstName;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $lastName;
+    public $lastName;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $email;
+    public $email;
 
     /**
      * @psalm-immutable
+     * @var string
      */
-    public string $password;
+    public $password;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $phoneNumber;
+    public $phoneNumber;
 
     /**
      * @psalm-immutable
+     * @var bool
      */
-    public bool $subscribedToNewsletter;
+    public $subscribedToNewsletter;
 
-    public ?string $channelCode = null;
+    /**
+     * @var string|null
+     */
+    public $channelCode;
 
-    public ?string $localeCode = null;
+    /**
+     * @var string|null
+     */
+    public $localeCode;
 
     public function __construct(
         string $firstName,

--- a/src/Sylius/Bundle/ApiBundle/Command/RequestResetPasswordToken.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/RequestResetPasswordToken.php
@@ -16,11 +16,20 @@ namespace Sylius\Bundle\ApiBundle\Command;
 /** @experimental */
 class RequestResetPasswordToken implements ChannelCodeAwareInterface, LocaleCodeAwareInterface
 {
-    public string $email;
+    /**
+     * @var string
+     */
+    public $email;
 
-    public ?string $channelCode = null;
+    /**
+     * @var string|null
+     */
+    public $channelCode;
 
-    public ?string $localeCode = null;
+    /**
+     * @var string|null
+     */
+    public $localeCode;
 
     public function __construct(string $email)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/ResendVerificationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ResendVerificationEmail.php
@@ -16,17 +16,22 @@ namespace Sylius\Bundle\ApiBundle\Command;
 /** @experimental */
 class ResendVerificationEmail implements ChannelCodeAwareInterface, LocaleCodeAwareInterface
 {
-    public string $email;
+    /**
+     * @var string
+     */
+    public $email;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $channelCode = null;
+    public $channelCode;
 
     /**
      * @psalm-immutable
+     * @var string|null
      */
-    public ?string $localeCode = null;
+    public $localeCode;
 
     public function __construct(string $email)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/ResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ResetPassword.php
@@ -16,11 +16,20 @@ namespace Sylius\Bundle\ApiBundle\Command;
 /** @experimental */
 class ResetPassword
 {
-    public ?string $newPassword = null;
+    /**
+     * @var string|null
+     */
+    public $newPassword;
 
-    public ?string $confirmNewPassword = null;
+    /**
+     * @var string|null
+     */
+    public $confirmNewPassword;
 
-    public string $resetPasswordToken;
+    /**
+     * @var string
+     */
+    public $resetPasswordToken;
 
     public function __construct(string $resetPasswordToken)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/SendAccountRegistrationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SendAccountRegistrationEmail.php
@@ -19,11 +19,20 @@ namespace Sylius\Bundle\ApiBundle\Command;
  */
 class SendAccountRegistrationEmail
 {
-    public string $shopUserEmail;
+    /**
+     * @var string
+     */
+    public $shopUserEmail;
 
-    public string $localeCode;
+    /**
+     * @var string
+     */
+    public $localeCode;
 
-    public string $channelCode;
+    /**
+     * @var string
+     */
+    public $channelCode;
 
     public function __construct(string $shopUserEmail, string $localeCode, string $channelCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/SendAccountVerificationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SendAccountVerificationEmail.php
@@ -19,11 +19,20 @@ namespace Sylius\Bundle\ApiBundle\Command;
  */
 class SendAccountVerificationEmail
 {
-    public string $shopUserEmail;
+    /**
+     * @var string
+     */
+    public $shopUserEmail;
 
-    public string $localeCode;
+    /**
+     * @var string
+     */
+    public $localeCode;
 
-    public string $channelCode;
+    /**
+     * @var string
+     */
+    public $channelCode;
 
     public function __construct(string $shopUserEmail, string $localeCode, string $channelCode)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/SendOrderConfirmation.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SendOrderConfirmation.php
@@ -16,7 +16,10 @@ namespace Sylius\Bundle\ApiBundle\Command;
 /** @experimental */
 class SendOrderConfirmation
 {
-    public string $orderToken;
+    /**
+     * @var string
+     */
+    public $orderToken;
 
     public function __construct(string $orderToken)
     {

--- a/src/Sylius/Bundle/ApiBundle/Command/SendResetPasswordEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SendResetPasswordEmail.php
@@ -16,11 +16,20 @@ namespace Sylius\Bundle\ApiBundle\Command;
 /** @experimental */
 class SendResetPasswordEmail
 {
-    public string $email;
+    /**
+     * @var string
+     */
+    public $email;
 
-    public string $channelCode;
+    /**
+     * @var string
+     */
+    public $channelCode;
 
-    public string $localeCode;
+    /**
+     * @var string
+     */
+    public $localeCode;
 
     public function __construct(
         string $email,

--- a/src/Sylius/Bundle/ApiBundle/Command/VerifyCustomerAccount.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/VerifyCustomerAccount.php
@@ -19,7 +19,10 @@ namespace Sylius\Bundle\ApiBundle\Command;
  */
 class VerifyCustomerAccount
 {
-    public string $token;
+    /**
+     * @var string
+     */
+    public $token;
 
     public function __construct(string $token)
     {

--- a/src/Sylius/Bundle/ApiBundle/Event/OrderCompleted.php
+++ b/src/Sylius/Bundle/ApiBundle/Event/OrderCompleted.php
@@ -15,7 +15,8 @@ namespace Sylius\Bundle\ApiBundle\Event;
 
 class OrderCompleted
 {
-    public string $orderToken;
+    /** @var string */
+    public $orderToken;
 
     public function __construct(string $orderToken)
     {

--- a/src/Sylius/Bundle/ApiBundle/View/CartShippingMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/View/CartShippingMethod.php
@@ -18,9 +18,11 @@ use Sylius\Component\Core\Model\ShippingMethodInterface;
 /** @experimental */
 class CartShippingMethod implements CartShippingMethodInterface
 {
-    private ShippingMethodInterface $shippingMethod;
+    /** @var ShippingMethodInterface */
+    private $shippingMethod;
 
-    private int $price;
+    /** @var int */
+    private $price;
 
     public function __construct(ShippingMethodInterface $shippingMethod, int $price)
     {

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeChoiceType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeChoiceType.php
@@ -18,12 +18,12 @@ use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AttributeChoiceType extends AbstractType
 {
-    protected RepositoryInterface $attributeRepository;
+    /** @var RepositoryInterface */
+    protected $attributeRepository;
 
     public function __construct(RepositoryInterface $attributeRepository)
     {

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType.php
@@ -25,9 +25,11 @@ use Symfony\Component\Form\FormEvents;
 
 abstract class AttributeType extends AbstractResourceType
 {
-    protected string $attributeTranslationType;
+    /** @var string */
+    protected $attributeTranslationType;
 
-    protected FormTypeRegistryInterface $formTypeRegistry;
+    /** @var FormTypeRegistryInterface */
+    protected $formTypeRegistry;
 
     public function __construct(
         string $dataClass,

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -28,13 +28,17 @@ use Symfony\Component\Form\ReversedTransformer;
 
 abstract class AttributeValueType extends AbstractResourceType
 {
-    protected string $attributeChoiceType;
+    /** @var string */
+    protected $attributeChoiceType;
 
-    protected RepositoryInterface $attributeRepository;
+    /** @var RepositoryInterface */
+    protected $attributeRepository;
 
-    protected RepositoryInterface $localeRepository;
+    /** @var RepositoryInterface */
+    protected $localeRepository;
 
-    protected FormTypeRegistryInterface $formTypeRegistry;
+    /** @var FormTypeRegistryInterface */
+    protected $formTypeRegistry;
 
     public function __construct(
         string $dataClass,

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -17,14 +17,11 @@ use Symfony\Component\Validator\Constraint;
 
 final class ValidSelectAttributeConfiguration extends Constraint
 {
-    /** @var string */
-    public $messageMultiple = 'sylius.attribute.configuration.multiple';
+    public string $messageMultiple = 'sylius.attribute.configuration.multiple';
 
-    /** @var string */
-    public $messageMinEntries = 'sylius.attribute.configuration.min_entries';
+    public string $messageMinEntries = 'sylius.attribute.configuration.min_entries';
 
-    /** @var string */
-    public $messageMaxEntries = 'sylius.attribute.configuration.max_entries';
+    public string $messageMaxEntries = 'sylius.attribute.configuration.max_entries';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -17,11 +17,14 @@ use Symfony\Component\Validator\Constraint;
 
 final class ValidSelectAttributeConfiguration extends Constraint
 {
-    public string $messageMultiple = 'sylius.attribute.configuration.multiple';
+    /** @var string */
+    public $messageMultiple = 'sylius.attribute.configuration.multiple';
 
-    public string $messageMinEntries = 'sylius.attribute.configuration.min_entries';
+    /** @var string */
+    public $messageMinEntries = 'sylius.attribute.configuration.min_entries';
 
-    public string $messageMaxEntries = 'sylius.attribute.configuration.max_entries';
+    /** @var string */
+    public $messageMaxEntries = 'sylius.attribute.configuration.max_entries';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -17,8 +17,7 @@ use Symfony\Component\Validator\Constraint;
 
 final class ValidTextAttributeConfiguration extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.attribute.configuration.max_length';
+    public string $message = 'sylius.attribute.configuration.max_length';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 final class ValidTextAttributeConfiguration extends Constraint
 {
-    public string $message = 'sylius.attribute.configuration.max_length';
+    /** @var string */
+    public $message = 'sylius.attribute.configuration.max_length';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -36,7 +36,8 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     /** @deprecated */
     public const WEB_MEDIA_IMAGE_DIRECTORY = 'web/media/image/';
 
-    protected ?CommandExecutor $commandExecutor = null;
+    /** @var CommandExecutor|null */
+    protected $commandExecutor = null;
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/AttributeRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/AttributeRepository.php
@@ -21,7 +21,8 @@ use SyliusLabs\AssociationHydrator\AssociationHydrator;
 
 class AttributeRepository extends EntityRepository
 {
-    protected AssociationHydrator $associationHydrator;
+    /** @var AssociationHydrator */
+    protected $associationHydrator;
 
     public function __construct(EntityManager $entityManager, ClassMetadata $class)
     {

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -30,7 +30,8 @@ use SyliusLabs\AssociationHydrator\AssociationHydrator;
 
 class OrderRepository extends BaseOrderRepository implements OrderRepositoryInterface
 {
-    protected AssociationHydrator $associationHydrator;
+    /** @var AssociationHydrator */
+    protected $associationHydrator;
 
     public function __construct(EntityManager $entityManager, ClassMetadata $class)
     {

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductOptionRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductOptionRepository.php
@@ -21,7 +21,8 @@ use SyliusLabs\AssociationHydrator\AssociationHydrator;
 
 class ProductOptionRepository extends BaseProductOptionRepository
 {
-    protected AssociationHydrator $associationHydrator;
+    /** @var AssociationHydrator */
+    protected $associationHydrator;
 
     public function __construct(EntityManager $entityManager, ClassMetadata $class)
     {

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
@@ -43,37 +43,53 @@ use Webmozart\Assert\Assert;
 
 class OrderExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected \Sylius\Component\Resource\Factory\FactoryInterface $orderFactory;
+    /** @var FactoryInterface */
+    protected $orderFactory;
 
-    protected \Sylius\Component\Resource\Factory\FactoryInterface $orderItemFactory;
+    /** @var FactoryInterface */
+    protected $orderItemFactory;
 
-    protected OrderItemQuantityModifierInterface $orderItemQuantityModifier;
+    /** @var OrderItemQuantityModifierInterface */
+    protected $orderItemQuantityModifier;
 
-    protected ObjectManager $orderManager;
+    /** @var ObjectManager */
+    protected $orderManager;
 
-    protected RepositoryInterface $channelRepository;
+    /** @var RepositoryInterface */
+    protected $channelRepository;
 
-    protected RepositoryInterface $customerRepository;
+    /** @var RepositoryInterface */
+    protected $customerRepository;
 
-    protected ProductRepositoryInterface $productRepository;
+    /** @var ProductRepositoryInterface */
+    protected $productRepository;
 
-    protected RepositoryInterface $countryRepository;
+    /** @var RepositoryInterface */
+    protected $countryRepository;
 
-    protected PaymentMethodRepositoryInterface $paymentMethodRepository;
+    /** @var PaymentMethodRepositoryInterface */
+    protected $paymentMethodRepository;
 
-    protected ShippingMethodRepositoryInterface $shippingMethodRepository;
+    /** @var ShippingMethodRepositoryInterface */
+    protected $shippingMethodRepository;
 
-    protected \Sylius\Component\Resource\Factory\FactoryInterface $addressFactory;
+    /** @var FactoryInterface */
+    protected $addressFactory;
 
-    protected StateMachineFactoryInterface $stateMachineFactory;
+    /** @var StateMachineFactoryInterface */
+    protected $stateMachineFactory;
 
-    protected OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker;
+    /** @var OrderShippingMethodSelectionRequirementCheckerInterface */
+    protected $orderShippingMethodSelectionRequirementChecker;
 
-    protected OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker;
+    /** @var OrderPaymentMethodSelectionRequirementCheckerInterface */
+    protected $orderPaymentMethodSelectionRequirementChecker;
 
-    protected OptionsResolver $optionsResolver;
+    /** @var OptionsResolver */
+    protected $optionsResolver;
 
-    protected Generator $faker;
+    /** @var Generator */
+    protected $faker;
 
     public function __construct(
         FactoryInterface $orderFactory,

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -30,9 +30,11 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 
 class OrderFixture extends AbstractFixture
 {
-    protected OrderExampleFactory $orderExampleFactory;
+    /** @var OrderExampleFactory */
+    protected $orderExampleFactory;
 
-    protected ObjectManager $orderManager;
+    /** @var ObjectManager */
+    protected $orderManager;
 
     private Generator $faker;
 

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/RequirementCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/RequirementCollection.php
@@ -15,10 +15,11 @@ namespace Sylius\Bundle\CoreBundle\Installer\Requirement;
 
 abstract class RequirementCollection implements \IteratorAggregate
 {
-    protected string $label;
+    /** @var string */
+    protected $label;
 
-    /** @var Requirement[] */
-    protected array $requirements = [];
+    /** @var array|Requirement[] */
+    protected $requirements = [];
 
     public function __construct(string $label)
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 class UniqueReviewerEmail extends Constraint
 {
-    public string $message = 'sylius.review.author.already_exists';
+    /** @var string */
+    public $message = 'sylius.review.author.already_exists';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 class DifferentSourceTargetCurrency extends Constraint
 {
-    public string $message = 'sylius.exchange_rate.different_source_target_currency';
+    /** @var string */
+    public $message = 'sylius.exchange_rate.different_source_target_currency';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 class UniqueCurrencyPair extends Constraint
 {
-    public string $message = 'sylius.exchange_rate.unique_currency_pair';
+    /** @var string */
+    public $message = 'sylius.exchange_rate.unique_currency_pair';
 
     public function getTargets(): string
     {

--- a/src/Sylius/Bundle/PayumBundle/Model/GatewayConfig.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/GatewayConfig.php
@@ -17,7 +17,8 @@ use Payum\Core\Model\GatewayConfig as BaseGatewayConfig;
 
 class GatewayConfig extends BaseGatewayConfig implements GatewayConfigInterface
 {
-    protected int $id;
+    /** @var int */
+    protected $id;
 
     public function getId(): int
     {

--- a/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
@@ -20,13 +20,17 @@ class PaymentSecurityToken implements PaymentSecurityTokenInterface
     /** @var string */
     protected $hash;
 
-    protected ?object $details = null;
+    /** @var object|null */
+    protected $details = null;
 
-    protected ?string $afterUrl = null;
+    /** @var string|null */
+    protected $afterUrl = null;
 
-    protected ?string $targetUrl = null;
+    /** @var string|null */
+    protected $targetUrl = null;
 
-    protected ?string $gatewayName = null;
+    /** @var string|null */
+    protected $gatewayName = null;
 
     public function __construct()
     {

--- a/src/Sylius/Bundle/PayumBundle/Storage/DoctrineStorage.php
+++ b/src/Sylius/Bundle/PayumBundle/Storage/DoctrineStorage.php
@@ -18,7 +18,8 @@ use Payum\Core\Storage\AbstractStorage;
  */
 class DoctrineStorage extends AbstractStorage
 {
-    protected ObjectManager $objectManager;
+    /** @var ObjectManager */
+    protected $objectManager;
 
     public function __construct(ObjectManager $objectManager, $modelClass)
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -17,8 +17,7 @@ use Symfony\Component\Validator\Constraint;
 
 final class ProductVariantCombination extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.product_variant.combination';
+    public string $message = 'sylius.product_variant.combination';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 final class ProductVariantCombination extends Constraint
 {
-    public string $message = 'sylius.product_variant.combination';
+    /** @var string */
+    public $message = 'sylius.product_variant.combination';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -17,8 +17,7 @@ use Symfony\Component\Validator\Constraint;
 
 final class UniqueSimpleProductCode extends Constraint
 {
-    /** @var string */
-    public $message = 'sylius.simple_product.code.unique';
+    public string $message = 'sylius.simple_product.code.unique';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -17,7 +17,8 @@ use Symfony\Component\Validator\Constraint;
 
 final class UniqueSimpleProductCode extends Constraint
 {
-    public string $message = 'sylius.simple_product.code.unique';
+    /** @var string */
+    public $message = 'sylius.simple_product.code.unique';
 
     public function validatedBy(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
@@ -23,7 +23,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractConfigurationCollectionType extends AbstractType
 {
-    protected ServiceRegistryInterface $registry;
+    /** @var ServiceRegistryInterface */
+    protected $registry;
 
     public function __construct(ServiceRegistryInterface $registry)
     {

--- a/src/Sylius/Bundle/PromotionBundle/test/src/AppBundle/Entity/PromotionSubject.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/src/AppBundle/Entity/PromotionSubject.php
@@ -27,7 +27,7 @@ class PromotionSubject implements ResourceInterface, PromotionSubjectInterface
      *
      * @psalm-var Collection<array-key, PromotionInterface>
      */
-    protected Collection $promotions;
+    protected $promotions;
 
     public function getId(): int
     {

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
@@ -23,7 +23,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractConfigurationCollectionType extends AbstractType
 {
-    protected ServiceRegistryInterface $registry;
+    /** @var ServiceRegistryInterface */
+    protected $registry;
 
     public function __construct(ServiceRegistryInterface $registry)
     {

--- a/src/Sylius/Bundle/UserBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/MailerListener.php
@@ -20,7 +20,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 class MailerListener
 {
-    protected SenderInterface $emailSender;
+    /** @var SenderInterface */
+    protected $emailSender;
 
     public function __construct(SenderInterface $emailSender)
     {

--- a/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
+++ b/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
@@ -22,11 +22,14 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 abstract class AbstractUserProvider implements UserProviderInterface
 {
-    protected string $supportedUserClass = UserInterface::class;
+    /** @var string */
+    protected $supportedUserClass = UserInterface::class;
 
-    protected UserRepositoryInterface $userRepository;
+    /** @var UserRepositoryInterface */
+    protected $userRepository;
 
-    protected CanonicalizerInterface $canonicalizer;
+    /** @var CanonicalizerInterface */
+    protected $canonicalizer;
 
     /**
      * @param string $supportedUserClass FQCN

--- a/src/Sylius/Component/Addressing/Model/Address.php
+++ b/src/Sylius/Component/Addressing/Model/Address.php
@@ -22,25 +22,55 @@ class Address implements AddressInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $firstName = null;
+    /**
+     * @var string|null
+     */
+    protected $firstName;
 
-    protected ?string $lastName = null;
+    /**
+     * @var string|null
+     */
+    protected $lastName;
 
-    protected ?string $phoneNumber = null;
+    /**
+     * @var string|null
+     */
+    protected $phoneNumber;
 
-    protected ?string $company = null;
+    /**
+     * @var string|null
+     */
+    protected $company;
 
-    protected ?string $countryCode = null;
+    /**
+     * @var string|null
+     */
+    protected $countryCode;
 
-    protected ?string $provinceCode = null;
+    /**
+     * @var string|null
+     */
+    protected $provinceCode;
 
-    protected ?string $provinceName = null;
+    /**
+     * @var string|null
+     */
+    protected $provinceName;
 
-    protected ?string $street = null;
+    /**
+     * @var string|null
+     */
+    protected $street;
 
-    protected ?string $city = null;
+    /**
+     * @var string|null
+     */
+    protected $city;
 
-    protected ?string $postcode = null;
+    /**
+     * @var string|null
+     */
+    protected $postcode;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -27,15 +27,16 @@ class Country implements CountryInterface
 
     /**
      * Country code ISO 3166-1 alpha-2.
+     * @var string|null
      */
-    protected ?string $code = null;
+    protected $code;
 
     /**
      * @var Collection|ProvinceInterface[]
      *
      * @psalm-var Collection<array-key, ProvinceInterface>
      */
-    protected Collection $provinces;
+    protected $provinces;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Addressing/Model/Province.php
+++ b/src/Sylius/Component/Addressing/Model/Province.php
@@ -18,13 +18,25 @@ class Province implements ProvinceInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $abbreviation = null;
+    /**
+     * @var string|null
+     */
+    protected $abbreviation;
 
-    protected ?CountryInterface $country = null;
+    /**
+     * @var CountryInterface|null
+     */
+    protected $country;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -21,20 +21,32 @@ class Zone implements ZoneInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected ?string $scope = Scope::ALL;
+    /**
+     * @var string
+     */
+    protected $scope = Scope::ALL;
 
     /**
      * @var Collection|ZoneMemberInterface[]
      *
      * @psalm-var Collection<array-key, ZoneMemberInterface>
      */
-    protected Collection $members;
+    protected $members;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Addressing/Model/ZoneMember.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMember.php
@@ -18,9 +18,15 @@ class ZoneMember implements ZoneMemberInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?ZoneInterface $belongsTo = null;
+    /**
+     * @var ZoneInterface|null
+     */
+    protected $belongsTo;
 
     public function getId()
     {

--- a/src/Sylius/Component/Attribute/Model/Attribute.php
+++ b/src/Sylius/Component/Attribute/Model/Attribute.php
@@ -29,17 +29,35 @@ class Attribute implements AttributeInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $type = TextAttributeType::TYPE;
+    /**
+     * @var string
+     */
+    protected $type = TextAttributeType::TYPE;
 
-    protected array $configuration = [];
+    /**
+     * @var mixed[]
+     */
+    protected $configuration = [];
 
-    protected ?string $storageType = null;
+    /**
+     * @var string|null
+     */
+    protected $storageType;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
-    protected bool $translatable = true;
+    /**
+     * @var bool
+     */
+    protected $translatable = true;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Attribute/Model/AttributeTranslation.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeTranslation.php
@@ -20,7 +20,10 @@ class AttributeTranslation extends AbstractTranslation implements AttributeTrans
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function getId()
     {

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -18,25 +18,55 @@ class AttributeValue implements AttributeValueInterface
     /** @var mixed */
     protected $id;
 
-    protected ?AttributeSubjectInterface $subject = null;
+    /**
+     * @var AttributeSubjectInterface|null
+     */
+    protected $subject;
 
-    protected ?AttributeInterface $attribute = null;
+    /**
+     * @var AttributeInterface|null
+     */
+    protected $attribute;
 
-    protected ?string $localeCode = null;
+    /**
+     * @var string|null
+     */
+    protected $localeCode;
 
-    private ?string $text = null;
+    /**
+     * @var string|null
+     */
+    private $text;
 
-    private ?bool $boolean = null;
+    /**
+     * @var bool|null
+     */
+    private $boolean;
 
-    private ?int $integer = null;
+    /**
+     * @var int|null
+     */
+    private $integer;
 
-    private ?float $float = null;
+    /**
+     * @var float|null
+     */
+    private $float;
 
-    private ?\DateTimeInterface $datetime = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    private $datetime;
 
-    private ?\DateTimeInterface $date = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    private $date;
 
-    private ?array $json = null;
+    /**
+     * @var mixed[]|null
+     */
+    private $json;
 
     public function getId()
     {

--- a/src/Sylius/Component/Channel/Model/Channel.php
+++ b/src/Sylius/Component/Channel/Model/Channel.php
@@ -23,15 +23,30 @@ class Channel implements ChannelInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
-    protected ?string $hostname = null;
+    /**
+     * @var string|null
+     */
+    protected $hostname;
 
-    protected ?string $color = null;
+    /**
+     * @var string|null
+     */
+    protected $color;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Adjustment.php
+++ b/src/Sylius/Component/Core/Model/Adjustment.php
@@ -17,7 +17,10 @@ use Sylius\Component\Order\Model\Adjustment as BaseAdjustment;
 
 class Adjustment extends BaseAdjustment implements AdjustmentInterface
 {
-    protected ?ShipmentInterface $shipment = null;
+    /**
+     * @var ShipmentInterface|null
+     */
+    protected $shipment;
 
     public function getShipment(): ?ShipmentInterface
     {

--- a/src/Sylius/Component/Core/Model/AdminUser.php
+++ b/src/Sylius/Component/Core/Model/AdminUser.php
@@ -17,13 +17,25 @@ use Sylius\Component\User\Model\User;
 
 class AdminUser extends User implements AdminUserInterface
 {
-    protected ?string $firstName = null;
+    /**
+     * @var string|null
+     */
+    protected $firstName;
 
-    protected ?string $lastName = null;
+    /**
+     * @var string|null
+     */
+    protected $lastName;
 
-    protected ?string $localeCode = null;
+    /**
+     * @var string|null
+     */
+    protected $localeCode;
 
-    protected ?ImageInterface $avatar = null;
+    /**
+     * @var ImageInterface|null
+     */
+    protected $avatar;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -23,50 +23,86 @@ use Sylius\Component\Locale\Model\LocaleInterface;
 
 class Channel extends BaseChannel implements ChannelInterface
 {
-    protected ?CurrencyInterface $baseCurrency = null;
+    /**
+     * @var CurrencyInterface|null
+     */
+    protected $baseCurrency;
 
-    protected ?LocaleInterface $defaultLocale = null;
+    /**
+     * @var LocaleInterface|null
+     */
+    protected $defaultLocale;
 
-    protected ?ZoneInterface $defaultTaxZone = null;
+    /**
+     * @var ZoneInterface|null
+     */
+    protected $defaultTaxZone;
 
-    protected ?string $taxCalculationStrategy = null;
+    /**
+     * @var string|null
+     */
+    protected $taxCalculationStrategy;
 
     /**
      * @var Collection|CurrencyInterface[]
      *
      * @psalm-var Collection<array-key, CurrencyInterface>
      */
-    protected Collection $currencies;
+    protected $currencies;
 
     /**
      * @var Collection|LocaleInterface[]
      *
      * @psalm-var Collection<array-key, LocaleInterface>
      */
-    protected Collection $locales;
+    protected $locales;
 
     /**
      * @var Collection|CountryInterface[]
      *
      * @psalm-var Collection<array-key, CountryInterface>
      */
-    protected Collection $countries;
+    protected $countries;
 
-    protected ?string $themeName = null;
+    /**
+     * @var string|null
+     */
+    protected $themeName;
 
-    protected ?string $contactEmail = null;
+    /**
+     * @var string|null
+     */
+    protected $contactEmail;
 
-    protected ?string $contactPhoneNumber = null;
+    /**
+     * @var string|null
+     */
+    protected $contactPhoneNumber;
 
-    protected bool $skippingShippingStepAllowed = false;
+    /**
+     * @var bool
+     */
+    protected $skippingShippingStepAllowed = false;
 
-    protected bool $skippingPaymentStepAllowed = false;
+    /**
+     * @var bool
+     */
+    protected $skippingPaymentStepAllowed = false;
 
-    protected bool $accountVerificationRequired = true;
+    /**
+     * @var bool
+     */
+    protected $accountVerificationRequired = true;
 
-    protected ?ShopBillingDataInterface $shopBillingData = null;
+    /**
+     * @var ShopBillingDataInterface|null
+     */
+    protected $shopBillingData;
 
-    protected ?TaxonInterface $menuTaxon = null;
+    /**
+     * @var TaxonInterface|null
+     */
+    protected $menuTaxon;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/ChannelPricing.php
+++ b/src/Sylius/Component/Core/Model/ChannelPricing.php
@@ -18,13 +18,25 @@ class ChannelPricing implements ChannelPricingInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $channelCode = null;
+    /**
+     * @var string|null
+     */
+    protected $channelCode;
 
-    protected ?ProductVariantInterface $productVariant = null;
+    /**
+     * @var ProductVariantInterface|null
+     */
+    protected $productVariant;
 
-    protected ?int $price = null;
+    /**
+     * @var int|null
+     */
+    protected $price;
 
-    protected ?int $originalPrice = null;
+    /**
+     * @var int|null
+     */
+    protected $originalPrice;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/Core/Model/Customer.php
+++ b/src/Sylius/Component/Core/Model/Customer.php
@@ -26,18 +26,24 @@ class Customer extends BaseCustomer implements CustomerInterface
      *
      * @psalm-var Collection<array-key, OrderInterface>
      */
-    protected Collection $orders;
+    protected $orders;
 
-    protected ?AddressInterface $defaultAddress = null;
+    /**
+     * @var AddressInterface|null
+     */
+    protected $defaultAddress;
 
     /**
      * @var Collection|AddressInterface[]
      *
      * @psalm-var Collection<array-key, AddressInterface>
      */
-    protected Collection $addresses;
+    protected $addresses;
 
-    protected ?ShopUserInterface $user = null;
+    /**
+     * @var ShopUserInterface|null
+     */
+    protected $user;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Image.php
+++ b/src/Sylius/Component/Core/Model/Image.php
@@ -18,13 +18,25 @@ abstract class Image implements ImageInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected ?\SplFileInfo $file = null;
+    /**
+     * @var \SplFileInfo|null
+     */
+    protected $file;
 
-    protected ?string $path = null;
+    /**
+     * @var string|null
+     */
+    protected $path;
 
-    protected ?object $owner = null;
+    /**
+     * @var object|null
+     */
+    protected $owner;
 
     public function getId()
     {

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -29,50 +29,86 @@ use Webmozart\Assert\Assert;
 
 class Order extends BaseOrder implements OrderInterface
 {
-    protected ?CustomerInterface $customer = null;
+    /**
+     * @var \Sylius\Component\Core\Model\CustomerInterface|null
+     */
+    protected $customer;
 
-    protected ?ChannelInterface $channel = null;
+    /**
+     * @var \Sylius\Component\Core\Model\ChannelInterface|null
+     */
+    protected $channel;
 
-    protected ?AddressInterface $shippingAddress = null;
+    /**
+     * @var AddressInterface|null
+     */
+    protected $shippingAddress;
 
-    protected ?AddressInterface $billingAddress = null;
+    /**
+     * @var AddressInterface|null
+     */
+    protected $billingAddress;
 
     /**
      * @var Collection|PaymentInterface[]
      *
      * @psalm-var Collection<array-key, PaymentInterface>
      */
-    protected Collection $payments;
+    protected $payments;
 
     /**
      * @var Collection|ShipmentInterface[]
      *
      * @psalm-var Collection<array-key, ShipmentInterface>
      */
-    protected Collection $shipments;
+    protected $shipments;
 
-    protected ?string $currencyCode = null;
+    /**
+     * @var string|null
+     */
+    protected $currencyCode;
 
-    protected ?string $localeCode = null;
+    /**
+     * @var string|null
+     */
+    protected $localeCode;
 
-    protected ?BaseCouponInterface $promotionCoupon = null;
+    /**
+     * @var BaseCouponInterface|null
+     */
+    protected $promotionCoupon;
 
-    protected ?string $checkoutState = OrderCheckoutStates::STATE_CART;
+    /**
+     * @var string|null
+     */
+    protected $checkoutState;
 
-    protected ?string $paymentState = OrderPaymentStates::STATE_CART;
+    /**
+     * @var string|null
+     */
+    protected $paymentState;
 
-    protected ?string $shippingState = OrderShippingStates::STATE_CART;
+    /**
+     * @var string|null
+     */
+    protected $shippingState;
 
     /**
      * @var Collection|BasePromotionInterface[]
      *
      * @psalm-var Collection<array-key, BasePromotionInterface>
      */
-    protected Collection $promotions;
+    protected $promotions;
 
-    protected ?string $tokenValue = null;
+    /**
+     * @var string|null
+     */
+    protected $tokenValue;
 
-    protected ?string $customerIp = null;
+    /**
+     * @var string|null
+     */
+    protected $customerIp;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -79,19 +79,19 @@ class Order extends BaseOrder implements OrderInterface
     protected $promotionCoupon;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $checkoutState;
+    protected $checkoutState = OrderCheckoutStates::STATE_CART;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $paymentState;
+    protected $paymentState = OrderPaymentStates::STATE_CART;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $shippingState;
+    protected $shippingState = OrderShippingStates::STATE_CART;
 
     /**
      * @var Collection|BasePromotionInterface[]

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -19,13 +19,25 @@ use Webmozart\Assert\Assert;
 
 class OrderItem extends BaseOrderItem implements OrderItemInterface
 {
-    protected ?int $version = 1;
+    /**
+     * @var int|null
+     */
+    protected $version;
 
-    protected ?ProductVariantInterface $variant = null;
+    /**
+     * @var ProductVariantInterface|null
+     */
+    protected $variant;
 
-    protected ?string $productName = null;
+    /**
+     * @var string|null
+     */
+    protected $productName;
 
-    protected ?string $variantName = null;
+    /**
+     * @var string|null
+     */
+    protected $variantName;
 
     public function getVersion(): ?int
     {

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -20,9 +20,9 @@ use Webmozart\Assert\Assert;
 class OrderItem extends BaseOrderItem implements OrderItemInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
-    protected $version;
+    protected $version = 1;
 
     /**
      * @var ProductVariantInterface|null

--- a/src/Sylius/Component/Core/Model/OrderSequence.php
+++ b/src/Sylius/Component/Core/Model/OrderSequence.php
@@ -17,7 +17,10 @@ use Sylius\Component\Order\Model\OrderSequence as BaseOrderSequence;
 
 class OrderSequence extends BaseOrderSequence implements OrderSequenceInterface
 {
-    protected ?int $version = 1;
+    /**
+     * @var int|null
+     */
+    protected $version;
 
     public function getVersion(): ?int
     {

--- a/src/Sylius/Component/Core/Model/OrderSequence.php
+++ b/src/Sylius/Component/Core/Model/OrderSequence.php
@@ -18,9 +18,9 @@ use Sylius\Component\Order\Model\OrderSequence as BaseOrderSequence;
 class OrderSequence extends BaseOrderSequence implements OrderSequenceInterface
 {
     /**
-     * @var int|null
+     * @var int
      */
-    protected $version;
+    protected $version = 1;
 
     public function getVersion(): ?int
     {

--- a/src/Sylius/Component/Core/Model/PaymentMethod.php
+++ b/src/Sylius/Component/Core/Model/PaymentMethod.php
@@ -27,9 +27,12 @@ class PaymentMethod extends BasePaymentMethod implements PaymentMethodInterface
      *
      * @psalm-var Collection<array-key, BaseChannelInterface>
      */
-    protected Collection $channels;
+    protected $channels;
 
-    protected ?GatewayConfigInterface $gatewayConfig = null;
+    /**
+     * @var GatewayConfigInterface|null
+     */
+    protected $gatewayConfig;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -28,7 +28,7 @@ class Product extends BaseProduct implements ProductInterface, ReviewableProduct
     /**
      * @var string|null
      */
-    protected $variantSelectionMethod;
+    protected $variantSelectionMethod = self::VARIANT_SELECTION_CHOICE;
 
     /**
      * @var Collection|ProductTaxonInterface[]

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -25,39 +25,48 @@ use Webmozart\Assert\Assert;
 
 class Product extends BaseProduct implements ProductInterface, ReviewableProductInterface
 {
-    protected ?string $variantSelectionMethod = self::VARIANT_SELECTION_CHOICE;
+    /**
+     * @var string|null
+     */
+    protected $variantSelectionMethod;
 
     /**
      * @var Collection|ProductTaxonInterface[]
      *
      * @psalm-var Collection<array-key, ProductTaxonInterface>
      */
-    protected Collection $productTaxons;
+    protected $productTaxons;
 
     /**
      * @var Collection|ChannelInterface[]
      *
      * @psalm-var Collection<array-key, ChannelInterface>
      */
-    protected Collection $channels;
+    protected $channels;
 
-    protected ?TaxonInterface $mainTaxon = null;
+    /**
+     * @var \Sylius\Component\Core\Model\TaxonInterface|null
+     */
+    protected $mainTaxon;
 
     /**
      * @var Collection|ReviewInterface[]
      *
      * @psalm-var Collection<array-key, ReviewInterface>
      */
-    protected Collection $reviews;
+    protected $reviews;
 
-    protected float $averageRating = 0.0;
+    /**
+     * @var float
+     */
+    protected $averageRating = 0.0;
 
     /**
      * @var Collection|ImageInterface[]
      *
      * @psalm-var Collection<array-key, ImageInterface>
      */
-    protected Collection $images;
+    protected $images;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/ProductImage.php
+++ b/src/Sylius/Component/Core/Model/ProductImage.php
@@ -23,7 +23,7 @@ class ProductImage extends Image implements ProductImageInterface
      *
      * @psalm-var Collection<array-key, ProductVariantInterface>
      */
-    protected Collection $productVariants;
+    protected $productVariants;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/ProductTaxon.php
+++ b/src/Sylius/Component/Core/Model/ProductTaxon.php
@@ -18,11 +18,20 @@ class ProductTaxon implements ProductTaxonInterface
     /** @var mixed */
     protected $id;
 
-    protected ?ProductInterface $product = null;
+    /**
+     * @var ProductInterface|null
+     */
+    protected $product;
 
-    protected ?TaxonInterface $taxon = null;
+    /**
+     * @var TaxonInterface|null
+     */
+    protected $taxon;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
     public function getId()
     {

--- a/src/Sylius/Component/Core/Model/ProductTranslation.php
+++ b/src/Sylius/Component/Core/Model/ProductTranslation.php
@@ -17,7 +17,10 @@ use Sylius\Component\Product\Model\ProductTranslation as BaseProductTranslation;
 
 class ProductTranslation extends BaseProductTranslation implements ProductTranslationInterface
 {
-    protected ?string $shortDescription = null;
+    /**
+     * @var string|null
+     */
+    protected $shortDescription;
 
     public function getShortDescription(): ?string
     {

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -23,19 +23,19 @@ use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 class ProductVariant extends BaseVariant implements ProductVariantInterface, Comparable
 {
     /**
-     * @var int|null
+     * @var int
      */
-    protected $version;
+    protected $version = 1;
 
     /**
-     * @var int|null
+     * @var int
      */
-    protected $onHold;
+    protected $onHold = 0;
 
     /**
-     * @var int|null
+     * @var int
      */
-    protected $onHand;
+    protected $onHand = 0;
 
     /**
      * @var bool

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -22,36 +22,72 @@ use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 class ProductVariant extends BaseVariant implements ProductVariantInterface, Comparable
 {
-    protected ?int $version = 1;
+    /**
+     * @var int|null
+     */
+    protected $version;
 
-    protected ?int $onHold = 0;
+    /**
+     * @var int|null
+     */
+    protected $onHold;
 
-    protected ?int $onHand = 0;
+    /**
+     * @var int|null
+     */
+    protected $onHand;
 
-    protected bool $tracked = false;
+    /**
+     * @var bool
+     */
+    protected $tracked = false;
 
-    protected ?float $weight = null;
+    /**
+     * @var float|null
+     */
+    protected $weight;
 
-    protected ?float $width = null;
+    /**
+     * @var float|null
+     */
+    protected $width;
 
-    protected ?float $height = null;
+    /**
+     * @var float|null
+     */
+    protected $height;
 
-    protected ?float $depth = null;
+    /**
+     * @var float|null
+     */
+    protected $depth;
 
-    protected ?TaxCategoryInterface $taxCategory = null;
+    /**
+     * @var TaxCategoryInterface|null
+     */
+    protected $taxCategory;
 
-    protected ?ShippingCategoryInterface $shippingCategory = null;
+    /**
+     * @var ShippingCategoryInterface|null
+     */
+    protected $shippingCategory;
 
-    protected Collection $channelPricings;
+    /**
+     * @var Collection
+     */
+    protected $channelPricings;
 
-    protected bool $shippingRequired = true;
+    /**
+     * @var bool
+     */
+    protected $shippingRequired = true;
 
     /**
      * @var Collection|ProductImageInterface[]
      *
      * @psalm-var Collection<array-key, ProductImageInterface>
      */
-    protected Collection $images;
+    protected $images;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/Promotion.php
+++ b/src/Sylius/Component/Core/Model/Promotion.php
@@ -25,7 +25,7 @@ class Promotion extends BasePromotion implements PromotionInterface
      *
      * @psalm-var Collection<array-key, ChannelInterface>
      */
-    protected Collection $channels;
+    protected $channels;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/PromotionCoupon.php
+++ b/src/Sylius/Component/Core/Model/PromotionCoupon.php
@@ -17,9 +17,15 @@ use Sylius\Component\Promotion\Model\PromotionCoupon as BasePromotionCoupon;
 
 class PromotionCoupon extends BasePromotionCoupon implements PromotionCouponInterface
 {
-    protected ?int $perCustomerUsageLimit = null;
+    /**
+     * @var int|null
+     */
+    protected $perCustomerUsageLimit;
 
-    protected bool $reusableFromCancelledOrders = true;
+    /**
+     * @var bool
+     */
+    protected $reusableFromCancelledOrders = true;
 
     public function getPerCustomerUsageLimit(): ?int
     {

--- a/src/Sylius/Component/Core/Model/Shipment.php
+++ b/src/Sylius/Component/Core/Model/Shipment.php
@@ -29,9 +29,12 @@ class Shipment extends BaseShipment implements ShipmentInterface
      *
      * @psalm-var Collection<array-key, BaseAdjustmentInterface>
      */
-    protected Collection $adjustments;
+    protected $adjustments;
 
-    protected int $adjustmentsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $adjustmentsTotal = 0;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -23,16 +23,22 @@ use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterface
 {
-    protected ?ZoneInterface $zone = null;
+    /**
+     * @var ZoneInterface|null
+     */
+    protected $zone;
 
-    protected ?TaxCategoryInterface $taxCategory = null;
+    /**
+     * @var TaxCategoryInterface|null
+     */
+    protected $taxCategory;
 
     /**
      * @var Collection|ChannelInterface[]
      *
      * @psalm-var Collection<array-key, ChannelInterface>
      */
-    protected Collection $channels;
+    protected $channels;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Model/ShopBillingData.php
+++ b/src/Sylius/Component/Core/Model/ShopBillingData.php
@@ -18,17 +18,35 @@ class ShopBillingData implements ShopBillingDataInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $company = null;
+    /**
+     * @var string|null
+     */
+    protected $company;
 
-    protected ?string $taxId = null;
+    /**
+     * @var string|null
+     */
+    protected $taxId;
 
-    protected ?string $countryCode = null;
+    /**
+     * @var string|null
+     */
+    protected $countryCode;
 
-    protected ?string $street = null;
+    /**
+     * @var string|null
+     */
+    protected $street;
 
-    protected ?string $city = null;
+    /**
+     * @var string|null
+     */
+    protected $city;
 
-    protected ?string $postcode = null;
+    /**
+     * @var string|null
+     */
+    protected $postcode;
 
     public function getId()
     {

--- a/src/Sylius/Component/Core/Model/TaxRate.php
+++ b/src/Sylius/Component/Core/Model/TaxRate.php
@@ -18,7 +18,10 @@ use Sylius\Component\Taxation\Model\TaxRate as BaseTaxRate;
 
 class TaxRate extends BaseTaxRate implements TaxRateInterface
 {
-    protected ?ZoneInterface $zone = null;
+    /**
+     * @var ZoneInterface|null
+     */
+    protected $zone;
 
     public function getZone(): ?ZoneInterface
     {

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -29,7 +29,7 @@ class Taxon extends BaseTaxon implements TaxonInterface, Comparable
      *
      * @psalm-var Collection<array-key, ImageInterface>
      */
-    protected Collection $images;
+    protected $images;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
@@ -26,7 +26,8 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 
 abstract class UnitDiscountPromotionActionCommand implements PromotionActionCommandInterface
 {
-    protected FactoryInterface $adjustmentFactory;
+    /** @var FactoryInterface */
+    protected $adjustmentFactory;
 
     public function __construct(FactoryInterface $adjustmentFactory)
     {

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -24,7 +24,8 @@ use Webmozart\Assert\Assert;
 
 class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterface
 {
-    protected PaymentMethodRepositoryInterface $paymentMethodRepository;
+    /** @var PaymentMethodRepositoryInterface */
+    protected $paymentMethodRepository;
 
     public function __construct(PaymentMethodRepositoryInterface $paymentMethodRepository)
     {

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -22,9 +22,11 @@ use Webmozart\Assert\Assert;
 
 class ImageUploader implements ImageUploaderInterface
 {
-    protected Filesystem $filesystem;
+    /** @var Filesystem */
+    protected $filesystem;
 
-    protected ImagePathGeneratorInterface $imagePathGenerator;
+    /** @var ImagePathGeneratorInterface */
+    protected $imagePathGenerator;
 
     public function __construct(
         Filesystem $filesystem,

--- a/src/Sylius/Component/Currency/Model/Currency.php
+++ b/src/Sylius/Component/Currency/Model/Currency.php
@@ -23,7 +23,10 @@ class Currency implements CurrencyInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Currency/Model/ExchangeRate.php
+++ b/src/Sylius/Component/Currency/Model/ExchangeRate.php
@@ -22,11 +22,20 @@ class ExchangeRate implements ExchangeRateInterface
     /** @var mixed */
     protected $id;
 
-    protected ?float $ratio = null;
+    /**
+     * @var float|null
+     */
+    protected $ratio;
 
-    protected ?CurrencyInterface $sourceCurrency = null;
+    /**
+     * @var CurrencyInterface|null
+     */
+    protected $sourceCurrency;
 
-    protected ?CurrencyInterface $targetCurrency = null;
+    /**
+     * @var CurrencyInterface|null
+     */
+    protected $targetCurrency;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Customer/Model/Customer.php
+++ b/src/Sylius/Component/Customer/Model/Customer.php
@@ -48,9 +48,9 @@ class Customer implements CustomerInterface
     protected $birthday;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $gender;
+    protected $gender = CustomerInterface::UNKNOWN_GENDER;
 
     /**
      * @var CustomerGroupInterface|null

--- a/src/Sylius/Component/Customer/Model/Customer.php
+++ b/src/Sylius/Component/Customer/Model/Customer.php
@@ -22,23 +22,50 @@ class Customer implements CustomerInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $email = null;
+    /**
+     * @var string|null
+     */
+    protected $email;
 
-    protected ?string $emailCanonical = null;
+    /**
+     * @var string|null
+     */
+    protected $emailCanonical;
 
-    protected ?string $firstName = null;
+    /**
+     * @var string|null
+     */
+    protected $firstName;
 
-    protected ?string $lastName = null;
+    /**
+     * @var string|null
+     */
+    protected $lastName;
 
-    protected ?\DateTimeInterface $birthday = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $birthday;
 
-    protected ?string $gender = CustomerInterface::UNKNOWN_GENDER;
+    /**
+     * @var string|null
+     */
+    protected $gender;
 
-    protected ?CustomerGroupInterface $group = null;
+    /**
+     * @var CustomerGroupInterface|null
+     */
+    protected $group;
 
-    protected ?string $phoneNumber = null;
+    /**
+     * @var string|null
+     */
+    protected $phoneNumber;
 
-    protected bool $subscribedToNewsletter = false;
+    /**
+     * @var bool
+     */
+    protected $subscribedToNewsletter = false;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Customer/Model/CustomerGroup.php
+++ b/src/Sylius/Component/Customer/Model/CustomerGroup.php
@@ -18,9 +18,15 @@ class CustomerGroup implements CustomerGroupInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/Inventory/Model/InventoryUnit.php
+++ b/src/Sylius/Component/Inventory/Model/InventoryUnit.php
@@ -18,7 +18,10 @@ class InventoryUnit implements InventoryUnitInterface
     /** @var mixed */
     protected $id;
 
-    protected ?StockableInterface $stockable = null;
+    /**
+     * @var StockableInterface|null
+     */
+    protected $stockable;
 
     public function getId()
     {

--- a/src/Sylius/Component/Locale/Model/Locale.php
+++ b/src/Sylius/Component/Locale/Model/Locale.php
@@ -23,7 +23,10 @@ class Locale implements LocaleInterface
     /** @var mixed  */
     protected $id = null;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Order/Model/Adjustment.php
+++ b/src/Sylius/Component/Order/Model/Adjustment.php
@@ -22,25 +22,55 @@ class Adjustment implements AdjustmentInterface
     /** @var mixed */
     protected $id;
 
-    protected ?OrderInterface $order = null;
+    /**
+     * @var OrderInterface|null
+     */
+    protected $order;
 
-    protected ?OrderItemInterface $orderItem = null;
+    /**
+     * @var OrderItemInterface|null
+     */
+    protected $orderItem;
 
-    protected ?OrderItemUnitInterface $orderItemUnit = null;
+    /**
+     * @var OrderItemUnitInterface|null
+     */
+    protected $orderItemUnit;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected ?string $label = null;
+    /**
+     * @var string|null
+     */
+    protected $label;
 
-    protected int $amount = 0;
+    /**
+     * @var int
+     */
+    protected $amount = 0;
 
-    protected bool $neutral = false;
+    /**
+     * @var bool
+     */
+    protected $neutral = false;
 
-    protected bool $locked = false;
+    /**
+     * @var bool
+     */
+    protected $locked = false;
 
-    protected ?string $originCode = null;
+    /**
+     * @var string|null
+     */
+    protected $originCode;
 
-    protected array $details = [];
+    /**
+     * @var mixed[]
+     */
+    protected $details = [];
 
     public function __construct()
     {

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -24,36 +24,55 @@ class Order implements OrderInterface
     /** @var mixed */
     protected $id;
 
-    protected ?\DateTimeInterface $checkoutCompletedAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $checkoutCompletedAt;
 
-    protected ?string $number = null;
+    /**
+     * @var string|null
+     */
+    protected $number;
 
-    protected ?string $notes = null;
+    /**
+     * @var string|null
+     */
+    protected $notes;
 
     /**
      * @var Collection|OrderItemInterface[]
      *
      * @psalm-var Collection<array-key, OrderItemInterface>
      */
-    protected Collection $items;
+    protected $items;
 
-    protected int $itemsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $itemsTotal = 0;
 
     /**
      * @var Collection|AdjustmentInterface[]
      *
      * @psalm-var Collection<array-key, AdjustmentInterface>
      */
-    protected Collection $adjustments;
+    protected $adjustments;
 
-    protected int $adjustmentsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $adjustmentsTotal = 0;
 
     /**
      * Items total + adjustments total.
+     * @var int
      */
-    protected int $total = 0;
+    protected $total = 0;
 
-    protected string $state = OrderInterface::STATE_CART;
+    /**
+     * @var string
+     */
+    protected $state = OrderInterface::STATE_CART;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -21,33 +21,54 @@ class OrderItem implements OrderItemInterface
     /** @var mixed */
     protected $id;
 
-    protected ?OrderInterface $order = null;
+    /**
+     * @var OrderInterface|null
+     */
+    protected $order;
 
-    protected int $quantity = 0;
+    /**
+     * @var int
+     */
+    protected $quantity = 0;
 
-    protected int $unitPrice = 0;
+    /**
+     * @var int
+     */
+    protected $unitPrice = 0;
 
-    protected int $total = 0;
+    /**
+     * @var int
+     */
+    protected $total = 0;
 
-    protected bool $immutable = false;
+    /**
+     * @var bool
+     */
+    protected $immutable = false;
 
     /**
      * @var Collection|OrderItemUnitInterface[]
      *
      * @psalm-var Collection<array-key, OrderItemUnitInterface>
      */
-    protected Collection $units;
+    protected $units;
 
-    protected int $unitsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $unitsTotal = 0;
 
     /**
      * @var Collection|AdjustmentInterface[]
      *
      * @psalm-var Collection<array-key, AdjustmentInterface>
      */
-    protected Collection $adjustments;
+    protected $adjustments;
 
-    protected int $adjustmentsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $adjustmentsTotal = 0;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -21,16 +21,22 @@ class OrderItemUnit implements OrderItemUnitInterface
     /** @var mixed */
     protected $id = null;
 
-    protected OrderItemInterface $orderItem;
+    /**
+     * @var OrderItemInterface
+     */
+    protected $orderItem;
 
     /**
      * @var Collection|AdjustmentInterface[]
      *
      * @psalm-var Collection<array-key, AdjustmentInterface>
      */
-    protected Collection $adjustments;
+    protected $adjustments;
 
-    protected int $adjustmentsTotal = 0;
+    /**
+     * @var int
+     */
+    protected $adjustmentsTotal = 0;
 
     public function __construct(OrderItemInterface $orderItem)
     {

--- a/src/Sylius/Component/Order/Model/OrderSequence.php
+++ b/src/Sylius/Component/Order/Model/OrderSequence.php
@@ -18,7 +18,10 @@ class OrderSequence implements OrderSequenceInterface
     /** @var mixed */
     protected $id;
 
-    protected int $index = 0;
+    /**
+     * @var int
+     */
+    protected $index = 0;
 
     public function getId()
     {

--- a/src/Sylius/Component/Payment/Model/Payment.php
+++ b/src/Sylius/Component/Payment/Model/Payment.php
@@ -33,14 +33,14 @@ class Payment implements PaymentInterface
     protected $currencyCode;
 
     /**
-     * @var int|null
+     * @var int
      */
-    protected $amount;
+    protected $amount = 0;
 
     /**
      * @var string|null
      */
-    protected $state;
+    protected $state = PaymentInterface::STATE_CART;
 
     /**
      * @var mixed[]

--- a/src/Sylius/Component/Payment/Model/Payment.php
+++ b/src/Sylius/Component/Payment/Model/Payment.php
@@ -22,15 +22,30 @@ class Payment implements PaymentInterface
     /** @var mixed */
     protected $id;
 
-    protected ?PaymentMethodInterface $method = null;
+    /**
+     * @var PaymentMethodInterface|null
+     */
+    protected $method;
 
-    protected ?string $currencyCode = null;
+    /**
+     * @var string|null
+     */
+    protected $currencyCode;
 
-    protected ?int $amount = 0;
+    /**
+     * @var int|null
+     */
+    protected $amount;
 
-    protected ?string $state = PaymentInterface::STATE_CART;
+    /**
+     * @var string|null
+     */
+    protected $state;
 
-    protected array $details = [];
+    /**
+     * @var mixed[]
+     */
+    protected $details = [];
 
     public function __construct()
     {

--- a/src/Sylius/Component/Payment/Model/PaymentMethod.php
+++ b/src/Sylius/Component/Payment/Model/PaymentMethod.php
@@ -29,11 +29,20 @@ class PaymentMethod implements PaymentMethodInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $environment = null;
+    /**
+     * @var string|null
+     */
+    protected $environment;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Payment/Model/PaymentMethodTranslation.php
+++ b/src/Sylius/Component/Payment/Model/PaymentMethodTranslation.php
@@ -20,11 +20,20 @@ class PaymentMethodTranslation extends AbstractTranslation implements PaymentMet
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
-    protected ?string $instructions = null;
+    /**
+     * @var string|null
+     */
+    protected $instructions;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -33,35 +33,38 @@ class Product implements ProductInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
     /**
      * @var Collection|AttributeValueInterface[]
      *
      * @psalm-var Collection<array-key, AttributeValueInterface>
      */
-    protected Collection $attributes;
+    protected $attributes;
 
     /**
      * @var Collection|ProductVariantInterface[]
      *
      * @psalm-var Collection<array-key, ProductVariantInterface>
      */
-    protected Collection $variants;
+    protected $variants;
 
     /**
      * @var Collection|ProductOptionInterface[]
      *
      * @psalm-var Collection<array-key, ProductOptionInterface>
      */
-    protected Collection $options;
+    protected $options;
 
     /**
      * @var Collection|ProductAssociationInterface[]
      *
      * @psalm-var Collection<array-key, ProductAssociationInterface>
      */
-    protected Collection $associations;
+    protected $associations;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductAssociation.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociation.php
@@ -24,16 +24,22 @@ class ProductAssociation implements ProductAssociationInterface
     /** @var mixed */
     protected $id;
 
-    protected ?ProductAssociationTypeInterface $type = null;
+    /**
+     * @var ProductAssociationTypeInterface|null
+     */
+    protected $type;
 
-    protected ?ProductInterface $owner = null;
+    /**
+     * @var ProductInterface|null
+     */
+    protected $owner;
 
     /**
      * @var Collection|ProductInterface[]
      *
      * @psalm-var Collection<array-key, ProductInterface>
      */
-    protected Collection $associatedProducts;
+    protected $associatedProducts;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductAssociationType.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociationType.php
@@ -28,9 +28,15 @@ class ProductAssociationType implements ProductAssociationTypeInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductAssociationTypeTranslation.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociationTypeTranslation.php
@@ -20,7 +20,10 @@ class ProductAssociationTypeTranslation extends AbstractTranslation implements P
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function getId()
     {

--- a/src/Sylius/Component/Product/Model/ProductOption.php
+++ b/src/Sylius/Component/Product/Model/ProductOption.php
@@ -30,16 +30,22 @@ class ProductOption implements ProductOptionInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
     /**
      * @var Collection|ProductOptionValueInterface[]
      *
      * @psalm-var Collection<array-key, ProductOptionValueInterface>
      */
-    protected Collection $values;
+    protected $values;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductOptionTranslation.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionTranslation.php
@@ -20,7 +20,10 @@ class ProductOptionTranslation extends AbstractTranslation implements ProductOpt
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function getId()
     {

--- a/src/Sylius/Component/Product/Model/ProductOptionValue.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionValue.php
@@ -26,9 +26,15 @@ class ProductOptionValue implements ProductOptionValueInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?ProductOptionInterface $option = null;
+    /**
+     * @var ProductOptionInterface|null
+     */
+    protected $option;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductOptionValueTranslation.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionValueTranslation.php
@@ -20,7 +20,10 @@ class ProductOptionValueTranslation extends AbstractTranslation implements Produ
     /** @var mixed */
     protected $id;
 
-    protected ?string $value = null;
+    /**
+     * @var string|null
+     */
+    protected $value;
 
     public function getId()
     {

--- a/src/Sylius/Component/Product/Model/ProductTranslation.php
+++ b/src/Sylius/Component/Product/Model/ProductTranslation.php
@@ -20,15 +20,30 @@ class ProductTranslation extends AbstractTranslation implements ProductTranslati
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $slug = null;
+    /**
+     * @var string|null
+     */
+    protected $slug;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
-    protected ?string $metaKeywords = null;
+    /**
+     * @var string|null
+     */
+    protected $metaKeywords;
 
-    protected ?string $metaDescription = null;
+    /**
+     * @var string|null
+     */
+    protected $metaDescription;
 
     public function getId()
     {

--- a/src/Sylius/Component/Product/Model/ProductVariant.php
+++ b/src/Sylius/Component/Product/Model/ProductVariant.php
@@ -31,18 +31,27 @@ class ProductVariant implements ProductVariantInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?ProductInterface $product = null;
+    /**
+     * @var ProductInterface|null
+     */
+    protected $product;
 
     /**
      * @var Collection|ProductOptionValueInterface[]
      *
      * @psalm-var Collection<array-key, ProductOptionValueInterface>
      */
-    protected Collection $optionValues;
+    protected $optionValues;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Product/Model/ProductVariantTranslation.php
+++ b/src/Sylius/Component/Product/Model/ProductVariantTranslation.php
@@ -20,7 +20,10 @@ class ProductVariantTranslation extends AbstractTranslation implements ProductVa
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
     public function getId()
     {

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -47,9 +47,9 @@ class Promotion implements PromotionInterface
 
     /**
      * Cannot be applied together with other promotions
-     * @var bool|null
+     * @var bool
      */
-    protected $exclusive;
+    protected $exclusive = false;
 
     /**
      * @var int|null
@@ -57,9 +57,9 @@ class Promotion implements PromotionInterface
     protected $usageLimit;
 
     /**
-     * @var int|null
+     * @var int
      */
-    protected $used;
+    protected $used = 0;
 
     /**
      * @var \DateTimeInterface|null

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -24,52 +24,78 @@ class Promotion implements PromotionInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
     /**
      * When exclusive, promotion with top priority will be applied
+     * @var int
      */
-    protected int $priority = 0;
+    protected $priority = 0;
 
     /**
      * Cannot be applied together with other promotions
+     * @var bool|null
      */
-    protected ?bool $exclusive = false;
+    protected $exclusive;
 
-    protected ?int $usageLimit = null;
+    /**
+     * @var int|null
+     */
+    protected $usageLimit;
 
-    protected ?int $used = 0;
+    /**
+     * @var int|null
+     */
+    protected $used;
 
-    protected ?\DateTimeInterface $startsAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $startsAt;
 
-    protected ?\DateTimeInterface $endsAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $endsAt;
 
-    protected bool $couponBased = false;
+    /**
+     * @var bool
+     */
+    protected $couponBased = false;
 
     /**
      * @var Collection|PromotionCouponInterface[]
      *
      * @psalm-var Collection<array-key, PromotionCouponInterface>
      */
-    protected Collection $coupons;
+    protected $coupons;
 
     /**
      * @var Collection|PromotionRuleInterface[]
      *
      * @psalm-var Collection<array-key, PromotionRuleInterface>
      */
-    protected Collection $rules;
+    protected $rules;
 
     /**
      * @var Collection|PromotionActionInterface[]
      *
      * @psalm-var Collection<array-key, PromotionActionInterface>
      */
-    protected Collection $actions;
+    protected $actions;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Promotion/Model/PromotionAction.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionAction.php
@@ -18,11 +18,20 @@ class PromotionAction implements PromotionActionInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected array $configuration = [];
+    /**
+     * @var mixed[]
+     */
+    protected $configuration = [];
 
-    protected ?PromotionInterface $promotion = null;
+    /**
+     * @var PromotionInterface|null
+     */
+    protected $promotion;
 
     public function getId()
     {

--- a/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
@@ -22,15 +22,30 @@ class PromotionCoupon implements PromotionCouponInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?int $usageLimit = null;
+    /**
+     * @var int|null
+     */
+    protected $usageLimit;
 
-    protected int $used = 0;
+    /**
+     * @var int
+     */
+    protected $used = 0;
 
-    protected ?PromotionInterface $promotion = null;
+    /**
+     * @var PromotionInterface|null
+     */
+    protected $promotion;
 
-    protected ?\DateTimeInterface $expiresAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $expiresAt;
 
     public function getId()
     {

--- a/src/Sylius/Component/Promotion/Model/PromotionRule.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionRule.php
@@ -18,11 +18,20 @@ class PromotionRule implements PromotionRuleInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected array $configuration = [];
+    /**
+     * @var mixed[]
+     */
+    protected $configuration = [];
 
-    protected ?PromotionInterface $promotion = null;
+    /**
+     * @var PromotionInterface|null
+     */
+    protected $promotion;
 
     public function getId()
     {

--- a/src/Sylius/Component/Review/Model/Review.php
+++ b/src/Sylius/Component/Review/Model/Review.php
@@ -22,17 +22,35 @@ class Review implements ReviewInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $title = null;
+    /**
+     * @var string|null
+     */
+    protected $title;
 
-    protected ?int $rating = null;
+    /**
+     * @var int|null
+     */
+    protected $rating;
 
-    protected ?string $comment = null;
+    /**
+     * @var string|null
+     */
+    protected $comment;
 
-    protected ?ReviewerInterface $author = null;
+    /**
+     * @var ReviewerInterface|null
+     */
+    protected $author;
 
-    protected ?string $status = ReviewInterface::STATUS_NEW;
+    /**
+     * @var string|null
+     */
+    protected $status;
 
-    protected ?ReviewableInterface $reviewSubject = null;
+    /**
+     * @var ReviewableInterface|null
+     */
+    protected $reviewSubject;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Review/Model/Review.php
+++ b/src/Sylius/Component/Review/Model/Review.php
@@ -43,9 +43,9 @@ class Review implements ReviewInterface
     protected $author;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $status;
+    protected $status = ReviewInterface::STATUS_NEW;
 
     /**
      * @var ReviewableInterface|null

--- a/src/Sylius/Component/Review/Model/Reviewer.php
+++ b/src/Sylius/Component/Review/Model/Reviewer.php
@@ -18,11 +18,20 @@ class Reviewer implements ReviewerInterface
     /** @var mixed */
     protected $id = null;
 
-    protected ?string $email = null;
+    /**
+     * @var string|null
+     */
+    protected $email;
 
-    protected ?string $firstName = null;
+    /**
+     * @var string|null
+     */
+    protected $firstName;
 
-    protected ?string $lastName = null;
+    /**
+     * @var string|null
+     */
+    protected $lastName;
 
     /**
      * @return mixed

--- a/src/Sylius/Component/Shipping/Model/Shipment.php
+++ b/src/Sylius/Component/Shipping/Model/Shipment.php
@@ -24,20 +24,32 @@ class Shipment implements ShipmentInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $state = ShipmentInterface::STATE_CART;
+    /**
+     * @var string|null
+     */
+    protected $state;
 
-    protected ?ShippingMethodInterface $method = null;
+    /**
+     * @var ShippingMethodInterface|null
+     */
+    protected $method;
 
     /**
      * @var Collection|ShipmentUnitInterface[]
      *
      * @psalm-var Collection<array-key, ShipmentUnitInterface>
      */
-    protected Collection $units;
+    protected $units;
 
-    protected ?string $tracking = null;
+    /**
+     * @var string|null
+     */
+    protected $tracking;
 
-    protected ?\DateTimeInterface $shippedAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $shippedAt;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Shipping/Model/Shipment.php
+++ b/src/Sylius/Component/Shipping/Model/Shipment.php
@@ -25,9 +25,9 @@ class Shipment implements ShipmentInterface
     protected $id;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected $state;
+    protected $state = ShipmentInterface::STATE_CART;
 
     /**
      * @var ShippingMethodInterface|null

--- a/src/Sylius/Component/Shipping/Model/ShipmentUnit.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentUnit.php
@@ -22,9 +22,15 @@ class ShipmentUnit implements ShipmentUnitInterface
     /** @var mixed */
     protected $id;
 
-    protected ?ShipmentInterface $shipment = null;
+    /**
+     * @var ShipmentInterface|null
+     */
+    protected $shipment;
 
-    protected ?ShippableInterface $shippable = null;
+    /**
+     * @var ShippableInterface|null
+     */
+    protected $shippable;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Shipping/Model/ShippingCategory.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingCategory.php
@@ -22,11 +22,20 @@ class ShippingCategory implements ShippingCategoryInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -32,24 +32,42 @@ class ShippingMethod implements ShippingMethodInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
-    protected ?ShippingCategoryInterface $category = null;
+    /**
+     * @var ShippingCategoryInterface|null
+     */
+    protected $category;
 
-    protected ?int $categoryRequirement = ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY;
+    /**
+     * @var int|null
+     */
+    protected $categoryRequirement;
 
-    protected ?string $calculator = null;
+    /**
+     * @var string|null
+     */
+    protected $calculator;
 
-    protected array $configuration = [];
+    /**
+     * @var mixed[]
+     */
+    protected $configuration = [];
 
     /**
      * @var Collection|ShippingMethodRuleInterface[]
      *
      * @psalm-var Collection<array-key, ShippingMethodRuleInterface>
      */
-    protected Collection $rules;
+    protected $rules;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -48,9 +48,9 @@ class ShippingMethod implements ShippingMethodInterface
     protected $category;
 
     /**
-     * @var int|null
+     * @var int
      */
-    protected $categoryRequirement;
+    protected $categoryRequirement = ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY;
 
     /**
      * @var string|null

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodRule.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodRule.php
@@ -21,11 +21,20 @@ class ShippingMethodRule implements ShippingMethodRuleInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $type = null;
+    /**
+     * @var string|null
+     */
+    protected $type;
 
-    protected array $configuration = [];
+    /**
+     * @var mixed[]
+     */
+    protected $configuration = [];
 
-    protected ?ShippingMethodInterface $shippingMethod = null;
+    /**
+     * @var ShippingMethodInterface|null
+     */
+    protected $shippingMethod;
 
     public function getId()
     {

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodTranslation.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodTranslation.php
@@ -20,9 +20,15 @@ class ShippingMethodTranslation extends AbstractTranslation implements ShippingM
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/Taxation/Model/TaxCategory.php
+++ b/src/Sylius/Component/Taxation/Model/TaxCategory.php
@@ -24,18 +24,27 @@ class TaxCategory implements TaxCategoryInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
     /**
      * @var Collection|TaxRateInterface[]
      *
      * @psalm-var Collection<array-key, TaxRateInterface>
      */
-    protected Collection $rates;
+    protected $rates;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Taxation/Model/TaxRate.php
+++ b/src/Sylius/Component/Taxation/Model/TaxRate.php
@@ -22,17 +22,35 @@ class TaxRate implements TaxRateInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?TaxCategoryInterface $category = null;
+    /**
+     * @var TaxCategoryInterface|null
+     */
+    protected $category;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?float $amount = 0.0;
+    /**
+     * @var float|null
+     */
+    protected $amount;
 
-    protected ?bool $includedInPrice = false;
+    /**
+     * @var bool|null
+     */
+    protected $includedInPrice;
 
-    protected ?string $calculator = null;
+    /**
+     * @var string|null
+     */
+    protected $calculator;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Taxation/Model/TaxRate.php
+++ b/src/Sylius/Component/Taxation/Model/TaxRate.php
@@ -40,12 +40,12 @@ class TaxRate implements TaxRateInterface
     /**
      * @var float|null
      */
-    protected $amount;
+    protected $amount = 0.0;
 
     /**
-     * @var bool|null
+     * @var bool
      */
-    protected $includedInPrice;
+    protected $includedInPrice = false;
 
     /**
      * @var string|null

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
@@ -19,11 +19,9 @@ use Sylius\Component\Taxation\Model\TaxRateInterface;
 
 class TaxRateResolver implements TaxRateResolverInterface
 {
-    protected RepositoryInterface $taxRateRepository;
+    /** @var RepositoryInterface */
+    protected $taxRateRepository;
 
-    /**
-     * @var RepositoryInterface
-     */
     public function __construct(RepositoryInterface $taxRateRepository)
     {
         $this->taxRateRepository = $taxRateRepository;

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -30,26 +30,47 @@ class Taxon implements TaxonInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $code = null;
+    /**
+     * @var string|null
+     */
+    protected $code;
 
-    protected ?TaxonInterface $root = null;
+    /**
+     * @var TaxonInterface|null
+     */
+    protected $root;
 
-    protected ?TaxonInterface $parent = null;
+    /**
+     * @var TaxonInterface|null
+     */
+    protected $parent;
 
     /**
      * @var Collection|TaxonInterface[]
      *
      * @psalm-var Collection<array-key, TaxonInterface>
      */
-    protected Collection $children;
+    protected $children;
 
-    protected ?int $left = null;
+    /**
+     * @var int|null
+     */
+    protected $left;
 
-    protected ?int $right = null;
+    /**
+     * @var int|null
+     */
+    protected $right;
 
-    protected ?int $level = null;
+    /**
+     * @var int|null
+     */
+    protected $level;
 
-    protected ?int $position = null;
+    /**
+     * @var int|null
+     */
+    protected $position;
 
     public function __construct()
     {

--- a/src/Sylius/Component/Taxonomy/Model/TaxonTranslation.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonTranslation.php
@@ -20,11 +20,20 @@ class TaxonTranslation extends AbstractTranslation implements TaxonTranslationIn
     /** @var mixed */
     protected $id;
 
-    protected ?string $name = null;
+    /**
+     * @var string|null
+     */
+    protected $name;
 
-    protected ?string $slug = null;
+    /**
+     * @var string|null
+     */
+    protected $slug;
 
-    protected ?string $description = null;
+    /**
+     * @var string|null
+     */
+    protected $description;
 
     public function __toString(): string
     {

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -25,67 +25,104 @@ class User implements UserInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $username = null;
+    /**
+     * @var string|null
+     */
+    protected $username;
 
     /**
      * Normalized representation of a username.
+     * @var string|null
      */
-    protected ?string $usernameCanonical = null;
+    protected $usernameCanonical;
 
     /**
      * Random data that is used as an additional input to a function that hashes a password.
+     * @var string
      */
-    protected string $salt;
+    protected $salt;
 
     /**
      * Encrypted password. Must be persisted.
+     * @var string|null
      */
-    protected ?string $password = null;
+    protected $password;
 
     /**
      * Password before encryption. Used for model validation. Must not be persisted.
+     * @var string|null
      */
-    protected ?string $plainPassword = null;
+    protected $plainPassword;
 
-    protected ?\DateTimeInterface $lastLogin = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $lastLogin;
 
     /**
      * Random string sent to the user email address in order to verify it
+     * @var string|null
      */
-    protected ?string $emailVerificationToken = null;
+    protected $emailVerificationToken;
 
     /**
      * Random string sent to the user email address in order to verify the password resetting request
+     * @var string|null
      */
-    protected ?string $passwordResetToken = null;
+    protected $passwordResetToken;
 
-    protected ?\DateTimeInterface $passwordRequestedAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $passwordRequestedAt;
 
-    protected ?\DateTimeInterface $verifiedAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $verifiedAt;
 
-    protected bool $locked = false;
+    /**
+     * @var bool
+     */
+    protected $locked = false;
 
-    protected ?\DateTimeInterface $expiresAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $expiresAt;
 
-    protected ?\DateTimeInterface $credentialsExpireAt = null;
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $credentialsExpireAt;
 
     /**
      * We need at least one role to be able to authenticate
+     * @var mixed[]
      */
-    protected array $roles = [UserInterface::DEFAULT_ROLE];
+    protected $roles = [UserInterface::DEFAULT_ROLE];
 
     /**
      * @var Collection|UserOAuthInterface[]
      *
      * @psalm-var Collection<array-key, UserOAuthInterface>
      */
-    protected Collection $oauthAccounts;
+    protected $oauthAccounts;
 
-    protected ?string $email = null;
+    /**
+     * @var string|null
+     */
+    protected $email;
 
-    protected ?string $emailCanonical = null;
+    /**
+     * @var string|null
+     */
+    protected $emailCanonical;
 
-    protected ?string $encoderName = null;
+    /**
+     * @var string|null
+     */
+    protected $encoderName;
 
     public function __construct()
     {

--- a/src/Sylius/Component/User/Model/UserOAuth.php
+++ b/src/Sylius/Component/User/Model/UserOAuth.php
@@ -18,15 +18,30 @@ class UserOAuth implements UserOAuthInterface
     /** @var mixed */
     protected $id;
 
-    protected ?string $provider = null;
+    /**
+     * @var string|null
+     */
+    protected $provider;
 
-    protected ?string $identifier = null;
+    /**
+     * @var string|null
+     */
+    protected $identifier;
 
-    protected ?string $accessToken = null;
+    /**
+     * @var string|null
+     */
+    protected $accessToken;
 
-    protected ?string $refreshToken = null;
+    /**
+     * @var string|null
+     */
+    protected $refreshToken;
 
-    protected ?UserInterface $user = null;
+    /**
+     * @var UserInterface|null
+     */
+    protected $user;
 
     public function getId()
     {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It went too smooth :smile: With the v1.10.3 tag we released code transformed to use PHP7.4 syntax (typed properties). **However** there is one problem with such an approach. If the property is overridable (so is either public or protected and its class is not final), it has to have a type defined also in the child class. Even though overriding properties is much less common than overriding functions (and most of our classes are final :dancer:), it's technically possible these changes could break the applications after upgrade to Sylius v1.10.3.

I then revert this change for non-private properties from not final classes. These are mostly models from components, validator constraints and API commands.

Live long and prosper 🖖 