### PR TITLE
[CatalogPromotion] fix pricing clearer

### DIFF
--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_on_variant_once_its_prices_changes.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_on_variant_once_its_prices_changes.feature
@@ -23,3 +23,9 @@ Feature: Reapplying catalog promotions on variant once its prices changes
         When I change the original price of the "PHP T-Shirt" product variant to "$50.00" in "Web-US" channel
         Then the visitor should see "$17.50" as the price of the "T-Shirt" product in the "Web-US" channel
         And the visitor should see "$50.00" as the original price of the "T-Shirt" product in the "Web-US" channel
+
+    @api @ui
+    Scenario: Removing the original price of the variant
+        When I remove the original price of the "PHP T-Shirt" product variant in "Web-US" channel
+        Then the visitor should see "$12.25" as the price of the "T-Shirt" product in the "Web-US" channel
+        And the visitor should see "$35.00" as the original price of the "T-Shirt" product in the "Web-US" channel

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
@@ -49,10 +49,20 @@ final class ManagingProductVariantsContext implements Context
         $this->updateChannelPricingField($variant, $channel, $originalPrice, 'originalPrice');
     }
 
+    /**
+     * @When /^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/
+     */
+    public function iRemoveTheOriginalPriceOfTheProductVariantInChannel(
+        ProductVariantInterface $variant,
+        ChannelInterface $channel
+    ): void {
+        $this->updateChannelPricingField($variant, $channel, null, 'originalPrice');
+    }
+
     private function updateChannelPricingField(
         ProductVariantInterface $variant,
         ChannelInterface $channel,
-        int $price,
+        ?int $price,
         string $field
     ): void {
         $this->client->buildUpdateRequest($variant->getCode());

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
@@ -53,4 +53,16 @@ final class ManagingProductVariantsPricesContext implements Context
         $this->updatePage->specifyOriginalPrice($originalPrice, $channel);
         $this->updatePage->saveChanges();
     }
+
+    /**
+     * @When /^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/
+     */
+    public function iRemoveTheOriginalPriceOfTheProductVariantInChannel(
+        ProductVariantInterface $variant,
+        ChannelInterface $channel
+    ): void {
+        $this->updatePage->open(['productId' => $variant->getProduct()->getId(), 'id' => $variant->getId()]);
+        $this->updatePage->specifyOriginalPrice(null, $channel);
+        $this->updatePage->saveChanges();
+    }
 }

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
@@ -39,7 +39,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getElement('price', ['%channelCode%' => $channel->getCode()])->setValue($price);
     }
 
-    public function specifyOriginalPrice(int $originalPrice, ?ChannelInterface $channel = null): void
+    public function specifyOriginalPrice(?int $originalPrice, ?ChannelInterface $channel = null): void
     {
         if ($channel === null) {
             $this->getDocument()->fillField('Original price', $originalPrice);

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
@@ -51,7 +51,7 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
 
     public function specifyPrice(int $price, ?ChannelInterface $channelName = null): void;
 
-    public function specifyOriginalPrice(int $originalPrice, ?ChannelInterface $channel = null): void;
+    public function specifyOriginalPrice(?int $originalPrice, ?ChannelInterface $channel = null): void;
 
     public function disable(): void;
 

--- a/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionClearer.php
+++ b/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionClearer.php
@@ -47,7 +47,9 @@ final class CatalogPromotionClearer implements CatalogPromotionClearerInterface
             return;
         }
 
-        $channelPricing->setPrice($channelPricing->getOriginalPrice());
+        if ($channelPricing->getOriginalPrice() !== null) {
+            $channelPricing->setPrice($channelPricing->getOriginalPrice());
+        }
         $channelPricing->clearAppliedPromotions();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionClearerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionClearerSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Bundle\CoreBundle\Processor;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearerInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -83,6 +84,17 @@ final class CatalogPromotionClearerSpec extends ObjectBehavior
         $channelPricing->getAppliedPromotions()->willReturn(['winter_sale' => ['en_US' => ['name' => 'Winter sale']]]);
         $channelPricing->getOriginalPrice()->willReturn(1000);
         $channelPricing->setPrice(1000)->shouldBeCalled();
+        $channelPricing->clearAppliedPromotions()->shouldBeCalled();
+
+        $this->clearChannelPricing($channelPricing);
+    }
+
+    function it_does_not_copy_update_price_when_original_price_is_null(
+        ChannelPricingInterface $channelPricing
+    ): void {
+        $channelPricing->getAppliedPromotions()->willReturn(['winter_sale' => ['en_US' => ['name' => 'Winter sale']]]);
+        $channelPricing->getOriginalPrice()->willReturn(null);
+        $channelPricing->setPrice(Argument::any())->shouldNotBeCalled();
         $channelPricing->clearAppliedPromotions()->shouldBeCalled();
 
         $this->clearChannelPricing($channelPricing);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Before this change when Admin removes original Price from product with applied Catalog Promotion it makes both prices null and finally maker Price equal zero
