### PR TITLE
[Shop][Admin] Order variant option values by options' positions

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_imageVariants.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_imageVariants.html.twig
@@ -1,7 +1,7 @@
 <div class="sylius-image-variants">
 {% if product.getVariantSelectionMethod() == 'match' %}
     {% for variant in image.productVariants %}
-    <div data-variant-options="{% for option in variant.optionValues %}{{ option.code }} {% endfor %}"></div>
+    <div data-variant-options="{% for option in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}{{ option.code }} {% endfor %}"></div>
     {% endfor %}
 {% else %}
     {% for variant in image.productVariants %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantItem.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantItem.html.twig
@@ -22,7 +22,7 @@
         </div>
     </td>
     <td>
-        {% for optionValue in variant.optionValues %}
+        {% for optionValue in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}
             <div><span class="gray text">{{ optionValue.option.name }}:</span> {{ optionValue.value }}</div>
         {% endfor %}
     </td>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_info.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_info.html.twig
@@ -9,7 +9,7 @@
 </div>
 {% if product.hasOptions() %}
     <div class="ui horizontal divided list sylius-product-options">
-        {% for optionValue in variant.optionValues %}
+        {% for optionValue in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}
             <div class="item" data-sylius-option-name="{{ optionValue.name }}">
                 {{ optionValue.value }}
             </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Grid/Field/name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Grid/Field/name.html.twig
@@ -5,7 +5,7 @@
 {% if data.optionValues|length > 0 %}
     <br>
     <div class="ui horizontal divided list">
-        {% for optionValue in data.optionValues %}
+        {% for optionValue in data.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}
             <div class="item">
                 {{ optionValue.value }}
             </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_imageVariants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_imageVariants.html.twig
@@ -1,7 +1,7 @@
 <div class="sylius-image-variants">
 {% if product.getVariantSelectionMethod() == 'match' %}
     {% for variant in image.productVariants %}
-    <div data-variant-options="{% for option in variant.optionValues %}{{ option.code }} {% endfor %}"></div>
+    <div data-variant-options="{% for option in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}{{ option.code }} {% endfor %}"></div>
     {% endfor %}
 {% else %}
     {% for variant in image.productVariants %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
@@ -15,7 +15,7 @@
                 {{ variant.name }}
                 {% if product.hasOptions() %}
                     <div class="ui horizontal divided list">
-                        {% for optionValue in variant.optionValues %}
+                        {% for optionValue in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}
                             <div class="item">
                                 {{ optionValue.value }}
                             </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_info.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_info.html.twig
@@ -17,7 +17,7 @@
 </div>
 {% if product.hasOptions() %}
     <div class="ui horizontal divided list sylius-product-options" {{ sylius_test_html_attribute('product-options') }}>
-        {% for optionValue in variant.optionValues %}
+        {% for optionValue in variant.optionValues|sort((a, b) => a.option.position <=> b.option.position) %}
             <div class="item" data-sylius-option-name="{{ optionValue.name }}" {{ sylius_test_html_attribute('option-name', optionValue.name) }}>
                 {{ optionValue.value }}
             </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | ~
| License         | MIT


Depending on how option values are generated (programmatically) they might not be in the desired order. This can lead to variants where the order of options differ, confusing users and customers.

There's already a column on `product_option`, `position`, which – I think – was meant to enforce correct ordering.

This is just a cosmetic UI change and should not influence behavior at all.