### PR TITLE
[UX] Feat: Use https to view shop if current request use it

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_channelLinks.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_channelLinks.html.twig
@@ -6,7 +6,7 @@
         <i class="dropdown icon"></i>
         <div class="menu">
             {% for channel in channels|filter(channel => channel.hostname is not empty) %}
-            <a href="http://{{ channel.hostname }}" target="_blank" class="item">
+            <a href="{{ app.request.scheme ?? 'http' }}://{{ channel.hostname }}" target="_blank" class="item">
                 {% include '@SyliusAdmin/Common/_channel.html.twig' %}
             </a>
             {% endfor %}
@@ -16,6 +16,6 @@
     {% set channel = channels|first %}
 
     {% if channel.hostname is not empty %}
-    <a href="http://{{ channel.hostname }}" target="_blank" class="item">{{ 'sylius.ui.view_your_store'|trans }}</a>
+    <a href="{{ app.request.scheme ?? 'http' }}://{{ channel.hostname }}" target="_blank" class="item">{{ 'sylius.ui.view_your_store'|trans }}</a>
     {% endif %}
 {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_showInShopButton.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_showInShopButton.html.twig
@@ -15,7 +15,7 @@
             <div class="menu">
                 <div class="scrolling menu">
                     {% for channel in enabledChannels %}
-                        {% set url = channel.hostname is not null ? 'http://' ~ channel.hostname ~ path('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) : url('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) %}
+                        {% set url = channel.hostname is not null ? (app.request.scheme ?? 'http') ~ '://' ~ channel.hostname ~ path('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) : url('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) %}
                         <a href="{{ url|raw }}" class="item" target="_blank">
                             <i class="angle right icon"></i>
                             {{ 'sylius.ui.show_in'|trans }}
@@ -27,7 +27,7 @@
         </div>
     {% else %}
         {% for channel in enabledChannels %}
-            {% set url = channel.hostname is not null ? 'http://' ~ channel.hostname ~ path('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) : url('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) %}
+            {% set url = channel.hostname is not null ? (app.request.scheme ?? 'http') ~ '://' ~ channel.hostname ~ path('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) : url('sylius_shop_product_show', {'slug': product.slug, '_locale': channel.defaultLocale.code}) %}
             <a class="ui labeled icon button" href="{{ url|raw }}" target="_blank">
                 <i class="angle right icon"></i>
                 {{ 'sylius.ui.show_product_in_shop_page'|trans }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Hi team :wave: 

This PR add a https redirection from admin to shop when clicking "**View your store**" or "**Show product in shop page**" when current request is in **https**. 

WDYT ?
