### PR TITLE
[Fixtures] USA deleted from the World zone

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -54,9 +54,8 @@ sylius_fixtures:
                                 countries:
                                     - 'US'
                             WORLD:
-                                name: 'World'
+                                name: 'Rest of the World'
                                 countries:
-                                    - 'US'
                                     - 'FR'
                                     - 'DE'
                                     - 'AU'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10  <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
USA being a part of 2 zones at once was misleading with the concept of actual work predicted for zones and was causing some problems when calculating taxes for this country in case this 2 zones had different taxes.