### PR TITLE
Use loadUserByIdentifier() since Symfony 5.3

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
+++ b/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
@@ -58,6 +58,11 @@ abstract class AbstractUserProvider implements UserProviderInterface
         return $user;
     }
 
+    public function loadUserByIdentifier(string $identifier): UserInterface
+    {
+        return $this->loadUserByUsername($identifier);
+    }
+
     public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof SyliusUserInterface) {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


Since Symfony 5.3, UserProviderInterface in Symfony suggest to use loadUserByIdentifier to replace loadUserByUsername

https://github.com/symfony/symfony/blob/1e968b49f516d8b1305d0b94158dabef557d334e/src/Symfony/Component/Security/Core/User/UserProviderInterface.php#L61-L68
