### PR TITLE
fix(translation): Useful `%stock%` value for translated message

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStockValidator.php
+++ b/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStockValidator.php
@@ -50,7 +50,7 @@ final class InStockValidator extends ConstraintValidator
         if (!$this->availabilityChecker->isStockSufficient($stockable, $quantity)) {
             $this->context->addViolation(
                 $constraint->message,
-                ['%itemName%' => $stockable->getInventoryName()]
+                ['%itemName%' => $stockable->getInventoryName(), '%stock%' => $quantity],
             );
         }
     }


### PR DESCRIPTION
Useful `%stock%` value for translated message

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no/yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT
