### PR TITLE
OAuth | `UserResponseInterface::getUsername()` can return integer

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -153,7 +153,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
 
         /** @var UserOAuthInterface $oauth */
         $oauth = $this->oauthFactory->createNew();
-        $oauth->setIdentifier($response->getUsername());
+        $oauth->setIdentifier((string) $response->getUsername());
         $oauth->setProvider($response->getResourceOwner()->getName());
         $oauth->setAccessToken($response->getAccessToken());
         $oauth->setRefreshToken($response->getRefreshToken());


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
