### PR TITLE
Minimize number of build for packages

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     list:
         runs-on: ubuntu-latest
-        
+
         name: "Create a list of packages"
 
         steps:
@@ -38,9 +38,9 @@ jobs:
 
     test:
         needs: list
-        
+
         runs-on: ubuntu-latest
-        
+
         name: "${{ matrix.package }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
 
         timeout-minutes: 10
@@ -49,7 +49,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "5.2.*", "5.3.*", "5.4.*"]
+                symfony: ["^4.4", "5.3.*", "5.4.*"]
                 package: "${{ fromJson(needs.list.outputs.packages) }}"
 
         steps:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It seems Github Actions are not content with our number of builds 😄 

<img width="423" alt="Zrzut ekranu 2021-12-6 o 14 47 33" src="https://user-images.githubusercontent.com/6212718/144859038-2a01a56a-3a97-4ce6-bdb0-c88d652547dc.png">

As a hot-fix, I propose we can run only Symfony `5.3.*` and `5.4.*` on packages builds, as **probably** most of the people uses these versions and 5.2 is no longer supported... and it allows the build to start :dancer: 