### PR TITLE
[Bug][Migrations] Add missing mysql check for our migrations to ensure proper syntax is available - master edition

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161202011555.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161202011555.php
@@ -20,7 +20,7 @@ class Version20161202011555 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE sylius_adjustment (id INT AUTO_INCREMENT NOT NULL, order_id INT DEFAULT NULL, order_item_id INT DEFAULT NULL, order_item_unit_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, `label` VARCHAR(255) DEFAULT NULL, amount INT NOT NULL, is_neutral TINYINT(1) NOT NULL, is_locked TINYINT(1) NOT NULL, origin_code VARCHAR(255) DEFAULT NULL, created_at DATETIME NOT NULL, updated_at DATETIME DEFAULT NULL, INDEX IDX_ACA6E0F28D9F6D38 (order_id), INDEX IDX_ACA6E0F2E415FB15 (order_item_id), INDEX IDX_ACA6E0F2F720C233 (order_item_unit_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
         $this->addSql('CREATE TABLE sylius_order_sequence (id INT AUTO_INCREMENT NOT NULL, idx INT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
@@ -173,7 +173,7 @@ class Version20161202011555 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_exchange_rate DROP FOREIGN KEY FK_5F52B852A76BEED');
         $this->addSql('ALTER TABLE sylius_exchange_rate DROP FOREIGN KEY FK_5F52B85B3FD5856');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161214153137.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161214153137.php
@@ -29,7 +29,7 @@ class Version20161214153137 extends AbstractMigration implements ContainerAwareI
 
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $defaultLocale = $this->container->getParameter('locale');
 
@@ -43,7 +43,7 @@ class Version20161214153137 extends AbstractMigration implements ContainerAwareI
     {
         $defaultLocale = $this->container->getParameter('locale');
 
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_variant ADD name VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci');
         $this->addSql('UPDATE sylius_product_variant SET name = (SELECT name FROM sylius_product_variant_translation WHERE sylius_product_variant_translation.translatable_id = sylius_product_variant.id AND sylius_product_variant_translation.locale = "' . $defaultLocale . '")');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161215103325.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161215103325.php
@@ -20,14 +20,14 @@ class Version20161215103325 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel ADD contact_email VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel DROP contact_email');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161219160441.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161219160441.php
@@ -29,7 +29,7 @@ class Version20161219160441 extends AbstractMigration implements ContainerAwareI
 
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $defaultLocale = $this->container->getParameter('locale');
 
@@ -41,7 +41,7 @@ class Version20161219160441 extends AbstractMigration implements ContainerAwareI
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $defaultLocale = $this->container->getParameter('locale');
 

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161220092422.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161220092422.php
@@ -20,14 +20,14 @@ class Version20161220092422 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE sylius_address_log_entries (id INT AUTO_INCREMENT NOT NULL, action VARCHAR(255) NOT NULL, loggedAt DATETIME NOT NULL, objectId VARCHAR(64) DEFAULT NULL, objectClass VARCHAR(255) NOT NULL, version INT NOT NULL, data LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', username VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('DROP TABLE sylius_address_log_entries');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161221133514.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161221133514.php
@@ -20,7 +20,7 @@ class Version20161221133514 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_option ADD position INT NOT NULL');
         $this->addSql('SET @row_number = -1');
@@ -29,7 +29,7 @@ class Version20161221133514 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_option DROP position');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161223091334.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161223091334.php
@@ -20,7 +20,7 @@ class Version20161223091334 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_variant ADD position INT NOT NULL');
         $this->addSql('SET @row_number = -1');
@@ -43,7 +43,7 @@ class Version20161223091334 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_variant DROP position');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20161223164558.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20161223164558.php
@@ -20,14 +20,14 @@ class Version20161223164558 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_shipping_method ADD archived_at DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_shipping_method DROP archived_at');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170103120334.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170103120334.php
@@ -20,14 +20,14 @@ class Version20170103120334 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_attribute_value ADD json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_attribute_value DROP json_value');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170109143010.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170109143010.php
@@ -29,7 +29,7 @@ class Version20170109143010 extends AbstractMigration implements ContainerAwareI
 
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $defaultLocale = $this->container->getParameter('locale');
 
@@ -39,7 +39,7 @@ class Version20170109143010 extends AbstractMigration implements ContainerAwareI
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_attribute_value DROP locale_code');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170110120125.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170110120125.php
@@ -20,7 +20,7 @@ class Version20170110120125 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_payment DROP FOREIGN KEY FK_D9191BD419883967');
         $this->addSql('ALTER TABLE sylius_payment ADD CONSTRAINT FK_D9191BD419883967 FOREIGN KEY (method_id) REFERENCES sylius_payment_method (id)');
@@ -28,7 +28,7 @@ class Version20170110120125 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_payment DROP FOREIGN KEY FK_D9191BD419883967');
         $this->addSql('ALTER TABLE sylius_payment ADD CONSTRAINT FK_D9191BD419883967 FOREIGN KEY (method_id) REFERENCES sylius_payment_method (id) ON DELETE SET NULL');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170120164250.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170120164250.php
@@ -20,7 +20,7 @@ class Version20170120164250 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_payment DROP FOREIGN KEY FK_D9191BD47048FD0F');
         $this->addSql('DROP TABLE sylius_credit_card');
@@ -30,7 +30,7 @@ class Version20170120164250 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE sylius_credit_card (id INT AUTO_INCREMENT NOT NULL, token VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, type VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, cardholder_name VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, number VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, security_code VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, expiry_month INT DEFAULT NULL, expiry_year INT DEFAULT NULL, created_at DATETIME NOT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_payment ADD credit_card_id INT DEFAULT NULL');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170124221955.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170124221955.php
@@ -20,14 +20,14 @@ class Version20170124221955 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_locale DROP enabled');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_locale ADD enabled TINYINT(1) NOT NULL');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20170303170201.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20170303170201.php
@@ -20,14 +20,14 @@ class Version20170303170201 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel_pricing ADD original_price INT');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel_pricing DROP original_price');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20190204092544.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20190204092544.php
@@ -23,7 +23,6 @@ final class Version20190204092544 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE INDEX IDX_6196A1F9A393D2FB43625D9F ON sylius_order (state, updated_at)');
@@ -31,7 +30,6 @@ final class Version20190204092544 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('DROP INDEX IDX_6196A1F9A393D2FB43625D9F ON sylius_order');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20190416073011.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20190416073011.php
@@ -23,7 +23,6 @@ final class Version20190416073011 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_promotion_coupon ADD reusable_from_cancelled_orders TINYINT(1) DEFAULT \'1\' NOT NULL');
@@ -31,7 +30,6 @@ final class Version20190416073011 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_promotion_coupon DROP reusable_from_cancelled_orders');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20200110132702.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20200110132702.php
@@ -20,7 +20,6 @@ final class Version20200110132702 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel ADD menu_taxon_id INT DEFAULT NULL');
@@ -30,7 +29,6 @@ final class Version20200110132702 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel DROP FOREIGN KEY FK_16C8119EF242B1E6');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20200122082429.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20200122082429.php
@@ -28,7 +28,6 @@ final class Version20200122082429 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE sylius_channel_countries (channel_id INT NOT NULL, country_id INT NOT NULL, INDEX IDX_D96E51AE72F5A1AA (channel_id), INDEX IDX_D96E51AEF92F3E70 (country_id), PRIMARY KEY(channel_id, country_id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
@@ -38,7 +37,6 @@ final class Version20200122082429 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('DROP TABLE sylius_channel_countries');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20200916093101.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20200916093101.php
@@ -25,7 +25,6 @@ final class Version20200916093101 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE price price INT DEFAULT NULL');
@@ -33,7 +32,6 @@ final class Version20200916093101 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE price price INT NOT NULL');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201017150005.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201017150005.php
@@ -25,11 +25,15 @@ final class Version20201017150005 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel ADD contact_phone_number VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel DROP contact_phone_number');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201104085538.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201104085538.php
@@ -20,12 +20,16 @@ final class Version20201104085538 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_product_attribute ADD translatable TINYINT(1) DEFAULT \'1\' NOT NULL');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE locale_code locale_code VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_product_attribute DROP translatable');
         $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE locale_code locale_code VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
@@ -25,6 +25,8 @@ final class Version20201130071338 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $adjustmentTable = $schema->getTable('sylius_adjustment');
         if ($adjustmentTable->hasColumn('shipment_id')) {
             return;
@@ -38,6 +40,8 @@ final class Version20201130071338 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $adjustmentTable = $schema->getTable('sylius_adjustment');
         if (!$adjustmentTable->hasColumn('shipment_id')) {
             return;

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -25,6 +25,8 @@ final class Version20201204071301 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $adjustmentTable = $schema->getTable('sylius_adjustment');
         if ($adjustmentTable->hasColumn('details')) {
             return;
@@ -35,6 +37,8 @@ final class Version20201204071301 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $adjustmentTable = $schema->getTable('sylius_adjustment');
         if (!$adjustmentTable->hasColumn('details')) {
             return;

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -27,6 +27,8 @@ final class Version20201208105207 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->setDefaultAdjustmentData();
 
         $adjustments = $this->getShipmentAdjustmentsWithData();
@@ -46,6 +48,8 @@ final class Version20201208105207 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->setDefaultAdjustmentData();
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210311142134.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210311142134.php
@@ -28,14 +28,16 @@ final class Version20210311142134 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_admin_user CHANGE password password VARCHAR(255) DEFAULT NULL');
         $this->addSql('ALTER TABLE sylius_shop_user CHANGE password password VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_admin_user CHANGE password password VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
         $this->addSql('ALTER TABLE sylius_shop_user CHANGE password password VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210408131321.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210408131321.php
@@ -25,11 +25,15 @@ final class Version20210408131321 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE UNIQUE INDEX UNIQ_6196A1F9BEA95C75 ON sylius_order (token_value)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP INDEX UNIQ_6196A1F9BEA95C75 ON sylius_order');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210422105530.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210422105530.php
@@ -25,11 +25,15 @@ final class Version20210422105530 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_order_item ADD version INT DEFAULT 1 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_order_item DROP version');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210809121349.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210809121349.php
@@ -16,11 +16,15 @@ final class Version20210809121349 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE INDEX created_at_index ON sylius_customer (created_at DESC)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP INDEX created_at_index ON sylius_customer');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210819203611.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210819203611.php
@@ -28,13 +28,11 @@ final class Version20210819203611 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE sylius_catalog_promotion (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_1055865077153098 (code), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('DROP TABLE sylius_catalog_promotion');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210819203611.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210819203611.php
@@ -28,11 +28,15 @@ final class Version20210819203611 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion (id INT AUTO_INCREMENT NOT NULL, code VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, UNIQUE INDEX UNIQ_1055865077153098 (code), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP TABLE sylius_catalog_promotion');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210824132538.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210824132538.php
@@ -19,14 +19,12 @@ final class Version20210824132538 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE sylius_catalog_promotion_rule (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_CB6904F1139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_rule ADD CONSTRAINT FK_CB6904F1139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('DROP TABLE sylius_catalog_promotion_rule');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210824132538.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210824132538.php
@@ -19,12 +19,16 @@ final class Version20210824132538 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_rule (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_CB6904F1139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_rule ADD CONSTRAINT FK_CB6904F1139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP TABLE sylius_catalog_promotion_rule');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210825090004.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210825090004.php
@@ -25,12 +25,16 @@ final class Version20210825090004 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT NOT NULL, label VARCHAR(255) DEFAULT NULL, description VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_BA065D3C2C2AC5D3 (translatable_id), UNIQUE INDEX sylius_catalog_promotion_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_translation ADD CONSTRAINT FK_BA065D3C2C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES sylius_catalog_promotion (id) ON DELETE CASCADE');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP TABLE sylius_catalog_promotion_translation');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826054355.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826054355.php
@@ -16,6 +16,8 @@ final class Version20210826054355 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_channels (catalog_promotion_id INT NOT NULL, channel_id INT NOT NULL, INDEX IDX_48E9AE7622E2CB5A (catalog_promotion_id), INDEX IDX_48E9AE7672F5A1AA (channel_id), PRIMARY KEY(catalog_promotion_id, channel_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_channels ADD CONSTRAINT FK_48E9AE7622E2CB5A FOREIGN KEY (catalog_promotion_id) REFERENCES sylius_catalog_promotion (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_channels ADD CONSTRAINT FK_48E9AE7672F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
@@ -23,6 +25,8 @@ final class Version20210826054355 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP TABLE sylius_catalog_promotion_channels');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826063828.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826063828.php
@@ -19,14 +19,12 @@ final class Version20210826063828 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE sylius_catalog_promotion_action (id INT AUTO_INCREMENT NOT NULL, catalog_promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_F529624722E2CB5A (catalog_promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_action ADD CONSTRAINT FK_F529624722E2CB5A FOREIGN KEY (catalog_promotion_id) REFERENCES sylius_catalog_promotion (id)');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('DROP TABLE sylius_catalog_promotion_action');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826063828.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210826063828.php
@@ -19,12 +19,16 @@ final class Version20210826063828 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_action (id INT AUTO_INCREMENT NOT NULL, catalog_promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_F529624722E2CB5A (catalog_promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_action ADD CONSTRAINT FK_F529624722E2CB5A FOREIGN KEY (catalog_promotion_id) REFERENCES sylius_catalog_promotion (id)');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('DROP TABLE sylius_catalog_promotion_action');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
@@ -19,11 +19,15 @@ final class Version20210830193340 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing ADD applied_promotions JSON DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing DROP applied_promotions');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
@@ -19,13 +19,11 @@ final class Version20210830193340 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing ADD applied_promotions JSON DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing DROP applied_promotions');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210921093619.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210921093619.php
@@ -28,13 +28,11 @@ final class Version20210921093619 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD enabled TINYINT(1) NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP enabled');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210921093619.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210921093619.php
@@ -28,11 +28,15 @@ final class Version20210921093619 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD enabled TINYINT(1) NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP enabled');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211001073918.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211001073918.php
@@ -19,6 +19,8 @@ final class Version20211001073918 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_scope (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_584AA86A139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_scope ADD CONSTRAINT FK_584AA86A139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
         $this->addSql('DROP TABLE sylius_catalog_promotion_rule');
@@ -26,6 +28,8 @@ final class Version20211001073918 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('CREATE TABLE sylius_catalog_promotion_rule (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`, configuration LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'(DC2Type:array)\', INDEX IDX_CB6904F1139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_rule ADD CONSTRAINT FK_CB6904F1139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
         $this->addSql('DROP TABLE sylius_catalog_promotion_scope');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211001073918.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211001073918.php
@@ -19,7 +19,6 @@ final class Version20211001073918 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE sylius_catalog_promotion_scope (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) NOT NULL, configuration LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', INDEX IDX_584AA86A139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_scope ADD CONSTRAINT FK_584AA86A139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
         $this->addSql('DROP TABLE sylius_catalog_promotion_rule');
@@ -27,7 +26,6 @@ final class Version20211001073918 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('CREATE TABLE sylius_catalog_promotion_rule (id INT AUTO_INCREMENT NOT NULL, promotion_id INT DEFAULT NULL, type VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`, configuration LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'(DC2Type:array)\', INDEX IDX_CB6904F1139DF194 (promotion_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
         $this->addSql('ALTER TABLE sylius_catalog_promotion_rule ADD CONSTRAINT FK_CB6904F1139DF194 FOREIGN KEY (promotion_id) REFERENCES sylius_catalog_promotion (id)');
         $this->addSql('DROP TABLE sylius_catalog_promotion_scope');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211006182150.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211006182150.php
@@ -19,13 +19,11 @@ final class Version20211006182150 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD start_date DATETIME DEFAULT NULL, ADD end_date DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP start_date, DROP end_date');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211006182150.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211006182150.php
@@ -19,11 +19,15 @@ final class Version20211006182150 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD start_date DATETIME DEFAULT NULL, ADD end_date DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP start_date, DROP end_date');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211008105704.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211008105704.php
@@ -16,12 +16,16 @@ final class Version20211008105704 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD state VARCHAR(255) NOT NULL');
         $this->addSql('UPDATE sylius_catalog_promotion SET state = "inactive"');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP state');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211025082311.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211025082311.php
@@ -19,13 +19,11 @@ final class Version20211025082311 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing ADD minimum_price INT DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing DROP minimum_price');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211025082311.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211025082311.php
@@ -19,11 +19,15 @@ final class Version20211025082311 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing ADD minimum_price INT DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing DROP minimum_price');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211028150911.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211028150911.php
@@ -19,11 +19,15 @@ final class Version20211028150911 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD priority INT DEFAULT 0 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP priority');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211028150911.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211028150911.php
@@ -19,13 +19,11 @@ final class Version20211028150911 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD priority INT DEFAULT 0 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP priority');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211122104644.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211122104644.php
@@ -19,11 +19,15 @@ final class Version20211122104644 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD exclusive TINYINT(1) DEFAULT \'0\' NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP exclusive');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211122104644.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211122104644.php
@@ -19,13 +19,11 @@ final class Version20211122104644 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion ADD exclusive TINYINT(1) DEFAULT \'0\' NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_catalog_promotion DROP exclusive');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
@@ -19,11 +19,15 @@ final class Version20211125085254 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT DEFAULT 0 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT NOT NULL');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
@@ -19,13 +19,11 @@ final class Version20211125085254 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT DEFAULT 0 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT NOT NULL');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125122631.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125122631.php
@@ -19,11 +19,15 @@ final class Version20211125122631 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_promotion ADD applies_to_discounted TINYINT(1) DEFAULT \'1\' NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
         $this->addSql('ALTER TABLE sylius_promotion DROP applies_to_discounted');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125122631.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125122631.php
@@ -19,13 +19,11 @@ final class Version20211125122631 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_promotion ADD applies_to_discounted TINYINT(1) DEFAULT \'1\' NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_promotion DROP applies_to_discounted');
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Continuation of https://github.com/Sylius/Sylius/pull/13379
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
