### PR TITLE
[UI] change time format to 24H, autocomplete times on data change

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_details.html.twig
@@ -22,14 +22,14 @@
             {% if catalog_promotion.startDate is not null %}
             <tr>
                 <td class="five wide"><strong class="gray text">{{ 'sylius.ui.start_date'|trans }}</strong></td>
-                <td {{ sylius_test_html_attribute('start-date') }}>{{ catalog_promotion.startDate|format_datetime(pattern='YYYY-MM-dd HH:mm') }}</td>
+                <td {{ sylius_test_html_attribute('start-date') }}>{{ catalog_promotion.startDate|format_datetime(pattern='YYYY-MM-dd HH:mm:ss') }}</td>
             </tr>
             {% endif %}
 
             {% if catalog_promotion.endDate is not null %}
             <tr>
                 <td class="five wide"><strong class="gray text">{{ 'sylius.ui.end_date'|trans }}</strong></td>
-                <td {{ sylius_test_html_attribute('end-date') }}>{{ catalog_promotion.endDate|format_datetime(pattern='YYYY-MM-dd HH:mm') }}</td>
+                <td {{ sylius_test_html_attribute('end-date') }}>{{ catalog_promotion.endDate|format_datetime(pattern='YYYY-MM-dd HH:mm:ss') }}</td>
             </tr>
             {% endif %}
             <tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_details.html.twig
@@ -22,14 +22,14 @@
             {% if catalog_promotion.startDate is not null %}
             <tr>
                 <td class="five wide"><strong class="gray text">{{ 'sylius.ui.start_date'|trans }}</strong></td>
-                <td {{ sylius_test_html_attribute('start-date') }}>{{ catalog_promotion.startDate|format_datetime(pattern='YYYY-MM-dd hh:mm:ss') }}</td>
+                <td {{ sylius_test_html_attribute('start-date') }}>{{ catalog_promotion.startDate|format_datetime(pattern='YYYY-MM-dd HH:mm') }}</td>
             </tr>
             {% endif %}
 
             {% if catalog_promotion.endDate is not null %}
             <tr>
                 <td class="five wide"><strong class="gray text">{{ 'sylius.ui.end_date'|trans }}</strong></td>
-                <td {{ sylius_test_html_attribute('end-date') }}>{{ catalog_promotion.endDate|format_datetime(pattern='YYYY-MM-dd hh:mm:ss') }}</td>
+                <td {{ sylius_test_html_attribute('end-date') }}>{{ catalog_promotion.endDate|format_datetime(pattern='YYYY-MM-dd HH:mm') }}</td>
             </tr>
             {% endif %}
             <tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_form.html.twig
@@ -29,4 +29,20 @@
     <div class="column">
         {{ translationForm(form.translations) }}
     </div>
+    <script>
+        document.querySelector('#sylius_catalog_promotion_startDate_date').addEventListener('change', event => {
+            setValueForTimeInput(event, '00:00');
+        })
+        document.querySelector('#sylius_catalog_promotion_endDate_date').addEventListener('change', event => {
+            setValueForTimeInput(event, '23:59');
+        })
+
+        function setValueForTimeInput(input, value) {
+            let time = input.target.nextSibling;
+
+            if (!time.value) {
+                time.value = value;
+            }
+        }
+    </script>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_form.html.twig
@@ -29,20 +29,4 @@
     <div class="column">
         {{ translationForm(form.translations) }}
     </div>
-    <script>
-        document.querySelector('#sylius_catalog_promotion_startDate_date').addEventListener('change', event => {
-            setValueForTimeInput(event, '00:00');
-        })
-        document.querySelector('#sylius_catalog_promotion_endDate_date').addEventListener('change', event => {
-            setValueForTimeInput(event, '23:59');
-        })
-
-        function setValueForTimeInput(input, value) {
-            let time = input.target.nextSibling;
-
-            if (!time.value) {
-                time.value = value;
-            }
-        }
-    </script>
 </div>

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionType.php
@@ -61,12 +61,14 @@ final class CatalogPromotionType extends AbstractResourceType
                 'label' => 'sylius.form.catalog_promotion.start_date',
                 'date_widget' => 'single_text',
                 'time_widget' => 'single_text',
+                'with_seconds' => true,
                 'required' => false,
             ])
             ->add('endDate', DateTimeType::class, [
                 'label' => 'sylius.form.catalog_promotion.end_date',
                 'date_widget' => 'single_text',
                 'time_widget' => 'single_text',
+                'with_seconds' => true,
                 'required' => false,
             ])
             ->add('exclusive', CheckboxType::class, [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT


Time display format has been changed to Y-m-d H:m from Y-m-d h:m:s, where s was 00 by default and h was 12h format, form takes seconds to account

Before:
![image](https://user-images.githubusercontent.com/22825722/145371526-16c88c57-dd38-4d47-8da1-3bc3cddfa3d5.png)

After:
![image](https://user-images.githubusercontent.com/22825722/145371395-b4fae619-752b-4869-bb05-7c693ecc8a81.png)

<!--
 - Bug fixes must be submitted against the 1.10 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
