### PR TITLE
Add Symfony 5.4 support for Sylius 1.10 

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -32,7 +32,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "5.2.*", "5.3.*"]
+                symfony: ["^4.4", "5.2.*", "5.3.*", "5.4.*"]
 
         steps:
             -
@@ -120,7 +120,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "5.2.*", "5.3.*"]
+                symfony: ["^4.4", "5.2.*", "5.3.*", "5.4.*"]
                 node: ["14.x"]
                 mysql: ["5.7", "8.0"]
 
@@ -249,7 +249,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "5.2.*", "5.3.*"]
+                symfony: ["^4.4", "5.2.*", "5.3.*", "5.4.*"]
                 node: ["14.x"]
                 mysql: ["5.7", "8.0"]
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,7 +49,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "5.2.*"]
+                symfony: ["^4.4", "5.2.*", "5.3.*", "5.4.*"]
                 package: "${{ fromJson(needs.list.outputs.packages) }}"
 
         steps:

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -3,6 +3,10 @@
 This document explains why certain conflicts were added to `composer.json` and
 references related issues.
 
+- `symfony/password-hasher": "^6.0`:
+
+  Symfony in version 5.3 change password hashing logic, and in version 6.0 they removed BC layer
+
  - `doctrine/doctrine-bundle:2.3.0`:
 
    This version makes Gedmo Doctrine Extensions fail (tree and position behaviour mostly).

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -3,6 +3,13 @@
 This document explains why certain conflicts were added to `composer.json` and
 references related issues.
 
+ - `symfony/cache": "^6.0`, "symfony/amqp-messenger": "^6.0", "symfony/doctrine-messenger": "^6.0", 
+"symfony/error-handler": "^6.0", "symfony/redis-messenger": "^6.0", "symfony/stopwatch": "^6.0", "symfony/twig-bridge": "^6.0", 
+"symfony/var-dumper": "^6.0", "symfony/var-exporter": "^6.0",:
+
+   Symfony in version 5.2 is installing amqp-messenger, doctrine-messenger, error-handler, redis-messenger, stopwatch, 
+twig-bridge, var-dumper, var-exporter 6.0, which is not compatible with the current version of Sylius. This is not happening for Sf4.4, Sf5.3, Sf5.4. 
+
  - `symfony/password-hasher": "^6.0`:
 
    Symfony in version 5.3 change password hashing logic, and in version 6.0 they removed BC layer
@@ -41,13 +48,13 @@ references related issues.
 
    Probably introduced in: https://github.com/symfony/symfony/pull/40811
 
-- `doctrine/orm:2.10.0`:
+ - `doctrine/orm:2.10.0`:
 
-  This version causes a problem with the creation of nested taxons by throwing the exception:
+   This version causes a problem with the creation of nested taxons by throwing the exception:
   
-  `Gedmo\Exception\UnexpectedValueException: Root cannot be changed manually, change parent instead in vendor/gedmo/doctrine-extensions/src/Tree/Strategy/ORM/Nested.php:145`
+   `Gedmo\Exception\UnexpectedValueException: Root cannot be changed manually, change parent instead in vendor/gedmo/doctrine-extensions/src/Tree/Strategy/ORM/Nested.php:145`
 
-  References: https://github.com/doctrine-extensions/DoctrineExtensions/issues/2155
+   References: https://github.com/doctrine-extensions/DoctrineExtensions/issues/2155
 
 In this section we keep track of the reasons, why some restrictions were added to the `requires` section of `composer.json`
 

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -3,9 +3,9 @@
 This document explains why certain conflicts were added to `composer.json` and
 references related issues.
 
-- `symfony/password-hasher": "^6.0`:
+ - `symfony/password-hasher": "^6.0`:
 
-  Symfony in version 5.3 change password hashing logic, and in version 6.0 they removed BC layer
+   Symfony in version 5.3 change password hashing logic, and in version 6.0 they removed BC layer
 
  - `doctrine/doctrine-bundle:2.3.0`:
 

--- a/composer.json
+++ b/composer.json
@@ -161,11 +161,20 @@
         "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/orm": "^2.10.0",
         "jms/serializer-bundle": "3.9.0",
+        "symfony/cache": "^6.0",
         "symfony/doctrine-bridge": "4.4.16",
+        "symfony/password-hasher": "^6.0",
+        "symfony/amqp-messenger": "^6.0",
+        "symfony/doctrine-messenger": "^6.0",
+        "symfony/error-handler": "^6.0",
+        "symfony/redis-messenger": "^6.0",
+        "symfony/stopwatch": "^6.0",
+        "symfony/twig-bridge": "^6.0",
+        "symfony/var-dumper": "^6.0",
+        "symfony/var-exporter": "^6.0",
         "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2",
-        "liip/imagine-bundle": "^2.7",
-        "symfony/password-hasher": "^6.0"
+        "liip/imagine-bundle": "^2.7"
     },
     "require-dev": {
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -164,7 +164,8 @@
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2",
-        "liip/imagine-bundle": "^2.7"
+        "liip/imagine-bundle": "^2.7",
+        "symfony/password-hasher": "^6.0"
     },
     "require-dev": {
         "ext-json": "*",

--- a/psalm.xml
+++ b/psalm.xml
@@ -119,6 +119,7 @@
                 <referencedMethod name="Symfony\Component\Security\Core\User\UserInterface::getUsername" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedMethod name="Symfony\Component\Security\Core\User\UserProviderInterface::loadUserByUsername" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedMethod name="Faker\Generator::__get"/>
+                <referencedMethod name="Symfony\Component\Security\Core\Authentication\Token\AbstractToken::isAuthenticated" /> <!-- deprecated in Symfony 5.4 -->
             </errorLevel>
         </DeprecatedMethod>
 
@@ -202,6 +203,7 @@
                 <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch" />
                 <referencedFunction name="Symfony\Component\HttpKernel\Config\FileLocator::__construct" />
                 <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch" />
+                <referencedFunction name="Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::__construct" /> <!-- removed parameter in Symfony 5.4 -->
             </errorLevel>
             <errorLevel type="suppress">
                 <referencedFunction name="Doctrine\ORM\Query\Expr::andX" />
@@ -225,6 +227,7 @@
             <errorLevel type="info">
                 <referencedFunction name="Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch" />
                 <referencedFunction name="SyliusLabs\AssociationHydrator\AssociationHydrator::__construct" />
+                <referencedFunction name="Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::__construct" />
             </errorLevel>
         </InvalidArgument>
 

--- a/src/Sylius/Behat/Service/SecurityService.php
+++ b/src/Sylius/Behat/Service/SecurityService.php
@@ -43,7 +43,13 @@ final class SecurityService implements SecurityServiceInterface
 
     public function logIn(UserInterface $user): void
     {
-        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->firewallContextName, $user->getRoles());
+        /** @deprecated parameter credential was deprecated in Symfony 5.4, so in Sylius 1.11 too, in Sylius 2.0 providing 4 arguments will be prohibited. */
+        if (3 === (new \ReflectionClass(UsernamePasswordToken::class))->getConstructor()->getNumberOfParameters()) {
+            $token = new UsernamePasswordToken($user, $this->firewallContextName, $user->getRoles());
+        } else {
+            $token = new UsernamePasswordToken($user, $user->getPassword(), $this->firewallContextName, $user->getRoles());
+        }
+
         $this->setToken($token);
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payment/GetPaymentConfiguration.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payment/GetPaymentConfiguration.php
@@ -38,7 +38,10 @@ final class GetPaymentConfiguration
     public function __invoke(Request $request): JsonResponse
     {
         /** @var PaymentInterface|null $payment */
-        $payment = $this->paymentRepository->findOneByOrderToken($request->get('paymentId'), $request->get('id'));
+        $payment = $this->paymentRepository->findOneByOrderToken(
+            $request->attributes->get('paymentId'),
+            $request->attributes->get('id')
+        );
 
         Assert::notNull($payment);
 

--- a/src/Sylius/Bundle/ApiBundle/Controller/UploadAvatarImageAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/UploadAvatarImageAction.php
@@ -57,7 +57,7 @@ final class UploadAvatarImageAction
         $image->setFile($file);
 
         /** @var string $ownerIri */
-        $ownerIri = $request->get('owner');
+        $ownerIri = $request->request->get('owner');
         Assert::notEmpty($ownerIri);
 
         /** @var ResourceInterface|AdminUserInterface $owner */

--- a/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
@@ -112,7 +112,7 @@ EOT
                     /** @var ConstraintViolationListInterface $errors */
                     $errors = $this->getContainer()->get('validator')->validate((string) $value, [new Email(), new NotBlank()]);
                     foreach ($errors as $error) {
-                        throw new \DomainException($error->getMessage());
+                        throw new \DomainException((string) $error->getMessage());
                     }
 
                     return $value;
@@ -191,7 +191,7 @@ EOT
                 /** @var ConstraintViolationListInterface $errors */
                 $errors = $this->getContainer()->get('validator')->validate($value, [new NotBlank()]);
                 foreach ($errors as $error) {
-                    throw new \DomainException($error->getMessage());
+                    throw new \DomainException((string) $error->getMessage());
                 }
 
                 return $value;

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -30,13 +30,14 @@ class ProductTaxonController extends ResourceController
      * @throws HttpException
      *
      * @deprecated This ajax action is deprecated and will be removed in Sylius 2.0 - use ProductTaxonController::updateProductTaxonsPositionsAction instead.
+     *
+     * @psalm-suppress DeprecatedMethod
      */
     public function updatePositionsAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
-        $productTaxons = $request->get('productTaxons');
-
+        $productTaxons = $this->getParameterFromRequest($request,'productTaxons');
         $this->validateCsrfProtection($request, $configuration);
 
         if ($this->shouldProductsPositionsBeUpdated($request, $productTaxons)) {
@@ -55,11 +56,14 @@ class ProductTaxonController extends ResourceController
         return new JsonResponse();
     }
 
+    /**
+     * @psalm-suppress DeprecatedMethod
+     */
     public function updateProductTaxonsPositionsAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
-        $productTaxons = $request->get('productTaxons');
+        $productTaxons = $this->getParameterFromRequest($request,'productTaxons');
 
         $this->validateCsrfProtection($request, $configuration);
 
@@ -102,5 +106,28 @@ class ProductTaxonController extends ResourceController
 
         $productTaxonFromBase = $this->repository->findOneBy(['id' => $id]);
         $productTaxonFromBase->setPosition((int) $position);
+    }
+
+    /**
+     * @return mixed
+     *
+     * @deprecated This function will be removed in Sylius 2.0, since Symfony 5.4, use explicit input sources instead
+     * based on Symfony\Component\HttpFoundation\Request::get
+     */
+    private function getParameterFromRequest(Request $request, string $key)
+    {
+        if ($request !== $result = $request->attributes->get($key, $request)) {
+            return $result;
+        }
+
+        if ($request->query->has($key)) {
+            return $request->query->all()[$key];
+        }
+
+        if ($request->request->has($key)) {
+            return $request->request->all()[$key];
+        }
+
+        return null;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductVariantController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductVariantController.php
@@ -25,12 +25,13 @@ class ProductVariantController extends ResourceController
 {
     /**
      * @throws HttpException
+     * @psalm-suppress DeprecatedMethod
      */
     public function updatePositionsAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
-        $productVariantsToUpdate = $request->get('productVariants');
+        $productVariantsToUpdate = $this->getParameterFromRequest($request, 'productVariants');
 
         if ($configuration->isCsrfProtectionEnabled() && !$this->isCsrfTokenValid('update-product-variant-position', (string) $request->request->get('_csrf_token'))) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
@@ -53,5 +54,28 @@ class ProductVariantController extends ResourceController
         }
 
         return new JsonResponse();
+    }
+
+    /**
+     * @return mixed
+     *
+     * @deprecated This function will be removed in Sylius 2.0, since Symfony 5.4, use explicit input sources instead
+     * based on Symfony\Component\HttpFoundation\Request::get
+     */
+    private function getParameterFromRequest(Request $request, string $key)
+    {
+        if ($request !== $result = $request->attributes->get($key, $request)) {
+            return $result;
+        }
+
+        if ($request->query->has($key)) {
+            return $request->query->all()[$key];
+        }
+
+        if ($request->request->has($key)) {
+            return $request->request->all()[$key];
+        }
+
+        return null;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -243,5 +243,7 @@
         <service class="Sylius\Bundle\CoreBundle\Mailer\OrderEmailManager" id="sylius.mailer.order_email_manager">
             <argument type="service" id="sylius.email_sender" />
         </service>
+
+        <service id="security.authentication_manager" alias="security.authentication.manager" />
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
@@ -40,12 +40,22 @@ final class UserImpersonator implements UserImpersonatorInterface
 
     public function impersonate(UserInterface $user): void
     {
-        $token = new UsernamePasswordToken(
-            $user,
-            $user->getPassword(),
-            $this->firewallContextName,
-            array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
-        );
+        /** @deprecated parameter credential was deprecated in Symfony 5.4, so in Sylius 1.11 too, in Sylius 2.0 providing 4 arguments will be prohibited. */
+        if (3 === (new \ReflectionClass(UsernamePasswordToken::class))->getConstructor()->getNumberOfParameters()) {
+            $token = new UsernamePasswordToken(
+                $user,
+                $this->firewallContextName,
+                array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+            );
+        } else {
+            $token = new UsernamePasswordToken(
+                $user,
+                $user->getPassword(),
+                $this->firewallContextName,
+                array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+            );
+        }
+
         $this->session->set($this->sessionTokenParameter, serialize($token));
         $this->session->save();
 

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ProductBundle\Controller;
 
+use Sylius\Component\Product\Generator\SlugGeneratorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,9 +21,29 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductSlugController extends AbstractController
 {
+    private ?SlugGeneratorInterface $slugGenerator;
+
+    public function __construct(?SlugGeneratorInterface $slugGenerator = null)
+    {
+        $this->slugGenerator = $slugGenerator;
+
+        if ($this->slugGenerator === null) {
+            @trigger_error(sprintf('Not passing a $slugGenerator to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+        }
+    }
+
+    /**
+     * @psalm-suppress DeprecatedMethod
+     */
     public function generateAction(Request $request): Response
     {
         $name = $request->query->get('name');
+
+        if ($this->slugGenerator !== null) {
+            return new JsonResponse([
+                'slug' => $this->slugGenerator->generate((string) $name),
+            ]);
+        }
 
         return new JsonResponse([
             'slug' => $this->get('sylius.generator.slug')->generate($name),

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
@@ -20,6 +20,7 @@
         <defaults public="true" />
 
         <service id="sylius.controller.product_slug" class="Sylius\Bundle\ProductBundle\Controller\ProductSlugController">
+            <argument type="service" id="sylius.generator.slug" />
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>

--- a/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
@@ -15,18 +15,45 @@ namespace Sylius\Bundle\UserBundle\Controller;
 
 use Sylius\Bundle\UserBundle\Form\Type\UserLoginType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Webmozart\Assert\Assert;
 
 class SecurityController extends AbstractController
 {
+    private ?AuthenticationUtils $authenticationUtils;
+
+    private ?FormFactoryInterface $formFactory;
+
+    public function __construct(?AuthenticationUtils $authenticationUtils = null, ?FormFactoryInterface $formFactory = null)
+    {
+        $this->authenticationUtils = $authenticationUtils;
+        $this->formFactory = $formFactory;
+
+        if ($this->authenticationUtils === null) {
+            @trigger_error(sprintf('Not passing a $authenticationUtils to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+        }
+
+        if ($this->formFactory === null) {
+            @trigger_error(sprintf('Not passing a $formFactory to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+        }
+    }
+
     /**
      * Login form action.
+     *
+     * @psalm-suppress DeprecatedMethod
      */
     public function loginAction(Request $request): Response
     {
-        $authenticationUtils = $this->get('security.authentication_utils');
+        if ($this->authenticationUtils !== null) {
+            $authenticationUtils = $this->authenticationUtils;
+        } else {
+            $authenticationUtils = $this->get('security.authentication_utils');
+        }
+
         $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
 
@@ -36,7 +63,12 @@ class SecurityController extends AbstractController
         Assert::notNull($template, 'Template is not configured.');
 
         $formType = $options['form'] ?? UserLoginType::class;
-        $form = $this->get('form.factory')->createNamed('', $formType);
+
+        if ($this->formFactory !== null) {
+            $form = $this->formFactory->createNamed('', $formType);
+        } else {
+            $form = $this->get('form.factory')->createNamed('', $formType);
+        }
 
         return $this->render($template, [
             'form' => $form->createView(),

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -40,6 +40,8 @@
 
         <!-- Controllers -->
         <service id="sylius.controller.user_security" class="Sylius\Bundle\UserBundle\Controller\SecurityController">
+            <argument type="service" id="security.authentication_utils" />
+            <argument type="service" id="form.factory" />
             <call method="setContainer">
                 <argument type="service" id="service_container" />
             </call>

--- a/src/Sylius/Bundle/UserBundle/Security/UserLogin.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserLogin.php
@@ -58,6 +58,15 @@ class UserLogin implements UserLoginInterface
 
     protected function createToken(UserInterface $user, string $firewallName): UsernamePasswordToken
     {
+        /** @deprecated parameter credential was deprecated in Symfony 5.4, so in Sylius 1.11 too, in Sylius 2.0 providing 4 arguments will be prohibited. */
+        if (3 === (new \ReflectionClass(UsernamePasswordToken::class))->getConstructor()->getNumberOfParameters()) {
+            return new UsernamePasswordToken(
+                $user,
+                $firewallName,
+                array_map(/** @param object|string $role */ static function ($role): string { return (string) $role; }, $user->getRoles())
+            );
+        }
+
         return new UsernamePasswordToken(
             $user,
             null,

--- a/tests/Controller/AdminProductAjaxTest.php
+++ b/tests/Controller/AdminProductAjaxTest.php
@@ -65,7 +65,14 @@ final class AdminProductAjaxTest extends JsonApiTestCase
         $session = self::$container->get('session');
         $firewallName = 'admin';
         $firewallContext = 'admin';
-        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+
+        /** @deprecated parameter credential was deprecated in Symfony 5.4, so in Sylius 1.11 too, in Sylius 2.0 providing 4 arguments will be prohibited. */
+        if (3 === (new \ReflectionClass(UsernamePasswordToken::class))->getConstructor()->getNumberOfParameters()) {
+            $token = new UsernamePasswordToken($user, $firewallName, $user->getRoles());
+        } else {
+            $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        }
+
         $session->set(sprintf('_security_%s', $firewallContext), serialize($token));
         $session->save();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Backport of https://github.com/Sylius/Sylius/pull/13339/ and https://github.com/Sylius/Sylius/pull/13358, fixes https://github.com/Sylius/Sylius-Standard/issues/630
| License         | MIT

Let's bring Sf5.4 support to Sylius 1.10. This way, current users will benefit from Symfony 5.4 with current installations. I'm considering it as a bug-fix, as it is already possible to install this version according to our composer.json. What is more, it will make it possible to migrate first to Sf5.4 and then upgrade to Sylius 1.11.

<!--
 - Bug fixes must be submitted against the 1.10 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
