### PR TITLE
[Catalog Promotion] Move catalog promotion processing after the fixture execution

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
@@ -40,8 +40,6 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
 
     private ExampleFactoryInterface $catalogPromotionActionExampleFactory;
 
-    private AllProductVariantsCatalogPromotionsProcessorInterface $allProductVariantsCatalogPromotionsProcessor;
-
     private Generator $faker;
 
     private OptionsResolver $optionsResolver;
@@ -51,15 +49,13 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
         RepositoryInterface $localeRepository,
         ChannelRepositoryInterface $channelRepository,
         ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
-        ExampleFactoryInterface $catalogPromotionActionExampleFactory,
-        AllProductVariantsCatalogPromotionsProcessorInterface $allProductVariantsCatalogPromotionsProcessor
+        ExampleFactoryInterface $catalogPromotionActionExampleFactory
     ) {
         $this->catalogPromotionFactory = $catalogPromotionFactory;
         $this->localeRepository = $localeRepository;
         $this->channelRepository = $channelRepository;
         $this->catalogPromotionScopeExampleFactory = $catalogPromotionScopeExampleFactory;
         $this->catalogPromotionActionExampleFactory = $catalogPromotionActionExampleFactory;
-        $this->allProductVariantsCatalogPromotionsProcessor = $allProductVariantsCatalogPromotionsProcessor;
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();
 
@@ -109,8 +105,6 @@ class CatalogPromotionExampleFactory extends AbstractExampleFactory implements E
                 $catalogPromotion->addAction($catalogPromotionAction);
             }
         }
-
-        $this->allProductVariantsCatalogPromotionsProcessor->process();
 
         return $catalogPromotion;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Listener/CatalogPromotionExecutorListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Listener/CatalogPromotionExecutorListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Fixture\Listener;
+
+use Sylius\Bundle\CoreBundle\Fixture\CatalogPromotionFixture;
+use Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface;
+use Sylius\Bundle\FixturesBundle\Listener\AbstractListener;
+use Sylius\Bundle\FixturesBundle\Listener\AfterFixtureListenerInterface;
+use Sylius\Bundle\FixturesBundle\Listener\FixtureEvent;
+
+final class CatalogPromotionExecutorListener extends AbstractListener implements AfterFixtureListenerInterface
+{
+    public function __construct(private AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor)
+    {
+    }
+
+    public function afterFixture(FixtureEvent $fixtureEvent, array $options): void
+    {
+        if ($fixtureEvent->fixture() instanceof CatalogPromotionFixture) {
+            $this->allCatalogPromotionsProcessor->process();
+        }
+    }
+
+    public function getName(): string
+    {
+        return 'catalog_promotion_processor_executor';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/promotion.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/promotion.yaml
@@ -4,6 +4,8 @@
 sylius_fixtures:
     suites:
         default:
+            listeners:
+                catalog_promotion_processor_executor: ~
             fixtures:
                 promotion:
                     options:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -21,6 +21,7 @@
         <import resource="services/dashboard.xml" />
         <import resource="services/emails.xml" />
         <import resource="services/fixtures.xml" />
+        <import resource="services/fixtures_listeners.xml" />
         <import resource="services/fixtures_factories.xml" />
         <import resource="services/form.xml" />
         <import resource="services/installer.xml" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -21,7 +21,6 @@
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionScopeExampleFactory" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionActionExampleFactory" />
-            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface" />
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\Fixture\Factory\CatalogPromotionScopeExampleFactory">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius_fixtures.listener.catalog_promotion_executor" class="Sylius\Bundle\CoreBundle\Fixture\Listener\CatalogPromotionExecutorListener" public="false">
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface" />
+            <tag name="sylius_fixtures.listener" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Fixture\Listener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Fixture\CatalogPromotionFixture;
+use Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+use Sylius\Bundle\FixturesBundle\Listener\AfterFixtureListenerInterface;
+use Sylius\Bundle\FixturesBundle\Listener\FixtureEvent;
+use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
+
+final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
+{
+    function let(AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor): void
+    {
+        $this->beConstructedWith($allCatalogPromotionsProcessor);
+    }
+
+    function it_implements_listener_interface(): void
+    {
+        $this->shouldImplement(ListenerInterface::class);
+    }
+
+    function it_listens_for_after_fixture_events(): void
+    {
+        $this->shouldImplement(AfterFixtureListenerInterface::class);
+    }
+
+    function it_triggers_catalog_promotion_processing_after_catalog_promotion_fixture_execution(
+        AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        SuiteInterface $suite,
+        CatalogPromotionFixture $catalogPromotionFixture
+    ): void {
+        $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $catalogPromotionFixture->getWrappedObject(), []), []);
+
+        $allCatalogPromotionsProcessor->process()->shouldBeCalled();
+    }
+
+    function it_does_not_trigger_catalog_promotion_processing_after_any_other_fixture_execution(
+        AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        SuiteInterface $suite,
+        FixtureInterface $fixture
+    ): void {
+        $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $fixture->getWrappedObject(), []), []);
+
+        $allCatalogPromotionsProcessor->process()->shouldNotBeCalled();
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Previous:
~With clearing entity manger we don't need to trace that many objects in UnitOfWork, therefore we are not calculating that much changes and we save ton of memory.~

~Ref. https://blackfire.io/profiles/compare/7c9cb9fd-c43f-4420-8e0a-0af2a7b4b000/graph~

Now:
Just a refactor of CP fixtures. The EntityManager will be cleared with https://github.com/symfony/doctrine-bridge/blob/5.4/Messenger/DoctrineClearEntityManagerWorkerSubscriber.php just by the fact, that it will be processed asynced. Which will be done in #13578. 

#13578 vs previous implementation -https://blackfire.io/profiles/compare/f560f723-f970-41b3-ac1a-7fe3a8858d77/graph

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
