### PR TITLE
[Migrations] Remove invalid NOT NULL usage

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20211125085254.php
@@ -21,7 +21,7 @@ final class Version20211125085254 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT DEFAULT 0 NOT NULL');
+        $this->addSql('ALTER TABLE sylius_channel_pricing CHANGE minimum_price minimum_price INT DEFAULT 0');
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
@@ -27,7 +27,7 @@
         </id>
         <field name="price" column="price" type="integer" nullable="true" />
         <field name="originalPrice" column="original_price" type="integer" nullable="true" />
-        <field name="minimumPrice" column="minimum_price" type="integer" nullable="false" >
+        <field name="minimumPrice" column="minimum_price" type="integer" nullable="true">
             <options>
                 <option name="default">0</option>
             </options>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

As far as I see, this `NOT NULL` is not needed at all when the default value is `0`. Additionally, when changing from Sylius 1.10 to `dev-master` (or rather - upcoming 1.11), it results in exception while migrations are applied:

<img width="1433" alt="Zrzut ekranu 2021-12-14 o 13 41 54" src="https://user-images.githubusercontent.com/6212718/146000923-11afffed-7729-4a3e-8000-298716267ed9.png">
