### PR TITLE
Update catalog promotion instantly if date is set on future

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncer.php
+++ b/src/Sylius/Bundle/CoreBundle/Announcer/CatalogPromotionAnnouncer.php
@@ -42,6 +42,10 @@ final class CatalogPromotionAnnouncer implements CatalogPromotionAnnouncerInterf
 
     public function dispatchCatalogPromotionUpdatedEvent(CatalogPromotionInterface $catalogPromotion): void
     {
+        if ($catalogPromotion->getStartDate() > $this->dateTimeProvider->now()) {
+            $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()), []);
+        }
+
         $this->eventBus->dispatch(
             new CatalogPromotionUpdated($catalogPromotion->getCode()),
             $this->calculateStartDateStamp($catalogPromotion)


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no/
| Related tickets | 
| License         | MIT

If we had CatalogPromotion already applied on channelPricings, after changing its startDate to next day, previous discounts would still be applied, with this event we force to recalculate catalog promotions.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
