### PR TITLE
Replace `json_array` with `json` type as requested by the deprecation

### DIFF
--- a/UPGRADE-1.10.md
+++ b/UPGRADE-1.10.md
@@ -1,3 +1,25 @@
+# UPGRADE FROM `v1.10.x` TO `v1.10.8`
+
+1. Update `payum/payum` to `^1.7` and execute Doctrine Migrations
+
+If `payum/payum` is a root requirement (in the project's `composer.json`), then run:
+
+```shell
+composer require payum/payum:^1.7
+```
+
+otherwise, run:
+
+```shell
+composer update payum/payum
+```
+
+then execute the migrations:
+
+```shell
+bin/console doctrine:migrations:migrate
+```
+
 # UPGRADE FROM `v1.10.0` TO `v1.10.1`
 
 1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "laminas/laminas-stdlib": "^3.3.1",
         "lexik/jwt-authentication-bundle": "^2.11",
         "liip/imagine-bundle": "^2.3",
-        "payum/payum": "^1.6",
+        "payum/payum": "^1.7",
         "payum/payum-bundle": "^2.4",
         "php-http/guzzle6-adapter": "^2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
@@ -29,7 +29,7 @@
         <field name="float" column="float_value" type="float" nullable="true" />
         <field name="datetime" column="datetime_value" type="datetime" nullable="true" />
         <field name="date" column="date_value" type="date" nullable="true" />
-        <field name="json" column="json_value" type="json_array" nullable="true" />
+        <field name="json" column="json_value" type="json" nullable="true" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
@@ -25,6 +25,8 @@ final class Version20211018130725 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_payment CHANGE details details JSON NOT NULL');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value JSON DEFAULT NULL');
         $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config JSON NOT NULL');
@@ -32,6 +34,8 @@ final class Version20211018130725 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_payment CHANGE details details LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
         $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config LONGTEXT NOT NULL COMMENT \'(DC2Type:json_array)\'');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20211018130725 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change json_array(deprecated) to json type';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_payment CHANGE details details JSON NOT NULL');
+        $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_payment CHANGE details details LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+        $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211018130725.php
@@ -27,11 +27,13 @@ final class Version20211018130725 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE sylius_payment CHANGE details details JSON NOT NULL');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config JSON NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE sylius_payment CHANGE details details LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+        $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config LONGTEXT NOT NULL COMMENT \'(DC2Type:json_array)\'');
     }
 }

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
@@ -26,7 +26,7 @@
         <field name="currencyCode" column="currency_code" length="3" type="string" />
         <field name="amount" column="amount" type="integer" />
         <field name="state" column="state" type="string" />
-        <field name="details" column="details" type="json_array" />
+        <field name="details" column="details" type="json" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9, 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13211 
| License         | MIT

`doctrine/dbal:"^3"` remove `json_array` field type, previously it was deprecated in favor of `json` field type.
