### PR TITLE
[Documentation][CatalogPromotion] Add cookbook about creating a custom action + minor improvements

### DIFF
--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -74,6 +74,7 @@ Promotions
     promotions/custom-cart-promotion-rule
     promotions/custom-cart-promotion-action
     promotions/custom-catalog-promotion-scope
+    promotions/custom-catalog-promotion-action
 
 .. include:: /cookbook/promotions/map.rst.inc
 

--- a/docs/cookbook/promotions/custom-catalog-promotion-action.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-action.rst
@@ -1,7 +1,7 @@
 How to add a custom catalog promotion action?
 =============================================
 
-Adding a new, custom catalog promotion action to your shop should become a quite helpful extension to your own Catalog Promotions.
+Adding a new, custom catalog promotion action to your shop may become a quite helpful extension to your own Catalog Promotions.
 You can create your own calculator tailored to your product catalog to attract as many people as possible.
 
 Let's try to implement the new **Catalog Promotion Action** in this cookbook that will lower the price of the product
@@ -32,7 +32,7 @@ The new action needs to be declared somewhere, the first step would be to extend
         public const TYPE_FIXED_PRICE = 'fixed_price';
     }
 
-Now let's declare the parameter with action types, with added our additional custom action as the last one:
+Now let's declare the parameter with action types, with our additional custom action added as the last one:
 
 .. code-block:: yaml
 
@@ -106,11 +106,11 @@ And the code for the calculator itself:
         }
     }
 
-Now the catalog promotion should work with your new action for programmatically and API created resources.
-Let's now prepare a custom validator for a created action.
+Now the catalog promotion should work with your new action for resources created both programmatically and via API.
+Let's now prepare a custom validator for the newly created action.
 
-Prepare a custom validator for a new action
--------------------------------------------
+Prepare a custom validator for the new action
+---------------------------------------------
 
 We can start with configuration, declare our basic validator for this particular action:
 
@@ -124,7 +124,7 @@ We can start with configuration, declare our basic validator for this particular
         tags:
             - { name: 'sylius.catalog_promotion.action_validator', key: 'fixed_price' }
 
-In this validator we will check the provided configuration if necessary data is provided and the configured channels exist.
+In this validator, we will check the provided configuration for necessary data and if the configured channels exist.
 
 .. code-block:: php
 
@@ -177,14 +177,14 @@ In this validator we will check the provided configuration if necessary data is 
         }
     }
 
-Alright we have a working basic validation, and our new type of action exists and can be created, and edited
-programmatically or by API. Let's now prepare a UI part of this new feature.
+Alright, we have a working basic validation, and our new type of action exists, can be created, and edited
+programmatically or by API. Let's now prepare the UI part of this new feature.
 
-Prepare a configuration form type for a new action
---------------------------------------------------
+Prepare a configuration form type for the new action
+----------------------------------------------------
 
 To be able to configure a catalog promotion with your new action you will need a form type for the admin panel.
-And with current implementation, as our action is channel based, you need to create 2 form types as below:
+And with the current implementation, as our action is channel-based, you need to create 2 form types as below:
 
 .. code-block:: yaml
 
@@ -307,7 +307,7 @@ The last thing is to create a template to display our new action properly. Remem
         </tbody>
     </table>
 
-That's all. You will now should be able to choose the new action while creating or editing a catalog promotion.
+That's all. You will now be able to choose the new action while creating or editing a catalog promotion.
 
 Learn more
 ----------

--- a/docs/cookbook/promotions/custom-catalog-promotion-action.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-action.rst
@@ -1,0 +1,316 @@
+How to add a custom catalog promotion action?
+=============================================
+
+Adding a new, custom catalog promotion action to your shop should become a quite helpful extension to your own Catalog Promotions.
+You can create your own calculator tailored to your product catalog to attract as many people as possible.
+
+Let's try to implement the new **Catalog Promotion Action** in this cookbook that will lower the price of the product
+or product variant to a specific value.
+
+.. note::
+
+    If you are familiar with **Cart Promotions** and you know how **Cart Promotion Actions** work,
+    then the Catalog Promotion Action should look familiar, as the concept of them is quite similar.
+
+Create a new catalog promotion action
+-------------------------------------
+
+The new action needs to be declared somewhere, the first step would be to extend the base interface:
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Model;
+
+    use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface as BaseCatalogPromotionActionInterface;
+
+    interface CatalogPromotionActionInterface extends BaseCatalogPromotionActionInterface
+    {
+        public const TYPE_FIXED_PRICE = 'fixed_price';
+    }
+
+Now let's declare the parameter with action types, with added our additional custom action as the last one:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+
+    parameters:
+        sylius.catalog_promotion.actions:
+            - !php/const Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT
+            - !php/const Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT
+            - !php/const App\Model\CatalogPromotionActionInterface::TYPE_FIXED_PRICE
+
+We should now create a calculator that will return a proper price for given channel pricing. We can start with configuration:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+
+     App\Calculator\FixedPriceCalculator:
+        tags:
+            - { name: 'sylius.catalog_promotion.price_calculator' }
+
+.. note::
+
+    Please take a note on a declared tag of calculator, it is necessary for this service to be taken into account.
+
+And the code for the calculator itself:
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Calculator;
+
+    use App\Model\CatalogPromotionActionInterface;
+    use Sylius\Bundle\CoreBundle\Calculator\ActionBasedPriceCalculatorInterface;
+    use Sylius\Component\Core\Model\ChannelPricingInterface;
+    use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface as BaseCatalogPromotionActionInterface;
+
+    final class FixedPriceCalculator implements ActionBasedPriceCalculatorInterface
+    {
+        public function supports(BaseCatalogPromotionActionInterface $action): bool
+        {
+            return $action->getType() === CatalogPromotionActionInterface::TYPE_FIXED_PRICE;
+        }
+
+        public function calculate(ChannelPricingInterface $channelPricing, BaseCatalogPromotionActionInterface $action): int
+        {
+            if (!isset($action->getConfiguration()[$channelPricing->getChannelCode()])) {
+                return $channelPricing->getPrice();
+            }
+
+            $price = $action->getConfiguration()[$channelPricing->getChannelCode()]['price'];
+
+            $minimumPrice = $this->provideMinimumPrice($channelPricing);
+            if ($price < $minimumPrice) {
+                return $minimumPrice;
+            }
+
+            return $price;
+        }
+
+        private function provideMinimumPrice(ChannelPricingInterface $channelPricing): int
+        {
+            if ($channelPricing->getMinimumPrice() <= 0) {
+                return 0;
+            }
+
+            return $channelPricing->getMinimumPrice();
+        }
+    }
+
+Now the catalog promotion should work with your new action for programmatically and API created resources.
+Let's now prepare a custom validator for a created action.
+
+Prepare a custom validator for a new action
+-------------------------------------------
+
+We can start with configuration, declare our basic validator for this particular action:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+
+    App\Validator\CatalogPromotionAction\FixedPriceActionValidator:
+        arguments:
+            - '@sylius.repository.channel'
+        tags:
+            - { name: 'sylius.catalog_promotion.action_validator', key: 'fixed_price' }
+
+In this validator we will check the provided configuration if necessary data is provided and the configured channels exist.
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Validator\CatalogPromotionAction;
+
+    use Sylius\Bundle\PromotionBundle\Validator\CatalogPromotionAction\ActionValidatorInterface;
+    use Sylius\Bundle\PromotionBundle\Validator\Constraints\CatalogPromotionAction;
+    use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+    use Symfony\Component\Validator\Constraint;
+    use Symfony\Component\Validator\Context\ExecutionContextInterface;
+    use Webmozart\Assert\Assert;
+
+    final class FixedPriceActionValidator implements ActionValidatorInterface
+    {
+        private ChannelRepositoryInterface $channelRepository;
+
+        public function __construct(ChannelRepositoryInterface $channelRepository)
+        {
+            $this->channelRepository = $channelRepository;
+        }
+
+        public function validate(array $configuration, Constraint $constraint, ExecutionContextInterface $context): void
+        {
+            /** @var CatalogPromotionAction $constraint */
+            Assert::isInstanceOf($constraint, CatalogPromotionAction::class);
+
+            if (empty($configuration)) {
+                $context->buildViolation('There is no configuration provided.')->atPath('configuration')->addViolation();
+
+                return;
+            }
+
+            foreach ($configuration as $channelCode => $channelConfiguration) {
+                if (null === $this->channelRepository->findOneBy(['code' => $channelCode])) {
+                    $context->buildViolation('The provided channel is not valid.')->atPath('configuration')->addViolation();
+
+                    return;
+                }
+
+                if (!array_key_exists('price', $channelConfiguration) || !is_integer($channelConfiguration['price']) || $channelConfiguration['price'] < 0) {
+                    $context->buildViolation('The provided configuration for channel is not valid.')->atPath('configuration')->addViolation();
+
+                    return;
+                }
+            }
+        }
+    }
+
+Alright we have a working basic validation, and our new type of action exists and can be created, and edited
+programmatically or by API. Let's now prepare a UI part of this new feature.
+
+Prepare a configuration form type for a new action
+--------------------------------------------------
+
+To be able to configure a catalog promotion with your new action you will need a form type for the admin panel.
+And with current implementation, as our action is channel based, you need to create 2 form types as below:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+
+    App\Form\Type\CatalogPromotionAction\ChannelBasedFixedPriceActionConfigurationType:
+        tags:
+            - { name: 'sylius.catalog_promotion.action_configuration_type', key: 'fixed_price' }
+            - { name: 'form.type' }
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Form\Type\CatalogPromotionAction;
+
+    use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+
+    final class FixedPriceActionConfigurationType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder
+                ->add('price', MoneyType::class, [
+                    'label' => 'Price',
+                    'currency' => $options['currency'],
+                ])
+            ;
+        }
+
+        public function configureOptions(OptionsResolver $resolver): void
+        {
+            $resolver
+                ->setRequired('currency')
+                ->setAllowedTypes('currency', 'string')
+            ;
+        }
+
+        public function getBlockPrefix(): string
+        {
+            return 'app_catalog_promotion_action_fixed_price_configuration';
+        }
+    }
+
+.. code-block:: php
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Form\Type\CatalogPromotionAction;
+
+    use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+    use Sylius\Component\Core\Model\ChannelInterface;
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\OptionsResolver\OptionsResolver;
+
+    final class ChannelBasedFixedPriceActionConfigurationType extends AbstractType
+    {
+        public function configureOptions(OptionsResolver $resolver): void
+        {
+            $resolver->setDefaults([
+                'entry_type' => FixedPriceActionConfigurationType::class,
+                'entry_options' => function (ChannelInterface $channel) {
+                    return [
+                        'label' => $channel->getName(),
+                        'currency' => $channel->getBaseCurrency()->getCode(),
+                    ];
+                },
+            ]);
+        }
+
+        public function getParent(): string
+        {
+            return ChannelCollectionType::class;
+        }
+    }
+
+And define the translation for our new action type:
+
+.. code-block:: yaml
+
+    # translations/messages.en.yaml
+
+    sylius:
+        form:
+            catalog_promotion:
+                action:
+                    fixed_price: 'Fixed price'
+
+Prepare an action template for show page of catalog promotion
+-------------------------------------------------------------
+
+The last thing is to create a template to display our new action properly. Remember to name it the same as the action type.
+
+.. code-block:: html+twig
+
+    {# templates/bundles/SyliusAdminBundle/CatalogPromotion/Show/Action/fixed_price.html.twig #}
+
+    {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
+
+    <table class="ui very basic celled table">
+        <tbody>
+        <tr>
+            <td class="five wide"><strong class="gray text">Type</strong></td>
+            <td>Fixed price</td>
+        </tr>
+        {% set currencies = sylius_channels_currencies() %}
+        {% for channelCode, channelConfiguration in action.configuration %}
+            <tr>
+                <td class="five wide"><strong class="gray text">{{ channelCode }}</strong></td>
+                <td>{{ money.format(channelConfiguration.price, currencies[channelCode]) }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+
+That's all. You will now should be able to choose the new action while creating or editing a catalog promotion.
+
+Learn more
+----------
+
+* :doc:`Customization Guide </customization/index>`
+* :doc:`Catalog Promotion Concept Book </book/products/catalog_promotions>`

--- a/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
@@ -1,7 +1,7 @@
 How to add a custom catalog promotion scope?
 ============================================
 
-Adding a new, custom catalog promotion scope to your shop should become a quite helpful extension to your own Catalog Promotions.
+Adding a new, custom catalog promotion scope to your shop may become a quite helpful extension to your own Catalog Promotions.
 You can imagine for instance, that you have some custom way of aggregating products, or any other method of filtering them.
 These products that will fulfill your specific scope will become eligible for actions of Catalog Promotion, and as we know
 cheaper Products attract more customers.
@@ -30,7 +30,7 @@ The new Scope needs to be declared somewhere, it would be nice to extend the cur
         public const TYPE_BY_PHRASE = 'by_phrase';
     }
 
-Now let's declare the parameter with scope types, with added our additional custom scope as the last one:
+Now let's declare the parameter with scope types, with our additional custom scope added as the last one:
 
 .. code-block:: yaml
 
@@ -102,8 +102,8 @@ And the code for the provider itself:
 
 Now the Catalog Promotion should work with your new Scope for programmatically and API created resource.
 
-Prepare a custom validator for a new scope
-------------------------------------------
+Prepare a custom validator for the new scope
+--------------------------------------------
 
 We can start with configuration, declare our basic validator for this particular scope:
 
@@ -143,8 +143,8 @@ keys to check as well as their corresponding values.
         }
     }
 
-Alright we have a working basic validation, and our new type of scope exists and can be created, and edited
-programmatically or by API. Let's now prepare a UI part of this new feature.
+Alright, we have a working basic validation, and our new type of scope exists, can be created, and edited
+programmatically or by API. Let's now prepare the UI part of this new feature.
 
 Prepare a configuration form type for your new scope
 ----------------------------------------------------
@@ -238,7 +238,7 @@ The last thing is to create a template to display our new scope properly. Rememb
     </table>
 
 
-That's all. You will now should be able to choose the new scope while creating or editing a catalog promotion.
+That's all. You will now be able to choose the new scope while creating or editing a catalog promotion.
 
 Learn more
 ----------

--- a/docs/cookbook/promotions/map.rst.inc
+++ b/docs/cookbook/promotions/map.rst.inc
@@ -1,3 +1,4 @@
-* :doc:`/cookbook/promotions/custom-cart-promotion-action`
 * :doc:`/cookbook/promotions/custom-cart-promotion-rule`
+* :doc:`/cookbook/promotions/custom-cart-promotion-action`
 * :doc:`/cookbook/promotions/custom-catalog-promotion-scope`
+* :doc:`/cookbook/promotions/custom-catalog-promotion-action`

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
@@ -12,6 +12,14 @@
 -->
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.catalog_promotion.scopes" type="collection">
+            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS</parameter>
+            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_TAXONS</parameter>
+            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS</parameter>
+        </parameter>
+    </parameters>
+
     <services>
         <defaults public="true" />
 
@@ -65,11 +73,7 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Validator\Constraints\CatalogPromotionScopeValidator">
-            <argument type="collection">
-                <argument type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS</argument>
-                <argument type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_TAXONS</argument>
-                <argument type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS</argument>
-            </argument>
+            <argument>%sylius.catalog_promotion.scopes%</argument>
             <argument type="tagged_iterator" tag="sylius.catalog_promotion.scope_validator" index-by="key" />
             <tag name="validator.constraint_validator" alias="sylius_catalog_promotion_scope" />
         </service>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
@@ -12,6 +12,13 @@
 -->
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.catalog_promotion.actions" type="collection">
+            <parameter type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT</parameter>
+            <parameter type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT</parameter>
+        </parameter>
+    </parameters>
+
     <services>
         <defaults public="true" />
 
@@ -34,10 +41,7 @@
         </service>
 
         <service id="Sylius\Bundle\PromotionBundle\Validator\CatalogPromotionActionValidator">
-            <argument type="collection">
-                <argument type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT</argument>
-                <argument type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT</argument>
-            </argument>
+            <argument>%sylius.catalog_promotion.actions%</argument>
             <argument type="tagged_iterator" tag="sylius.catalog_promotion.action_validator" index-by="key" />
             <tag name="validator.constraint_validator" alias="sylius_catalog_promotion_action" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially fixes #https://github.com/Sylius/Sylius/pull/13325#discussion_r756750238
| License         | MIT

This PR contains a minor refactor of parameters with types of actions/scopes passed to validators.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
