### PR TITLE
[CatalogPromotions] Display taxons with names in scope

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionScope/ForTaxonsScopeConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionScope/ForTaxonsScopeConfigurationType.php
@@ -33,7 +33,7 @@ final class ForTaxonsScopeConfigurationType extends AbstractType
             'label' => 'sylius.ui.taxons',
             'multiple' => true,
             'required' => false,
-            'choice_name' => 'code',
+            'choice_name' => 'name',
             'choice_value' => 'code',
             'resource' => 'sylius.taxon',
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | introduced in https://github.com/Sylius/Sylius/pull/13175
| License         | MIT

Fixing [this comment](https://github.com/Sylius/Sylius/pull/13175#pullrequestreview-774616513)

Before: 

<img width="548" alt="Zrzut ekranu 2021-10-8 o 08 03 32" src="https://user-images.githubusercontent.com/6212718/136506249-1bd4cf8d-5c94-4902-8479-6809135f81a0.png">

After:

<img width="512" alt="Zrzut ekranu 2021-10-8 o 08 02 29" src="https://user-images.githubusercontent.com/6212718/136506260-0a1318df-f833-47bd-9502-9ea4ac96a487.png">

