### PR TITLE
Fix security shop regex

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -9,7 +9,7 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/grids/product.yml" }
 
 parameters:
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius.security.shop_regex: "^(?:/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++)?"
     
 sylius_grid:
     templates:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12377, #13144  
| License         | MIT

As documented [here](https://docs.sylius.com/en/1.10/cookbook/shop/disabling-localised-urls.html), Sylius should work properly even if there is no locale in route paths. But with the current `sylius.security.shop_regex` many access control paths don't match when there is no locale in the route path.

This change fix this. The regex now matches even if the string before `/account` or `/login` is empty.
