### PR TITLE
[Core][Checkout] fixed #13201

### DIFF
--- a/features/checkout/ability_to_checkout_as_guest_with_a_registered_email.feature
+++ b/features/checkout/ability_to_checkout_as_guest_with_a_registered_email.feature
@@ -20,3 +20,13 @@ Feature: Checking out as guest with a registered email
         And I choose "Offline" payment method
         And I confirm my order
         Then I should see the thank you page
+
+    @ui
+    Scenario: Placing an order using email with mixed case
+        Given I have product "PHP T-Shirt" in the cart
+        When I complete addressing step with email "JOhn@example.COM" and "United States" based billing address
+        And I select "Free" shipping method
+        And I complete the shipping step
+        And I choose "Offline" payment method
+        And I confirm my order
+        Then I should see the thank you page

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerCheckoutGuestType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerCheckoutGuestType.php
@@ -29,6 +29,7 @@ final class CustomerCheckoutGuestType extends AbstractResourceType
         array $validationGroups,
         private RepositoryInterface $customerRepository,
         private FactoryInterface $customerFactory,
+        private CanonicalizerInterface $canonicalizer
     ) {
         parent::__construct($dataClass, $validationGroups);
     }
@@ -46,8 +47,10 @@ final class CustomerCheckoutGuestType extends AbstractResourceType
                     return;
                 }
 
+                $emailCanonical = $this->canonicalizer->canonicalize($data['email']);
+
                 /** @var CustomerInterface|null $customer */
-                $customer = $this->customerRepository->findOneBy(['email' => $data['email']]);
+                $customer = $this->customerRepository->findOneBy(['emailCanonical' => $emailCanonical]);
 
                 // assign existing customer or create a new one
                 if (null === $customer) {

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerCheckoutGuestType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerCheckoutGuestType.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
@@ -29,6 +29,7 @@ final class CustomerGuestType extends AbstractResourceType
         array $validationGroups,
         private RepositoryInterface $customerRepository,
         private FactoryInterface $customerFactory,
+        private CanonicalizerInterface $canonicalizer
     ) {
         parent::__construct($dataClass, $validationGroups);
     }
@@ -46,8 +47,10 @@ final class CustomerGuestType extends AbstractResourceType
                     return;
                 }
 
+                $emailCanonical = $this->canonicalizer->canonicalize($data['email']);
+
                 /** @var CustomerInterface|null $customer */
-                $customer = $this->customerRepository->findOneBy(['email' => $data['email']]);
+                $customer = $this->customerRepository->findOneBy(['emailCanonical' => $emailCanonical]);
 
                 // assign existing customer or create a new one
                 $form = $event->getForm();

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -230,6 +230,7 @@
             <argument>%sylius.form.type.customer_guest.validation_groups%</argument>
             <argument type="service" id="sylius.repository.customer" />
             <argument type="service" id="sylius.factory.customer" />
+            <argument type="service" id="sylius.canonicalizer" />
             <tag name="form.type" />
         </service>
         <service id="sylius.form.type.customer_checkout_guest" class="Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerCheckoutGuestType">
@@ -237,6 +238,7 @@
             <argument>%sylius.form.type.customer_checkout_guest.validation_groups%</argument>
             <argument type="service" id="sylius.repository.customer" />
             <argument type="service" id="sylius.factory.customer" />
+            <argument type="service" id="sylius.canonicalizer" />
             <tag name="form.type" />
         </service>
         <service id="sylius.form.type.customer_simple_registration" class="Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerSimpleRegistrationType">


### PR DESCRIPTION
use canonicalized email for customer lookup on CustomerGuestFormTypes

Caused insert duplicate errors on customer table for repeat guest customers

| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | fixes #13201
| License         | MIT

