### PR TITLE
[Core][Optimalization] Assign fallback locale for command based requests

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
@@ -25,11 +25,7 @@
         </service>
 
         <service id="Sylius\Component\Core\Checker\CLIContextCheckerInterface" class="Sylius\Component\Core\Checker\CLIContextChecker">
-            <argument type="string">%kernel.environment%</argument>
-            <argument type="collection">
-                <argument type="string">test</argument>
-                <argument type="string">test_cached</argument>
-            </argument>
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface" alias="sylius.checker.order_payment_method_selection_requirement" />

--- a/src/Sylius/Component/Core/Checker/CLIContextChecker.php
+++ b/src/Sylius/Component/Core/Checker/CLIContextChecker.php
@@ -13,17 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Checker;
 
+use Symfony\Component\HttpFoundation\RequestStack;
+
 final class CLIContextChecker implements CLIContextCheckerInterface
 {
-    private const CLI = 'cli';
-
-    public function __construct(
-        private string $runningEnvironment,
-        private array $restrictedEnvironments
-    ) { }
+    public function __construct(private RequestStack $requestStack)
+    { }
 
     public function isExecutedFromCLI(): bool
     {
-        return !in_array($this->runningEnvironment, $this->restrictedEnvironments) && \php_sapi_name() === self::CLI;
+        return null === $this->requestStack->getCurrentRequest();
     }
 }

--- a/src/Sylius/Component/Core/spec/Checker/CLIContextCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Checker/CLIContextCheckerSpec.php
@@ -15,12 +15,14 @@ namespace spec\Sylius\Component\Core\Checker;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Checker\CLIContextCheckerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CLIContextCheckerSpec extends ObjectBehavior
 {
-    function let(): void
+    function let(RequestStack $requestStack): void
     {
-        $this->beConstructedWith('dev', ['test', 'test_cached']);
+        $this->beConstructedWith($requestStack);
     }
 
     function it_implements_command_based_context_checker_interface(): void
@@ -28,21 +30,18 @@ final class CLIContextCheckerSpec extends ObjectBehavior
         $this->shouldImplement(CLIContextCheckerInterface::class);
     }
 
-    function it_returns_true_if_process_is_not_running_in_test_environment_and_from_cli(): void
+    function it_returns_true_if_process_is_running_without_current_request(RequestStack $requestStack): void
     {
+        $requestStack->getCurrentRequest()->willReturn(null);
+
         $this->isExecutedFromCLI()->shouldReturn(true);
     }
 
-    function it_returns_false_if_process_is_running_in_test_environment_and_from_cli(): void
-    {
-        $this->beConstructedWith('test', ['test', 'test_cached']);
-
-        $this->isExecutedFromCLI()->shouldReturn(false);
-    }
-
-    function it_returns_false_if_process_is_running_in_test_cached_environment_and_from_cli(): void
-    {
-        $this->beConstructedWith('test_cached', ['test', 'test_cached']);
+    function it_returns_false_if_process_is_running_with_current_request_defined(
+        RequestStack $requestStack,
+        Request $request
+    ): void {
+        $requestStack->getCurrentRequest()->willReturn($request);
 
         $this->isExecutedFromCLI()->shouldReturn(false);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I'm proposing alternative implementation to #13545, that takes into account request stack instead of env & SAPI. This way, we will have coherent behaviour among all envs which, in my opinion, will reduce possibility of bugs that exists on prod on dev, but where not detected by test.

Perhaps, we should consider similar behaviour just as a locale context - so fallbacking in the locale context to config value if CLI is executed