### PR TITLE
Fixed logic at NthOrderRuleChecker

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/NthOrderRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/NthOrderRuleChecker.php
@@ -45,12 +45,9 @@ final class NthOrderRuleChecker implements RuleCheckerInterface
         }
 
         $customer = $subject->getCustomer();
-        if (null === $customer) {
-            return false;
-        }
 
-        //eligible if it is first order of guest and the promotion is on first order
-        if (null === $customer->getId()) {
+        // Eligible if it is first order of guest and the promotion is on first order
+        if (null === $customer) {
             return 1 === $configuration['nth'];
         }
 


### PR DESCRIPTION
So, now `nth_order` rule is eligible not only for logged-in users.

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13269
| License         | MIT
