### PR TITLE
[Maintenance] Remove NelmioAlice from the main packages config

### DIFF
--- a/config/packages/nelmio_alice.yaml
+++ b/config/packages/nelmio_alice.yaml
@@ -1,3 +1,0 @@
-nelmio_alice:
-    functions_blacklist:
-        - 'current'

--- a/config/packages/test_cached/nelmio_alice.yaml
+++ b/config/packages/test_cached/nelmio_alice.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../dev/nelmio_alice.yaml }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This bundle is not turned on in all configuration. Without removal of it, no one can start prod env for example

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
