### PR TITLE
Upgrade to Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "liip/imagine-bundle": "^2.3",
         "payum/payum": "^1.7",
         "payum/payum-bundle": "^2.4",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "ramsey/uuid": "^3.9",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -31,7 +31,7 @@
         "php": "^8.0",
         "payum/payum": "^1.6",
         "payum/payum-bundle": "^2.4",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "sylius/core": "^1.6",
         "sylius/currency": "^1.6",
         "sylius/order-bundle": "^1.6",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -54,7 +54,7 @@
     "require-dev": {
         "hwi/oauth-bundle": "^1.1",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "phpspec/phpspec": "^7.1",
         "phpunit/phpunit": "^8.5",
         "symfony/dependency-injection": "^4.4 || ^5.4",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -29,7 +29,7 @@
         "php": "^8.0",
         "knplabs/gaufrette": "^0.8",
         "payum/payum": "^1.6",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "sylius/addressing": "^1.6",
         "sylius/attribute": "^1.6",
         "sylius/channel": "^1.6",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Guzzle 6 is EOL, it's time to upgrade.