### PR TITLE
Remove wrong trailing space in test attribute

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/_address.html.twig
@@ -4,7 +4,7 @@
     {% if address.company is not null %}
         <strong>{{ address.company }}</strong><br>
     {% endif %}
-    <strong {{ sylius_test_html_attribute('full-name ', "%s %s"|format(address.firstName, address.lastName)) }}>{{ address.firstName }} {{ address.lastName }}</strong><br>
+    <strong {{ sylius_test_html_attribute('full-name', "%s %s"|format(address.firstName, address.lastName)) }}>{{ address.firstName }} {{ address.lastName }}</strong><br>
     {% if address.phoneNumber is not null %}
         {{ address.phoneNumber }}<br/>
     {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces #13286
| License         | MIT

Remove wrong trailing space in address full name test attribute.