### PR TITLE
move default criteria to catalog promotion provider

### DIFF
--- a/features/promotion/applying_catalog_promotions/not_reapplying_catalog_promotions_on_variant_once_its_prices_changes.feature
+++ b/features/promotion/applying_catalog_promotions/not_reapplying_catalog_promotions_on_variant_once_its_prices_changes.feature
@@ -1,0 +1,26 @@
+@applying_catalog_promotions
+Feature: Not reapplying catalog promotions on variant once its prices changes
+    In order to have proper discounts on variants
+    As a Store Owner
+    I do not want to have discounts reapplied on variant once its prices changes if the catalog promotion criteria are not met
+
+    Background:
+        Given the store operates on a channel named "Web-US" with hostname "web-us"
+        And it is "2022-01-01" now
+        And the store has a "T-Shirt" configurable product
+        And this product has "PHP T-Shirt" variant priced at "$100.00" in "Web-US" channel
+        And there is a catalog promotion "Winter sale" between "2021-12-20" and "2021-12-30" available in "Web-US" channel that reduces price by "30%" and applies on "PHP T-Shirt" variant
+        And there is another catalog promotion "Spring sale" between "2022-04-01" and "2022-05-01" available in "Web-US" channel that reduces price by "25%" and applies on "PHP T-Shirt" variant
+        And there is disabled catalog promotion "Surprise sale" between "2021-07-01" and "2022-05-04" available in "Web-US" channel that reduces price by "90%" and applies on "PHP T-Shirt" variant
+        And I am logged in as an administrator
+
+    @api @ui
+    Scenario: Changing the price of the variant
+        When I change the price of the "PHP T-Shirt" product variant to "$50.00" in "Web-US" channel
+        Then the visitor should see "$50.00" as the price of the "T-Shirt" product in the "Web-US" channel
+
+    @api @ui
+    Scenario: Changing the original price of the variant
+        When I change the original price of the "PHP T-Shirt" product variant to "$105.00" in "Web-US" channel
+        Then the visitor should see "$100.00" as the price of the "T-Shirt" product in the "Web-US" channel
+        And the visitor should see "$105.00" as the original price of the "T-Shirt" product in the "Web-US" channel

--- a/features/promotion/applying_catalog_promotions/not_reapplying_catalog_promotions_on_variants_once_products_taxon_changes.feature
+++ b/features/promotion/applying_catalog_promotions/not_reapplying_catalog_promotions_on_variants_once_products_taxon_changes.feature
@@ -1,0 +1,31 @@
+@applying_catalog_promotions
+Feature: Not reapplying catalog promotions on variants once the product’s taxon changes
+    In order to have proper discounts in product catalog
+    As a Store Owner
+    I do not want to have discounts reapplied on variants once the product’s taxon changes if the catalog promotion criteria are not met
+
+    Background:
+        Given the store operates on a channel named "Web-US" with hostname "web-us"
+        And the store classifies its products as "Clothes", "Shirts" and "Dishes"
+        And the store has a "T-Shirt" configurable product
+        And this product belongs to "Clothes"
+        And this product has "PHP T-Shirt" variant priced at "$100.00"
+        And it is "2022-01-01" now
+        And there is a catalog promotion "Winter sale" between "2021-12-20" and "2021-12-30" available in "Web-US" channel that reduces price by "30%" and applies on "Clothes" taxon
+        And there is another catalog promotion "Spring sale" between "2022-04-01" and "2022-05-01" available in "Web-US" channel that reduces price by "25%" and applies on "Shirts" taxon
+        And there is disabled catalog promotion "Surprise sale" between "2021-07-01" and "2022-05-04" available in "Web-US" channel that reduces price by "90%" and applies on "Dishes" taxon
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Changing products taxon to taxon with scheduled catalog promotion
+        When I change that the "T-Shirt" product does not belong to the "Clothes" taxon
+        And I change that the "T-Shirt" product belongs to the "Shirts" taxon
+        Then the visitor should see that the "PHP T-Shirt" variant is not discounted
+        And the visitor should still see "$100.00" as the price of the "T-Shirt" product in the "Web-US" channel
+
+    @ui
+    Scenario: Changing products taxon to taxon with disabled catalog promotion
+        When I change that the "T-Shirt" product does not belong to the "Clothes" taxon
+        And I change that the "T-Shirt" product belongs to the "Dishes" taxon
+        Then the visitor should see that the "PHP T-Shirt" variant is not discounted
+        And the visitor should still see "$100.00" as the price of the "T-Shirt" product in the "Web-US" channel

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -26,6 +26,7 @@ use Sylius\Bundle\CoreBundle\Provider\ForVariantsScopeVariantsProvider;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
 use Sylius\Component\Promotion\Model\CatalogPromotionScopeInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -228,6 +229,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -254,6 +257,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -280,6 +285,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -306,6 +313,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -345,6 +354,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -370,6 +381,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -462,6 +475,65 @@ final class CatalogPromotionContext implements Context
     }
 
     /**
+     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/
+     */
+    public function thereIsACatalogPromotionBetweenAvailableInChannelThatReducesPriceByAndAppliesOnTaxon(
+        string $name,
+        string $startDate,
+        string $endDate,
+        ChannelInterface $channel,
+        float $discount,
+        TaxonInterface $taxon
+    ): void {
+        $this->createCatalogPromotion(
+            name: $name,
+            channels: [$channel->getCode()],
+            scopes: [[
+                'type' => ForTaxonsScopeVariantsProvider::TYPE,
+                'configuration' => ['taxons' => [$taxon->getCode()]],
+            ]],
+            actions: [[
+                'type' => PercentageDiscountPriceCalculator::TYPE,
+                'configuration' => ['amount' => $discount],
+            ]],
+            startDate: new \DateTimeImmutable($startDate),
+            endDate: new \DateTimeImmutable($endDate)
+        );
+
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @Given /^there is disabled catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/
+     */
+    public function thereIsDisabledCatalogPromotionBetweenAvailableInChannelThatReducesPriceByAndAppliesOnTaxon(
+        string $name,
+        string $startDate,
+        string $endDate,
+        ChannelInterface $channel,
+        float $discount,
+        TaxonInterface $taxon
+    ): void {
+        $this->createCatalogPromotion(
+            name: $name,
+            channels: [$channel->getCode()],
+            scopes: [[
+                'type' => ForTaxonsScopeVariantsProvider::TYPE,
+                'configuration' => ['taxons' => [$taxon->getCode()]],
+            ]],
+            actions: [[
+                'type' => PercentageDiscountPriceCalculator::TYPE,
+                'configuration' => ['amount' => $discount],
+            ]],
+            startDate: new \DateTimeImmutable($startDate),
+            endDate: new \DateTimeImmutable($endDate),
+            enabled: false
+        );
+
+        $this->entityManager->flush();
+    }
+
+    /**
      * @Given /^there is(?: a| another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" product)$/
      */
     public function thereIsACatalogPromotionThatReducesPriceByAndAppliesOnProduct(
@@ -484,6 +556,8 @@ final class CatalogPromotionContext implements Context
         );
 
         $this->entityManager->flush();
+
+        $this->eventBus->dispatch(new CatalogPromotionCreated(StringInflector::nameToCode($name)));
     }
 
     /**
@@ -636,7 +710,7 @@ final class CatalogPromotionContext implements Context
 
     /**
      * @Given the catalog promotion :catalogPromotion operates between :startDate and :endDate
-     * @Given /^(this catalog promotion) operates between ("[^"]+") and ("[^"]+")$/
+     * @Given /^(this catalog promotion) operates between "([^"]+)" and "([^"]+)"$/
      */
     public function theCatalogPromotionOperatesBetweenDates(
         CatalogPromotionInterface $catalogPromotion,

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -460,6 +460,21 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then the original price of the :product product in the :channel channel should be empty
+     */
+    public function theOriginalPriceOfTheProductInTheChannelShouldBeEmpty(
+        ProductInterface $product,
+        ChannelInterface $channel
+    ): void {
+        $this->channelContextSetter->setChannel($channel);
+
+        $localeCode = $channel->getDefaultLocale()->getCode();
+        $this->showPage->open(['slug' => $product->getTranslation($localeCode)->getSlug(), '_locale' => $localeCode]);
+
+        Assert::null($this->showPage->getOriginalPrice());
+    }
+
+    /**
      * @When I select its :optionName as :optionValue
      */
     public function iSelectItsOptionAs(string $optionName, string $optionValue): void

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
 use Faker\Factory;
 use Faker\Generator;
 use Sylius\Bundle\CoreBundle\Fixture\OptionsResolver\LazyOption;
-use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
+use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
@@ -40,7 +40,7 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
 
     private ExampleFactoryInterface $catalogPromotionActionExampleFactory;
 
-    private CatalogPromotionProcessorInterface $catalogPromotionProcessor;
+    private AllCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor;
 
     private Generator $faker;
 
@@ -52,14 +52,14 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
         ChannelRepositoryInterface $channelRepository,
         ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
         ExampleFactoryInterface $catalogPromotionActionExampleFactory,
-        CatalogPromotionProcessorInterface $catalogPromotionProcessor
+        AllCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor
     ) {
         $this->catalogPromotionFactory = $catalogPromotionFactory;
         $this->localeRepository = $localeRepository;
         $this->channelRepository = $channelRepository;
         $this->catalogPromotionScopeExampleFactory = $catalogPromotionScopeExampleFactory;
         $this->catalogPromotionActionExampleFactory = $catalogPromotionActionExampleFactory;
-        $this->catalogPromotionProcessor = $catalogPromotionProcessor;
+        $this->allCatalogPromotionsProcessor = $allCatalogPromotionsProcessor;
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();
 
@@ -74,6 +74,9 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
         $catalogPromotion = $this->catalogPromotionFactory->createNew();
         $catalogPromotion->setCode($options['code']);
         $catalogPromotion->setName($options['name']);
+        $catalogPromotion->setStartDate($options['startDate']);
+        $catalogPromotion->setEndDate($options['endDate']);
+        $catalogPromotion->setEnabled($options['enabled']);
         $catalogPromotion->setPriority($options['priority'] ?? 0);
         $catalogPromotion->setExclusive($options['exclusive'] ?? false);
 
@@ -107,7 +110,7 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
             }
         }
 
-        $this->catalogPromotionProcessor->process($catalogPromotion);
+        $this->allCatalogPromotionsProcessor->process();
 
         return $catalogPromotion;
     }
@@ -146,6 +149,12 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
             ->setAllowedTypes('priority', ['integer', 'null'])
             ->setDefault('exclusive', false)
             ->setAllowedTypes('exclusive', ['boolean', 'null'])
+            ->setDefault('startDate', null)
+            ->setAllowedTypes('startDate', [\DateTimeInterface::class, 'null'])
+            ->setDefault('endDate', null)
+            ->setAllowedTypes('endDate', [\DateTimeInterface::class, 'null'])
+            ->setDefault('enabled', true)
+            ->setAllowedTypes('enabled', 'boolean')
         ;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Processor/AllCatalogPromotionsProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/Processor/AllCatalogPromotionsProcessor.php
@@ -24,24 +24,20 @@ final class AllCatalogPromotionsProcessor implements AllCatalogPromotionsProcess
 
     private EligibleCatalogPromotionsProviderInterface $catalogPromotionsProvider;
 
-    private iterable $defaultCriteria;
-
     public function __construct(
         CatalogPromotionClearerInterface $catalogPromotionClearer,
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
         EligibleCatalogPromotionsProviderInterface $catalogPromotionsProvider,
-        iterable $defaultCriteria = []
     ) {
         $this->catalogPromotionClearer = $catalogPromotionClearer;
         $this->catalogPromotionProcessor = $catalogPromotionProcessor;
         $this->catalogPromotionsProvider = $catalogPromotionsProvider;
-        $this->defaultCriteria = $defaultCriteria;
     }
 
     public function process(): void
     {
         $this->catalogPromotionClearer->clear();
-        $eligibleCatalogPromotions = $this->catalogPromotionsProvider->provide($this->defaultCriteria);
+        $eligibleCatalogPromotions = $this->catalogPromotionsProvider->provide();
 
         foreach ($eligibleCatalogPromotions as $catalogPromotion) {
             $this->catalogPromotionProcessor->process($catalogPromotion);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionScopeExampleFactory" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionActionExampleFactory" />
-            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionScopeExampleFactory">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/processors.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/processors.xml
@@ -22,7 +22,6 @@
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearerInterface" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface" />
             <argument type="service" id="Sylius\Bundle\PromotionBundle\Provider\EligibleCatalogPromotionsProviderInterface" />
-            <argument type="tagged_iterator" tag="sylius.catalog_promotion.criteria" />
         </service>
 
         <service

--- a/src/Sylius/Bundle/CoreBundle/spec/Processor/AllCatalogPromotionsProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Processor/AllCatalogPromotionsProcessorSpec.php
@@ -28,15 +28,12 @@ final class AllCatalogPromotionsProcessorSpec extends ObjectBehavior
     function let(
         CatalogPromotionClearerInterface $catalogPromotionClearer,
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
-        EligibleCatalogPromotionsProviderInterface $catalogPromotionsProvider,
-        CriteriaInterface $firstCriteria,
-        CriteriaInterface $secondCriteria
+        EligibleCatalogPromotionsProviderInterface $catalogPromotionsProvider
     ): void {
         $this->beConstructedWith(
             $catalogPromotionClearer,
             $catalogPromotionProcessor,
-            $catalogPromotionsProvider,
-            [$firstCriteria, $secondCriteria]
+            $catalogPromotionsProvider
         );
     }
 
@@ -45,16 +42,11 @@ final class AllCatalogPromotionsProcessorSpec extends ObjectBehavior
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
         EligibleCatalogPromotionsProviderInterface $catalogPromotionsProvider,
         CatalogPromotionInterface $firstCatalogPromotion,
-        CatalogPromotionInterface $secondCatalogPromotion,
-        CriteriaInterface $firstCriteria,
-        CriteriaInterface $secondCriteria
+        CatalogPromotionInterface $secondCatalogPromotion
     ): void {
         $catalogPromotionClearer->clear()->shouldBeCalled();
 
-        $catalogPromotionsProvider
-            ->provide([$firstCriteria, $secondCriteria])
-            ->willReturn([$firstCatalogPromotion, $secondCatalogPromotion])
-        ;
+        $catalogPromotionsProvider->provide()->willReturn([$firstCatalogPromotion, $secondCatalogPromotion]);
 
         $catalogPromotionProcessor->process($firstCatalogPromotion)->shouldBeCalled();
         $catalogPromotionProcessor->process($secondCatalogPromotion)->shouldBeCalled();

--- a/src/Sylius/Bundle/PromotionBundle/Provider/EligibleCatalogPromotionsProvider.php
+++ b/src/Sylius/Bundle/PromotionBundle/Provider/EligibleCatalogPromotionsProvider.php
@@ -13,21 +13,24 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Provider;
 
-use Sylius\Bundle\PromotionBundle\Criteria\CriteriaInterface;
 use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class EligibleCatalogPromotionsProvider implements EligibleCatalogPromotionsProviderInterface
 {
     private CatalogPromotionRepositoryInterface $catalogPromotionRepository;
 
-    public function __construct(CatalogPromotionRepositoryInterface $catalogPromotionRepository)
-    {
+    private iterable $defaultCriteria;
+
+    public function __construct(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        iterable $defaultCriteria =  []
+    ) {
         $this->catalogPromotionRepository = $catalogPromotionRepository;
+        $this->defaultCriteria = $defaultCriteria;
     }
 
-    public function provide(iterable $criteria = []): array
+    public function provide(): array
     {
-        return $this->catalogPromotionRepository->findByCriteria($criteria);
+        return $this->catalogPromotionRepository->findByCriteria($this->defaultCriteria);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Provider/EligibleCatalogPromotionsProviderInterface.php
+++ b/src/Sylius/Bundle/PromotionBundle/Provider/EligibleCatalogPromotionsProviderInterface.php
@@ -10,9 +10,7 @@ use Sylius\Component\Core\Model\CatalogPromotionInterface;
 interface EligibleCatalogPromotionsProviderInterface
 {
     /**
-     * @param iterable|CriteriaInterface[] $criteria
-     *
      * @return array|CatalogPromotionInterface[]
      */
-    public function provide(iterable $criteria = []): array;
+    public function provide(): array;
 }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -78,6 +78,7 @@
             class="Sylius\Bundle\PromotionBundle\Provider\EligibleCatalogPromotionsProvider"
         >
             <argument type="service" id="sylius.repository.catalog_promotion" />
+            <argument type="tagged_iterator" tag="sylius.catalog_promotion.criteria" />
         </service>
 
         <service id="Sylius\Component\Promotion\Provider\DateTimeProviderInterface" class="Sylius\Component\Promotion\Provider\Calendar" />

--- a/src/Sylius/Bundle/PromotionBundle/spec/Provider/EligibleCatalogPromotionsProviderSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Provider/EligibleCatalogPromotionsProviderSpec.php
@@ -21,27 +21,17 @@ use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
 
 final class EligibleCatalogPromotionsProviderSpec extends ObjectBehavior
 {
-    function let(CatalogPromotionRepositoryInterface $catalogPromotionRepository): void
-    {
-        $this->beConstructedWith($catalogPromotionRepository);
+    function let(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        CriteriaInterface $firstCriterion,
+        CriteriaInterface $secondCriterion
+    ): void {
+        $this->beConstructedWith($catalogPromotionRepository, [$firstCriterion, $secondCriterion]);
     }
 
     function it_implements_eligible_catalog_promotions_provider_interface(): void
     {
         $this->shouldImplement(EligibleCatalogPromotionsProviderInterface::class);
-    }
-
-    function it_provides_all_catalog_promotions_when_no_criteria_is_specified(
-        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
-        CatalogPromotionInterface $firstCatalogPromotion,
-        CatalogPromotionInterface $secondCatalogPromotion
-    ): void {
-        $catalogPromotionRepository
-            ->findByCriteria([])
-            ->willReturn([$firstCatalogPromotion, $secondCatalogPromotion])
-        ;
-
-        $this->provide()->shouldReturn([$firstCatalogPromotion, $secondCatalogPromotion]);
     }
 
     function it_provides_catalog_promotions_based_on_criteria(
@@ -57,7 +47,7 @@ final class EligibleCatalogPromotionsProviderSpec extends ObjectBehavior
         ;
 
         $this
-            ->provide([$firstCriterion, $secondCriterion])
+            ->provide()
             ->shouldReturn([$firstCatalogPromotion, $secondCatalogPromotion])
         ;
     }

--- a/tests/Functional/EligibleCatalogPromotionsProcessorTest.php
+++ b/tests/Functional/EligibleCatalogPromotionsProcessorTest.php
@@ -49,9 +49,7 @@ class EligibleCatalogPromotionsProcessorTest extends WebTestCase
 
         file_put_contents(self::$kernel->getProjectDir() . '/var/temporaryDate.txt', '2021-10-12 00:00:02');
 
-        $dateRangeCriteria = self::$container->get('sylius.catalog_promotion.criteria.date_range');
-
-        $eligibleCatalogPromotions = $eligibleCatalogPromotionsProvider->provide([$dateRangeCriteria]);
+        $eligibleCatalogPromotions = $eligibleCatalogPromotionsProvider->provide();
 
         $expectedDateTimes = [
             new \DateTime('2021-10-12 00:00:00'),
@@ -79,9 +77,7 @@ class EligibleCatalogPromotionsProcessorTest extends WebTestCase
 
         file_put_contents(self::$kernel->getProjectDir() . '/var/temporaryDate.txt', '2021-10-12 23:59:58');
 
-        $dateRangeCriteria = self::$container->get('sylius.catalog_promotion.criteria.date_range');
-
-        $eligibleCatalogPromotions = $eligibleCatalogPromotionsProvider->provide([$dateRangeCriteria]);
+        $eligibleCatalogPromotions = $eligibleCatalogPromotionsProvider->provide();
 
         $expectedDateTimes = [
             new \DateTime('2021-10-12 23:59:59'),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

to avoid potential bugs default criteria should be on the provider level
<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
