### PR TITLE
[Catalog Promotion] Select more data during processing to avoid inefficient db calls

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductVariantRepository.php
@@ -101,6 +101,16 @@ class ProductVariantRepository extends EntityRepository implements ProductVarian
     public function findByCodes(array $codes): array
     {
         return $this->createQueryBuilder('o')
+            ->addSelect('product')
+            ->addSelect('channelPricings')
+            ->addSelect('appliedPromotions')
+            ->addSelect('productTaxon')
+            ->addSelect('taxon')
+            ->leftJoin('o.channelPricings', 'channelPricings')
+            ->leftJoin('channelPricings.appliedPromotions', 'appliedPromotions')
+            ->leftJoin('o.product', 'product')
+            ->leftJoin('product.productTaxons', 'productTaxon')
+            ->leftJoin('productTaxon.taxon', 'taxon')
             ->andWhere('o.code IN (:codes)')
             ->setParameter('codes', $codes)
             ->getQuery()

--- a/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/CatalogPromotionRepository.php
+++ b/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/CatalogPromotionRepository.php
@@ -21,7 +21,7 @@ class CatalogPromotionRepository extends EntityRepository implements CatalogProm
 {
     public function findByCriteria(iterable $criteria): array
     {
-        $queryBuilder = $this->createQueryBuilder('catalogPromotion');
+        $queryBuilder = $this->createQueryBuilder('o');
 
         /** @var CriteriaInterface $criterion */
         foreach ($criteria as $criterion) {
@@ -29,8 +29,12 @@ class CatalogPromotionRepository extends EntityRepository implements CatalogProm
         }
 
         return $queryBuilder
-            ->orderBy('catalogPromotion.exclusive', 'desc')
-            ->addOrderBy('catalogPromotion.priority', 'desc')
+            ->addSelect('scopes')
+            ->addSelect('actions')
+            ->leftJoin('o.scopes', 'scopes')
+            ->leftJoin('o.actions', 'actions')
+            ->orderBy('o.exclusive', 'desc')
+            ->addOrderBy('o.priority', 'desc')
             ->getQuery()
             ->getResult()
         ;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

With the proposed changes, we are omitting the n+1 problem. The idea is to load all data required for CP processing in one batch, so we can drastically reduce the number of DB queries(in the cost of computation memory, but it can be neglected, as still the biggest problem of it is that we do not clear UnitOfWork)

I've also adjusted alias of query builder to `o`, as this is Sylius default 

Ref. https://blackfire.io/profiles/compare/3d7cc083-575f-4e58-acba-e2f60f444cbc/graph

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
