### PR TITLE
Conflict liip/imagine-bundle ^2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,8 @@
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/polyfill-mbstring": "^1.22.0",
         "symfony/property-info": "4.4.22 || 5.2.7",
-        "symfony/serializer": "4.4.19 || 5.2.2"
+        "symfony/serializer": "4.4.19 || 5.2.2",
+        "liip/imagine-bundle": "^2.7"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

~Psalm complains about it after upgrading liip/imagine-bundle to 2.7. We should probably think about bumping the bundle's version and using the new configuration soon~

EDIT: I conflict with `liip/imagine-bundle:^2.7` for now, due to some other problems. Thanks, @mynameisbogdan for the suggestion 🖖 