### PR TITLE
Validation deleted from PercentageDiscountActionConfigurationType

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
@@ -16,9 +16,6 @@ final class PercentageDiscountActionConfigurationType extends AbstractType
         $builder
             ->add('amount', PercentType::class, [
                 'label' => 'sylius.ui.amount',
-                'constraints' => [
-                    new NotBlank(['groups' => ['sylius']]),
-                ]
             ])
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
We want to unify validation on both FixedDiscountActionConfigurationType and PercentageDiscountActionConfigurationType
and we have to choose beetween deletion additional validation or staying with additional validation on both

Close this PR in case [THIS](https://github.com/Sylius/Sylius/pull/13478) PR is merged