### PR TITLE
show the footer informations if in debug mode

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -27,7 +27,9 @@
 {% endblock %}
 
 {% block footer %}
-{{ 'sylius.ui.powered_by'|trans }} <a href="https://sylius.com" target="_blank">Sylius v{{ sylius_meta.version }}</a>. {{ 'sylius.ui.see_issue'|trans }}? <a href="https://github.com/Sylius/Sylius/issues" target="_blank">{{ 'sylius.ui.report_it'|trans }}!</a>
+    {% if app.debug %}
+        {{ 'sylius.ui.powered_by'|trans }} <a href="https://sylius.com" target="_blank">Sylius v{{ sylius_meta.version }}</a>. {{ 'sylius.ui.see_issue'|trans }}? <a href="https://github.com/Sylius/Sylius/issues" target="_blank">{{ 'sylius.ui.report_it'|trans }}!</a>
+    {% endif %}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

In Production, the Admins don't want to see the link to GitHub to submit issues, this is I believe for developers who work with the admin in Debug mode.
