### PR TITLE
[Architecture] Do not double install PHP dependencies

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -126,21 +126,6 @@ jobs:
                 uses: actions/checkout@v2
 
             -
-                name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "${{ matrix.php }}"
-                    ini-values: date.timezone=Europe/Warsaw, opcache.enable=1, opcache.enable_cli=1, opcache.memory_consumption=256, opcache.max_accelerated_files=32531, opcache.interned_strings_buffer=8, opcache.validate_timestamps=0, opcache.save_comments=1, opcache.fast_shutdown=0
-                    extensions: intl, gd, opcache, mysql, pdo_mysql, :xdebug
-                    tools: symfony
-                    coverage: none
-
-            -
-                name: Install PHP dependencies
-                run: composer update --no-interaction --no-scripts
-                id: end-of-setup
-
-            -
                 name: Run PHPArkitect
                 uses: docker://phparkitect/arkitect-github-actions
                 env:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Composer install is already part of architekt github action https://github.com/phparkitect/arkitect-github-actions/blob/main/entrypoint.sh#L23

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
