### PR TITLE
Class name typo

### DIFF
--- a/docs/book/plugins/guide/naming.rst
+++ b/docs/book/plugins/guide/naming.rst
@@ -24,7 +24,7 @@ to reflect your plugin functionality. Basing on the vendor and plugin names esta
 
 * In ``tests/Application/config/bundles.php``:
 
-    * ``Acme\SyliusExamplePlugin\AcmeSyliusExamplePlugin::class`` -> ``IronMan\SyliusProductOnDemandPlugin\SyliusProductOnDemandPlugin::class``
+    * ``Acme\SyliusExamplePlugin\AcmeSyliusExamplePlugin::class`` -> ``IronMan\SyliusProductOnDemandPlugin\IronManSyliusProductOnDemandPlugin::class``
 
 * In ``phpspec.yml.dist`` (if you want to use PHPSpec in your plugin):
 


### PR DESCRIPTION
The Bundle file includes any namespace prefixes, so it should be `IronManSyliusProductOnDemandPlugin` instead of `SyliusProductOnDemandPlugin`

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT