### PR TITLE
Decorate OpenApi documentation (Api Platform 2.6). Fixes #13384

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -31,10 +31,12 @@ final class SyliusApiExtension extends Extension
 
         $loader->load('services.xml');
 
-        if (!$container->hasParameter('enable_swagger') || !$container->getParameter('enable_swagger')) {
-            return;
+        if ($container->hasParameter('enable_swagger') && $container->getParameter('enable_swagger')) {
+            $loader->load('integrations/swagger.xml');
         }
 
-        $loader->load('integrations/swagger.xml');
+        if (class_exists(\ApiPlatform\Core\OpenApi\OpenApi::class)) {
+            $loader->load('integrations/openapi.xml');
+        }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/OpenApi/AdminAuthenticationTokenDocumentationFactory.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/AdminAuthenticationTokenDocumentationFactory.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\OpenApi;
+
+use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
+use ApiPlatform\Core\OpenApi\Model\Operation;
+use ApiPlatform\Core\OpenApi\Model\PathItem;
+use ApiPlatform\Core\OpenApi\Model\RequestBody;
+use ApiPlatform\Core\OpenApi\OpenApi;
+use Symfony\Component\HttpFoundation\Response;
+
+/** @experimental */
+final class AdminAuthenticationTokenDocumentationFactory implements OpenApiFactoryInterface
+{
+    private OpenApiFactoryInterface $decoratedFactory;
+
+    private string $apiRoute;
+
+    public function __construct(OpenApiFactoryInterface $decoratedFactory, string $apiRoute)
+    {
+        $this->decoratedFactory = $decoratedFactory;
+        $this->apiRoute = $apiRoute;
+    }
+
+    public function __invoke(array $context = []): OpenApi
+    {
+        $openApi = ($this->decoratedFactory)($context);
+
+        $schemas = $openApi->getComponents()->getSchemas();
+
+        $schemas['AdminUserToken'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'token' => [
+                    'type' => 'string',
+                    'readOnly' => true,
+                ],
+            ],
+        ]);
+
+        $schemas['AdminUserCredentials'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'email' => [
+                    'type' => 'string',
+                    'example' => 'api@example.com',
+                ],
+                'password' => [
+                    'type' => 'string',
+                    'example' => 'sylius-api',
+                ],
+            ],
+        ]);
+
+        $tokenDocumentation = new PathItem(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new Operation(
+                'postCredentialsItem',
+                ['AdminUserToken'],
+                [
+                    Response::HTTP_OK => [
+                        'description' => 'Get JWT token',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/AdminUserToken',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'Get JWT token to login.',
+                '',
+                null,
+                [],
+                new RequestBody(
+                    'Create new JWT Token',
+                    new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                '$ref' => '#/components/schemas/AdminUserCredentials',
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
+        );
+
+        $openApi->getPaths()->addPath($this->apiRoute . '/admin/authentication-token', $tokenDocumentation);
+
+        return $openApi;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/OpenApi/ProductDocumentationFactory.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/ProductDocumentationFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\OpenApi;
+
+use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
+use ApiPlatform\Core\OpenApi\OpenApi;
+
+/** @experimental */
+final class ProductDocumentationFactory implements OpenApiFactoryInterface
+{
+    private OpenApiFactoryInterface $decoratedFactory;
+
+    public function __construct(OpenApiFactoryInterface $decoratedFactory)
+    {
+        $this->decoratedFactory = $decoratedFactory;
+    }
+
+    public function __invoke(array $context = []): OpenApi
+    {
+        $openApi = ($this->decoratedFactory)($context);
+
+        $schemas = $openApi->getComponents()->getSchemas();
+
+        $defaultVariantSchema = new \ArrayObject([
+            'type' => 'string',
+            'format' => 'iri-reference',
+            'nullable' => true,
+            'readOnly' => true,
+        ]);
+
+        $schemas['Product.jsonld-admin.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;
+        $schemas['Product.jsonld-shop.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;
+
+        return $openApi;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/OpenApi/ProductVariantDocumentationFactory.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/ProductVariantDocumentationFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\OpenApi;
+
+use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
+use ApiPlatform\Core\OpenApi\OpenApi;
+
+/** @experimental */
+final class ProductVariantDocumentationFactory implements OpenApiFactoryInterface
+{
+    private OpenApiFactoryInterface $decoratedFactory;
+
+    public function __construct(OpenApiFactoryInterface $decoratedFactory)
+    {
+        $this->decoratedFactory = $decoratedFactory;
+    }
+
+    public function __invoke(array $context = []): OpenApi
+    {
+        $openApi = ($this->decoratedFactory)($context);
+
+        $schemas = $openApi->getComponents()->getSchemas();
+
+        $schemas['ProductVariant.jsonld-shop.product_variant.read']['properties']['price'] = new \ArrayObject([
+            'type' => 'int',
+            'readOnly' => true,
+            'default' => 0,
+        ]);
+
+        $schemas['ProductVariant.jsonld-shop.product_variant.read']['properties']['inStock'] = new \ArrayObject([
+            'type' => 'boolean',
+            'readOnly' => true,
+        ]);
+
+        return $openApi;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/OpenApi/ShopAuthenticationTokenDocumentationFactory.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/ShopAuthenticationTokenDocumentationFactory.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\OpenApi;
+
+use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;
+use ApiPlatform\Core\OpenApi\Model\Operation;
+use ApiPlatform\Core\OpenApi\Model\PathItem;
+use ApiPlatform\Core\OpenApi\Model\RequestBody;
+use ApiPlatform\Core\OpenApi\OpenApi;
+use Symfony\Component\HttpFoundation\Response;
+
+/** @experimental */
+final class ShopAuthenticationTokenDocumentationFactory implements OpenApiFactoryInterface
+{
+    private OpenApiFactoryInterface $decoratedFactory;
+
+    private string $apiRoute;
+
+    public function __construct(OpenApiFactoryInterface $decoratedFactory, string $apiRoute)
+    {
+        $this->decoratedFactory = $decoratedFactory;
+        $this->apiRoute = $apiRoute;
+    }
+
+    public function __invoke(array $context = []): OpenApi
+    {
+        $openApi = ($this->decoratedFactory)($context);
+
+        $schemas = $openApi->getComponents()->getSchemas();
+
+        $schemas['ShopUserToken'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'token' => [
+                    'type' => 'string',
+                    'readOnly' => true,
+                ],
+            ],
+        ]);
+
+        $schemas['ShopUserCredentials'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'email' => [
+                    'type' => 'string',
+                    'example' => 'shop@example.com',
+                ],
+                'password' => [
+                    'type' => 'string',
+                    'example' => 'sylius',
+                ],
+            ],
+        ]);
+
+        $tokenDocumentation = new PathItem(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new Operation(
+                'postCredentialsItem',
+                ['ShopUserToken'],
+                [
+                    Response::HTTP_OK => [
+                        'description' => 'Get JWT token',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/ShopUserToken',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'Get JWT token to login.',
+                '',
+                null,
+                [],
+                new RequestBody(
+                    'Create new JWT Token',
+                    new \ArrayObject([
+                        'application/json' => [
+                            'schema' => [
+                                '$ref' => '#/components/schemas/ShopUserCredentials',
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
+        );
+
+        $openApi->getPaths()->addPath($this->apiRoute . '/shop/authentication-token', $tokenDocumentation);
+
+        return $openApi;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/openapi.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/openapi.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <defaults public="true" />
+
+        <service
+            id="sylius.api.openapi_admin_authentication_documentation_factory"
+            class="Sylius\Bundle\ApiBundle\OpenApi\AdminAuthenticationTokenDocumentationFactory"
+            decorates="api_platform.openapi.factory"
+            decoration-on-invalid="ignore"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="sylius.api.openapi_admin_authentication_documentation_factory.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
+        </service>
+
+        <service
+            id="sylius.api.openapi_shop_authentication_documentation_factory"
+            class="Sylius\Bundle\ApiBundle\OpenApi\ShopAuthenticationTokenDocumentationFactory"
+            decorates="api_platform.openapi.factory"
+            decoration-on-invalid="ignore"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="10"
+        >
+            <argument type="service" id="sylius.api.openapi_shop_authentication_documentation_factory.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
+        </service>
+
+        <service
+            id="sylius.api.openapi_product_documentation_factory"
+            class="Sylius\Bundle\ApiBundle\OpenApi\ProductDocumentationFactory"
+            decorates="api_platform.openapi.factory"
+            decoration-on-invalid="ignore"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="sylius.api.openapi_product_documentation_factory.inner" />
+        </service>
+
+        <service
+            id="sylius.api.openapi_product_variant_documentation_factory"
+            class="Sylius\Bundle\ApiBundle\OpenApi\ProductVariantDocumentationFactory"
+            decorates="api_platform.openapi.factory"
+            decoration-on-invalid="ignore"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="sylius.api.openapi_product_variant_documentation_factory.inner" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | not sure
| New feature?    | not sure
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13384
| License         | MIT

I don't think this breaks anything (very reassuring, I know :sunglasses:), since it only adds extra bits to the OpenApi documentation generated by ApiPlatform 2.6 to make it on par with what we have for Api Platform 2.5.

No tests, and I don't think I could add any quickly. Sorry!