### PR TITLE
[Behat][CatalogPromotion] Removing catalog promotion after postponing the start date

### DIFF
--- a/features/promotion/applying_catalog_promotions/applying_catalog_promotions_in_proper_time_range.feature
+++ b/features/promotion/applying_catalog_promotions/applying_catalog_promotions_in_proper_time_range.feature
@@ -41,3 +41,11 @@ Feature: Applying catalog promotions in proper time range
         And the end date of catalog promotion "Winter sale" was changed to "2021-12-23"
         When I view product "T-Shirt"
         Then I should see the product price "$20.00"
+
+    @api @ui
+    Scenario: Remove catalog promotion if its start date has been postponed
+        Given it is "2021-12-25" now
+        And the catalog promotion "Winter sale" operates between "2021-12-20" and "2021-12-30"
+        And the start date of catalog promotion "Winter sale" was changed to "2021-12-27"
+        When I view product "T-Shirt"
+        Then I should see the product price "$20.00"

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -736,6 +736,19 @@ final class CatalogPromotionContext implements Context
     }
 
     /**
+     * @Given the start date of catalog promotion :catalogPromotion was changed to :startDate
+     */
+    public function theStartDateOfCatalogPromotionWasChangedTo(
+        CatalogPromotionInterface $catalogPromotion,
+        string $startDate
+    ): void {
+        $catalogPromotion->setStartDate(new \DateTime($startDate));
+
+        $this->entityManager->flush();
+        $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
+    }
+
+    /**
      * @Given the end date of catalog promotion :catalogPromotion was changed to :endDate
      */
     public function theEndDateOfCatalogPromotionWasChangedTo(


### PR DESCRIPTION

| Q               | A
| --------------- | -----
| Branch?         | 1.11  <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Behat that covers a missing catalog promotion scenario

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
