### PR TITLE
[UI][Admin] add divider after form elements

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/default.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/default.html.twig
@@ -1,1 +1,3 @@
 {% include '@SyliusAdmin/CatalogPromotion/Scope/for_products.html.twig' %}
+
+<div class="catalog-promotion-form-divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_products.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_products.html.twig
@@ -2,4 +2,4 @@
 
 {{ form_row(field.products, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
 
-<div class="ui hidden divider"></div>
+<div class="catalog-promotion-form-divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_products.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_products.html.twig
@@ -1,3 +1,5 @@
 {% form_theme field '@SyliusAdmin/Form/theme.html.twig' %}
 
 {{ form_row(field.products, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
+
+<div class="ui hidden divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_taxons.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_taxons.html.twig
@@ -2,4 +2,4 @@
 
 {{ form_row(field.taxons, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
 
-<div class="ui hidden divider"></div>
+<div class="catalog-promotion-form-divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_taxons.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_taxons.html.twig
@@ -1,3 +1,5 @@
 {% form_theme field '@SyliusAdmin/Form/theme.html.twig' %}
 
 {{ form_row(field.taxons, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
+
+<div class="ui hidden divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_variants.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_variants.html.twig
@@ -2,4 +2,4 @@
 
 {{ form_row(field.variants, {'remote_url': path('sylius_admin_ajax_all_product_variants_by_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_all_product_variants_by_codes')}) }}
 
-<div class="ui hidden divider"></div>
+<div class="catalog-promotion-form-divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_variants.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/Scope/for_variants.html.twig
@@ -1,3 +1,5 @@
 {% form_theme field '@SyliusAdmin/Form/theme.html.twig' %}
 
 {{ form_row(field.variants, {'remote_url': path('sylius_admin_ajax_all_product_variants_by_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_all_product_variants_by_codes')}) }}
+
+<div class="ui hidden divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_action.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_action.html.twig
@@ -1,3 +1,5 @@
 {% form_theme field '@SyliusAdmin/Form/theme.html.twig' %}
 
 {{ form_row(field) }}
+
+<div class="ui hidden divider"></div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_action.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/_action.html.twig
@@ -2,4 +2,4 @@
 
 {{ form_row(field) }}
 
-<div class="ui hidden divider"></div>
+<div class="catalog-promotion-form-divider"></div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

add Small imrovement to divide taxon/scopes elements with delete button
![image](https://user-images.githubusercontent.com/22825722/151348023-b1437200-4671-46e4-acb2-6b10e69f0b8a.png)
<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
