### PR TITLE
[UX][Attribute] Use single_text widget for Date&DateTime attribute form type

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DateAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DateAttributeType.php
@@ -29,6 +29,7 @@ final class DateAttributeType extends AbstractType
         $resolver
             ->setDefaults([
                 'label' => false,
+                'widget' => 'single_text',
             ])
             ->setRequired('configuration')
             ->setDefined('locale_code')

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DatetimeAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DatetimeAttributeType.php
@@ -29,6 +29,8 @@ final class DatetimeAttributeType extends AbstractType
         $resolver
             ->setDefaults([
                 'label' => false,
+                'date_widget' => 'single_text',
+                'time_widget' => 'single_text',
             ])
             ->setRequired('configuration')
             ->setDefined('locale_code')


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Hi :wave: 

I notice that Date and DateTime attribute use the default render on Product attribute tabs:

![image](https://user-images.githubusercontent.com/3168281/135748246-9c4577fd-5b8f-4604-a729-67498a580612.png)

This PR change this to use the great `single_text` rendering, combined with `semantic-ui`: 

![image](https://user-images.githubusercontent.com/3168281/135748309-c67d66ea-9ca1-4469-89d8-f3e710dad88c.png)

I think it would provide a better User Experience to have unified display for date/datetime in the Admin.

I targetted `master` branch cause it could be considered as a new feature, but I can change to `1.10` if needed.

WDYT ?  
