### PR TITLE
[CatalogPromotions] Always prevent CP dates editing - even if they're not set during creation

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionType.php
@@ -72,8 +72,7 @@ final class CatalogPromotionType extends AbstractResourceType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event): void {
             /** @var CatalogPromotionInterface $catalogPromotion */
             $catalogPromotion = $event->getData();
-            $startDateDisabled = $catalogPromotion->getStartDate() !== null;
-            $endDateDisabled = $catalogPromotion->getEndDate() !== null;
+            $disabled = $catalogPromotion->getId() !== null;
 
             $form = $event->getForm();
             $form
@@ -82,14 +81,14 @@ final class CatalogPromotionType extends AbstractResourceType
                     'date_widget' => 'single_text',
                     'time_widget' => 'single_text',
                     'required' => false,
-                    'disabled' => $startDateDisabled,
+                    'disabled' => $disabled,
                 ])
                 ->add('endDate', DateTimeType::class, [
                     'label' => 'sylius.form.catalog_promotion.end_date',
                     'date_widget' => 'single_text',
                     'time_widget' => 'single_text',
                     'required' => false,
-                    'disabled' => $endDateDisabled,
+                    'disabled' => $disabled,
                 ])
             ;
         });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | continuation of https://github.com/Sylius/Sylius/pull/13221
| License         | MIT
