### PR TITLE
symfony/password-hasher compatibility issue

### DIFF
--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -17,8 +17,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\Resource\Model\ToggleableTrait;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
-class User implements UserInterface
+class User implements UserInterface, PasswordAuthenticatedUserInterface
 {
     use TimestampableTrait, ToggleableTrait;
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes (Symfony 4.4 support breaks)
| Deprecations?   | no
| Related tickets | fixes #13362 
| License         | MIT

The latest version of symfony/password-hasher requires the User object to implement `PasswordAuthenticatedUserInterface`, or `PasswordHasherAwareInterface`, otherwise it'll convert the User object into a string (and throw the error `No password hasher has been configured for account "[username]".` when logging in to the admin panel).

`PasswordHasherAwareInterface` requires the hasher to be configured on the User class, which requires a lot of changes to be able to configure the hasher from the configuration files.

`PasswordAuthenticatedUserInterface` only requires a 'getPassword()' function to be present (which is already there) and uses the configuration from `security.yaml` to decide on the hasher. This therefore seems to be the prefered approach, which is therefore implemented in this PR.
