### PR TITLE
Remove ORM 2.10 conflict

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -48,14 +48,6 @@ twig-bridge, var-dumper, var-exporter 6.0, which is not compatible with the curr
 
    Probably introduced in: https://github.com/symfony/symfony/pull/40811
 
- - `doctrine/orm:2.10.0`:
-
-   This version causes a problem with the creation of nested taxons by throwing the exception:
-  
-   `Gedmo\Exception\UnexpectedValueException: Root cannot be changed manually, change parent instead in vendor/gedmo/doctrine-extensions/src/Tree/Strategy/ORM/Nested.php:145`
-
-   References: https://github.com/doctrine-extensions/DoctrineExtensions/issues/2155
-
 In this section we keep track of the reasons, why some restrictions were added to the `requires` section of `composer.json`
 
 - `doctrine/dbal:^2`:

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,6 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "2.3.0",
-        "doctrine/orm": "^2.10.0",
         "jms/serializer-bundle": "3.9.0",
         "symfony/cache": "^6.0",
         "symfony/doctrine-bridge": "4.4.16",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

The conflict against `doctrine/orm:^2.10` has been unnecessary since the `gedmo/doctrine-extensions` 3.2 release.  In fact, the actual conflict was between the extensions package and the ORM, Sylius was never directly conflicted against it.  Now that newer versions of the extensions package either have the appropriate conflict or fixed the conflict and now require newer ORM versions, Sylius no longer needs to have this conflict.