### PR TITLE
[CatalogPromotion] Refactor names of listeners to be consistent with others

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionUpdatedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionUpdatedListener.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-final class CatalogPromotionUpdateListener
+final class CatalogPromotionUpdatedListener
 {
     private AllCatalogPromotionsProcessorInterface $catalogPromotionsProcessor;
 

--- a/src/Sylius/Bundle/CoreBundle/Listener/ProductUpdatedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/ProductUpdatedListener.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Event\ProductUpdated;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 
-final class ProductUpdateListener
+final class ProductUpdatedListener
 {
     private ProductRepositoryInterface $productRepository;
 

--- a/src/Sylius/Bundle/CoreBundle/Listener/ProductVariantUpdatedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/ProductVariantUpdatedListener.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Event\ProductVariantUpdated;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 
-final class ProductVariantUpdateListener
+final class ProductVariantUpdatedListener
 {
     private ProductVariantRepositoryInterface $productVariantRepository;
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -116,7 +116,7 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
-        <service id="Sylius\Bundle\CoreBundle\Listener\CatalogPromotionUpdateListener">
+        <service id="Sylius\Bundle\CoreBundle\Listener\CatalogPromotionUpdatedListener">
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface" />
             <argument type="service" id="sylius.repository.catalog_promotion" />
             <argument type="service" id="doctrine.orm.entity_manager" />
@@ -139,14 +139,14 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
-        <service id="Sylius\Bundle\CoreBundle\Listener\ProductUpdateListener">
+        <service id="Sylius\Bundle\CoreBundle\Listener\ProductUpdatedListener">
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\ProductCatalogPromotionsProcessorInterface" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
-        <service id="Sylius\Bundle\CoreBundle\Listener\ProductVariantUpdateListener">
+        <service id="Sylius\Bundle\CoreBundle\Listener\ProductVariantUpdatedListener">
             <argument type="service" id="sylius.repository.product_variant" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\ProductVariantCatalogPromotionsProcessorInterface" />
             <argument type="service" id="doctrine.orm.entity_manager" />

--- a/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionUpdatedListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionUpdatedListenerSpec.php
@@ -16,14 +16,12 @@ namespace spec\Sylius\Bundle\CoreBundle\Listener;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
 use SM\Factory\FactoryInterface;
-use SM\StateMachine\StateMachineInterface;
 use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
-use Sylius\Component\Promotion\Model\CatalogPromotionTransitions;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-final class CatalogPromotionUpdateListenerSpec extends ObjectBehavior
+final class CatalogPromotionUpdatedListenerSpec extends ObjectBehavior
 {
     function let(
         AllCatalogPromotionsProcessorInterface $catalogPromotionReprocessor,

--- a/src/Sylius/Bundle/CoreBundle/spec/Listener/ProductUpdatedListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Listener/ProductUpdatedListenerSpec.php
@@ -21,7 +21,7 @@ use Sylius\Component\Core\Event\ProductUpdated;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 
-final class ProductUpdateListenerSpec extends ObjectBehavior
+final class ProductUpdatedListenerSpec extends ObjectBehavior
 {
     function let(
         ProductRepositoryInterface $productRepository,

--- a/src/Sylius/Bundle/CoreBundle/spec/Listener/ProductVariantUpdatedListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Listener/ProductVariantUpdatedListenerSpec.php
@@ -21,7 +21,7 @@ use Sylius\Component\Core\Event\ProductVariantUpdated;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
 
-final class ProductVariantUpdateListenerSpec extends ObjectBehavior
+final class ProductVariantUpdatedListenerSpec extends ObjectBehavior
 {
     function let(
         ProductVariantRepositoryInterface $productVariantRepository,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
