### PR TITLE
[Minor] Removal of logic duplication in shipping charges processor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -41,9 +41,6 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        // Remove all shipping adjustments, we recalculate everything from scratch.
-        $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT);
-
         foreach ($order->getShipments() as $shipment) {
             $shipment->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT);
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -39,14 +39,12 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
     function it_removes_existing_shipping_adjustments(OrderInterface $order): void
     {
         $order->getShipments()->willReturn(new ArrayCollection([]));
-        $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
 
         $this->process($order);
     }
 
     function it_does_not_apply_any_shipping_charge_if_order_has_no_shipments(OrderInterface $order): void
     {
-        $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $order->getShipments()->willReturn(new ArrayCollection([]));
         $order->addAdjustment(Argument::any())->shouldNotBeCalled();
 
@@ -81,7 +79,6 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $shipment->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $shipment->addAdjustment($adjustment)->shouldBeCalled();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This code is with us since 2014. Since then, we have adjustment clearer - which is the first processor we run and it should clean up shipping adjustment already. Therefore, this fragment should not have any effect over codebase

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
