### PR TITLE
[1.10] Maintain | Relax conflict rule with "liip/imagine-bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
         "symfony/var-exporter": "^6.0",
         "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2",
-        "liip/imagine-bundle": "^2.7"
+        "liip/imagine-bundle": "2.7.0"
     },
     "require-dev": {
         "ext-json": "*",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no?
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #13261 
| License         | MIT

The conflict rule was to wide, as it also prevented to install fixed version (`2.7.1`).
