### PR TITLE
[CatalogPromotion] Process all catalog promotions when catalog promotion is created

### DIFF
--- a/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
@@ -132,6 +132,23 @@ Feature: Creating a catalog promotion
         And it should have "winter_sale" code and "Winter sale" name
         And it should have priority equal to 10
 
+    @api @ui @javascript
+    Scenario: Creating a new catalog promotion with priorities with other exclusive already existing
+        Given there is an exclusive catalog promotion "Exclusive PHP stuff promotion" with priority 500 that reduces price by "30%" and applies on "PHP T-Shirt" variant
+        When I want to create a new catalog promotion
+        And I specify its code as "winter_sale"
+        And I name it "Winter sale"
+        And I specify its label as "Winter sale" in "English (United States)"
+        And I describe it as "This promotion gives a 50% discount on all products" in "English (United States)"
+        And I add scope that applies on variants "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
+        And I add action that gives "50%" percentage discount
+        And I make it start yesterday and ends tomorrow
+        And I make it available in channel "United States"
+        And I add it
+        Then I should be notified that catalog promotion has been successfully created
+        And the visitor should see that the "PHP T-Shirt" variant is discounted from "$20.00" to "$14.00" with "Exclusive PHP stuff promotion" promotion
+        And the visitor should see that the "Kotlin T-Shirt" variant is discounted from "$40.00" to "$20.00" with "Winter sale" promotion
+
     @ui @javascript
     Scenario: Adding a new catalog promotion of default type with one action
         When I want to create a new catalog promotion

--- a/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
@@ -133,21 +133,23 @@ Feature: Creating a catalog promotion
         And it should have priority equal to 10
 
     @api @ui @javascript
-    Scenario: Creating a new catalog promotion with priorities with other exclusive already existing
-        Given there is an exclusive catalog promotion "Exclusive PHP stuff promotion" with priority 500 that reduces price by "30%" and applies on "PHP T-Shirt" variant
+    Scenario: Creating a new catalog promotion with priorities with others already existing
+        Given there is a catalog promotion "PHP stuff promotion" with priority 100 that reduces price by "30%" and applies on "PHP T-Shirt" variant
+        And there is a catalog promotion "T-Shirt sale" with priority 200 that reduces price by "10%" and applies on "PHP T-Shirt" variant
         When I want to create a new catalog promotion
         And I specify its code as "winter_sale"
         And I name it "Winter sale"
         And I specify its label as "Winter sale" in "English (United States)"
-        And I describe it as "This promotion gives a 50% discount on all products" in "English (United States)"
+        And I describe it as "This promotion gives a 5$ discount on all products" in "English (United States)"
+        And I set its priority to 150
         And I add scope that applies on variants "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
-        And I add action that gives "50%" percentage discount
+        And I add action that gives "$5" of fixed discount in the "United States" channel
         And I make it start yesterday and ends tomorrow
         And I make it available in channel "United States"
         And I add it
         Then I should be notified that catalog promotion has been successfully created
-        And the visitor should see that the "PHP T-Shirt" variant is discounted from "$20.00" to "$14.00" with "Exclusive PHP stuff promotion" promotion
-        And the visitor should see that the "Kotlin T-Shirt" variant is discounted from "$40.00" to "$20.00" with "Winter sale" promotion
+        And the visitor should see that the "PHP T-Shirt" variant is discounted from "$20.00" to "$9.10" with 3 promotions
+        And the visitor should see that the "Kotlin T-Shirt" variant is discounted from "$40.00" to "$35.00" with "Winter sale" promotion
 
     @ui @javascript
     Scenario: Adding a new catalog promotion of default type with one action

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -17,6 +17,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Webmozart\Assert\Assert;
 
@@ -164,6 +165,21 @@ final class ProductVariantContext implements Context
         $this->variantClient->show($productVariant->getCode());
 
         $this->iShouldSeeVariantIsDiscountedFromToWithPromotions($productVariant, $originalPrice, $price, $promotionName);
+    }
+
+    /**
+     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with ([^"]+) promotions$/
+     */
+    public function theVisitorShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions(
+        ProductVariantInterface $variant,
+        int $originalPrice,
+        int $price,
+        int $numberOfPromotions
+    ): void {
+        $this->sharedStorage->set('token', null);
+        $this->variantClient->show($variant->getCode());
+
+        $this->iShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions($variant, $originalPrice, $price, $numberOfPromotions);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -566,6 +566,23 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from "([^"]+)" to "([^"]+)" with ([^"]+) promotions$/
+     */
+    public function theVisitorShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions(
+        ProductVariantInterface $variant,
+        string $originalPrice,
+        string $price,
+        int $numberOfPromotions
+    ): void {
+        /** @var ProductInterface $product */
+        $product = $variant->getProduct();
+
+        $this->iOpenProductPage($product);
+
+        $this->iShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions($variant, $originalPrice, $price, $numberOfPromotions);
+    }
+
+    /**
      * @Then its current variant should be named :name
      */
     public function itsCurrentVariantShouldBeNamed($name)

--- a/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionCreatedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionCreatedListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Listener;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
@@ -21,18 +22,18 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class CatalogPromotionCreatedListener
 {
-    private CatalogPromotionProcessorInterface $catalogPromotionProcessor;
+    private AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor;
 
     private RepositoryInterface $catalogPromotionRepository;
 
     private EntityManagerInterface $entityManager;
 
     public function __construct(
-        CatalogPromotionProcessorInterface $catalogPromotionProcessor,
+        AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor,
         RepositoryInterface $catalogPromotionRepository,
-        EntityManagerInterface $entityManager
+        EntityManagerInterface $entityManager,
     ) {
-        $this->catalogPromotionProcessor = $catalogPromotionProcessor;
+        $this->allCatalogPromotionProcessor = $allCatalogPromotionProcessor;
         $this->catalogPromotionRepository = $catalogPromotionRepository;
         $this->entityManager = $entityManager;
     }
@@ -45,7 +46,7 @@ final class CatalogPromotionCreatedListener
             return;
         }
 
-        $this->catalogPromotionProcessor->process($catalogPromotion);
+        $this->allCatalogPromotionProcessor->process();
 
         $this->entityManager->flush();
     }

--- a/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionCreatedListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionCreatedListener.php
@@ -15,14 +15,13 @@ namespace Sylius\Bundle\CoreBundle\Listener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
-use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class CatalogPromotionCreatedListener
 {
-    private AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor;
+    private AllCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor;
 
     private RepositoryInterface $catalogPromotionRepository;
 
@@ -33,7 +32,7 @@ final class CatalogPromotionCreatedListener
         RepositoryInterface $catalogPromotionRepository,
         EntityManagerInterface $entityManager,
     ) {
-        $this->allCatalogPromotionProcessor = $allCatalogPromotionProcessor;
+        $this->allCatalogPromotionsProcessor = $allCatalogPromotionProcessor;
         $this->catalogPromotionRepository = $catalogPromotionRepository;
         $this->entityManager = $entityManager;
     }
@@ -46,7 +45,7 @@ final class CatalogPromotionCreatedListener
             return;
         }
 
-        $this->allCatalogPromotionProcessor->process();
+        $this->allCatalogPromotionsProcessor->process();
 
         $this->entityManager->flush();
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -108,7 +108,7 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Listener\CatalogPromotionCreatedListener">
-            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface" />
             <argument type="service" id="sylius.repository.catalog_promotion" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />

--- a/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionCreatedListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionCreatedListenerSpec.php
@@ -15,9 +15,8 @@ namespace spec\Sylius\Bundle\CoreBundle\Listener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use SM\Factory\FactoryInterface;
-use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
+use Sylius\Bundle\CoreBundle\Processor\AllCatalogPromotionsProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -25,36 +24,36 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 final class CatalogPromotionCreatedListenerSpec extends ObjectBehavior
 {
     function let(
-        CatalogPromotionProcessorInterface $catalogPromotionProcessor,
+        AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor,
         RepositoryInterface $catalogPromotionRepository,
         EntityManagerInterface $entityManager,
         FactoryInterface $stateMachine
     ): void {
-        $this->beConstructedWith($catalogPromotionProcessor, $catalogPromotionRepository, $entityManager, $stateMachine);
+        $this->beConstructedWith($allCatalogPromotionProcessor, $catalogPromotionRepository, $entityManager, $stateMachine);
     }
 
     function it_processes_catalog_promotion_that_has_just_been_created(
-        CatalogPromotionProcessorInterface $catalogPromotionProcessor,
+        AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor,
         RepositoryInterface $catalogPromotionRepository,
         EntityManagerInterface $entityManager,
         CatalogPromotionInterface $catalogPromotion
     ): void {
         $catalogPromotionRepository->findOneBy(['code' => 'WINTER_MUGS_SALE'])->willReturn($catalogPromotion);
 
-        $catalogPromotionProcessor->process($catalogPromotion)->shouldBeCalled();
+        $allCatalogPromotionProcessor->process()->shouldBeCalled();
         $entityManager->flush()->shouldBeCalled();
 
         $this(new CatalogPromotionCreated('WINTER_MUGS_SALE'));
     }
 
     function it_does_nothing_if_there_is_no_catalog_promotion_with_given_code(
-        CatalogPromotionProcessorInterface $catalogPromotionProcessor,
+        AllCatalogPromotionsProcessorInterface $allCatalogPromotionProcessor,
         RepositoryInterface $catalogPromotionRepository,
         EntityManagerInterface $entityManager
     ): void {
         $catalogPromotionRepository->findOneBy(['code' => 'WINTER_MUGS_SALE'])->willReturn(null);
 
-        $catalogPromotionProcessor->process(Argument::any())->shouldNotBeCalled();
+        $allCatalogPromotionProcessor->process()->shouldNotBeCalled();
         $entityManager->flush()->shouldNotBeCalled();
 
         $this(new CatalogPromotionCreated('WINTER_MUGS_SALE'));


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

During Handling CatalogPromotionCreated we weren't processing all available catalog promotions, now it takes all into account.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
