### PR TITLE
[Docs] Mention autoconfiguration case when extending the form

### DIFF
--- a/docs/customization/form.rst
+++ b/docs/customization/form.rst
@@ -93,6 +93,9 @@ As a result you will get the ``Sylius\Bundle\CustomerBundle\Form\Type\CustomerPr
 
 **3.** After creating your class, register this extension as a service in the ``config/services.yaml``:
 
+.. caution::
+    Remember! Service registration is not needed if you have autoconfiguration enabled in your services container.
+
 .. code-block:: yaml
 
     services:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

In fact, registering form extension **this way** when the autoconfiguration is enabled would result in registering it twice 💃 