### PR TITLE
feat: use sass instead of node-sass

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -130,3 +130,27 @@ If you don't already have configured the messenger transport, configure it accor
 ### API v2
 
 For changes according to the API v2, please visit [API v2 upgrade file](UPGRADE-API-1.11.md).
+
+### Asset management changes
+
+We updated gulp-sass plugin as well as the sass implementation we use to be compatible with most installation
+([node-sass](https://sass-lang.com/blog/libsass-is-deprecated) is deprecated and incompatible with many systems).
+Therefore you need to update your code to follow this change.
+
+1. Change the gulp-sass version you are using to `^5.1.0` (package.json file)
+   ```diff
+   - "gulp-sass": "^4.0.1",
+   + "gulp-sass": "^5.1.0",
+   ```
+2. Add sass to your package.json:
+   ```diff
+   + "sass": "^1.48.0",
+   ```
+3. Follow [this guide](https://github.com/dlmanning/gulp-sass/tree/master#migrating-to-version-5) to upgrade your
+   code when using gulp-sass this is an example:
+   ```diff
+   - import sass from 'gulp-sass';
+   + import gulpSass from 'gulp-sass';
+   + import realSass from 'sass';
+   + const sass = gulpSass(realSass);
+   ```

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-if": "^2.0.0",
     "gulp-livereload": "^4.0.1",
     "gulp-order": "^1.1.1",
-    "gulp-sass": "^4.0.1",
+    "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglifycss": "^1.0.5",
     "merge-stream": "^1.0.0",
@@ -39,6 +39,7 @@
     "rollup-plugin-inject": "^2.0.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^4.0.0",
+    "sass": "^1.48.0",
     "sass-loader": "^7.0.1",
     "upath": "^1.1.0",
     "yargs": "^6.4.0"

--- a/src/Sylius/Bundle/AdminBundle/gulpfile.babel.js
+++ b/src/Sylius/Bundle/AdminBundle/gulpfile.babel.js
@@ -6,16 +6,19 @@ import concat from 'gulp-concat';
 import dedent from 'dedent';
 import gulp from 'gulp';
 import gulpif from 'gulp-if';
+import gulpSass from 'gulp-sass';
 import inject from 'rollup-plugin-inject';
 import livereload from 'gulp-livereload';
 import merge from 'merge-stream';
 import order from 'gulp-order';
+import realSass from 'sass';
 import resolve from 'rollup-plugin-node-resolve';
-import sass from 'gulp-sass';
 import sourcemaps from 'gulp-sourcemaps';
 import uglifycss from 'gulp-uglifycss';
 import upath from 'upath';
 import yargs from 'yargs';
+
+const sass = gulpSass(realSass);
 
 const { argv } = yargs
   .options({

--- a/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js
+++ b/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js
@@ -6,16 +6,19 @@ import concat from 'gulp-concat';
 import dedent from 'dedent';
 import gulp from 'gulp';
 import gulpif from 'gulp-if';
+import gulpSass from 'gulp-sass';
 import inject from 'rollup-plugin-inject';
 import livereload from 'gulp-livereload';
 import merge from 'merge-stream';
 import order from 'gulp-order';
+import realSass from 'sass';
 import resolve from 'rollup-plugin-node-resolve';
-import sass from 'gulp-sass';
 import sourcemaps from 'gulp-sourcemaps';
 import uglifycss from 'gulp-uglifycss';
 import upath from 'upath';
 import yargs from 'yargs';
+
+const sass = gulpSass(realSass);
 
 const { argv } = yargs
   .options({


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master (could be done on others, your call)
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes (it won't work with gulp-sass 4.0 anymore I think)
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | #12893 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
node-sass is deprecated and its installation breaks on many many setups depending on:
- Node version (up to 12 it seems fine, it breaks for 13+)
- gpy installed or not
- Already installed tooling
- Platform (linux/mac/windows)

All of these problems make the `sass` package a benediction. This commit makes the sylius codebase compatible with it.