### PR TITLE
[CatalogPromotion] Add compiler pass tests for setting action/scope types parameters

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPassTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\SetCatalogPromotionActionTypesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class SetCatalogPromotionActionTypesPassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_sets_action_types_parameter(): void
+    {
+        $this->setDefinition(
+            'price_calculator',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.price_calculator', ['type' => 'custom'])
+                ->addTag('sylius.catalog_promotion.price_calculator', ['type' => 'another_custom'])
+        );
+        $this->setDefinition(
+            'second_price_calculator',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.price_calculator', ['type' => 'second_custom'])
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius.catalog_promotion.actions',
+            ['custom', 'another_custom', 'second_custom']
+        );
+    }
+    /** @test */
+    public function it_throws_an_exception_if_there_is_no_type_attribute_defined(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tagged catalog promotion price calculator `price_calculator` needs to have `type` attribute.');
+
+        $this->setDefinition(
+            'price_calculator',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.price_calculator', [])
+        );
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SetCatalogPromotionActionTypesPass());
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPassTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\PromotionBundle\DependencyInjection\Compiler\SetCatalogPromotionScopeTypesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class SetCatalogPromotionScopeTypesPassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_sets_scope_types_parameter(): void
+    {
+        $this->setDefinition(
+            'variants_provider',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.variants_provider', ['type' => 'custom'])
+                ->addTag('sylius.catalog_promotion.variants_provider', ['type' => 'another_custom'])
+        );
+        $this->setDefinition(
+            'second_variants_provider',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.variants_provider', ['type' => 'second_custom'])
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius.catalog_promotion.scopes',
+            ['custom', 'another_custom', 'second_custom']
+        );
+    }
+    /** @test */
+    public function it_throws_an_exception_if_there_is_no_type_attribute_defined(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tagged catalog promotion variants provider `variants_provider` needs to have `type` attribute.');
+
+        $this->setDefinition(
+            'variants_provider',
+            (new Definition())
+                ->addTag('sylius.catalog_promotion.variants_provider', [])
+        );
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new SetCatalogPromotionScopeTypesPass());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/13403#pullrequestreview-836220149
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
