### PR TITLE
[Products] move channel pricing to separate tab

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Menu/ProductFormMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/ProductFormMenuBuilder.php
@@ -78,6 +78,12 @@ final class ProductFormMenuBuilder
                 ->setAttribute('template', '@SyliusAdmin/Product/Tab/_inventory.html.twig')
                 ->setLabel('sylius.ui.inventory')
             ;
+
+            $menu
+                ->addChild('channel_pricings')
+                ->setAttribute('template', '@SyliusAdmin/Product/Tab/_channelPricings.html.twig')
+                ->setLabel('sylius.ui.channel_pricings')
+            ;
         }
 
         $this->eventDispatcher->dispatch(

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_channelPricings.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_channelPricings.html.twig
@@ -1,0 +1,29 @@
+<div class="ui tab" data-tab="channel_pricings">
+    <h3 class="ui dividing header">{{ 'sylius.ui.channel_pricings'|trans }}</h3>
+    <div class="ui info message">
+        {{ 'sylius.ui.price_details'|trans }}
+        <br/>
+        {{ 'sylius.ui.original_price_details'|trans }}
+        <br/>
+        {{ 'sylius.ui.minimum_price_details'|trans }}
+    </div>
+    <div id="sylius_product_variant_channelPricings">
+        {{ form_errors(form.variant.channelPricings) }}
+        {% for channelCode, channelPricing in form.variant.channelPricings %}
+            <div class="ui segment">
+                <div>
+                    <strong>{{ channelPricing.vars.label }}</strong>
+                </div>
+                {% if channelCode not in product.channels|map(channel => channel.code) %}
+                    <div class="ui info message">
+                        {{ 'sylius.ui.product.product_not_active_in_channel'|trans }}
+                    </div>
+                {% endif %}
+                {{ form_row(channelPricing.price) }}
+                {{ form_row(channelPricing.originalPrice) }}
+                {{ form_row(channelPricing.minimumPrice) }}
+            </div>
+        {% endfor %}
+    </div>
+    {{ sylius_template_event(['sylius.admin.product_variant.' ~ action ~ '.tab_channel_pricings', 'sylius.admin.product_variant.channelPricings'], {'form': form}) }}
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -31,14 +31,6 @@
                 {{ form_row(form.channels) }}
             </div>
         </div>
-        {% if product.simple %}
-            <div class="ui one column stackable grid">
-                <div class="column">
-                    <h4 class="ui dividing header">{{ 'sylius.ui.pricing'|trans }}</h4>
-                    {% include "@SyliusAdmin/Product/_channel_pricing.html.twig" with { product: product, variantForm: form.variant } only %}
-                </div>
-            </div>
-        {% endif %}
         <div class="ui hidden divider"></div>
         {{ translationFormWithSlug(form.translations, '@SyliusAdmin/Product/_slugField.html.twig', product) }}
         {% if product.simple %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| License         | MIT

now when we display more info about prices it should be in a 
<img width="1358" alt="Screenshot 2021-12-14 at 15 01 28" src="https://user-images.githubusercontent.com/29897151/146013600-f93f17f1-cac4-4e50-ae9c-5c914fc4c3ec.png">
separate tab (similar to variant page)
<!--
 - Bug fixes must be submitted against the 1.10 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
