### PR TITLE
[Conflict] add conflict to new release of fos-rest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,8 @@
         "laminas/laminas-code": "^4.0",
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/property-info": "4.4.22 || 5.2.7",
-        "symfony/serializer": "4.4.19 || 5.2.2"
+        "symfony/serializer": "4.4.19 || 5.2.2",
+        "friendsofsymfony/rest-bundle": "3.1.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

new release of https://github.com/FriendsOfSymfony/FOSRestBundle/releases/tag/3.1.0 broke some of our api behat scenarios

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
