### PR TITLE
Exclude PHP Arkitect rules files from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -258,7 +258,8 @@
             "src/Sylius/*/*/Tests/",
             "src/Sylius/Component/Core/Test/Tests/",
             "src/Sylius/*/*/spec/",
-            "src/Sylius/*/*/test/"
+            "src/Sylius/*/*/test/",
+            "src/Sylius/*/*/phparkitect.php"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

@lchrusciel `src/Sylius/*/*/phparkitect.php` files must be excluded from the autoloader because they use PHP Arkitect symbols which is dev dependency and not a production one.