### PR TITLE
[Hot-fix] Conflict doctrine/dbal 3.* in ApiBundle

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -42,6 +42,7 @@
         "theofidry/alice-data-fixtures": "^1.4"
     },
     "conflict": {
+        "doctrine/dbal": "3.*",
         "doctrine/doctrine-bundle": "2.3.0",
         "symfony/doctrine-bridge": "4.4.20 || 5.2.4 || 5.2.5"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The build is failing with this version due to problems with the json_array field. We should definitely investigate the problem, but a hot-fix would make the build green again to allow other PR's to pass 🖖 