### PR TITLE
[CatalogPromotion] Extract dispatching catalog promotion events from listeners to a separate service

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/EventSubscriber/CatalogPromotionEventSubscriber.php
+++ b/src/Sylius/Bundle/ApiBundle/EventSubscriber/CatalogPromotionEventSubscriber.php
@@ -14,34 +14,20 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\EventSubscriber;
 
 use ApiPlatform\Core\EventListener\EventPriorities;
-use Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface;
+use Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
-use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
-use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
-use Sylius\Component\Promotion\Provider\DateTimeProviderInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 final class CatalogPromotionEventSubscriber implements EventSubscriberInterface
 {
-    private MessageBusInterface $eventBus;
+    private CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer;
 
-    private DelayStampCalculatorInterface $delayStampCalculator;
-
-    private DateTimeProviderInterface $dateTimeProvider;
-
-    public function __construct(
-        MessageBusInterface $eventBus,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ) {
-        $this->eventBus = $eventBus;
-        $this->delayStampCalculator = $delayStampCalculator;
-        $this->dateTimeProvider = $dateTimeProvider;
+    public function __construct(CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer)
+    {
+        $this->catalogPromotionAnnouncer = $catalogPromotionAnnouncer;
     }
 
     public static function getSubscribedEvents(): array
@@ -53,36 +39,21 @@ final class CatalogPromotionEventSubscriber implements EventSubscriberInterface
 
     public function postWrite(ViewEvent $event): void
     {
-        $entity = $event->getControllerResult();
+        $catalogPromotion = $event->getControllerResult();
 
-        if (!$entity instanceof CatalogPromotionInterface) {
+        if (!$catalogPromotion instanceof CatalogPromotionInterface) {
             return;
         }
 
         $method = $event->getRequest()->getMethod();
-        if (!in_array($method, [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH], true)) {
+        if ($method === Request::METHOD_POST) {
+            $this->catalogPromotionAnnouncer->dispatchCatalogPromotionCreatedEvent($catalogPromotion);
+
             return;
         }
 
-        $stamps = [];
-        if ($entity->getStartDate() !== null) {
-            $stamps[] = $this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $entity->getStartDate());
-        }
-
-        $code = $entity->getCode();
-        if ($method === Request::METHOD_POST) {
-            $this->eventBus->dispatch(new CatalogPromotionCreated($code), $stamps);
-        }
-
         if (in_array($method, [Request::METHOD_PUT, Request::METHOD_PATCH], true)) {
-            $this->eventBus->dispatch(new CatalogPromotionUpdated($code), $stamps);
-        }
-
-        if ($entity->getEndDate() !== null) {
-            $this->eventBus->dispatch(
-                new CatalogPromotionEnded($code),
-                [$this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $entity->getEndDate())]
-            );
+            $this->catalogPromotionAnnouncer->dispatchCatalogPromotionUpdatedEvent($catalogPromotion);
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/event_subscribers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/event_subscribers.xml
@@ -24,9 +24,7 @@
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\EventSubscriber\CatalogPromotionEventSubscriber">
-            <argument type="service" id="sylius.event_bus" />
-            <argument type="service" id="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface" />
-            <argument type="service" id="Sylius\Component\Promotion\Provider\DateTimeProviderInterface" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface" />
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncer.php
+++ b/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncer.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Announcer;
+
+use Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
+use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
+use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
+use Sylius\Component\Promotion\Provider\DateTimeProviderInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CatalogPromotionAnnouncer implements CatalogPromotionAnnouncerInterface
+{
+    private MessageBusInterface $eventBus;
+
+    private DelayStampCalculatorInterface $delayStampCalculator;
+
+    private DateTimeProviderInterface $dateTimeProvider;
+
+    public function __construct(
+        MessageBusInterface $eventBus,
+        DelayStampCalculatorInterface $delayStampCalculator,
+        DateTimeProviderInterface $dateTimeProvider
+    ) {
+        $this->eventBus = $eventBus;
+        $this->delayStampCalculator = $delayStampCalculator;
+        $this->dateTimeProvider = $dateTimeProvider;
+    }
+
+    public function dispatchCatalogPromotionCreatedEvent(CatalogPromotionInterface $catalogPromotion): void
+    {
+        $this->eventBus->dispatch(
+            new CatalogPromotionCreated($catalogPromotion->getCode()),
+            $this->calculateStartDateStamp($catalogPromotion)
+        );
+
+        $this->dispatchCatalogPromotionEndedEvent($catalogPromotion);
+    }
+
+    public function dispatchCatalogPromotionUpdatedEvent(CatalogPromotionInterface $catalogPromotion): void
+    {
+        $this->eventBus->dispatch(
+            new CatalogPromotionUpdated($catalogPromotion->getCode()),
+            $this->calculateStartDateStamp($catalogPromotion)
+        );
+
+        $this->dispatchCatalogPromotionEndedEvent($catalogPromotion);
+    }
+
+    private function calculateStartDateStamp(CatalogPromotionInterface $catalogPromotion): array
+    {
+        if ($catalogPromotion->getStartDate() !== null) {
+            return [$this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $catalogPromotion->getStartDate())];
+        }
+
+        return [];
+    }
+
+    private function dispatchCatalogPromotionEndedEvent(CatalogPromotionInterface $catalogPromotion): void
+    {
+        if ($catalogPromotion->getEndDate() !== null) {
+            $this->eventBus->dispatch(
+                new CatalogPromotionEnded($catalogPromotion->getCode()),
+                [$this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $catalogPromotion->getEndDate())]
+            );
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncerInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncerInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Announcer;
+
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+
+interface CatalogPromotionAnnouncerInterface
+{
+    public function dispatchCatalogPromotionCreatedEvent(CatalogPromotionInterface $catalogPromotion): void;
+
+    public function dispatchCatalogPromotionUpdatedEvent(CatalogPromotionInterface $catalogPromotion): void;
+}

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
@@ -13,78 +13,35 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface;
+use Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
-use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
-use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
-use Sylius\Component\Promotion\Provider\DateTimeProviderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 
 final class CatalogPromotionEventListener
 {
-    private MessageBusInterface $eventBus;
+    private CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer;
 
-    private DelayStampCalculatorInterface $delayStampCalculator;
-
-    private DateTimeProviderInterface $dateTimeProvider;
-
-    public function __construct(
-        MessageBusInterface $eventBus,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ) {
-        $this->eventBus = $eventBus;
-        $this->delayStampCalculator = $delayStampCalculator;
-        $this->dateTimeProvider = $dateTimeProvider;
+    public function __construct(CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer)
+    {
+        $this->catalogPromotionAnnouncer = $catalogPromotionAnnouncer;
     }
 
-    public function dispatchCatalogPromotionCreatedEvent(GenericEvent $event): void
+    public function handleCatalogPromotionCreatedEvent(GenericEvent $event): void
     {
         /** @var CatalogPromotionInterface $catalogPromotion */
         $catalogPromotion = $event->getSubject();
         Assert::isInstanceOf($catalogPromotion, CatalogPromotionInterface::class);
 
-        $this->eventBus->dispatch(
-            new CatalogPromotionCreated($catalogPromotion->getCode()),
-            $this->calculateStartDateStamp($catalogPromotion)
-        );
-
-        $this->dispatchCatalogPromotionEndedEvent($catalogPromotion);
+        $this->catalogPromotionAnnouncer->dispatchCatalogPromotionCreatedEvent($catalogPromotion);
     }
 
-    public function dispatchCatalogPromotionUpdatedEvent(GenericEvent $event): void
+    public function handleCatalogPromotionUpdatedEvent(GenericEvent $event): void
     {
         /** @var CatalogPromotionInterface $catalogPromotion */
         $catalogPromotion = $event->getSubject();
         Assert::isInstanceOf($catalogPromotion, CatalogPromotionInterface::class);
 
-        $this->eventBus->dispatch(
-            new CatalogPromotionUpdated($catalogPromotion->getCode()),
-            $this->calculateStartDateStamp($catalogPromotion)
-        );
-
-        $this->dispatchCatalogPromotionEndedEvent($catalogPromotion);
-    }
-
-    private function calculateStartDateStamp(CatalogPromotionInterface $catalogPromotion): array
-    {
-        if ($catalogPromotion->getStartDate() !== null) {
-            return [$this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $catalogPromotion->getStartDate())];
-        }
-
-        return [];
-    }
-
-    private function dispatchCatalogPromotionEndedEvent(CatalogPromotionInterface $catalogPromotion): void
-    {
-        if ($catalogPromotion->getEndDate() !== null) {
-            $this->eventBus->dispatch(
-                new CatalogPromotionEnded($catalogPromotion->getCode()),
-                [$this->delayStampCalculator->calculate($this->dateTimeProvider->now(), $catalogPromotion->getEndDate())]
-            );
-        }
+        $this->catalogPromotionAnnouncer->dispatchCatalogPromotionUpdatedEvent($catalogPromotion);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -254,7 +254,7 @@
         <service class="Sylius\Bundle\CoreBundle\Mailer\OrderEmailManager" id="sylius.mailer.order_email_manager">
             <argument type="service" id="sylius.email_sender" />
         </service>
-        
+
         <service
             id="Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface"
             class="Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicator"
@@ -288,5 +288,14 @@
         <service id="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface" class="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculator"/>
 
         <service id="security.authentication_manager" alias="security.authentication.manager" />
+
+        <service
+            id="Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface"
+            class="Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncer"
+        >
+            <argument type="service" id="sylius.event_bus" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface" />
+            <argument type="service" id="Sylius\Component\Promotion\Provider\DateTimeProviderInterface" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -92,11 +92,9 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\EventListener\CatalogPromotionEventListener">
-            <argument type="service" id="sylius.event_bus" />
-            <argument type="service" id="Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface" />
-            <argument type="service" id="Sylius\Component\Promotion\Provider\DateTimeProviderInterface" />
-            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_create" method="dispatchCatalogPromotionCreatedEvent" />
-            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_update" method="dispatchCatalogPromotionUpdatedEvent" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface" />
+            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_create" method="handleCatalogPromotionCreatedEvent" />
+            <tag name="kernel.event_listener" event="sylius.catalog_promotion.post_update" method="handleCatalogPromotionUpdatedEvent" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\EventListener\ProductEventListener">

--- a/src/Sylius/Bundle/CoreBundle/spec/Announcer/CatalogPromotionAnnouncerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Announcer/CatalogPromotionAnnouncerSpec.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Announcer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface;
+use Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
+use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
+use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
+use Sylius\Component\Promotion\Provider\DateTimeProviderInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+final class CatalogPromotionAnnouncerSpec extends ObjectBehavior
+{
+    function let(
+        MessageBusInterface $eventBus,
+        DelayStampCalculatorInterface $delayStampCalculator,
+        DateTimeProviderInterface $dateTimeProvider
+    ): void {
+        $this->beConstructedWith($eventBus, $delayStampCalculator, $dateTimeProvider);
+    }
+
+    function it_implements_catalog_promotion_announcer_interface(): void
+    {
+        $this->shouldImplement(CatalogPromotionAnnouncerInterface::class);
+    }
+
+    function it_dispatches_catalog_promotion_created_and_catalog_promotion_ended_events(
+        MessageBusInterface $eventBus,
+        DelayStampCalculatorInterface $delayStampCalculator,
+        DateTimeProviderInterface $dateTimeProvider,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        $startDateTime = new \DateTime('2021-10-10');
+        $endDateTime = new \DateTime('2021-10-11');
+
+        $dateTimeProvider->now()->willReturn(new \DateTime());
+
+        $catalogPromotion->getCode()->willReturn('SALE');
+        $catalogPromotion->getStartDate()->willReturn($startDateTime);
+        $catalogPromotion->getEndDate()->willReturn($endDateTime);
+
+        $startDelayStamp = new DelayStamp(200000);
+        $endDelayStamp = new DelayStamp(300000);
+
+        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
+        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
+
+        $messageCreate = new CatalogPromotionCreated('SALE');
+        $messageEnd = new CatalogPromotionEnded('SALE');
+
+        $eventBus->dispatch($messageCreate, [$startDelayStamp])->willReturn(new Envelope($messageCreate))->shouldBeCalled();
+        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldBeCalled();
+
+        $this->dispatchCatalogPromotionCreatedEvent($catalogPromotion);
+    }
+
+    function it_does_not_dispatch_catalog_promotion_ended_when_catalog_promotion_has_no_end_date_configured(
+        MessageBusInterface $eventBus,
+        DelayStampCalculatorInterface $delayStampCalculator,
+        DateTimeProviderInterface $dateTimeProvider,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        $startDateTime = new \DateTime('2021-10-10');
+
+        $dateTimeProvider->now()->willReturn(new \DateTime());
+
+        $catalogPromotion->getCode()->willReturn('SALE');
+        $catalogPromotion->getStartDate()->willReturn($startDateTime);
+        $catalogPromotion->getEndDate()->willReturn(null);
+
+        $startDelayStamp = new DelayStamp(200000);
+
+        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
+
+        $messageUpdate = new CatalogPromotionCreated('SALE');
+        $messageEnd = new CatalogPromotionEnded('SALE');
+
+        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
+        $eventBus->dispatch($messageEnd, [Argument::any()])->shouldNotBeCalled();
+
+        $this->dispatchCatalogPromotionCreatedEvent($catalogPromotion);
+    }
+
+    function it_dispatches_catalog_promotion_updated_and_catalog_promotion_ended_events(
+        MessageBusInterface $eventBus,
+        DelayStampCalculatorInterface $delayStampCalculator,
+        DateTimeProviderInterface $dateTimeProvider,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        $startDateTime = new \DateTime('2021-10-10');
+        $endDateTime = new \DateTime('2021-10-11');
+
+        $dateTimeProvider->now()->willReturn(new \DateTime());
+
+        $catalogPromotion->getCode()->willReturn('SALE');
+        $catalogPromotion->getStartDate()->willReturn($startDateTime);
+        $catalogPromotion->getEndDate()->willReturn($endDateTime);
+
+        $startDelayStamp = new DelayStamp(200000);
+        $endDelayStamp = new DelayStamp(300000);
+
+        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
+        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
+
+        $messageUpdate = new CatalogPromotionUpdated('SALE');
+        $messageEnd = new CatalogPromotionEnded('SALE');
+
+        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
+        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldBeCalled();
+
+        $this->dispatchCatalogPromotionUpdatedEvent($catalogPromotion);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
@@ -14,184 +14,39 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Sylius\Bundle\CoreBundle\Calculator\DelayStampCalculatorInterface;
+use Sylius\Bundle\CoreBundle\Announcer\CatalogPromotionAnnouncerInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
-use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
-use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
-use Sylius\Component\Promotion\Provider\DateTimeProviderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 final class CatalogPromotionEventListenerSpec extends ObjectBehavior
 {
-    function let(
-        MessageBusInterface $eventBus,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ): void {
-        $this->beConstructedWith($eventBus, $delayStampCalculator, $dateTimeProvider);
+    function let(CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer): void
+    {
+        $this->beConstructedWith($catalogPromotionAnnouncer);
     }
 
-    function it_dispatches_catalog_promotion_created_and_catalog_promotion_ended_after_creating_catalog_promotion(
-        MessageBusInterface $eventBus,
+    function it_uses_announcer_to_dispatch_catalog_promotion_created_event_after_creating_catalog_promotion(
+        CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer,
         GenericEvent $event,
-        CatalogPromotionInterface $catalogPromotion,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
+        CatalogPromotionInterface $catalogPromotion
     ): void {
         $event->getSubject()->willReturn($catalogPromotion);
-        $startDateTime = new \DateTime('2021-10-10');
-        $endDateTime = new \DateTime('2021-10-11');
 
-        $dateTimeProvider->now()->willReturn(new \DateTime());
+        $catalogPromotionAnnouncer->dispatchCatalogPromotionCreatedEvent($catalogPromotion)->shouldBeCalled();
 
-        $catalogPromotion->getCode()->willReturn('SALE');
-        $catalogPromotion->getStartDate()->willReturn($startDateTime);
-        $catalogPromotion->getEndDate()->willReturn($endDateTime);
-
-        $startDelayStamp = new DelayStamp(200000);
-        $endDelayStamp = new DelayStamp(300000);
-
-        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
-        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
-
-        $messageUpdate = new CatalogPromotionCreated('SALE');
-        $messageEnd = new CatalogPromotionEnded('SALE');
-
-        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
-        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldBeCalled();
-
-        $this->dispatchCatalogPromotionCreatedEvent($event);
+        $this->handleCatalogPromotionCreatedEvent($event);
     }
 
-    function it_does_not_dispatch_catalog_promotion_ended_after_creating_catalog_promotion_when_no_end_date_is_provided(
-        MessageBusInterface $eventBus,
+    function it_uses_announcer_to_dispatch_catalog_promotion_updated_event_after_updating_catalog_promotion(
+        CatalogPromotionAnnouncerInterface $catalogPromotionAnnouncer,
         GenericEvent $event,
-        CatalogPromotionInterface $catalogPromotion,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
+        CatalogPromotionInterface $catalogPromotion
     ): void {
         $event->getSubject()->willReturn($catalogPromotion);
-        $startDateTime = new \DateTime('2021-10-10');
-        $endDateTime = new \DateTime('2021-10-11');
 
-        $dateTimeProvider->now()->willReturn(new \DateTime());
+        $catalogPromotionAnnouncer->dispatchCatalogPromotionUpdatedEvent($catalogPromotion)->shouldBeCalled();
 
-        $catalogPromotion->getCode()->willReturn('SALE');
-        $catalogPromotion->getStartDate()->willReturn($startDateTime);
-        $catalogPromotion->getEndDate()->willReturn(null);
-
-        $startDelayStamp = new DelayStamp(200000);
-        $endDelayStamp = new DelayStamp(300000);
-
-        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
-        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
-
-        $messageUpdate = new CatalogPromotionCreated('SALE');
-        $messageEnd = new CatalogPromotionEnded('SALE');
-
-        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
-        $eventBus->dispatch($messageEnd, [Argument::any()])->shouldNotBeCalled();
-
-        $this->dispatchCatalogPromotionCreatedEvent($event);
-    }
-
-    function it_dispatches_catalog_promotion_updated_and_catalog_promotion_ended_after_updating_catalog_promotion(
-        MessageBusInterface $eventBus,
-        GenericEvent $event,
-        CatalogPromotionInterface $catalogPromotion,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ): void {
-        $event->getSubject()->willReturn($catalogPromotion);
-        $startDateTime = new \DateTime('2021-10-10');
-        $endDateTime = new \DateTime('2021-10-11');
-
-        $dateTimeProvider->now()->willReturn(new \DateTime());
-
-        $catalogPromotion->getCode()->willReturn('SALE');
-        $catalogPromotion->getStartDate()->willReturn($startDateTime);
-        $catalogPromotion->getEndDate()->willReturn($endDateTime);
-
-        $startDelayStamp = new DelayStamp(200000);
-        $endDelayStamp = new DelayStamp(300000);
-
-        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
-        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
-
-        $messageUpdate = new CatalogPromotionUpdated('SALE');
-        $messageEnd = new CatalogPromotionEnded('SALE');
-
-        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
-        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldBeCalled();
-
-        $this->dispatchCatalogPromotionUpdatedEvent($event);
-    }
-
-    function it_does_not_dispatch_catalog_promotion_ended_after_updating_catalog_promotion_when_no_end_date_is_provided(
-        MessageBusInterface $eventBus,
-        GenericEvent $event,
-        CatalogPromotionInterface $catalogPromotion,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ): void {
-        $event->getSubject()->willReturn($catalogPromotion);
-        $startDateTime = new \DateTime('2021-10-10');
-        $endDateTime = new \DateTime('2021-10-11');
-
-        $dateTimeProvider->now()->willReturn(new \DateTime());
-
-        $catalogPromotion->getCode()->willReturn('SALE');
-        $catalogPromotion->getStartDate()->willReturn($startDateTime);
-        $catalogPromotion->getEndDate()->willReturn(null);
-
-        $startDelayStamp = new DelayStamp(200000);
-        $endDelayStamp = new DelayStamp(300000);
-
-        $delayStampCalculator->calculate(Argument::any(), $startDateTime)->willReturn($startDelayStamp);
-        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
-
-        $messageUpdate = new CatalogPromotionUpdated('SALE');
-        $messageEnd = new CatalogPromotionEnded('SALE');
-
-        $eventBus->dispatch($messageUpdate, [$startDelayStamp])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
-        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldNotBeCalled();
-
-        $this->dispatchCatalogPromotionUpdatedEvent($event);
-    }
-
-    function it_dispatches_catalog_promotion_started_without_delay_if_start_date_is_not_provided(
-        MessageBusInterface $eventBus,
-        GenericEvent $event,
-        CatalogPromotionInterface $catalogPromotion,
-        DelayStampCalculatorInterface $delayStampCalculator,
-        DateTimeProviderInterface $dateTimeProvider
-    ): void {
-        $event->getSubject()->willReturn($catalogPromotion);
-        $endDateTime = new \DateTime('2021-10-11');
-
-        $dateTimeProvider->now()->willReturn(new \DateTime());
-
-        $catalogPromotion->getCode()->willReturn('SALE');
-        $catalogPromotion->getStartDate()->willReturn(null);
-        $catalogPromotion->getEndDate()->willReturn($endDateTime);
-
-        $endDelayStamp = new DelayStamp(300000);
-
-        $delayStampCalculator->calculate(Argument::any(), null)->shouldNotBeCalled();
-        $delayStampCalculator->calculate(Argument::any(), $endDateTime)->willReturn($endDelayStamp);
-
-        $messageUpdate = new CatalogPromotionUpdated('SALE');
-        $messageEnd = new CatalogPromotionEnded('SALE');
-
-        $eventBus->dispatch($messageUpdate, [])->willReturn(new Envelope($messageUpdate))->shouldBeCalled();
-        $eventBus->dispatch($messageEnd, [$endDelayStamp])->willReturn(new Envelope($messageEnd))->shouldBeCalled();
-
-        $this->dispatchCatalogPromotionUpdatedEvent($event);
+        $this->handleCatalogPromotionUpdatedEvent($event);
     }
 
     function it_throws_an_exception_if_event_object_is_not_a_catalog_promotion(GenericEvent $event): void
@@ -200,7 +55,7 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('dispatchCatalogPromotionUpdatedEvent', [$event])
+            ->during('handleCatalogPromotionUpdatedEvent', [$event])
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/13473#pullrequestreview-851633441
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
