### PR TITLE
Remove swagger decorators when docs are disabled

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -29,5 +30,11 @@ final class SyliusApiExtension extends Extension
         $container->setParameter('sylius_api.enabled', $config['enabled']);
 
         $loader->load('services.xml');
+
+        if (!$container->hasParameter('enable_swagger') || !$container->getParameter('enable_swagger')) {
+            return;
+        }
+
+        $loader->load('integrations/swagger.xml');
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -16,6 +16,35 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <services>
+        <defaults public="true" />
+
+        <service id="api_platform.swagger.action.ui" class="Sylius\Bundle\ApiBundle\ApiPlatform\Bridge\Symfony\Bundle\Action\SwaggerUiAction">
+            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.serializer" />
+            <argument type="service" id="twig" />
+            <argument type="service" id="router" />
+            <argument>%api_platform.title%</argument>
+            <argument>%api_platform.description%</argument>
+            <argument>%api_platform.version%</argument>
+            <argument>%api_platform.formats%</argument>
+            <argument>%api_platform.oauth.enabled%</argument>
+            <argument>%api_platform.oauth.clientId%</argument>
+            <argument>%api_platform.oauth.clientSecret%</argument>
+            <argument>%api_platform.oauth.type%</argument>
+            <argument>%api_platform.oauth.flow%</argument>
+            <argument>%api_platform.oauth.tokenUrl%</argument>
+            <argument>%api_platform.oauth.authorizationUrl%</argument>
+            <argument>%api_platform.oauth.scopes%</argument>
+            <argument>%api_platform.show_webby%</argument>
+            <argument>%api_platform.enable_swagger_ui%</argument>
+            <argument>%api_platform.enable_re_doc%</argument>
+            <argument>%api_platform.graphql.enabled%</argument>
+            <argument>%api_platform.graphql.graphiql.enabled%</argument>
+            <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
+            <argument>%api_platform.swagger.versions%</argument>
+        </service>
+
         <service
             id="sylius.api.swagger_admin_authentication_documentation_normalizer"
             class="Sylius\Bundle\ApiBundle\Swagger\AdminAuthenticationTokenDocumentationNormalizer"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -31,33 +31,6 @@
             <argument type="service" id="api_platform.iri_converter" />
         </service>
 
-        <service id="api_platform.swagger.action.ui" class="Sylius\Bundle\ApiBundle\ApiPlatform\Bridge\Symfony\Bundle\Action\SwaggerUiAction" public="true">
-            <argument type="service" id="api_platform.metadata.resource.name_collection_factory" />
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
-            <argument type="service" id="api_platform.serializer" />
-            <argument type="service" id="twig" />
-            <argument type="service" id="router" />
-            <argument>%api_platform.title%</argument>
-            <argument>%api_platform.description%</argument>
-            <argument>%api_platform.version%</argument>
-            <argument>%api_platform.formats%</argument>
-            <argument>%api_platform.oauth.enabled%</argument>
-            <argument>%api_platform.oauth.clientId%</argument>
-            <argument>%api_platform.oauth.clientSecret%</argument>
-            <argument>%api_platform.oauth.type%</argument>
-            <argument>%api_platform.oauth.flow%</argument>
-            <argument>%api_platform.oauth.tokenUrl%</argument>
-            <argument>%api_platform.oauth.authorizationUrl%</argument>
-            <argument>%api_platform.oauth.scopes%</argument>
-            <argument>%api_platform.show_webby%</argument>
-            <argument>%api_platform.enable_swagger_ui%</argument>
-            <argument>%api_platform.enable_re_doc%</argument>
-            <argument>%api_platform.graphql.enabled%</argument>
-            <argument>%api_platform.graphql.graphiql.enabled%</argument>
-            <argument>%api_platform.graphql.graphql_playground.enabled%</argument>
-            <argument>%api_platform.swagger.versions%</argument>
-        </service>
-
         <service id="sylius.api.property_info.extractor.empty_list_extractor" class="Sylius\Bundle\ApiBundle\PropertyInfo\Extractor\EmptyPropertyListExtractor">
             <tag name="property_info.list_extractor" priority="-2000" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
@@ -9,6 +9,11 @@ parameters:
     database_path: "%kernel.project_dir%/var/db.sql"
 
 api_platform:
+    enable_swagger_ui: false
+    enable_re_doc: false
+    enable_swagger: false
+    enable_entrypoint: false
+    enable_docs: false
     mapping:
         paths:
             - '%kernel.api_bundle_path%/Resources/config/api_resources'

--- a/src/Sylius/Bundle/ApiBundle/test/src/Tests/DisablingDocumentationTest.php
+++ b/src/Sylius/Bundle/ApiBundle/test/src/Tests/DisablingDocumentationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Application\Tests;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DisablingDocumentationTest extends ApiTestCase
+{
+    use SetUpTestsTrait;
+
+    public function setUp(): void
+    {
+        $this->setFixturesFiles([]);
+
+        $this->setUpTest();
+    }
+
+    /** @test */
+    public function it_disables_documentation(): void
+    {
+        static::createClient()->request(
+            'GET',
+            'api/v2/docs'
+        );
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/12832
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
