### PR TITLE
Don't calculate shipping taxes with all adjustments

### DIFF
--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
@@ -64,7 +64,10 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
                 continue;
             }
 
-            $taxAmount = $this->calculator->calculate($shipment->getAdjustmentsTotal(), $taxRate);
+            $shippingTotal = $shipment->getAdjustmentsTotal(AdjustmentInterface::SHIPPING_ADJUSTMENT)
+                + $shipment->getAdjustmentsTotal(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT);
+
+            $taxAmount = $this->calculator->calculate($shippingTotal, $taxRate);
             if (0.00 === $taxAmount) {
                 continue;
             }


### PR DESCRIPTION
If a shipment has more than one shipping adjustments the taxes for shipping will be calculated from a sum that could even be negative (e.g. with discounts).

| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no (not sure)
| Deprecations?   | no
| Related tickets | fixes #13224
| License         | MIT

