### PR TITLE
FIX: Avoid passing empty needle to strpos()

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -47,7 +47,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
         $propertyPath = $this->context->getPropertyPath();
 
         foreach (iterator_to_array($this->context->getViolations()) as $violation) {
-            if (0 === strpos($violation->getPropertyPath(), $propertyPath)) {
+            if ('' === $propertyPath || 0 === strpos($violation->getPropertyPath(), $propertyPath)) {
                 return;
             }
         }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\AddressingBundle\Validator\Constraints\ProvinceAddressConstrai
 use Sylius\Bundle\AddressingBundle\Validator\Constraints\ProvinceAddressConstraintValidator;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Addressing\Model\Country;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\Province;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Validator\Constraint;
@@ -46,10 +47,19 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
     }
 
     function it_does_not_add_violation_because_a_violation_exists(
+        RepositoryInterface $countryRepository,
         AddressInterface $address,
+        Country $country,
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context
     ): void {
+        $country->getCode()->willReturn('PL');
+        $address->getCountryCode()->willReturn('PL');
+        $countryRepository->findOneBy(['code' => 'PL'])->willReturn($country);
+
+        $country->hasProvinces()->willReturn(true);
+        $address->getProvinceCode()->willReturn(null);
+
         $this->initialize($context);
 
         $context->getPropertyPath()->willReturn('property_path');
@@ -63,10 +73,19 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
     }
 
     function it_does_not_add_violation_because_a_violation_exists_when_address_is_the_root_object(
+        RepositoryInterface $countryRepository,
         AddressInterface $address,
+        Country $country,
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context
     ): void {
+        $country->getCode()->willReturn('PL');
+        $address->getCountryCode()->willReturn('PL');
+        $countryRepository->findOneBy(['code' => 'PL'])->willReturn($country);
+
+        $country->hasProvinces()->willReturn(true);
+        $address->getProvinceCode()->willReturn(null);
+
         $this->initialize($context);
 
         $context->getPropertyPath()->willReturn('');

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
@@ -62,6 +62,23 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         $this->validate($address, $constraint);
     }
 
+    function it_does_not_add_violation_because_a_violation_exists_when_address_is_the_root_object(
+        AddressInterface $address,
+        ProvinceAddressConstraint $constraint,
+        ExecutionContextInterface $context
+    ): void {
+        $this->initialize($context);
+
+        $context->getPropertyPath()->willReturn('');
+        $context->getViolations()->willReturn(new \ArrayIterator([
+            $this->createViolation('property_path'),
+        ]));
+
+        $context->addViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($address, $constraint);
+    }
+
     function it_adds_violation_because_address_has_no_province(
         RepositoryInterface $countryRepository,
         AddressInterface $address,

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
@@ -53,6 +53,8 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context
     ): void {
+        // DO NOT REMOVE THIS CODE: it ensures that there is a violation that can be added
+        // if the logic that is being tested (NOT adding a validation) does not work.
         $country->getCode()->willReturn('PL');
         $address->getCountryCode()->willReturn('PL');
         $countryRepository->findOneBy(['code' => 'PL'])->willReturn($country);
@@ -79,6 +81,8 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context
     ): void {
+        // DO NOT REMOVE THIS CODE: it ensures that there is a violation that can be added
+        // if the logic that is being tested (NOT adding a validation) does not work.
         $country->getCode()->willReturn('PL');
         $address->getCountryCode()->willReturn('PL');
         $countryRepository->findOneBy(['code' => 'PL'])->willReturn($country);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

The province validator returns early if it finds preexisting validation errors on the address. However, when checking that, it uses `strpos()` and passes current `$propertyPath` as a needle. This might cause problems when an address is validated as a top-level entity, because `$propertyPath` is an empty string in such case.