### PR TITLE
[Catalog Promotion] Moved labels to separate twig

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
@@ -96,7 +96,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     public function getProductPromotionLabel(string $productName): ?string
     {
         $element = $this->getElement('product_name', ['%productName%' => $productName]);
-        $promotionLabelElement = $element->getParent()->find('css', '[data-test-product-promotion-label]');
+        $promotionLabelElement = $element->getParent()->find('css', '.sylius_catalog_promotion');
 
         return ($promotionLabelElement !== null) ? $promotionLabelElement->getText() : null;
     }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -139,7 +139,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         $catalogPromotions = [];
 
         /** @var NodeElement $catalogPromotion */
-        foreach ($this->getElement('applied_promotions')->findAll('css', '.promotion_label') as $catalogPromotion) {
+        foreach ($this->getElement('product_price_content')->findAll('css', '.promotion_label') as $catalogPromotion) {
             $catalogPromotions[] = explode(' - ', $catalogPromotion->getText())[0];
         }
 
@@ -148,7 +148,9 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
 
     public function getCatalogPromotionNames(): array
     {
-        $catalogPromotions = $this->getDocument()->findAll('css', '.promotion_label');
+        /** @var NodeElement $productPriceContent */
+        $productPriceContent = $this->getElement('product_price_content');
+        $catalogPromotions = $productPriceContent->findAll('css', '.promotion_label');
 
         return array_map(function (NodeElement $element): string {
             return $element->getText();
@@ -370,6 +372,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'product_name' => '[data-test-product-name]',
             'product_original_price' => '[data-test-product-price-content] [data-test-product-original-price]',
             'product_price' => '[data-test-product-price-content] [data-test-product-price]',
+            'product_price_content' => '[data-test-product-price-content]',
             'quantity' => '[data-test-quantity]',
             'reviews' => '[data-test-product-reviews]',
             'reviews_comment' => '[data-test-comment="%title%"]',

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Box/_content.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Box/_content.html.twig
@@ -19,9 +19,7 @@
             {% set price = money.calculatePrice(product|sylius_resolve_variant) %}
             {% set originalPrice = money.calculateOriginalPrice(product|sylius_resolve_variant) %}
 
-            {% for promotion in appliedPromotions %}
-            <a class="ui blue label" {{ sylius_test_html_attribute('product-promotion-label') }}>{{ promotion.label}}</a>
-            {% endfor %}
+            {% include '@SyliusShop/Product/Show/_catalogPromotionLabels.html.twig' with {'appliedPromotions': appliedPromotions, 'withDescription': false} %}
 
             {% if price != originalPrice %}
             <div class="sylius-product-original-price" {{ sylius_test_html_attribute('product-original-price') }}><del>{{ originalPrice }}</del></div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_catalogPromotionLabels.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_catalogPromotionLabels.html.twig
@@ -1,0 +1,9 @@
+<div id="appliedPromotions" data-applied-promotions-locale="{{ sylius.localeCode }}">
+    {% for appliedPromotion in appliedPromotions %}
+        <div class="ui blue label promotion_label" style="margin: 0.5rem 0;">
+            <div class="row ui small sylius_catalog_promotion">
+                {{ appliedPromotion.label }}{% if appliedPromotion.description and withDescription %} - {{ appliedPromotion.description }}{% endif %}
+            </div>
+        </div>
+    {% endfor %}
+</div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
@@ -2,8 +2,7 @@
 
 {% set variant = product|sylius_resolve_variant %}
 {% set hasDiscount = variant|sylius_has_discount({'channel': sylius.channel}) %}
-{% set channelPricing = variant.getChannelPricingForChannel(sylius.channel) %}
-{% set promotion = null %}
+{% set appliedPromotions = variant.getChannelPricingForChannel(sylius.channel).getAppliedPromotions() %}
 
 <span class="ui small header" id="product-original-price"{% if not hasDiscount %} style="display: none;"{% endif %} {{ sylius_test_html_attribute('product-original-price', money.calculateOriginalPrice(variant)) }}>
     {% if hasDiscount %}
@@ -11,15 +10,7 @@
     {% endif %}
 </span>
 
-<div id="appliedPromotions" data-applied-promotions-locale="{{ sylius.localeCode }}">
-    {% for appliedPromotion in channelPricing.appliedPromotions %}
-    <div class="ui blue label promotion_label" style="margin: 1rem 0;">
-        <div class="row ui small sylius_catalog_promotion">
-            {{ appliedPromotion.label }}{% if appliedPromotion.description %} - {{ appliedPromotion.description }}{% endif %}
-        </div>
-    </div>
-    {% endfor %}
-</div>
+{% include '@SyliusShop/Product/Show/_catalogPromotionLabels.html.twig' with {'appliedPromotions': appliedPromotions, 'withDescription': true} %}
 
 <span class="ui huge header" id="product-price" {{ sylius_test_html_attribute('product-price', money.calculatePrice(variant)) }}>
     {{ money.calculatePrice(variant) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/
| Related tickets | #13386 - this doc will be modified after this merge
| License         | MIT

to make customization easier we want to move catalog promotion labels to separate file
<!--
 - Bug fixes must be submitted against the 1.10 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
