### PR TITLE
[API][Minor] Archiving shipping methods filter rename to maintain naming convention

### DIFF
--- a/UPGRADE-API-1.11.md
+++ b/UPGRADE-API-1.11.md
@@ -372,3 +372,5 @@
 1. `Sylius\Bundle\ApiBundle\Command\Cart\ApplyCouponToCart` and `Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder` commands have been replaced with `Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart`.
 
 1. `Sylius\Bundle\ApiBundle\CommandHandler\Cart\ApplyCouponToCartHandler` and `Sylius\Bundle\ApiBundle\CommandHandler\Checkout\AddressOrderHandler` command handlers have been replaced with `Sylius\Bundle\ApiBundle\CommandHandler\Checkout\UpdateCartHandler`.
+
+1. The `sylius.api.filter_archived_shipping_methods` services has been renamed to `sylius.api.archived_shipping_methods_filter` to be coherent with rest of the filters

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -82,7 +82,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/shipping-methods</attribute>
                 <attribute name="filters">
-                    <attribute>sylius.api.filter_archived_shipping_methods</attribute>
+                    <attribute>sylius.api.archived_shipping_methods_filter</attribute>
                     <attribute>sylius.api.shipping_method_order_filter</attribute>
                     <attribute>Sylius\Bundle\ApiBundle\Doctrine\Filter\TranslationOrderNameAndLocaleFilter</attribute>
                 </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -26,7 +26,7 @@
             <tag name="api_platform.filter" />
         </service>
 
-        <service id="sylius.api.filter_archived_shipping_methods" parent="api_platform.doctrine.orm.exists_filter" public="true">
+        <service id="sylius.api.archived_shipping_methods_filter" parent="api_platform.doctrine.orm.exists_filter" public="true">
             <argument type="collection">
                 <argument key="archivedAt">false</argument>
             </argument>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

I've moved `filter` word to the end of the service name, as this is a convention we have for the rest of the filters. The question arises if we shouldn't move to the old Symfony service convention for filters to have the same structure here, but I don't have any strong opinion about it.  
