### PR TITLE
[CatalogPromotion] Rename actions and scopes

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
@@ -65,7 +65,7 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Validator\Constraints\CatalogPromotionScopeValidator">
-            <argument>%sylius.catalog_promotion.scopes%</argument>
+            <argument>%sylius.catalog_promotion.scopes_types%</argument>
             <argument type="tagged_iterator" tag="sylius.catalog_promotion.scope_validator" index-by="key" />
             <tag name="validator.constraint_validator" alias="sylius_catalog_promotion_scope" />
         </service>

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPass.php
@@ -31,6 +31,6 @@ final class SetCatalogPromotionActionTypesPass implements CompilerPassInterface
             }
         }
 
-        $container->setParameter('sylius.catalog_promotion.actions', $types);
+        $container->setParameter('sylius.catalog_promotion.actions_types', $types);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPass.php
@@ -31,6 +31,6 @@ final class SetCatalogPromotionScopeTypesPass implements CompilerPassInterface
             }
         }
 
-        $container->setParameter('sylius.catalog_promotion.scopes', $types);
+        $container->setParameter('sylius.catalog_promotion.scopes_types', $types);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/validators.xml
@@ -34,7 +34,7 @@
         </service>
 
         <service id="Sylius\Bundle\PromotionBundle\Validator\CatalogPromotionActionValidator">
-            <argument>%sylius.catalog_promotion.actions%</argument>
+            <argument>%sylius.catalog_promotion.actions_types%</argument>
             <argument type="tagged_iterator" tag="sylius.catalog_promotion.action_validator" index-by="key" />
             <tag name="validator.constraint_validator" alias="sylius_catalog_promotion_action" />
         </service>

--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPassTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionActionTypesPassTest.php
@@ -38,7 +38,7 @@ final class SetCatalogPromotionActionTypesPassTest extends AbstractCompilerPassT
         $this->compile();
 
         $this->assertContainerBuilderHasParameter(
-            'sylius.catalog_promotion.actions',
+            'sylius.catalog_promotion.actions_types',
             ['custom', 'another_custom', 'second_custom']
         );
     }

--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPassTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/Compiler/SetCatalogPromotionScopeTypesPassTest.php
@@ -38,7 +38,7 @@ final class SetCatalogPromotionScopeTypesPassTest extends AbstractCompilerPassTe
         $this->compile();
 
         $this->assertContainerBuilderHasParameter(
-            'sylius.catalog_promotion.scopes',
+            'sylius.catalog_promotion.scopes_types',
             ['custom', 'another_custom', 'second_custom']
         );
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Renaming 
`sylius.catalog_promotion.actions` => `sylius.catalog_promotion.actions_types`
`sylius.catalog_promotion.scopes` => `sylius.catalog_promotion.scopes_types`


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
