### PR TITLE
Bugfix: display full cart promotion rule form when adding a new rule

### DIFF
--- a/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
@@ -131,3 +131,11 @@ Feature: Creating a catalog promotion
         Then there should be 1 new catalog promotion on the list
         And it should have "winter_sale" code and "Winter sale" name
         And it should have priority equal to 10
+
+    @ui @javascript
+    Scenario: Adding a new catalog promotion of default type with one action
+        When I want to create a new catalog promotion
+        And I add a new catalog promotion scope
+        And I add a new catalog promotion action
+        Then I should see the catalog promotion scope configuration form
+        And I should see the catalog promotion action configuration form

--- a/features/promotion/managing_promotions/adding_promotion_with_rule.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_rule.feature
@@ -50,3 +50,11 @@ Feature: Adding a new promotion with rule
         And I add it
         Then I should be notified that it has been successfully created
         And the "Wholesale promotion" promotion should appear in the registry
+
+    @ui @javascript
+    Scenario: Adding a new promotion of default type with one action
+        When I want to create a new promotion
+        And I add a new rule
+        And I add a new action
+        Then I should see the rule configuration form
+        And I should see the action configuration form

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -206,6 +206,14 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I add a new catalog promotion scope
+     */
+    public function iAddANewCatalogPromotionScope(): void
+    {
+        $this->formElement->addScope();
+    }
+
+    /**
      * @When /^I add(?:| another) scope that applies on ("[^"]+" variant)$/
      * @When /^I add scope that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
      * @When /^I add scope that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
@@ -251,6 +259,14 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iRemoveItsEveryAction(): void
     {
         $this->formElement->removeAllActions();
+    }
+
+    /**
+     * @When I add a new catalog promotion action
+     */
+    public function iAddANewCatalogPromotionAction(): void
+    {
+        $this->formElement->addAction();
     }
 
     /**
@@ -1008,5 +1024,21 @@ final class ManagingCatalogPromotionsContext implements Context
     public function itsPriorityShouldBe(int $priority): void
     {
         Assert::same($this->showPage->getPriority(), $priority);
+    }
+
+    /**
+     * @Then I should see the catalog promotion scope configuration form
+     */
+    public function iShouldSeeTheCatalogPromotionScopeConfigurationForm(): void
+    {
+        Assert::true($this->createPage->checkIfScopeConfigurationFormIsVisible(), 'Catalog promotion scope configuration form is not visible.');
+    }
+
+    /**
+     * @Then I should see the catalog promotion action configuration form
+     */
+    public function iShouldSeeTheCatalogPromotionActionConfigurationForm(): void
+    {
+        Assert::true($this->createPage->checkIfActionConfigurationFormIsVisible(), 'Catalog promotion action configuration form is not visible.');
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -695,6 +695,38 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
+     * @When I add a new rule
+     */
+    public function iAddANewRule()
+    {
+        $this->createPage->addRule(null);
+    }
+
+    /**
+     * @When I add a new action
+     */
+    public function iAddANewAction()
+    {
+        $this->createPage->addAction(null);
+    }
+
+    /**
+     * @Then I should see the rule configuration form
+     */
+    public function iShouldSeeTheRuleConfigurationForm()
+    {
+        Assert::true($this->createPage->checkIfRuleConfigurationFormIsVisible(), 'Cart promotion rule configuration form is not visible.');
+    }
+
+    /**
+     * @Then I should see the action configuration form
+     */
+    public function iShouldSeeTheActionConfigurationForm()
+    {
+        Assert::true($this->createPage->checkIfActionConfigurationFormIsVisible(), 'Cart promotion action configuration form is not visible.');
+    }
+
+    /**
      * @param string $element
      * @param string $expectedMessage
      */

--- a/src/Sylius/Behat/Page/Admin/CatalogPromotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/CatalogPromotion/CreatePage.php
@@ -20,12 +20,24 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
+    public function checkIfScopeConfigurationFormIsVisible(): bool
+    {
+        return $this->hasElement('products');
+    }
+
+    public function checkIfActionConfigurationFormIsVisible(): bool
+    {
+        return $this->hasElement('amount');
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
             'code' => '#sylius_catalog_promotion_code',
             'endDate' => '#sylius_catalog_promotion_endDate',
             'name' => '#sylius_catalog_promotion_name',
+            'products' => '[name="sylius_catalog_promotion[scopes][0][configuration][products]"]',
+            'amount' => '[name="sylius_catalog_promotion[actions][0][configuration][amount]"]',
         ]);
     }
 }

--- a/src/Sylius/Behat/Page/Admin/CatalogPromotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/CatalogPromotion/CreatePageInterface.php
@@ -17,5 +17,9 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
+    public function checkIfScopeConfigurationFormIsVisible(): bool;
+
+    public function checkIfActionConfigurationFormIsVisible(): bool;
+
     public function specifyCode(string $code): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -26,7 +26,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    public function addRule(string $ruleName): void
+    public function addRule(?string $ruleName): void
     {
         $count = count($this->getCollectionItems('rules'));
 
@@ -36,7 +36,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
             return $count + 1 === count($this->getCollectionItems('rules'));
         });
 
-        $this->selectRuleOption('Type', $ruleName);
+        if (null !== $ruleName) {
+            $this->selectRuleOption('Type', $ruleName);
+        }
     }
 
     public function selectRuleOption(string $option, string $value, bool $multiple = false): void
@@ -74,7 +76,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $lastAction->fillField($option, $value);
     }
 
-    public function addAction(string $actionName): void
+    public function addAction(?string $actionName): void
     {
         $count = count($this->getCollectionItems('actions'));
 
@@ -84,7 +86,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
             return $count + 1 === count($this->getCollectionItems('actions'));
         });
 
-        $this->selectActionOption('Type', $actionName);
+        if (null !== $actionName) {
+            $this->selectActionOption('Type', $actionName);
+        }
     }
 
     public function selectActionOption(string $option, string $value, bool $multiple = false): void
@@ -175,6 +179,16 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         AutocompleteHelper::chooseValue($this->getSession(), $filterAutocomplete, $value);
     }
 
+    public function checkIfRuleConfigurationFormIsVisible(): bool
+    {
+        return $this->hasElement('count');
+    }
+
+    public function checkIfActionConfigurationFormIsVisible(): bool
+    {
+        return $this->hasElement('amount');
+    }
+
     protected function getDefinedElements(): array
     {
         return [
@@ -186,6 +200,8 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
             'name' => '#sylius_promotion_name',
             'rules' => '#sylius_promotion_rules',
             'starts_at' => '#sylius_promotion_startsAt',
+            'count' => '#sylius_promotion_rules_0_configuration_count',
+            'amount' => '#sylius_promotion_actions_0_configuration_WEB-US_amount',
         ];
     }
 

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -22,7 +22,7 @@ interface CreatePageInterface extends BaseCreatePageInterface
 
     public function nameIt(string $name): void;
 
-    public function addRule(string $ruleName): void;
+    public function addRule(?string $ruleName): void;
 
     public function selectRuleOption(string $option, string $value, bool $multiple = false): void;
 
@@ -35,7 +35,7 @@ interface CreatePageInterface extends BaseCreatePageInterface
 
     public function fillRuleOptionForChannel(string $channelName, string $option, string $value): void;
 
-    public function addAction(string $actionName): void;
+    public function addAction(?string $actionName): void;
 
     public function selectActionOption(string $option, string $value, bool $multiple = false): void;
 
@@ -66,4 +66,8 @@ interface CreatePageInterface extends BaseCreatePageInterface
      * @param string|string[] $value
      */
     public function selectAutoCompleteFilterOption(string $option, $value, bool $multiple = false): void;
+
+    public function checkIfRuleConfigurationFormIsVisible(): bool;
+
+    public function checkIfActionConfigurationFormIsVisible(): bool;
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -61,16 +61,24 @@ $(document).ready(() => {
     containerSelector: '.configuration',
   });
 
-  $('#actions a[data-form-collection="add"]').on('click', () => {
+  $('#sylius_promotion_actions > a[data-form-collection="add"]').on('click', () => {
     setTimeout(() => {
       $('select[name^="sylius_promotion[actions]"][name$="[type]"]').last().change();
     }, 50);
   });
-  $('#scopes a[data-form-collection="add"]').on('click', (event) => {
-    const name = $(event.target).closest('form').attr('name');
-
+  $('#sylius_promotion_rules > a[data-form-collection="add"]').on('click', () => {
     setTimeout(() => {
-      $(`select[name^="${name}[scopes]"][name$="[type]"]`).last().change();
+      $(`select[name^="sylius_promotion[rules]"][name$="[type]"]`).last().change();
+    }, 50);
+  });
+  $('#sylius_catalog_promotion_actions > a[data-form-collection="add"]').on('click', () => {
+    setTimeout(() => {
+      $('select[name^="sylius_catalog_promotion[actions]"][name$="[type]"]').last().change();
+    }, 50);
+  });
+  $('#sylius_catalog_promotion_scopes > a[data-form-collection="add"]').on('click', () => {
+    setTimeout(() => {
+      $(`select[name^="sylius_catalog_promotion[scopes]"][name$="[type]"]`).last().change();
     }, 50);
   });
 


### PR DESCRIPTION
Fixes #13463

| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13463
| License         | MIT

Additionally to the bugfix, I made the jquery selectors more explicit by using direct ancestors. In fact, that's how I discovered this bug, because we were patching app.js to make these selectors more explicit, which allowed us embed additional collection forms inside action/rule collections forms.
