### PR TITLE
Generate correct full url to docs.json

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php
@@ -164,7 +164,7 @@ final class SwaggerUiAction
         }
 
         $swaggerData = [
-            'url' => $this->urlGenerator->generate('api_doc', ['format' => 'json']),
+            'url' => $this->urlGenerator->generate('api_doc', ['_format' => 'json'], $this->urlGenerator::ABSOLUTE_URL),
             'spec' => $this->normalizer->normalize($documentation, 'json', $swaggerContext),
         ];
 


### PR DESCRIPTION
Fix a typo of parameter `_format` and change url type to `ABSOLUTE_URL` to generate correct absolute url to `docs.json`.

| Q               | A
| --------------- | -----
| Branch?         | 1.9, 1.10 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/yes
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
