### PR TITLE
[CatalogPromotion] change icon on show page

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Show/_header.html.twig
@@ -1,6 +1,6 @@
 <div class="ten wide column">
     <h1 class="ui header">
-        <i class="circular user icon"></i>
+        <i class="circular bookmark icon"></i>
         <div class="content">
             {{ catalog_promotion.name }}
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Catalog Promotion on all pages should have same icon.

<img width="453" alt="Screenshot 2021-12-10 at 08 33 06" src="https://user-images.githubusercontent.com/29897151/145535227-6fc221b0-c996-45cd-8096-64c9b19b212c.png">
