### PR TITLE
[RFC][CatalogPromotion] Refactor actions and scopes to dynamically set parameters with types without obligatory getType method

### DIFF
--- a/docs/cookbook/promotions/custom-catalog-promotion-action.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-action.rst
@@ -23,7 +23,7 @@ We should start from creating a calculator that will return a proper price for g
 
      App\Calculator\FixedPriceCalculator:
         tags:
-            - { name: 'sylius.catalog_promotion.price_calculator' }
+            - { name: 'sylius.catalog_promotion.price_calculator', type: 'fixed_price' }
 
 .. note::
 
@@ -47,11 +47,6 @@ And the code for the calculator itself:
     final class FixedPriceCalculator implements ActionBasedPriceCalculatorInterface
     {
         public const TYPE = 'fixed_price';
-
-        public static function getType(): string
-        {
-            return self::TYPE;
-        }
 
         public function supports(BaseCatalogPromotionActionInterface $action): bool
         {

--- a/docs/cookbook/promotions/custom-catalog-promotion-action.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-action.rst
@@ -15,36 +15,7 @@ or product variant to a specific value.
 Create a new catalog promotion action
 -------------------------------------
 
-The new action needs to be declared somewhere, the first step would be to extend the base interface:
-
-.. code-block:: php
-
-    <?php
-
-    declare(strict_types=1);
-
-    namespace App\Model;
-
-    use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface as BaseCatalogPromotionActionInterface;
-
-    interface CatalogPromotionActionInterface extends BaseCatalogPromotionActionInterface
-    {
-        public const TYPE_FIXED_PRICE = 'fixed_price';
-    }
-
-Now let's declare the parameter with action types, with our additional custom action added as the last one:
-
-.. code-block:: yaml
-
-    # config/services.yaml
-
-    parameters:
-        sylius.catalog_promotion.actions:
-            - !php/const Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT
-            - !php/const Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT
-            - !php/const App\Model\CatalogPromotionActionInterface::TYPE_FIXED_PRICE
-
-We should now create a calculator that will return a proper price for given channel pricing. We can start with configuration:
+We should start from creating a calculator that will return a proper price for given channel pricing. Let's declare the service:
 
 .. code-block:: yaml
 
@@ -75,9 +46,16 @@ And the code for the calculator itself:
 
     final class FixedPriceCalculator implements ActionBasedPriceCalculatorInterface
     {
+        public const TYPE = 'fixed_price';
+
+        public static function getType(): string
+        {
+            return self::TYPE;
+        }
+
         public function supports(BaseCatalogPromotionActionInterface $action): bool
         {
-            return $action->getType() === CatalogPromotionActionInterface::TYPE_FIXED_PRICE;
+            return $action->getType() === self::TYPE;
         }
 
         public function calculate(ChannelPricingInterface $channelPricing, BaseCatalogPromotionActionInterface $action): int

--- a/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
@@ -25,7 +25,7 @@ We should start from creating a provider that will return for us all of eligible
         arguments:
             - '@sylius.repository.product_variant'
         tags:
-            - { name: 'sylius.catalog_promotion.variants_provider' }
+            - { name: 'sylius.catalog_promotion.variants_provider', type: 'by_phrase' }
 
 .. note::
 
@@ -53,11 +53,6 @@ And the code for the provider itself:
         public function __construct(ProductVariantRepositoryInterface $productVariantRepository)
         {
             $this->productVariantRepository = $productVariantRepository;
-        }
-
-        public static function getType(): string
-        {
-            return self::TYPE;
         }
 
         public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool

--- a/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
+++ b/docs/cookbook/promotions/custom-catalog-promotion-scope.rst
@@ -70,7 +70,7 @@ And the code for the provider itself:
     use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
     use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
     use Webmozart\Assert\Assert;
-    use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+    use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
     class ByPhraseVariantsProvider implements VariantsProviderInterface
     {

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -587,7 +587,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $content = $this->client->getContent();
 
         $content['actions'] = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => [$channel->getCode() => ['amount' => $amount]],
         ]];
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -20,9 +20,12 @@ use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -252,7 +255,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $scopes = $this->client->getContent()['scopes'];
 
         $additionalScope = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+            'type' => ForVariantsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'variants' => [$productVariant->getCode()],
             ],
@@ -348,7 +351,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddScopeThatAppliesOnVariants(ProductVariantInterface $firstVariant, ProductVariantInterface $secondVariant): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+            'type' => ForVariantsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'variants' => [
                     $firstVariant->getCode(),
@@ -366,7 +369,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddCatalogPromotionScopeForTaxonWithoutTaxons(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+            'type' => ForTaxonsScopeVariantsProvider::TYPE,
             'configuration' => ['taxons' => []],
         ]];
 
@@ -379,7 +382,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddCatalogPromotionScopeForTaxonWithNonexistentTaxons(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+            'type' => ForTaxonsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'taxons' => [
                     'BAD_TAXON',
@@ -397,7 +400,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddCatalogPromotionScopeForProductWithoutProducts(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+            'type' => ForProductsScopeVariantsProvider::TYPE,
             'configuration' => ['products' => []],
         ]];
 
@@ -410,7 +413,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddCatalogPromotionScopeForProductsWithNonexistentProducts(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+            'type' => ForProductsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'products' => [
                     'BAD_PRODUCT',
@@ -428,7 +431,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddScopeThatAppliesOnTaxon(TaxonInterface $taxon): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+            'type' => ForTaxonsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'taxons' => [$taxon->getCode()]
             ],
@@ -443,7 +446,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddScopeThatAppliesOnProduct(ProductInterface $product): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+            'type' => ForProductsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'products' => [$product->getCode()]
             ],
@@ -471,7 +474,7 @@ final class ManagingCatalogPromotionsContext implements Context
     ): void {
         $this->client->buildUpdateRequest($catalogPromotion->getCode());
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+            'type' => ForVariantsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'variants' => [
                     $productVariant->getCode(),
@@ -494,7 +497,7 @@ final class ManagingCatalogPromotionsContext implements Context
 
         $content = $this->client->getContent();
         unset($content['scopes'][0]['configuration']['variants']);
-        $content['scopes'][0]['type'] = CatalogPromotionScopeInterface::TYPE_FOR_TAXONS;
+        $content['scopes'][0]['type'] = ForTaxonsScopeVariantsProvider::TYPE;
         $content['scopes'][0]['configuration']['taxons'] = [$taxon->getCode()];
 
         $this->client->setRequestData($content);;
@@ -513,7 +516,7 @@ final class ManagingCatalogPromotionsContext implements Context
 
         $content = $this->client->getContent();
         unset($content['scopes'][0]['configuration']['variants']);
-        $content['scopes'][0]['type'] = CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS;
+        $content['scopes'][0]['type'] = ForProductsScopeVariantsProvider::TYPE;
         $content['scopes'][0]['configuration']['products'] = [$product->getCode()];
 
         $this->client->setRequestData($content);;
@@ -612,7 +615,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddForVariantsScopeWithTheWrongConfiguration(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+            'type' => ForVariantsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'variants' => ['wrong_code'],
             ],
@@ -627,7 +630,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddForVariantsScopeWithoutVariantsConfigured(): void
     {
         $scopes = [[
-            'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+            'type' => ForVariantsScopeVariantsProvider::TYPE,
             'configuration' => [
                 'variants' => [],
             ],

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -18,6 +18,8 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
@@ -197,7 +199,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddActionThatGivesPercentageDiscount(float $amount): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+            'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [
                 'amount' => $amount
             ],
@@ -212,7 +214,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddActionThatGivesFixedDiscount(int $amount, ChannelInterface $channel): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => [
                 $channel->getCode() => [
                     'amount' => $amount
@@ -231,7 +233,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $actions = $this->client->getContent()['actions'];
 
         $additionalAction = [[
-            'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+            'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [
                 'amount' => $amount
             ],
@@ -287,7 +289,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddInvalidPercentageDiscountActionWithNonNumberInAmount(): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+            'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [
                 'amount' => 'text'
             ],
@@ -542,7 +544,7 @@ final class ManagingCatalogPromotionsContext implements Context
     {
         $this->client->buildUpdateRequest($catalogPromotion->getCode());
         $scopes = [[
-            'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+            'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [
                 'amount' => $amount,
             ],
@@ -564,7 +566,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $content = $this->client->getContent();
 
         $content['actions'] = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => [$channel->getCode() => ['amount' => $amount]],
         ]];
 
@@ -640,7 +642,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddPercentageDiscountActionWithoutAmountConfigured(): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+            'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [],
         ]];
 
@@ -653,7 +655,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddFixedDiscountActionWithoutAmountConfigured(): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => ['channel' => ['amount' => null]],
         ]];
 
@@ -667,7 +669,7 @@ final class ManagingCatalogPromotionsContext implements Context
         ChannelInterface $channel
     ): void {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => [$channel->getCode() => ['amount' => 'wrong value']],
         ]];
 
@@ -680,7 +682,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddInvalidFixedDiscountActionConfiguredForNonexistentChannel(): void
     {
         $actions = [[
-            'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            'type' => FixedDiscountPriceCalculator::TYPE,
             'configuration' => ['nonexistent_action' => ['amount' => 1000]],
         ]];
 
@@ -820,7 +822,7 @@ final class ManagingCatalogPromotionsContext implements Context
 
         foreach ($catalogPromotionActions as $catalogPromotionAction) {
             if (
-                $catalogPromotionAction['type'] === CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT &&
+                $catalogPromotionAction['type'] === FixedDiscountPriceCalculator::TYPE &&
                 $catalogPromotionAction['configuration'][$channel->getCode()]['amount'] === $amount
             ) {
                 return;
@@ -829,7 +831,7 @@ final class ManagingCatalogPromotionsContext implements Context
 
         throw new \Exception(sprintf(
             'There is no "%s" action with %d for "%s" channel',
-            CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+            FixedDiscountPriceCalculator::TYPE,
             $amount,
             $channel->getName()
         ));
@@ -845,13 +847,13 @@ final class ManagingCatalogPromotionsContext implements Context
         foreach ($catalogPromotionActions as $catalogPromotionAction) {
             if (
                 $catalogPromotionAction['configuration']['amount'] === $amount &&
-                $catalogPromotionAction['type'] === CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT
+                $catalogPromotionAction['type'] === PercentageDiscountPriceCalculator::TYPE
             ) {
                 return;
             }
         }
 
-        throw new \Exception(sprintf('There is no "%s" action with %f', CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT, $amount));
+        throw new \Exception(sprintf('There is no "%s" action with %f', PercentageDiscountPriceCalculator::TYPE, $amount));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -192,7 +192,7 @@ final class CatalogPromotionContext implements Context
     ): void {
         /** @var CatalogPromotionActionInterface $catalogPromotionAction */
         $catalogPromotionAction = $this->catalogPromotionActionFactory->createNew();
-        $catalogPromotionAction->setType(CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT);
+        $catalogPromotionAction->setType(FixedDiscountPriceCalculator::TYPE);
         $catalogPromotionAction->setConfiguration([$channel->getCode() => ['amount' => $discount]]);
 
         $catalogPromotion->addAction($catalogPromotionAction);

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -20,10 +20,13 @@ use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -139,7 +142,7 @@ final class CatalogPromotionContext implements Context
     {
         /** @var CatalogPromotionScopeInterface $catalogPromotionScope */
         $catalogPromotionScope = $this->catalogPromotionScopeFactory->createNew();
-        $catalogPromotionScope->setType(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $catalogPromotionScope->setType(ForVariantsScopeVariantsProvider::TYPE);
         $catalogPromotionScope->setConfiguration(['variants' => [$variant->getCode()]]);
 
         $catalogPromotion->addScope($catalogPromotionScope);
@@ -154,7 +157,7 @@ final class CatalogPromotionContext implements Context
     {
         /** @var CatalogPromotionScopeInterface $catalogPromotionScope */
         $catalogPromotionScope = $this->catalogPromotionScopeFactory->createNew();
-        $catalogPromotionScope->setType(CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS);
+        $catalogPromotionScope->setType(ForProductsScopeVariantsProvider::TYPE);
         $catalogPromotionScope->setConfiguration(['products' => [$product->getCode()]]);
 
         $catalogPromotion->addScope($catalogPromotionScope);
@@ -216,7 +219,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => $variantCodes],
             ]],
             [[
@@ -242,7 +245,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -268,7 +271,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                'type' => ForProductsScopeVariantsProvider::TYPE,
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
@@ -294,7 +297,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                'type' => ForTaxonsScopeVariantsProvider::TYPE,
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[
@@ -333,7 +336,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                'type' => ForTaxonsScopeVariantsProvider::TYPE,
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[
@@ -359,7 +362,7 @@ final class CatalogPromotionContext implements Context
             null,
             [$channel->getCode()],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -389,7 +392,7 @@ final class CatalogPromotionContext implements Context
                 $secondChannel->getCode()
             ],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -415,7 +418,7 @@ final class CatalogPromotionContext implements Context
             null,
             [$channel->getCode()],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -440,7 +443,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                'type' => ForProductsScopeVariantsProvider::TYPE,
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
@@ -466,7 +469,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -495,7 +498,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                'type' => ForVariantsScopeVariantsProvider::TYPE,
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
@@ -526,7 +529,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                'type' => ForProductsScopeVariantsProvider::TYPE,
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
@@ -556,7 +559,7 @@ final class CatalogPromotionContext implements Context
             null,
             [],
             [[
-                'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                'type' => ForTaxonsScopeVariantsProvider::TYPE,
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -17,6 +17,8 @@ use Behat\Behat\Context\Context;
 use Doctrine\ORM\EntityManagerInterface;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -169,7 +171,7 @@ final class CatalogPromotionContext implements Context
     {
         /** @var CatalogPromotionActionInterface $catalogPromotionAction */
         $catalogPromotionAction = $this->catalogPromotionActionFactory->createNew();
-        $catalogPromotionAction->setType(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
+        $catalogPromotionAction->setType(PercentageDiscountPriceCalculator::TYPE);
         $catalogPromotionAction->setConfiguration(['amount' => $discount]);
 
         $catalogPromotion->addAction($catalogPromotionAction);
@@ -218,7 +220,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => $variantCodes],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -244,7 +246,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                'type' => FixedDiscountPriceCalculator::TYPE,
                 'configuration' => [$channel->getCode() => ['amount' => $discount]],
             ]]
         );
@@ -270,7 +272,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                'type' => FixedDiscountPriceCalculator::TYPE,
                 'configuration' => [$channel->getCode() => ['amount' => $discount]],
             ]]
         );
@@ -296,7 +298,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                'type' => FixedDiscountPriceCalculator::TYPE,
                 'configuration' => [$channel->getCode() => ['amount' => $discount]],
             ]]
         );
@@ -335,7 +337,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -361,7 +363,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -391,7 +393,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -417,7 +419,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -442,7 +444,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]]
         );
@@ -468,7 +470,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]],
             $priority
@@ -497,7 +499,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['variants' => [$variant->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                'type' => PercentageDiscountPriceCalculator::TYPE,
                 'configuration' => ['amount' => $discount],
             ]],
             $priority,
@@ -528,7 +530,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['products' => [$product->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                'type' => FixedDiscountPriceCalculator::TYPE,
                 'configuration' => [$channel->getCode() => ['amount' => $discount]],
             ]],
             $priority
@@ -558,7 +560,7 @@ final class CatalogPromotionContext implements Context
                 'configuration' => ['taxons' => [$taxon->getCode()]],
             ]],
             [[
-                'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                'type' => FixedDiscountPriceCalculator::TYPE,
                 'configuration' => [$channel->getCode() => ['amount' => $discount]],
             ]],
             $priority,

--- a/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
@@ -18,8 +18,6 @@ use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 interface ActionBasedPriceCalculatorInterface
 {
-    public static function getType(): string;
-
     public function supports(CatalogPromotionActionInterface $action): bool;
 
     public function calculate(ChannelPricingInterface $channelPricing, CatalogPromotionActionInterface $action): int;

--- a/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
@@ -18,6 +18,8 @@ use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 interface ActionBasedPriceCalculatorInterface
 {
+    public function getType(): string;
+
     public function supports(CatalogPromotionActionInterface $action): bool;
 
     public function calculate(ChannelPricingInterface $channelPricing, CatalogPromotionActionInterface $action): int;

--- a/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/ActionBasedPriceCalculatorInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 interface ActionBasedPriceCalculatorInterface
 {
-    public function getType(): string;
+    public static function getType(): string;
 
     public function supports(CatalogPromotionActionInterface $action): bool;
 

--- a/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
@@ -20,11 +20,6 @@ final class FixedDiscountPriceCalculator implements ActionBasedPriceCalculatorIn
 {
     public const TYPE = 'fixed_discount';
 
-    public static function getType(): string
-    {
-        return self::TYPE;
-    }
-
     public function supports(CatalogPromotionActionInterface $action): bool
     {
         return $action->getType() === self::TYPE;

--- a/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
@@ -20,7 +20,7 @@ final class FixedDiscountPriceCalculator implements ActionBasedPriceCalculatorIn
 {
     public const TYPE = 'fixed_discount';
 
-    public function getType(): string
+    public static function getType(): string
     {
         return self::TYPE;
     }

--- a/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/FixedDiscountPriceCalculator.php
@@ -18,9 +18,16 @@ use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 final class FixedDiscountPriceCalculator implements ActionBasedPriceCalculatorInterface
 {
+    public const TYPE = 'fixed_discount';
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function supports(CatalogPromotionActionInterface $action): bool
     {
-        return $action->getType() === CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT;
+        return $action->getType() === self::TYPE;
     }
 
     public function calculate(ChannelPricingInterface $channelPricing, CatalogPromotionActionInterface $action): int

--- a/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
@@ -18,9 +18,16 @@ use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 final class PercentageDiscountPriceCalculator implements ActionBasedPriceCalculatorInterface
 {
+    public const TYPE = 'percentage_discount';
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function supports(CatalogPromotionActionInterface $action): bool
     {
-        return $action->getType() === CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT;
+        return $action->getType() === self::TYPE;
     }
 
     public function calculate(ChannelPricingInterface $channelPricing, CatalogPromotionActionInterface $action): int

--- a/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
@@ -20,7 +20,7 @@ final class PercentageDiscountPriceCalculator implements ActionBasedPriceCalcula
 {
     public const TYPE = 'percentage_discount';
 
-    public function getType(): string
+    public static function getType(): string
     {
         return self::TYPE;
     }

--- a/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Calculator/PercentageDiscountPriceCalculator.php
@@ -20,11 +20,6 @@ final class PercentageDiscountPriceCalculator implements ActionBasedPriceCalcula
 {
     public const TYPE = 'percentage_discount';
 
-    public static function getType(): string
-    {
-        return self::TYPE;
-    }
-
     public function supports(CatalogPromotionActionInterface $action): bool
     {
         return $action->getType() === self::TYPE;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
 
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -47,7 +48,7 @@ final class CatalogPromotionActionExampleFactory extends AbstractExampleFactory 
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('type', CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT)
+            ->setDefault('type', PercentageDiscountPriceCalculator::TYPE)
             ->setAllowedTypes('type', 'string')
             ->setDefault('configuration', [])
             ->setAllowedTypes('configuration', 'array')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
 
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -47,7 +48,7 @@ final class CatalogPromotionScopeExampleFactory extends AbstractExampleFactory i
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('type', CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS)
+            ->setDefault('type', ForVariantsScopeVariantsProvider::TYPE)
             ->setAllowedTypes('type', 'string')
             ->setDefault('configuration', [])
             ->setAllowedTypes('configuration', 'array')

--- a/src/Sylius/Bundle/CoreBundle/Provider/CatalogPromotionVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/CatalogPromotionVariantsProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Provider;
 
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface;
 

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Provider;
 
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Webmozart\Assert\Assert;
 
 final class ForProductsScopeVariantsProvider implements VariantsProviderInterface
 {
+    public const TYPE = 'for_products';
+
     private ProductRepositoryInterface $productRepository;
 
     public function __construct(ProductRepositoryInterface $productRepository)
@@ -27,9 +29,14 @@ final class ForProductsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productRepository = $productRepository;
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
-        return $catalogPromotionScopeType->getType() === CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS;
+        return $catalogPromotionScopeType->getType() === self::TYPE;
     }
 
     public function provideEligibleVariants(CatalogPromotionScopeInterface $scope): array

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
@@ -29,7 +29,7 @@ final class ForProductsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productRepository = $productRepository;
     }
 
-    public function getType(): string
+    public static function getType(): string
     {
         return self::TYPE;
     }

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForProductsScopeVariantsProvider.php
@@ -29,11 +29,6 @@ final class ForProductsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productRepository = $productRepository;
     }
 
-    public static function getType(): string
-    {
-        return self::TYPE;
-    }
-
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
         return $catalogPromotionScopeType->getType() === self::TYPE;

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Provider;
 
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
@@ -21,6 +21,8 @@ use Webmozart\Assert\Assert;
 
 final class ForTaxonsScopeVariantsProvider implements VariantsProviderInterface
 {
+    public const TYPE = 'for_taxons';
+
     private TaxonRepositoryInterface $taxonRepository;
 
     private ProductVariantRepositoryInterface $productVariantRepository;
@@ -33,9 +35,14 @@ final class ForTaxonsScopeVariantsProvider implements VariantsProviderInterface
         $this->productVariantRepository = $productVariantRepository;
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
-        return $catalogPromotionScopeType->getType() === CatalogPromotionScopeInterface::TYPE_FOR_TAXONS;
+        return $catalogPromotionScopeType->getType() === self::TYPE;
     }
 
     public function provideEligibleVariants(CatalogPromotionScopeInterface $scope): array

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
@@ -35,11 +35,6 @@ final class ForTaxonsScopeVariantsProvider implements VariantsProviderInterface
         $this->productVariantRepository = $productVariantRepository;
     }
 
-    public static function getType(): string
-    {
-        return self::TYPE;
-    }
-
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
         return $catalogPromotionScopeType->getType() === self::TYPE;

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForTaxonsScopeVariantsProvider.php
@@ -35,7 +35,7 @@ final class ForTaxonsScopeVariantsProvider implements VariantsProviderInterface
         $this->productVariantRepository = $productVariantRepository;
     }
 
-    public function getType(): string
+    public static function getType(): string
     {
         return self::TYPE;
     }

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Provider;
 
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 use Webmozart\Assert\Assert;
 
 final class ForVariantsScopeVariantsProvider implements VariantsProviderInterface
 {
+    public const TYPE = 'for_variants';
+
     private ProductVariantRepositoryInterface $productVariantRepository;
 
     public function __construct(ProductVariantRepositoryInterface $productVariantRepository)
@@ -27,9 +29,14 @@ final class ForVariantsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productVariantRepository = $productVariantRepository;
     }
 
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
-        return $catalogPromotionScopeType->getType() === CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS;
+        return $catalogPromotionScopeType->getType() === self::TYPE;
     }
 
     public function provideEligibleVariants(CatalogPromotionScopeInterface $scope): array

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
@@ -29,7 +29,7 @@ final class ForVariantsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productVariantRepository = $productVariantRepository;
     }
 
-    public function getType(): string
+    public static function getType(): string
     {
         return self::TYPE;
     }

--- a/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/ForVariantsScopeVariantsProvider.php
@@ -29,11 +29,6 @@ final class ForVariantsScopeVariantsProvider implements VariantsProviderInterfac
         $this->productVariantRepository = $productVariantRepository;
     }
 
-    public static function getType(): string
-    {
-        return self::TYPE;
-    }
-
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool
     {
         return $catalogPromotionScopeType->getType() === self::TYPE;

--- a/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
@@ -17,7 +17,7 @@ use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
 interface VariantsProviderInterface
 {
-    public function getType(): string;
+    public static function getType(): string;
 
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool;
 

--- a/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Provider;
 
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
 interface VariantsProviderInterface
 {
+    public function getType(): string;
+
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool;
 
     public function provideEligibleVariants(CatalogPromotionScopeInterface $scope): array;

--- a/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/VariantsProviderInterface.php
@@ -17,8 +17,6 @@ use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
 interface VariantsProviderInterface
 {
-    public static function getType(): string;
-
     public function supports(CatalogPromotionScopeInterface $catalogPromotionScopeType): bool;
 
     public function provideEligibleVariants(CatalogPromotionScopeInterface $scope): array;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -276,18 +276,18 @@
 
         <service id="Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider">
             <argument type="service" id="sylius.repository.product" />
-            <tag name="sylius.catalog_promotion.variants_provider" />
+            <tag name="sylius.catalog_promotion.variants_provider" type="for_products" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider">
             <argument type="service" id="sylius.repository.product_variant" />
-            <tag name="sylius.catalog_promotion.variants_provider" />
+            <tag name="sylius.catalog_promotion.variants_provider" type="for_variants" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider">
             <argument type="service" id="sylius.repository.taxon" />
             <argument type="service" id="sylius.repository.product_variant" />
-            <tag name="sylius.catalog_promotion.variants_provider" />
+            <tag name="sylius.catalog_promotion.variants_provider" type="for_taxons" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface" class="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculator"/>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/calculators.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/calculators.xml
@@ -23,11 +23,11 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator">
-            <tag name="sylius.catalog_promotion.price_calculator" />
+            <tag name="sylius.catalog_promotion.price_calculator" type="fixed_discount" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator">
-            <tag name="sylius.catalog_promotion.price_calculator" />
+            <tag name="sylius.catalog_promotion.price_calculator" type="percentage_discount" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -54,9 +54,9 @@
         <parameter key="sylius.model.shop_billing_data.class">Sylius\Component\Core\Model\ShopBillingData</parameter>
         <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator::TYPE</parameter>
         <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator::TYPE</parameter>
-        <parameter key="sylius.catalog_promotion.scope.for_products" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS</parameter>
-        <parameter key="sylius.catalog_promotion.scope.for_taxons" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_TAXONS</parameter>
-        <parameter key="sylius.catalog_promotion.scope.for_variants" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS</parameter>
+        <parameter key="sylius.catalog_promotion.scope.for_products" type="constant">Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider::TYPE</parameter>
+        <parameter key="sylius.catalog_promotion.scope.for_taxons" type="constant">Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider::TYPE</parameter>
+        <parameter key="sylius.catalog_promotion.scope.for_variants" type="constant">Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider::TYPE</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -52,6 +52,8 @@
             <parameter>sylius</parameter>
         </parameter>
         <parameter key="sylius.model.shop_billing_data.class">Sylius\Component\Core\Model\ShopBillingData</parameter>
+        <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator::TYPE</parameter>
+        <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator::TYPE</parameter>
         <parameter key="sylius.catalog_promotion.scope.for_products" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS</parameter>
         <parameter key="sylius.catalog_promotion.scope.for_taxons" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_TAXONS</parameter>
         <parameter key="sylius.catalog_promotion.scope.for_variants" type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS</parameter>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
@@ -12,14 +12,6 @@
 -->
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sylius.catalog_promotion.scopes" type="collection">
-            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS</parameter>
-            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_TAXONS</parameter>
-            <parameter type="constant">Sylius\Component\Core\Model\CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS</parameter>
-        </parameter>
-    </parameters>
-
     <services>
         <defaults public="true" />
 

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionScopeValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionScopeValidator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Sylius\Bundle\CoreBundle\Validator\CatalogPromotionScope\ScopeValidatorInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Bundle/CoreBundle/spec/Calculator/FixedDiscountPriceCalculatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Calculator/FixedDiscountPriceCalculatorSpec.php
@@ -15,6 +15,8 @@ namespace spec\Sylius\Bundle\CoreBundle\Calculator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Calculator\ActionBasedPriceCalculatorInterface;
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
@@ -29,8 +31,8 @@ final class FixedDiscountPriceCalculatorSpec extends ObjectBehavior
         CatalogPromotionActionInterface $fixedDiscountAction,
         CatalogPromotionActionInterface $percentageDiscountAction
     ): void {
-        $fixedDiscountAction->getType()->willReturn(CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT);
-        $percentageDiscountAction->getType()->willReturn(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
+        $fixedDiscountAction->getType()->willReturn(FixedDiscountPriceCalculator::TYPE);
+        $percentageDiscountAction->getType()->willReturn(PercentageDiscountPriceCalculator::TYPE);
 
         $this->supports($fixedDiscountAction)->shouldReturn(true);
         $this->supports($percentageDiscountAction)->shouldReturn(false);

--- a/src/Sylius/Bundle/CoreBundle/spec/Calculator/PercentageDiscountPriceCalculatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Calculator/PercentageDiscountPriceCalculatorSpec.php
@@ -15,6 +15,8 @@ namespace spec\Sylius\Bundle\CoreBundle\Calculator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Calculator\ActionBasedPriceCalculatorInterface;
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
@@ -29,8 +31,8 @@ final class PercentageDiscountPriceCalculatorSpec extends ObjectBehavior
         CatalogPromotionActionInterface $fixedDiscountAction,
         CatalogPromotionActionInterface $percentageDiscountAction
     ): void {
-        $fixedDiscountAction->getType()->willReturn(CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT);
-        $percentageDiscountAction->getType()->willReturn(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
+        $fixedDiscountAction->getType()->willReturn(FixedDiscountPriceCalculator::TYPE);
+        $percentageDiscountAction->getType()->willReturn(PercentageDiscountPriceCalculator::TYPE);
 
         $this->supports($fixedDiscountAction)->shouldReturn(false);
         $this->supports($percentageDiscountAction)->shouldReturn(true);

--- a/src/Sylius/Bundle/CoreBundle/spec/Provider/CatalogPromotionVariantsProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Provider/CatalogPromotionVariantsProviderSpec.php
@@ -15,11 +15,12 @@ namespace spec\Sylius\Bundle\CoreBundle\Provider;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
 final class CatalogPromotionVariantsProviderSpec extends ObjectBehavior
 {
@@ -48,10 +49,10 @@ final class CatalogPromotionVariantsProviderSpec extends ObjectBehavior
             $secondScope->getWrappedObject()
         ]));
 
-        $firstScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $firstScope->getType()->willReturn(ForVariantsScopeVariantsProvider::TYPE);
         $firstScope->getConfiguration()->willReturn(['variants' => ['PHP_T_SHIRT', 'PHP_MUG']]);
 
-        $secondScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $secondScope->getType()->willReturn(ForVariantsScopeVariantsProvider::TYPE);
         $secondScope->getConfiguration()->willReturn(['variants' => ['PHP_MUG', 'PHP_CAP']]);
 
         $firstProvider->supports($firstScope)->willReturn(false);

--- a/src/Sylius/Bundle/CoreBundle/spec/Provider/ForProductsScopeVariantsProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Provider/ForProductsScopeVariantsProviderSpec.php
@@ -15,8 +15,10 @@ namespace spec\Sylius\Bundle\CoreBundle\Provider;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
@@ -37,8 +39,8 @@ final class ForProductsScopeVariantsProviderSpec extends ObjectBehavior
         CatalogPromotionScopeInterface $forProductsScope,
         CatalogPromotionScopeInterface $forVariantsScope
     ): void {
-        $forProductsScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS);
-        $forVariantsScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $forProductsScope->getType()->willReturn(ForProductsScopeVariantsProvider::TYPE);
+        $forVariantsScope->getType()->willReturn(ForVariantsScopeVariantsProvider::TYPE);
 
         $this->supports($forProductsScope)->shouldReturn(true);
         $this->supports($forVariantsScope)->shouldReturn(false);

--- a/src/Sylius/Bundle/CoreBundle/spec/Provider/ForTaxonsScopeVariantsProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Provider/ForTaxonsScopeVariantsProviderSpec.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\CoreBundle\Provider;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
@@ -39,8 +41,8 @@ final class ForTaxonsScopeVariantsProviderSpec extends ObjectBehavior
         CatalogPromotionScopeInterface $forTaxonsScope,
         CatalogPromotionScopeInterface $forVariantsScope
     ): void {
-        $forTaxonsScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_TAXONS);
-        $forVariantsScope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $forTaxonsScope->getType()->willReturn(ForTaxonsScopeVariantsProvider::TYPE);
+        $forVariantsScope->getType()->willReturn(ForVariantsScopeVariantsProvider::TYPE);
 
         $this->supports($forTaxonsScope)->shouldReturn(true);
         $this->supports($forVariantsScope)->shouldReturn(false);

--- a/src/Sylius/Bundle/CoreBundle/spec/Provider/ForVariantsScopeVariantsProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Provider/ForVariantsScopeVariantsProviderSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 
 final class ForVariantsScopeVariantsProviderSpec extends ObjectBehavior
 {

--- a/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionScopeValidatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionScopeValidatorSpec.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Bundle\CoreBundle\Validator\CatalogPromotionScope\ScopeValidatorInterface;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\CatalogPromotionScope;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -30,12 +32,12 @@ final class CatalogPromotionScopeValidatorSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith(
             [
-                CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
-                CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS
+                ForTaxonsScopeVariantsProvider::TYPE,
+                ForVariantsScopeVariantsProvider::TYPE
             ],
             [
-                CatalogPromotionScopeInterface::TYPE_FOR_TAXONS => $forTaxonsValidator,
-                CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS => $forVariantsValidator,
+                ForTaxonsScopeVariantsProvider::TYPE => $forTaxonsValidator,
+                ForVariantsScopeVariantsProvider::TYPE => $forVariantsValidator,
             ]
         );
 
@@ -68,7 +70,7 @@ final class CatalogPromotionScopeValidatorSpec extends ObjectBehavior
     ): void {
         $constraint = new CatalogPromotionScope();
 
-        $scope->getType()->willReturn(CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS);
+        $scope->getType()->willReturn(ForVariantsScopeVariantsProvider::TYPE);
         $scope->getConfiguration()->willReturn([]);
 
         $forVariantsValidator->validate([], $constraint, $executionContext)->shouldBeCalled();

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
@@ -23,9 +23,10 @@ final class SetCatalogPromotionActionTypesPass implements CompilerPassInterface
     {
         $types = [];
         foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.price_calculator') as $id => $attributes) {
-            /** @var ActionBasedPriceCalculatorInterface $calculator */
-            $calculator = $container->get($id);
-            $types[] = $calculator->getType();
+            $definition = $container->getDefinition($id);
+            /** @var ActionBasedPriceCalculatorInterface $class */
+            $class = $definition->getClass();
+            $types[] = $class::getType();
         }
 
         $container->setParameter('sylius.catalog_promotion.actions', $types);

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\CoreBundle\Calculator\ActionBasedPriceCalculatorInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class SetCatalogPromotionActionTypesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $types = [];
+        foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.price_calculator') as $id => $attributes) {
+            /** @var ActionBasedPriceCalculatorInterface $calculator */
+            $calculator = $container->get($id);
+            $types[] = $calculator->getType();
+        }
+
+        $container->setParameter('sylius.catalog_promotion.actions', $types);
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler;
 
-use Sylius\Bundle\CoreBundle\Calculator\ActionBasedPriceCalculatorInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -23,10 +22,13 @@ final class SetCatalogPromotionActionTypesPass implements CompilerPassInterface
     {
         $types = [];
         foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.price_calculator') as $id => $attributes) {
-            $definition = $container->getDefinition($id);
-            /** @var ActionBasedPriceCalculatorInterface $class */
-            $class = $definition->getClass();
-            $types[] = $class::getType();
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['type'])) {
+                    throw new \InvalidArgumentException('Tagged catalog promotion price calculator `' . $id . '` needs to have `type` attribute.');
+                }
+
+                $types[] = $attribute['type'];
+            }
         }
 
         $container->setParameter('sylius.catalog_promotion.actions', $types);

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler;
 
-use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\VarDumper\VarDumper;
 
 final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
 {
@@ -24,10 +22,13 @@ final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
     {
         $types = [];
         foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.variants_provider') as $id => $attributes) {
-            $definition = $container->getDefinition($id);
-            /** @var VariantsProviderInterface $class */
-            $class = $definition->getClass();
-            $types[] = $class::getType();
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['type'])) {
+                    throw new \InvalidArgumentException('Tagged catalog promotion variants provider `' . $id . '` needs to have `type` attribute.');
+                }
+
+                $types[] = $attribute['type'];
+            }
         }
 
         $container->setParameter('sylius.catalog_promotion.scopes', $types);

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $types = [];
+        foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.variants_provider') as $id => $attributes) {
+            /** @var VariantsProviderInterface $provider */
+            $provider = $container->get($id);
+            $types[] = $provider->getType();
+        }
+
+        $container->setParameter('sylius.catalog_promotion.scopes', $types);
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler;
 use Sylius\Bundle\CoreBundle\Provider\VariantsProviderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\VarDumper\VarDumper;
 
 final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
 {
@@ -23,9 +24,10 @@ final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
     {
         $types = [];
         foreach ($container->findTaggedServiceIds('sylius.catalog_promotion.variants_provider') as $id => $attributes) {
-            /** @var VariantsProviderInterface $provider */
-            $provider = $container->get($id);
-            $types[] = $provider->getType();
+            $definition = $container->getDefinition($id);
+            /** @var VariantsProviderInterface $class */
+            $class = $definition->getClass();
+            $types[] = $class::getType();
         }
 
         $container->setParameter('sylius.catalog_promotion.scopes', $types);

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type;
 
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -74,7 +75,7 @@ final class CatalogPromotionActionType extends AbstractResourceType
                     $formData->setType($data['type']);
                     $formData->setConfiguration($data['configuration']);
 
-                    if ($data['type'] === CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT) {
+                    if ($data['type'] === FixedDiscountPriceCalculator::TYPE) {
                         foreach ($data['configuration'] as $channelConfiguration) {
                             if ($channelConfiguration['amount'] === '') {
                                 return;

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
@@ -31,8 +31,6 @@
         <parameter key="sylius.form.type.promotion_coupon.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
-        <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator::TYPE</parameter>
-        <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator::TYPE</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
@@ -31,8 +31,8 @@
         <parameter key="sylius.form.type.promotion_coupon.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
-        <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT</parameter>
-        <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT</parameter>
+        <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator::TYPE</parameter>
+        <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator::TYPE</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
@@ -12,13 +12,6 @@
 -->
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sylius.catalog_promotion.actions" type="collection">
-            <parameter type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT</parameter>
-            <parameter type="constant">Sylius\Component\Promotion\Model\CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT</parameter>
-        </parameter>
-    </parameters>
-
     <services>
         <defaults public="true" />
 

--- a/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
+++ b/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\CompositePromotio
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\RegisterPromotionActionsPass;
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\RegisterRuleCheckersPass;
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\SetCatalogPromotionActionTypesPass;
+use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\SetCatalogPromotionScopeTypesPass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -42,6 +43,7 @@ final class SyliusPromotionBundle extends AbstractResourceBundle
         $container->addCompilerPass(new RegisterPromotionActionsPass());
 
         $container->addCompilerPass(new SetCatalogPromotionActionTypesPass());
+        $container->addCompilerPass(new SetCatalogPromotionScopeTypesPass());
     }
 
     /**

--- a/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
+++ b/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\CompositePromotio
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\CompositePromotionEligibilityCheckerPass;
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\RegisterPromotionActionsPass;
 use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\RegisterRuleCheckersPass;
+use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\SetCatalogPromotionActionTypesPass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -39,6 +40,8 @@ final class SyliusPromotionBundle extends AbstractResourceBundle
 
         $container->addCompilerPass(new RegisterRuleCheckersPass());
         $container->addCompilerPass(new RegisterPromotionActionsPass());
+
+        $container->addCompilerPass(new SetCatalogPromotionActionTypesPass());
     }
 
     /**

--- a/src/Sylius/Bundle/PromotionBundle/spec/Validator/CatalogPromotionActionValidatorSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Validator/CatalogPromotionActionValidatorSpec.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\PromotionBundle\Validator;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\PromotionBundle\Validator\CatalogPromotionAction\ActionValidatorInterface;
 use Sylius\Bundle\PromotionBundle\Validator\Constraints\CatalogPromotionAction;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
@@ -30,12 +32,12 @@ final class CatalogPromotionActionValidatorSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith(
             [
-                CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
-                CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                FixedDiscountPriceCalculator::TYPE,
+                PercentageDiscountPriceCalculator::TYPE,
             ],
             [
-                CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT => $fixedDiscountValidator,
-                CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT => $percentageDiscountValidator,
+                FixedDiscountPriceCalculator::TYPE => $fixedDiscountValidator,
+                PercentageDiscountPriceCalculator::TYPE => $percentageDiscountValidator,
             ]
         );
 
@@ -68,7 +70,7 @@ final class CatalogPromotionActionValidatorSpec extends ObjectBehavior
     ): void {
         $constraint = new CatalogPromotionAction();
 
-        $action->getType()->willReturn(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
+        $action->getType()->willReturn(PercentageDiscountPriceCalculator::TYPE);
         $action->getConfiguration()->willReturn([]);
 
         $percentageDiscountValidator->validate([], $constraint, $executionContext)->shouldBeCalled();

--- a/src/Sylius/Bundle/PromotionBundle/spec/Validator/CatalogPromotionActionValidatorSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Validator/CatalogPromotionActionValidatorSpec.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\PromotionBundle\Validator;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
-use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\PromotionBundle\Validator\CatalogPromotionAction\ActionValidatorInterface;
 use Sylius\Bundle\PromotionBundle\Validator\Constraints\CatalogPromotionAction;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
@@ -31,13 +29,10 @@ final class CatalogPromotionActionValidatorSpec extends ObjectBehavior
         ActionValidatorInterface $percentageDiscountValidator
     ): void {
         $this->beConstructedWith(
+            ['fixed_discount', 'percentage_discount'],
             [
-                FixedDiscountPriceCalculator::TYPE,
-                PercentageDiscountPriceCalculator::TYPE,
-            ],
-            [
-                FixedDiscountPriceCalculator::TYPE => $fixedDiscountValidator,
-                PercentageDiscountPriceCalculator::TYPE => $percentageDiscountValidator,
+                'fixed_discount' => $fixedDiscountValidator,
+                'percentage_discount' => $percentageDiscountValidator,
             ]
         );
 
@@ -70,7 +65,7 @@ final class CatalogPromotionActionValidatorSpec extends ObjectBehavior
     ): void {
         $constraint = new CatalogPromotionAction();
 
-        $action->getType()->willReturn(PercentageDiscountPriceCalculator::TYPE);
+        $action->getType()->willReturn('percentage_discount');
         $action->getConfiguration()->willReturn([]);
 
         $percentageDiscountValidator->validate([], $constraint, $executionContext)->shouldBeCalled();

--- a/src/Sylius/Component/Core/Model/CatalogPromotionScopeInterface.php
+++ b/src/Sylius/Component/Core/Model/CatalogPromotionScopeInterface.php
@@ -17,9 +17,4 @@ use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface as BaseCatal
 
 interface CatalogPromotionScopeInterface extends BaseCatalogPromotionScopeInterface
 {
-    public const TYPE_FOR_VARIANTS = 'for_variants';
-
-    public const TYPE_FOR_TAXONS = 'for_taxons';
-
-    public const TYPE_FOR_PRODUCTS = 'for_products';
 }

--- a/src/Sylius/Component/Core/spec/Model/CatalogPromotionScopeSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/CatalogPromotionScopeSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionScope;
 
 final class CatalogPromotionScopeSpec extends ObjectBehavior

--- a/src/Sylius/Component/Promotion/Model/CatalogPromotionActionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/CatalogPromotionActionInterface.php
@@ -17,10 +17,6 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 
 interface CatalogPromotionActionInterface extends ResourceInterface
 {
-    public const TYPE_FIXED_DISCOUNT = 'fixed_discount';
-
-    public const TYPE_PERCENTAGE_DISCOUNT = 'percentage_discount';
-
     public function setType(?string $type): void;
 
     public function setConfiguration(array $configuration): void;

--- a/src/Sylius/Component/Promotion/spec/Model/CatalogPromotionActionSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Model/CatalogPromotionActionSpec.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Promotion\Model;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionInterface;
 
@@ -33,8 +32,8 @@ final class CatalogPromotionActionSpec extends ObjectBehavior
     function its_type_is_mutable(): void
     {
         $this->getType()->shouldReturn(null);
-        $this->setType(PercentageDiscountPriceCalculator::TYPE);
-        $this->getType()->shouldReturn(PercentageDiscountPriceCalculator::TYPE);
+        $this->setType('percentage_discount');
+        $this->getType()->shouldReturn('percentage_discount');
     }
 
     function its_configuration_is_mutable(): void

--- a/src/Sylius/Component/Promotion/spec/Model/CatalogPromotionActionSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Model/CatalogPromotionActionSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Promotion\Model;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionInterface;
 
@@ -32,8 +33,8 @@ final class CatalogPromotionActionSpec extends ObjectBehavior
     function its_type_is_mutable(): void
     {
         $this->getType()->shouldReturn(null);
-        $this->setType(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
-        $this->getType()->shouldReturn(CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT);
+        $this->setType(PercentageDiscountPriceCalculator::TYPE);
+        $this->getType()->shouldReturn(PercentageDiscountPriceCalculator::TYPE);
     }
 
     function its_configuration_is_mutable(): void

--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -15,8 +15,11 @@ namespace Sylius\Tests\Api\Admin;
 
 use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Provider\ForProductsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForTaxonsScopeVariantsProvider;
+use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Sylius\Tests\Api\Utils\AdminUserLoginTrait;
 use Symfony\Component\HttpFoundation\Response;
@@ -97,7 +100,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 ],
                 'scopes' => [
                     [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'variants' => [
                                 'MUG'
@@ -229,41 +232,41 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                             'variants' => ['MUG']
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'variants' => []
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'variants' => ['invalid_variant']
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                        'type' => ForProductsScopeVariantsProvider::TYPE,
                         'configuration' => [],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                        'type' => ForProductsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'products' => []
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_PRODUCTS,
+                        'type' => ForProductsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'products' => ['invalid_product']
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                        'type' => ForTaxonsScopeVariantsProvider::TYPE,
                         'configuration' => [],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                        'type' => ForTaxonsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'taxons' => []
                         ],
                     ], [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_TAXONS,
+                        'type' => ForTaxonsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'taxons' => ['invalid_taxon']
                         ],
@@ -355,7 +358,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 ],
                 'scopes' => [
                     [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'variants' => [
                                 'MUG'
@@ -404,7 +407,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 ],
                 'scopes' => [
                     [
-                        'type' => CatalogPromotionScopeInterface::TYPE_FOR_VARIANTS,
+                        'type' => ForVariantsScopeVariantsProvider::TYPE,
                         'configuration' => [
                             'variants' => [
                                 'MUG'

--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Admin;
 
+use Sylius\Bundle\CoreBundle\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\CatalogPromotionScopeInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Sylius\Tests\Api\Utils\AdminUserLoginTrait;
 use Symfony\Component\HttpFoundation\Response;
@@ -88,7 +89,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 ],
                 'actions' => [
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'amount' => 0.5
                         ]
@@ -215,7 +216,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 ],
                 'actions' => [
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'amount' => 0.5
                         ]
@@ -310,33 +311,33 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                         ]
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => []
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'amount' => 1.5
                         ]
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'amount' => 'text'
                         ]
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                        'type' => FixedDiscountPriceCalculator::TYPE,
                         'configuration' => []
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                        'type' => FixedDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'WEB' => [],
                         ]
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                        'type' => FixedDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'invalid_channel' => [
                                 'amount' => 1000,
@@ -344,7 +345,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                         ]
                     ],
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_FIXED_DISCOUNT,
+                        'type' => FixedDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'WEB' => [
                                 'amount' => 'text',
@@ -395,7 +396,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                 'code' => 'new_code',
                 'actions' => [
                     [
-                        'type' => CatalogPromotionActionInterface::TYPE_PERCENTAGE_DISCOUNT,
+                        'type' => PercentageDiscountPriceCalculator::TYPE,
                         'configuration' => [
                             'amount' => 0.4
                         ]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no?
| BC breaks?      | no?
| Deprecations?   | 
| Related tickets | continuation of https://github.com/Sylius/Sylius/pull/13399
| License         | MIT

The same as https://github.com/Sylius/Sylius/pull/13399, but with defining action/scope type in tag instead of using static getType method
<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
