### PR TITLE
Introduce arrow functions from PHP 7.4

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php74\Rector\Property\TypedPropertyRector;
 use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -15,4 +16,5 @@ return static function (ContainerConfigurator $containerConfigurator): void
 
     $services = $containerConfigurator->services();
     $services->set(TypedPropertyRector::class);
+    $services->set(ClosureToArrowFunctionRector::class);
 };

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -65,9 +65,7 @@ final class CountryChoiceType extends AbstractType
                     $countries = array_filter($countries, $options['choice_filter']);
                 }
 
-                usort($countries, static function (CountryInterface $firstCountry, CountryInterface $secondCountry): int {
-                    return $firstCountry->getName() <=> $secondCountry->getName();
-                });
+                usort($countries, static fn(CountryInterface $firstCountry, CountryInterface $secondCountry): int => $firstCountry->getName() <=> $secondCountry->getName());
 
                 return $countries;
             })

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -71,9 +71,7 @@ final class ZoneType extends AbstractResourceType
             ];
 
             if ($zone->getType() === ZoneInterface::TYPE_ZONE) {
-                $entryOptions['entry_options']['choice_filter'] = static function (?ZoneInterface $subZone) use ($zone): bool {
-                    return $subZone !== null && $zone->getId() !== $subZone->getId();
-                };
+                $entryOptions['entry_options']['choice_filter'] = static fn(?ZoneInterface $subZone): bool => $subZone !== null && $zone->getId() !== $subZone->getId();
             }
 
             $event->getForm()->add('members', CollectionType::class, [

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/CountryChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/CountryChoiceTypeTest.php
@@ -110,9 +110,7 @@ final class CountryChoiceTypeTest extends TypeTestCase
             $this->poland->reveal(),
         ]);
 
-        $this->assertChoicesLabels(['Poland'], ['choice_filter' => static function (?CountryInterface $country): bool {
-            return $country !== null && $country->getName() === 'Poland';
-        }]);
+        $this->assertChoicesLabels(['Poland'], ['choice_filter' => static fn(?CountryInterface $country): bool => $country !== null && $country->getName() === 'Poland']);
     }
 
     private function assertChoicesLabels(array $expectedLabels, array $formConfiguration = []): void
@@ -120,8 +118,6 @@ final class CountryChoiceTypeTest extends TypeTestCase
         $form = $this->factory->create(CountryChoiceType::class, null, $formConfiguration);
         $view = $form->createView();
 
-        Assert::assertSame($expectedLabels, array_map(static function (ChoiceView $choiceView): string {
-            return $choiceView->label;
-        }, $view->vars['choices']));
+        Assert::assertSame($expectedLabels, array_map(static fn(ChoiceView $choiceView): string => $choiceView->label, $view->vars['choices']));
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
@@ -136,8 +136,6 @@ final class ZoneChoiceTypeTest extends TypeTestCase
         $form = $this->factory->create(ZoneChoiceType::class, null, $formConfiguration);
         $view = $form->createView();
 
-        Assert::assertSame($expectedLabels, array_map(function (ChoiceView $choiceView): string {
-            return $choiceView->label;
-        }, $view->vars['choices']));
+        Assert::assertSame($expectedLabels, array_map(fn(ChoiceView $choiceView): string => $choiceView->label, $view->vars['choices']));
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/test/src/Tests/SyliusAddressingBundleTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/test/src/Tests/SyliusAddressingBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusAddressingBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/AdminBundle/Twig/OrderUnitTaxesExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/OrderUnitTaxesExtension.php
@@ -43,9 +43,7 @@ final class OrderUnitTaxesExtension extends AbstractExtension
     {
         $total = array_reduce(
             $orderItem->getAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->toArray(),
-            static function (int $total, BaseAdjustmentInterface $adjustment) use ($neutral) {
-                return $neutral === $adjustment->isNeutral() ? $total + $adjustment->getAmount() : $total;
-            },
+            static fn(int $total, BaseAdjustmentInterface $adjustment) => $neutral === $adjustment->isNeutral() ? $total + $adjustment->getAmount() : $total,
             0
         );
 

--- a/src/Sylius/Bundle/AdminBundle/Twig/ShopExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/ShopExtension.php
@@ -28,9 +28,7 @@ final class ShopExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('is_shop_enabled', function (): bool {
-                return $this->isShopEnabled;
-            }),
+            new TwigFunction('is_shop_enabled', fn(): bool => $this->isShopEnabled),
         ];
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeValueTranslationsType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeValueTranslationsType.php
@@ -35,14 +35,10 @@ final class SelectAttributeValueTranslationsType extends AbstractType
     {
         $resolver->setDefaults([
             'entries' => $this->definedLocalesCodes,
-            'entry_name' => function (string $localeCode): string {
-                return $localeCode;
-            },
-            'entry_options' => function (string $localeCode): array {
-                return [
-                    'required' => $localeCode === $this->defaultLocaleCode,
-                ];
-            },
+            'entry_name' => fn(string $localeCode): string => $localeCode,
+            'entry_options' => fn(string $localeCode): array => [
+                'required' => $localeCode === $this->defaultLocaleCode,
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/AttributeBundle/Tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/Tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
@@ -68,8 +68,6 @@ final class SelectAttributeTypeTest extends TypeTestCase
         );
         $view = $form->createView();
 
-        Assert::assertSame($expectedLabels, array_map(function (ChoiceView $choiceView): string {
-            return $choiceView->label;
-        }, $view->vars['choices']));
+        Assert::assertSame($expectedLabels, array_map(fn(ChoiceView $choiceView): string => $choiceView->label, $view->vars['choices']));
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/test/src/Tests/SyliusAttributeBundleTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/test/src/Tests/SyliusAttributeBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusAttributeBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelChoiceType.php
+++ b/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelChoiceType.php
@@ -40,9 +40,7 @@ final class ChannelChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options): array {
-                return $this->channelRepository->findAll();
-            },
+            'choices' => fn(Options $options): array => $this->channelRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/ChannelBundle/spec/Context/FakeChannel/FakeChannelPersisterSpec.php
+++ b/src/Sylius/Bundle/ChannelBundle/spec/Context/FakeChannel/FakeChannelPersisterSpec.php
@@ -67,9 +67,7 @@ final class FakeChannelPersisterSpec extends ObjectBehavior
 
         $response->headers = $responseHeaderBag;
         $responseHeaderBag
-            ->setCookie(Argument::that(static function (Cookie $cookie): bool {
-                return $cookie->getName() === '_channel_code' && $cookie->getValue() === 'fake_channel_code';
-            }))
+            ->setCookie(Argument::that(static fn(Cookie $cookie): bool => $cookie->getName() === '_channel_code' && $cookie->getValue() === 'fake_channel_code'))
             ->shouldBeCalled()
         ;
 

--- a/src/Sylius/Bundle/ChannelBundle/test/src/Tests/SyliusChannelBundleTest.php
+++ b/src/Sylius/Bundle/ChannelBundle/test/src/Tests/SyliusChannelBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusChannelBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterUriBasedSectionResolverPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterUriBasedSectionResolverPass.php
@@ -37,9 +37,7 @@ final class RegisterUriBasedSectionResolverPass implements CompilerPassInterface
             }
         }
 
-        usort($uriBasedSectionProviders, static function (array $a, array $b): int {
-            return -($a['priority'] <=> $b['priority']);
-        });
+        usort($uriBasedSectionProviders, static fn(array $a, array $b): int => -($a['priority'] <=> $b['priority']));
 
         $uriBasedSectionResolver->setArgument(1, array_column($uriBasedSectionProviders, 'id'));
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
@@ -57,27 +57,13 @@ class AddressExampleFactory extends AbstractExampleFactory
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('first_name', function (Options $options): string {
-                return $this->faker->firstName;
-            })
-            ->setDefault('last_name', function (Options $options): string {
-                return $this->faker->lastName;
-            })
-            ->setDefault('phone_number', function (Options $options): ?string {
-                return random_int(1, 100) > 50 ? $this->faker->phoneNumber : null;
-            })
-            ->setDefault('company', function (Options $options): ?string {
-                return random_int(1, 100) > 50 ? $this->faker->company : null;
-            })
-            ->setDefault('street', function (Options $options): string {
-                return $this->faker->streetAddress;
-            })
-            ->setDefault('city', function (Options $options): string {
-                return $this->faker->city;
-            })
-            ->setDefault('postcode', function (Options $options): string {
-                return $this->faker->postcode;
-            })
+            ->setDefault('first_name', fn(Options $options): string => $this->faker->firstName)
+            ->setDefault('last_name', fn(Options $options): string => $this->faker->lastName)
+            ->setDefault('phone_number', fn(Options $options): ?string => random_int(1, 100) > 50 ? $this->faker->phoneNumber : null)
+            ->setDefault('company', fn(Options $options): ?string => random_int(1, 100) > 50 ? $this->faker->company : null)
+            ->setDefault('street', fn(Options $options): string => $this->faker->streetAddress)
+            ->setDefault('city', fn(Options $options): string => $this->faker->city)
+            ->setDefault('postcode', fn(Options $options): string => $this->faker->postcode)
             ->setDefault('country_code', function (Options $options): string {
                 $countries = $this->countryRepository->findAll();
                 shuffle($countries);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -101,12 +101,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', function (Options $options): string {
-                return $this->faker->email;
-            })
-            ->setDefault('username', function (Options $options): string {
-                return $this->faker->firstName . ' ' . $this->faker->lastName;
-            })
+            ->setDefault('email', fn(Options $options): string => $this->faker->email)
+            ->setDefault('username', fn(Options $options): string => $this->faker->firstName . ' ' . $this->faker->lastName)
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('password', 'password123')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -136,18 +136,10 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
-            ->setDefault('hostname', function (Options $options): string {
-                return $options['code'] . '.localhost';
-            })
-            ->setDefault('color', function (Options $options): string {
-                return $this->faker->colorName;
-            })
-            ->setDefault('enabled', function (Options $options): bool {
-                return $this->faker->boolean(90);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('hostname', fn(Options $options): string => $options['code'] . '.localhost')
+            ->setDefault('color', fn(Options $options): string => $this->faker->colorName)
+            ->setDefault('enabled', fn(Options $options): bool => $this->faker->boolean(90))
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('skipping_shipping_step_allowed', false)
             ->setAllowedTypes('skipping_shipping_step_allowed', 'bool')
@@ -166,17 +158,13 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             )
             ->setDefault('tax_calculation_strategy', 'order_items_based')
             ->setAllowedTypes('tax_calculation_strategy', 'string')
-            ->setDefault('default_locale', function (Options $options): LocaleInterface {
-                return $this->faker->randomElement($options['locales']);
-            })
+            ->setDefault('default_locale', fn(Options $options): LocaleInterface => $this->faker->randomElement($options['locales']))
             ->setAllowedTypes('default_locale', ['string', LocaleInterface::class])
             ->setNormalizer('default_locale', LazyOption::getOneBy($this->localeRepository, 'code'))
             ->setDefault('locales', LazyOption::all($this->localeRepository))
             ->setAllowedTypes('locales', 'array')
             ->setNormalizer('locales', LazyOption::findBy($this->localeRepository, 'code'))
-            ->setDefault('base_currency', function (Options $options): CurrencyInterface {
-                return $this->faker->randomElement($options['currencies']);
-            })
+            ->setDefault('base_currency', fn(Options $options): CurrencyInterface => $this->faker->randomElement($options['currencies']))
             ->setAllowedTypes('base_currency', ['string', CurrencyInterface::class])
             ->setNormalizer('base_currency', LazyOption::getOneBy($this->currencyRepository, 'code'))
             ->setDefault('currencies', LazyOption::all($this->currencyRepository))

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
@@ -60,9 +60,7 @@ class CustomerGroupExampleFactory extends AbstractExampleFactory implements Exam
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
@@ -157,9 +157,7 @@ class OrderExampleFactory extends AbstractExampleFactory implements ExampleFacto
             ->setAllowedTypes('country', ['null', 'string', CountryInterface::class])
             ->setNormalizer('country', LazyOption::findOneBy($this->countryRepository, 'code'))
 
-            ->setDefault('complete_date', function (Options $options): \DateTimeInterface {
-                return $this->faker->dateTimeBetween('-1 years', 'now');
-            })
+            ->setDefault('complete_date', fn(Options $options): \DateTimeInterface => $this->faker->dateTimeBetween('-1 years', 'now'))
             ->setAllowedTypes('complete_date', ['null', \DateTime::class])
 
             ->setDefault('fulfilled', false)

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -91,20 +91,14 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory implements Exam
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
-            ->setDefault('description', function (Options $options): string {
-                return $this->faker->sentence();
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('description', fn(Options $options): string => $this->faker->sentence())
             ->setDefault('instructions', null)
             ->setAllowedTypes('instructions', ['null', 'string'])
             ->setDefault('gatewayName', 'Offline')
             ->setDefault('gatewayFactory', 'offline')
             ->setDefault('gatewayConfig', [])
-            ->setDefault('enabled', function (Options $options): bool {
-                return $this->faker->boolean(90);
-            })
+            ->setDefault('enabled', fn(Options $options): bool => $this->faker->boolean(90))
             ->setDefault('channels', LazyOption::all($this->channelRepository))
             ->setAllowedTypes('channels', 'array')
             ->setNormalizer('channels', LazyOption::findBy($this->channelRepository, 'code'))

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
@@ -73,9 +73,7 @@ class ProductAssociationTypeExampleFactory extends AbstractExampleFactory implem
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
         ;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -81,15 +81,9 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
                 return $words;
             })
             ->setDefault('translatable', true)
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
-            ->setDefault('type', function (Options $options): string {
-                return $this->faker->randomElement(array_keys($this->attributeTypes));
-            })
-            ->setDefault('configuration', function (Options $options): array {
-                return [];
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('type', fn(Options $options): string => $this->faker->randomElement(array_keys($this->attributeTypes)))
+            ->setDefault('configuration', fn(Options $options): array => [])
             ->setAllowedValues('type', array_keys($this->attributeTypes))
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -155,9 +155,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
                 return $words;
             })
 
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
 
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
@@ -165,13 +163,9 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
             ->setDefault('tracked', false)
             ->setAllowedTypes('tracked', 'bool')
 
-            ->setDefault('slug', function (Options $options): string {
-                return $this->slugGenerator->generate($options['name']);
-            })
+            ->setDefault('slug', fn(Options $options): string => $this->slugGenerator->generate($options['name']))
 
-            ->setDefault('short_description', function (Options $options): string {
-                return $this->faker->paragraph;
-            })
+            ->setDefault('short_description', fn(Options $options): string => $this->faker->paragraph)
 
             ->setDefault('description', function (Options $options): string {
                 /** @var string $paragraphs */
@@ -197,9 +191,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
 
             ->setDefault('product_attributes', [])
             ->setAllowedTypes('product_attributes', 'array')
-            ->setNormalizer('product_attributes', function (Options $options, array $productAttributes): array {
-                return $this->setAttributeValues($productAttributes);
-            })
+            ->setNormalizer('product_attributes', fn(Options $options, array $productAttributes): array => $this->setAttributeValues($productAttributes))
 
             ->setDefault('product_options', [])
             ->setAllowedTypes('product_options', 'array')
@@ -417,9 +409,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
     {
         return trim(array_reduce(
             $variant->getOptionValues()->toArray(),
-            static function (?string $variantName, ProductOptionValueInterface $variantOption) {
-                return $variantName . sprintf('%s ', $variantOption->getValue());
-            },
+            static fn(?string $variantName, ProductOptionValueInterface $variantOption) => $variantName . sprintf('%s ', $variantOption->getValue()),
             ''
         ));
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -93,9 +93,7 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('values', null)
             ->setDefault('values', function (Options $options, ?array $values): array {
                 if (is_array($values)) {

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
@@ -84,9 +84,7 @@ class ProductReviewExampleFactory extends AbstractExampleFactory implements Exam
 
                 return $words;
             })
-            ->setDefault('rating', function (Options $options): int {
-                return $this->faker->numberBetween(1, 5);
-            })
+            ->setDefault('rating', fn(Options $options): int => $this->faker->numberBetween(1, 5))
             ->setDefault('comment', function (Options $options): string {
                 /** @var string $sentences */
                 $sentences = $this->faker->sentences(3, true);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -114,9 +114,7 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('name', $this->faker->words(3, true))
             ->setDefault('description', $this->faker->sentence())
             ->setDefault('usage_limit', null)

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
@@ -62,12 +62,8 @@ class ShippingCategoryExampleFactory extends AbstractExampleFactory implements E
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
-            ->setDefault('description', function (Options $options): string {
-                return $this->faker->paragraph;
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('description', fn(Options $options): string => $this->faker->paragraph)
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -111,21 +111,15 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('name', function (Options $options): string {
                 /** @var string $words */
                 $words = $this->faker->words(3, true);
 
                 return $words;
             })
-            ->setDefault('description', function (Options $options): string {
-                return $this->faker->sentence();
-            })
-            ->setDefault('enabled', function (Options $options): bool {
-                return $this->faker->boolean(90);
-            })
+            ->setDefault('description', fn(Options $options): string => $this->faker->sentence())
+            ->setDefault('enabled', fn(Options $options): bool => $this->faker->boolean(90))
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('zone', LazyOption::randomOne($this->zoneRepository))
             ->setAllowedTypes('zone', ['null', 'string', ZoneInterface::class])

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -79,15 +79,9 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', function (Options $options): string {
-                return $this->faker->email;
-            })
-            ->setDefault('first_name', function (Options $options): string {
-                return $this->faker->firstName;
-            })
-            ->setDefault('last_name', function (Options $options): string {
-                return $this->faker->lastName;
-            })
+            ->setDefault('email', fn(Options $options): string => $this->faker->email)
+            ->setDefault('first_name', fn(Options $options): string => $this->faker->firstName)
+            ->setDefault('last_name', fn(Options $options): string => $this->faker->lastName)
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('password', 'password123')
@@ -99,12 +93,8 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
                 'gender',
                 [CustomerComponent::UNKNOWN_GENDER, CustomerComponent::MALE_GENDER, CustomerComponent::FEMALE_GENDER]
             )
-            ->setDefault('phone_number', function (Options $options): string {
-                return $this->faker->phoneNumber;
-            })
-            ->setDefault('birthday', function (Options $options): \DateTime {
-                return $this->faker->dateTimeThisCentury();
-            })
+            ->setDefault('phone_number', fn(Options $options): string => $this->faker->phoneNumber)
+            ->setDefault('birthday', fn(Options $options): \DateTime => $this->faker->dateTimeThisCentury())
             ->setAllowedTypes('birthday', ['null', 'string', \DateTimeInterface::class])
             ->setNormalizer(
                 'birthday',

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
@@ -62,12 +62,8 @@ class TaxCategoryExampleFactory extends AbstractExampleFactory implements Exampl
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
-            ->setDefault('description', function (Options $options): string {
-                return $this->faker->paragraph;
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('description', fn(Options $options): string => $this->faker->paragraph)
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
@@ -73,22 +73,16 @@ class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFac
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('name', function (Options $options): string {
                 /** @var string $words */
                 $words = $this->faker->words(3, true);
 
                 return $words;
             })
-            ->setDefault('amount', function (Options $options): float {
-                return $this->faker->randomFloat(2, 0, 0.4);
-            })
+            ->setDefault('amount', fn(Options $options): float => $this->faker->randomFloat(2, 0, 0.4))
             ->setAllowedTypes('amount', 'float')
-            ->setDefault('included_in_price', function (Options $options): bool {
-                return $this->faker->boolean();
-            })
+            ->setDefault('included_in_price', fn(Options $options): bool => $this->faker->boolean())
             ->setAllowedTypes('included_in_price', 'bool')
             ->setDefault('calculator', 'default')
             ->setDefault('zone', LazyOption::randomOne($this->zoneRepository))

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -117,13 +117,9 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
 
                 return $words;
             })
-            ->setDefault('code', function (Options $options): string {
-                return StringInflector::nameToCode($options['name']);
-            })
+            ->setDefault('code', fn(Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('slug', null)
-            ->setDefault('description', function (Options $options): string {
-                return $this->faker->paragraph;
-            })
+            ->setDefault('description', fn(Options $options): string => $this->faker->paragraph)
             ->setDefault('translations', [])
             ->setAllowedTypes('translations', ['array'])
             ->setDefault('children', [])

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OptionsResolver/LazyOption.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OptionsResolver/LazyOption.php
@@ -95,9 +95,7 @@ final class LazyOption
 
     public static function all(RepositoryInterface $repository): \Closure
     {
-        return function (Options $options) use ($repository): iterable {
-            return $repository->findAll();
-        };
+        return fn(Options $options): iterable => $repository->findAll();
     }
 
     public static function findBy(RepositoryInterface $repository, string $field, array $criteria = []): \Closure

--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
@@ -50,8 +50,6 @@ final class TaxonsToCodesTransformer implements DataTransformerInterface
     {
         Assert::isInstanceOf($taxons, Collection::class);
 
-        return array_map(function (TaxonInterface $taxon) {
-            return $taxon->getCode();
-        }, $taxons->toArray());
+        return array_map(fn(TaxonInterface $taxon) => $taxon->getCode(), $taxons->toArray());
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
@@ -39,14 +39,12 @@ final class CartTypeExtension extends AbstractTypeExtension
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setNormalizer('validation_groups', function (Options $options, array $validationGroups) {
-            return function (FormInterface $form) use ($validationGroups) {
-                if ((bool) $form->get('promotionCoupon')->getNormData()) { // Validate the coupon if it was sent
-                    $validationGroups[] = 'sylius_promotion_coupon';
-                }
+        $resolver->setNormalizer('validation_groups', fn(Options $options, array $validationGroups) => function (FormInterface $form) use ($validationGroups) {
+            if ((bool) $form->get('promotionCoupon')->getNormData()) { // Validate the coupon if it was sent
+                $validationGroups[] = 'sylius_promotion_coupon';
+            }
 
-                return $validationGroups;
-            };
+            return $validationGroups;
         });
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
@@ -31,12 +31,10 @@ final class ProductVariantGenerationTypeExtension extends AbstractTypeExtension
 
             $event->getForm()->add('channelPricings', ChannelCollectionType::class, [
                 'entry_type' => ChannelPricingType::class,
-                'entry_options' => function (ChannelInterface $channel) use ($productVariant) {
-                    return [
-                        'channel' => $channel,
-                        'product_variant' => $productVariant,
-                    ];
-                },
+                'entry_options' => fn(ChannelInterface $channel) => [
+                    'channel' => $channel,
+                    'product_variant' => $productVariant,
+                ],
                 'label' => 'sylius.form.variant.price',
             ]);
         });

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
@@ -81,13 +81,11 @@ final class ProductVariantTypeExtension extends AbstractTypeExtension
 
             $event->getForm()->add('channelPricings', ChannelCollectionType::class, [
                 'entry_type' => ChannelPricingType::class,
-                'entry_options' => function (ChannelInterface $channel) use ($productVariant) {
-                    return [
-                        'channel' => $channel,
-                        'product_variant' => $productVariant,
-                        'required' => false,
-                    ];
-                },
+                'entry_options' => fn(ChannelInterface $channel) => [
+                    'channel' => $channel,
+                    'product_variant' => $productVariant,
+                    'required' => false,
+                ],
                 'label' => 'sylius.form.variant.price',
             ]);
         });

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
@@ -47,9 +47,7 @@ final class AmountType extends AbstractType
             ->setAllowedTypes('channel', [ChannelInterface::class])
 
             ->setDefaults([
-                'label' => static function (Options $options): string {
-                    return $options['channel']->getName();
-                },
+                'label' => static fn(Options $options): string => $options['channel']->getName(),
             ])
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ChannelCollectionType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ChannelCollectionType.php
@@ -32,9 +32,7 @@ final class ChannelCollectionType extends AbstractType
     {
         $resolver->setDefaults([
             'entries' => $this->channelRepository->findAll(),
-            'entry_name' => function (ChannelInterface $channel) {
-                return $channel->getCode();
-            },
+            'entry_name' => fn(ChannelInterface $channel) => $channel->getCode(),
             'error_bubbling' => false,
         ]);
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Product/ChannelPricingType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Product/ChannelPricingType.php
@@ -91,9 +91,7 @@ final class ChannelPricingType extends AbstractResourceType
             ->setAllowedTypes('product_variant', ['null', ProductVariantInterface::class])
 
             ->setDefaults([
-                'label' => function (Options $options): string {
-                    return $options['channel']->getName();
-                },
+                'label' => fn(Options $options): string => $options['channel']->getName(),
             ])
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedFixedDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedFixedDiscountConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedFixedDiscountConfigurationType extends AbstractType
     {
         $resolver->setDefaults([
             'entry_type' => FixedDiscountConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel) {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedUnitFixedDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedUnitFixedDiscountConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedUnitFixedDiscountConfigurationType extends AbstractType
     {
         $resolver->setDefaults([
             'entry_type' => UnitFixedDiscountConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel) {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedUnitPercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Action/ChannelBasedUnitPercentageDiscountConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedUnitPercentageDiscountConfigurationType extends Abstract
     {
         $resolver->setDefaults([
             'entry_type' => UnitPercentageDiscountConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel) {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedItemTotalConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedItemTotalConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedItemTotalConfigurationType extends AbstractType
     {
         $resolver->setDefaults([
             'entry_type' => ItemTotalConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel) {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel) => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedTotalOfItemsFromTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ChannelBasedTotalOfItemsFromTaxonConfigurationType.php
@@ -24,12 +24,10 @@ final class ChannelBasedTotalOfItemsFromTaxonConfigurationType extends AbstractT
     {
         $resolver->setDefaults([
             'entry_type' => TotalOfItemsFromTaxonConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel): array {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel): array => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedFlatRateConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedFlatRateConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedFlatRateConfigurationType extends AbstractType
     {
         $resolver->setDefaults([
             'entry_type' => FlatRateConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel): array {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel): array => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedPerUnitRateConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedPerUnitRateConfigurationType.php
@@ -25,12 +25,10 @@ final class ChannelBasedPerUnitRateConfigurationType extends AbstractType
     {
         $resolver->setDefaults([
             'entry_type' => PerUnitRateConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel): array {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel): array => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Rule/ChannelBasedOrderTotalGreaterThanOrEqualConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Rule/ChannelBasedOrderTotalGreaterThanOrEqualConfigurationType.php
@@ -24,12 +24,10 @@ final class ChannelBasedOrderTotalGreaterThanOrEqualConfigurationType extends Ab
     {
         $resolver->setDefaults([
             'entry_type' => OrderTotalGreaterThanOrEqualConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel): array {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel): array => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Rule/ChannelBasedOrderTotalLessThanOrEqualConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Rule/ChannelBasedOrderTotalLessThanOrEqualConfigurationType.php
@@ -24,12 +24,10 @@ final class ChannelBasedOrderTotalLessThanOrEqualConfigurationType extends Abstr
     {
         $resolver->setDefaults([
             'entry_type' => OrderTotalLessThanOrEqualConfigurationType::class,
-            'entry_options' => function (ChannelInterface $channel): array {
-                return [
-                    'label' => $channel->getName(),
-                    'currency' => $channel->getBaseCurrency()->getCode(),
-                ];
-            },
+            'entry_options' => fn(ChannelInterface $channel): array => [
+                'label' => $channel->getName(),
+                'currency' => $channel->getBaseCurrency()->getCode(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
@@ -45,14 +45,14 @@ final class UserImpersonator implements UserImpersonatorInterface
             $token = new UsernamePasswordToken(
                 $user,
                 $this->firewallContextName,
-                array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+                array_map(/** @param object|string $role */ static fn($role): string => (string) $role, $user->getRoles())
             );
         } else {
             $token = new UsernamePasswordToken(
                 $user,
                 $user->getPassword(),
                 $this->firewallContextName,
-                array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+                array_map(/** @param object|string $role */ static fn($role): string => (string) $role, $user->getRoles())
             );
         }
 

--- a/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyChoiceType.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyChoiceType.php
@@ -40,9 +40,7 @@ final class CurrencyChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options): array {
-                return $this->currencyRepository->findAll();
-            },
+            'choices' => fn(Options $options): array => $this->currencyRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/CurrencyBundle/test/src/Tests/SyliusCurrencyBundleTest.php
+++ b/src/Sylius/Bundle/CurrencyBundle/test/src/Tests/SyliusCurrencyBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusCurrencyBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
@@ -41,13 +41,9 @@ final class CustomerChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options): array {
-                return $this->customerRepository->findAll();
-            },
+            'choices' => fn(Options $options): array => $this->customerRepository->findAll(),
             'choice_value' => 'email',
-            'choice_label' => function (CustomerInterface $customer): string {
-                return sprintf('%s (%s)', $customer->getFullName(), $customer->getEmail());
-            },
+            'choice_label' => fn(CustomerInterface $customer): string => sprintf('%s (%s)', $customer->getFullName(), $customer->getEmail()),
             'choice_translation_domain' => false,
         ]);
     }

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerGroupChoiceType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerGroupChoiceType.php
@@ -40,9 +40,7 @@ final class CustomerGroupChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options): array {
-                return $this->customerGroupRepository->findAll();
-            },
+            'choices' => fn(Options $options): array => $this->customerGroupRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/CustomerBundle/test/src/Tests/SyliusCustomerBundleTest.php
+++ b/src/Sylius/Bundle/CustomerBundle/test/src/Tests/SyliusCustomerBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusCustomerBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/InventoryBundle/test/src/Tests/SyliusInventoryBundleTest.php
+++ b/src/Sylius/Bundle/InventoryBundle/test/src/Tests/SyliusInventoryBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusInventoryBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/LocaleBundle/test/src/Tests/SyliusLocaleBundleTest.php
+++ b/src/Sylius/Bundle/LocaleBundle/test/src/Tests/SyliusLocaleBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusLocaleBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/MoneyBundle/test/src/Tests/SyliusMoneyBundleTest.php
+++ b/src/Sylius/Bundle/MoneyBundle/test/src/Tests/SyliusMoneyBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusMoneyBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/OrderBundle/test/src/Tests/SyliusOrderBundleTest.php
+++ b/src/Sylius/Bundle/OrderBundle/test/src/Tests/SyliusOrderBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusOrderBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/PaymentBundle/test/src/Tests/SyliusPaymentBundleTest.php
+++ b/src/Sylius/Bundle/PaymentBundle/test/src/Tests/SyliusPaymentBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusPaymentBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
@@ -48,9 +48,7 @@ final class RegisterGatewayConfigTypePass implements CompilerPassInterface
             }
         }
 
-        usort($gatewayFactories, function (array $firstGateway, array $secondGateway): int {
-            return $secondGateway['priority'] - $firstGateway['priority'];
-        });
+        usort($gatewayFactories, fn(array $firstGateway, array $secondGateway): int => $secondGateway['priority'] - $firstGateway['priority']);
 
         $sortedGatewayFactories = [];
         foreach ($gatewayFactories as $key => $factory) {

--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
@@ -44,9 +44,7 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
 
         return array_combine(
             array_map(
-                function (ProductOptionValueInterface $productOptionValue): string {
-                    return (string) $productOptionValue->getOptionCode();
-                },
+                fn(ProductOptionValueInterface $productOptionValue): string => (string) $productOptionValue->getOptionCode(),
                 $value->getOptionValues()->toArray()
             ),
             $value->getOptionValues()->toArray()

--- a/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/BuildAttributesFormSubscriber.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/BuildAttributesFormSubscriber.php
@@ -59,9 +59,7 @@ final class BuildAttributesFormSubscriber implements EventSubscriberInterface
         $defaultLocaleCode = $this->localeProvider->getDefaultLocaleCode();
 
         $attributes = $product->getAttributes()->filter(
-            function (ProductAttributeValueInterface $attribute) use ($defaultLocaleCode) {
-                return $attribute->getLocaleCode() === $defaultLocaleCode;
-            }
+            fn(ProductAttributeValueInterface $attribute) => $attribute->getLocaleCode() === $defaultLocaleCode
         );
 
         /** @var ProductAttributeValueInterface $attribute */

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeChoiceType.php
@@ -40,9 +40,7 @@ final class ProductAssociationTypeChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
-                return $this->productAssociationTypeRepository->findAll();
-            },
+            'choices' => fn(Options $options) => $this->productAssociationTypeRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationsType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationsType.php
@@ -46,14 +46,10 @@ final class ProductAssociationsType extends AbstractType
         $resolver->setDefaults([
             'entries' => $this->productAssociationTypeRepository->findAll(),
             'entry_type' => TextType::class,
-            'entry_name' => function (ProductAssociationTypeInterface $productAssociationType) {
-                return $productAssociationType->getCode();
-            },
-            'entry_options' => function (ProductAssociationTypeInterface $productAssociationType) {
-                return [
-                    'label' => $productAssociationType->getName(),
-                ];
-            },
+            'entry_name' => fn(ProductAssociationTypeInterface $productAssociationType) => $productAssociationType->getCode(),
+            'entry_options' => fn(ProductAssociationTypeInterface $productAssociationType) => [
+                'label' => $productAssociationType->getName(),
+            ],
         ]);
     }
 

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductChoiceType.php
@@ -40,9 +40,7 @@ final class ProductChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
-                return $this->productRepository->findAll();
-            },
+            'choices' => fn(Options $options) => $this->productRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
@@ -40,9 +40,7 @@ final class ProductOptionChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options): array {
-                return $this->productOptionRepository->findAll();
-            },
+            'choices' => fn(Options $options): array => $this->productOptionRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantChoiceType.php
@@ -35,14 +35,9 @@ final class ProductVariantChoiceType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'choices' => function (Options $options): iterable {
-                    return $options['product']->getVariants();
-                },
+                'choices' => fn(Options $options): iterable => $options['product']->getVariants(),
                 'choice_value' => 'code',
-                'choice_label' => function (ProductVariantInterface $variant): string {
-                    /** @psalm-suppress InvalidCast */
-                    return (string) $variant;
-                },
+                'choice_label' => fn(ProductVariantInterface $variant): string => $variant->getName(),
                 'choice_translation_domain' => false,
                 'multiple' => false,
                 'expanded' => true,

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantMatchType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantMatchType.php
@@ -40,19 +40,13 @@ final class ProductVariantMatchType extends AbstractType
                     return $product->getOptions();
                 },
                 'entry_type' => ProductOptionValueChoiceType::class,
-                'entry_name' => function (ProductOptionInterface $productOption) {
-                    return $productOption->getCode();
-                },
-                'entry_options' => function (Options $options) {
-                    return function (ProductOptionInterface $productOption) use ($options) {
-                        return [
-                            'label' => $productOption->getName(),
-                            'option' => $productOption,
-                            'only_available_values' => true,
-                            'product' => $options['product'],
-                        ];
-                    };
-                },
+                'entry_name' => fn(ProductOptionInterface $productOption) => $productOption->getCode(),
+                'entry_options' => fn(Options $options) => fn(ProductOptionInterface $productOption) => [
+                    'label' => $productOption->getName(),
+                    'option' => $productOption,
+                    'only_available_values' => true,
+                    'product' => $options['product'],
+                ],
             ])
 
             ->setRequired('product')

--- a/src/Sylius/Bundle/ProductBundle/test/src/Tests/SyliusProductBundleTest.php
+++ b/src/Sylius/Bundle/ProductBundle/test/src/Tests/SyliusProductBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusProductBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/CompositePromotionCouponEligibilityCheckerPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/CompositePromotionCouponEligibilityCheckerPass.php
@@ -27,9 +27,7 @@ final class CompositePromotionCouponEligibilityCheckerPass implements CompilerPa
 
         $container->getDefinition('sylius.promotion_coupon_eligibility_checker')->setArguments([
             array_map(
-                function ($id) {
-                    return new Reference($id);
-                },
+                fn($id) => new Reference($id),
                 array_keys($container->findTaggedServiceIds('sylius.promotion_coupon_eligibility_checker'))
             ),
         ]);

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/CompositePromotionEligibilityCheckerPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/CompositePromotionEligibilityCheckerPass.php
@@ -27,9 +27,7 @@ final class CompositePromotionEligibilityCheckerPass implements CompilerPassInte
 
         $container->getDefinition('sylius.promotion_eligibility_checker')->setArguments([
             array_map(
-                function ($id) {
-                    return new Reference($id);
-                },
+                fn($id) => new Reference($id),
                 array_keys($container->findTaggedServiceIds('sylius.promotion_eligibility_checker'))
             ),
         ]);

--- a/src/Sylius/Bundle/PromotionBundle/test/src/Tests/SyliusPromotionBundleTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/src/Tests/SyliusPromotionBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusPromotionBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/ReviewBundle/test/src/Tests/SyliusReviewBundleTest.php
+++ b/src/Sylius/Bundle/ReviewBundle/test/src/Tests/SyliusReviewBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusReviewBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/CompositeShippingMethodEligibilityCheckerPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/CompositeShippingMethodEligibilityCheckerPass.php
@@ -27,9 +27,7 @@ final class CompositeShippingMethodEligibilityCheckerPass implements CompilerPas
 
         $container->getDefinition('sylius.shipping_method_eligibility_checker')->setArguments([
             array_map(
-                static function ($id): Reference {
-                    return new Reference($id);
-                },
+                static fn($id): Reference => new Reference($id),
                 array_keys($container->findTaggedServiceIds('sylius.shipping_method_eligibility_checker'))
             ),
         ]);

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryChoiceType.php
@@ -40,9 +40,7 @@ final class ShippingCategoryChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
-                return $this->shippingCategoryRepository->findAll();
-            },
+            'choices' => fn(Options $options) => $this->shippingCategoryRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/ShippingBundle/test/src/Tests/SyliusShippingBundleTest.php
+++ b/src/Sylius/Bundle/ShippingBundle/test/src/Tests/SyliusShippingBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusShippingBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
@@ -22,9 +22,7 @@ final class OrderItemsSubtotalCalculator implements OrderItemsSubtotalCalculator
     {
         return array_reduce(
             $order->getItems()->toArray(),
-            static function (int $subtotal, OrderItemInterface $item): int {
-                return $subtotal + $item->getSubtotal();
-            },
+            static fn(int $subtotal, OrderItemInterface $item): int => $subtotal + $item->getSubtotal(),
             0
         );
     }

--- a/src/Sylius/Bundle/ShopBundle/Controller/CurrencySwitchController.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/CurrencySwitchController.php
@@ -59,9 +59,7 @@ final class CurrencySwitchController
         $channel = $this->channelContext->getChannel();
 
         $availableCurrencies = array_map(
-            function (CurrencyInterface $currency) {
-                return $currency->getCode();
-            },
+            fn(CurrencyInterface $currency) => $currency->getCode(),
             $channel->getCurrencies()->toArray()
         );
 

--- a/src/Sylius/Bundle/ShopBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ShopBundle/DependencyInjection/Configuration.php
@@ -40,9 +40,7 @@ final class Configuration implements ConfigurationInterface
                             ->validate()
                             ->ifTrue(
                                 /** @param mixed $pattern */
-                                function ($pattern) {
-                                    return !is_string($pattern);
-                                }
+                                fn($pattern) => !is_string($pattern)
                             )
                                 ->thenInvalid('Invalid pattern "%s"')
                             ->end()

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
@@ -43,9 +43,7 @@ class OrderTaxesTotalExtension extends AbstractExtension
     {
         return array_reduce(
             $order->getAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->toArray(),
-            static function (int $total, BaseAdjustmentInterface $adjustment) use ($isNeutral) {
-                return $isNeutral === $adjustment->isNeutral() ? $total + $adjustment->getAmount() : $total;
-            },
+            static fn(int $total, BaseAdjustmentInterface $adjustment) => $isNeutral === $adjustment->isNeutral() ? $total + $adjustment->getAmount() : $total,
             0
         );
     }

--- a/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCategoryChoiceType.php
+++ b/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCategoryChoiceType.php
@@ -40,9 +40,7 @@ final class TaxCategoryChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
-                return $this->taxCategoryRepository->findAll();
-            },
+            'choices' => fn(Options $options) => $this->taxCategoryRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/TaxationBundle/test/src/Tests/SyliusTaxationBundleTest.php
+++ b/src/Sylius/Bundle/TaxationBundle/test/src/Tests/SyliusTaxationBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusTaxationBundleTest extends WebTestCase
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $services = array_filter($services, fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($services as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/SyliusTaxonomyBundleTest.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/SyliusTaxonomyBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusTaxonomyBundleTest extends KernelTestCase
         /** @var Container $container */
         $container = self::$kernel->getContainer();
 
-        $serviceIds = array_filter($container->getServiceIds(), function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $serviceIds = array_filter($container->getServiceIds(), fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($serviceIds as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));

--- a/src/Sylius/Bundle/UiBundle/Command/DebugTemplateEventCommand.php
+++ b/src/Sylius/Bundle/UiBundle/Command/DebugTemplateEventCommand.php
@@ -63,14 +63,12 @@ final class DebugTemplateEventCommand extends Command
         $io->table(
             ['Block name', 'Template', 'Priority', 'Enabled'],
             array_map(
-                static function (TemplateBlock $templateBlock): array {
-                    return [
-                        $templateBlock->getName(),
-                        $templateBlock->getTemplate(),
-                        $templateBlock->getPriority(),
-                        $templateBlock->isEnabled() ? 'TRUE' : 'FALSE',
-                    ];
-                },
+                static fn(TemplateBlock $templateBlock): array => [
+                    $templateBlock->getName(),
+                    $templateBlock->getTemplate(),
+                    $templateBlock->getPriority(),
+                    $templateBlock->isEnabled() ? 'TRUE' : 'FALSE',
+                ],
                 $this->templateBlockRegistry->all()[$eventName] ?? []
             )
         );

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
@@ -48,16 +48,12 @@ final class TemplateBlockDataCollector extends DataCollector
 
     public function getNumberOfRenderedBlocks(): int
     {
-        return array_reduce($this->data['renderedEvents'], static function (int $accumulator, array $event): int {
-            return $accumulator + count($event['blocks']);
-        }, 0);
+        return array_reduce($this->data['renderedEvents'], static fn(int $accumulator, array $event): int => $accumulator + count($event['blocks']), 0);
     }
 
     public function getTotalDuration(): float
     {
-        return array_reduce($this->data['renderedEvents'], static function (float $accumulator, array $event): float {
-            return $accumulator + $event['time'];
-        }, 0.0);
+        return array_reduce($this->data['renderedEvents'], static fn(float $accumulator, array $event): float => $accumulator + $event['time'], 0.0);
     }
 
     public function getName(): string

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
@@ -40,9 +40,7 @@ final class Configuration implements ConfigurationInterface
                                     ->canBeDisabled()
                                     ->beforeNormalization()
                                         ->ifString()
-                                        ->then(static function (?string $template): array {
-                                            return ['template' => $template];
-                                        })
+                                        ->then(static fn(?string $template): array => ['template' => $template])
                                     ->end()
                                     ->children()
                                         ->booleanNode('enabled')->defaultNull()->end()

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistry.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistry.php
@@ -46,17 +46,13 @@ final class TemplateBlockRegistry implements TemplateBlockRegistryInterface
 
             return array_values(array_filter(
                 $this->eventsToTemplateBlocks[$eventName] ?? [],
-                static function (TemplateBlock $templateBlock): bool {
-                    return $templateBlock->isEnabled();
-                }
+                static fn(TemplateBlock $templateBlock): bool => $templateBlock->isEnabled()
             ));
         }
 
         $enabledFinalizedTemplateBlocks = array_filter(
             $this->findFinalizedForEvents($eventNames),
-            static function (TemplateBlock $templateBlock): bool {
-                return $templateBlock->isEnabled();
-            }
+            static fn(TemplateBlock $templateBlock): bool => $templateBlock->isEnabled()
         );
 
         $templateBlocksPriorityQueue = new SplPriorityQueue();

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -61,8 +61,6 @@ final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInter
      */
     private function shouldRenderHtmlDebug(array $templateBlocks): bool
     {
-        return count($templateBlocks) === 0 || count(array_filter($templateBlocks, static function (TemplateBlock $templateBlock): bool {
-            return strrpos($templateBlock->getTemplate(), '.html.twig') !== false;
-        })) >= 1;
+        return count($templateBlocks) === 0 || count(array_filter($templateBlocks, static fn(TemplateBlock $templateBlock): bool => strrpos($templateBlock->getTemplate(), '.html.twig') !== false)) >= 1;
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Twig/MergeRecursiveExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/MergeRecursiveExtension.php
@@ -23,9 +23,7 @@ final class MergeRecursiveExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'sylius_merge_recursive',
-                function (array $firstArray, array $secondArray): array {
-                    return array_merge_recursive($firstArray, $secondArray);
-                }
+                fn(array $firstArray, array $secondArray): array => array_merge_recursive($firstArray, $secondArray)
             ),
         ];
     }

--- a/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
@@ -127,9 +127,7 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
         $config = $this->getContainer()->getParameter('sylius.user.users');
 
         // Keep only users types which implement \Sylius\Component\User\Model\UserInterface
-        $userTypes = array_filter($config, function (array $userTypeConfig): bool {
-            return isset($userTypeConfig['user']['classes']['model']) && is_a($userTypeConfig['user']['classes']['model'], UserInterface::class, true);
-        });
+        $userTypes = array_filter($config, fn(array $userTypeConfig): bool => isset($userTypeConfig['user']['classes']['model']) && is_a($userTypeConfig['user']['classes']['model'], UserInterface::class, true));
 
         return array_keys($userTypes);
     }

--- a/src/Sylius/Bundle/UserBundle/Security/UserLogin.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserLogin.php
@@ -71,7 +71,7 @@ class UserLogin implements UserLoginInterface
             $user,
             null,
             $firewallName,
-            array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+            array_map(/** @param object|string $role */ static fn($role): string => (string) $role, $user->getRoles())
         );
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/SyliusUserBundleTest.php
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/SyliusUserBundleTest.php
@@ -30,9 +30,7 @@ final class SyliusUserBundleTest extends KernelTestCase
         /** @var Container $container */
         $container = self::$kernel->getContainer();
 
-        $serviceIds = array_filter($container->getServiceIds(), function (string $serviceId): bool {
-            return 0 === strpos($serviceId, 'sylius.');
-        });
+        $serviceIds = array_filter($container->getServiceIds(), fn(string $serviceId): bool => 0 === strpos($serviceId, 'sylius.'));
 
         foreach ($serviceIds as $id) {
             Assert::assertNotNull($container->get($id, ContainerInterface::NULL_ON_INVALID_REFERENCE));


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Every Bundle except the ApiBundle (as it's a huge one :dancer:). Let's use PHP 7.4 on its finest :rocket: