### PR TITLE
Drop support for older `gedmo/doctrine-extensions` versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "fakerphp/faker": "^1.9",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "friendsofsymfony/rest-bundle": "^3.0",
-        "gedmo/doctrine-extensions": "^2.4.12 || ^3.0",
+        "gedmo/doctrine-extensions": "^3.2",
         "jms/serializer-bundle": "^3.5",
         "knplabs/gaufrette": "^0.8",
         "knplabs/knp-gaufrette-bundle": "^0.7",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | mentioned in #13372
| License         | MIT

The 2.x branch of `gedmo/doctrine-extensions` is no longer supported and isn't installable on PHP 8.  3.2 is set as the minimum to avoid allowing 3.0 or 3.1 to be installed with incompatible ORM versions.