### PR TITLE
Import lowercase chart.js/dist/chart.min

### DIFF
--- a/UPGRADE-1.10.md
+++ b/UPGRADE-1.10.md
@@ -115,3 +115,7 @@ bin/console doctrine:migrations:execute Sylius\\Bundle\\AdminApiBundle\\Migratio
 ### API v2
 
 For changes according to the API v2, please visit [API v2 upgrade file](UPGRADE-API-1.10.md).
+
+### chart.js
+
+Library chart.js upgraded from 2.9.3 to 3.7.1, please visit [3.x Migration Guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html) if needed.

--- a/UPGRADE-1.10.md
+++ b/UPGRADE-1.10.md
@@ -115,7 +115,3 @@ bin/console doctrine:migrations:execute Sylius\\Bundle\\AdminApiBundle\\Migratio
 ### API v2
 
 For changes according to the API v2, please visit [API v2 upgrade file](UPGRADE-API-1.10.md).
-
-### chart.js
-
-Library chart.js upgraded from 2.9.3 to 3.7.1, please visit [3.x Migration Guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html) if needed.

--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -25,3 +25,12 @@ Therefore you need to update your code to follow this change.
    + import realSass from 'sass';
    + const sass = gulpSass(realSass);
    ```
+
+4. Library chart.js lib has been upgraded from 2.9.3 to 3.7.1. Adjust your package.json as follows:
+
+   ```diff
+   - "chart.js": "^2.9.3",
+   + "chart.js": "^3.7.1", 
+   ```
+   
+    Please visit [3.x Migration Guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html) for more information.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "chart.js": "^3.7.0",
+    "chart.js": "^3.7.1",
     "jquery": "^3.5.0",
     "jquery.dirtyforms": "^2.0.0",
     "lightbox2": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "chart.js": "^2.9.3",
+    "chart.js": "^3.7.0",
     "jquery": "^3.5.0",
     "jquery.dirtyforms": "^2.0.0",
     "lightbox2": "^2.9.0",

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-chart.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-chart.js
@@ -1,4 +1,4 @@
-import 'chart.js/dist/Chart.min';
+import 'chart.js/dist/chart.min';
 
 const drawChart = function drawChart(canvas, labels = [], values = [], currency) {
   return new Chart(canvas, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,10 +2495,10 @@ chardet@^0.4.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
-chart.js@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.0.tgz#7a19c93035341df801d613993c2170a1fcf1d882"
-  integrity sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg==
+chart.js@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.1.tgz#0516f690c6a8680c6c707e31a4c1807a6f400ada"
+  integrity sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==
 
 chokidar@^2.0.0, chokidar@^2.1.8:
   version "2.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,28 +2495,10 @@ chardet@^0.4.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
   integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
-chart.js@^2.9.3:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.3.tgz#ae3884114dafd381bc600f5b35a189138aac1ef7"
-  integrity sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==
-  dependencies:
-    chartjs-color "^2.1.0"
-    moment "^2.10.2"
-
-chartjs-color-string@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
-  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
-  dependencies:
-    color-name "^1.0.0"
-
-chartjs-color@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
-  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
-  dependencies:
-    chartjs-color-string "^0.6.0"
-    color-convert "^1.9.3"
+chart.js@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.0.tgz#7a19c93035341df801d613993c2170a1fcf1d882"
+  integrity sha512-31gVuqqKp3lDIFmzpKIrBeum4OpZsQjSIAqlOpgjosHDJZlULtvwLEZKtEhIAZc7JMPaHlYMys40Qy9Mf+1AAg==
 
 chokidar@^2.0.0, chokidar@^2.1.8:
   version "2.1.8"
@@ -2703,7 +2685,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -6215,11 +6197,6 @@ mkdirp@1.0.4:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-moment@^2.10.2:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
-  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Related to #12560

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #12560
| License         | MIT

To follow chart.js documentation (https://www.chartjs.org/docs/latest/getting-started/v3-migration.html): 
Distributed files are now in lower case. For example: `dist/chart.js`

And to avoid error:
```
$ encore production --progress
Running webpack ...

ERROR  Failed to compile with 1 errors

Module build failed: Module not found:
"../vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-chart.js"
contains a reference to the file
"chart.js/dist/Chart.min".

This file can not be found, please check it for typos or update it if the file got moved.
```