### PR TITLE
[Spec] change username to runtime exception

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -24,6 +24,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
+        "doctrine/dbal": "^2.7",
         "api-platform/core": "^2.6",
         "lexik/jwt-authentication-bundle": "^2.6",
         "sylius/core-bundle": "^1.7",

--- a/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameOrEmailProviderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameOrEmailProviderSpec.php
@@ -19,6 +19,7 @@ use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\User;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\RuntimeException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
@@ -73,7 +74,7 @@ final class UsernameOrEmailProviderSpec extends ObjectBehavior
         $userRepository->findOneBy(['usernameCanonical' => 'testuser'])->willReturn(null);
         $userRepository->findOneByEmail('testuser')->willReturn(null);
 
-        $this->shouldThrow(new UsernameNotFoundException('Username "testuser" does not exist.'))->during('loadUserByUsername', ['testUser']);
+        $this->shouldThrow(new RuntimeException('Username "testuser" does not exist.'))->during('loadUserByUsername', ['testUser']);
     }
 
     function it_loads_user_by_email(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

just a spec fix, PhpSpec\Matcher\ThrowMatcher is unable to access $serialized, due to change on AuthenticationException, which unsets this field.
![image](https://user-images.githubusercontent.com/22825722/142998966-a4c03e62-dc3a-434c-bd64-f0b8177e8232.png)


<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
