### PR TITLE
Update cartItem Delete response HTTP code to 204

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
@@ -37,6 +37,6 @@ final class DeleteOrderItemAction
 
         $this->commandBus->dispatch($command);
 
-        return new JsonResponse();
+        return new JsonResponse([], 204);
     }
 }


### PR DESCRIPTION
In the [API swagger documentation](https://master.demo.sylius.com/api/v2/docs) the route :
 /api/v2/shop/orders/{tokenValue}/items/{itemId}

specifies that we should expect a 204 response code. This returned a 200.

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT