### PR TITLE
[Docs] Altered custom invoice logo path

### DIFF
--- a/docs/cookbook/payments/custom-invoice.rst
+++ b/docs/cookbook/payments/custom-invoice.rst
@@ -32,7 +32,7 @@ Example custom configuration:
 
 .. code-block:: text
 
-    SYLIUS_INVOICING_LOGO_FILE=%kernel.project_dir%/assets/custom-logo.png
+    SYLIUS_INVOICING_LOGO_FILE=%kernel.project_dir%/public/assets/custom-logo.png
 
 Make sure to clear the cache each time the configuration is changed.
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Changed path of the invoice logo asset to the correct directory