### PR TITLE
Remove invalid PHP version from PHPSpec build

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -116,7 +116,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ "7.4", "8.0" ]
+                php: [ "8.0" ]
                 symfony: [ "^4.4", "^5.2" ]
 
         steps:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
