### PR TITLE
[CatalogPromotion] batch configuration size made a part of config

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/CommandDispatcher/ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/CommandDispatcher/ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface.php
@@ -15,5 +15,5 @@ namespace Sylius\Bundle\CoreBundle\CommandDispatcher;
 
 interface ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface
 {
-    public function updateVariants(array $variants): void;
+    public function updateVariants(array $variantsCodes): void;
 }

--- a/src/Sylius/Bundle/CoreBundle/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher.php
+++ b/src/Sylius/Bundle/CoreBundle/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher.php
@@ -24,9 +24,9 @@ final class BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher implements 
     ) {
     }
 
-    public function updateVariants(array $variants): void
+    public function updateVariants(array $variantsCodes): void
     {
-        $batchedVariants = array_chunk($variants, $this->size);
+        $batchedVariants = array_chunk($variantsCodes, $this->size);
 
         foreach ($batchedVariants as $batch) {
             $this->messageBus->dispatch(new ApplyCatalogPromotionsOnVariants($batch));

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -51,6 +51,12 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
                 ->booleanNode('prepend_doctrine_migrations')->defaultTrue()->end()
                 ->booleanNode('shipping_address_based_taxation')->defaultFalse()->end()
+                ->arrayNode('catalog_promotions')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('batch_size')->defaultValue(100)->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -54,6 +54,7 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
         $loader->load('services.xml');
 
         $container->setParameter('sylius_core.taxation.shipping_address_based_taxation', $config['shipping_address_based_taxation']);
+        $container->setParameter('sylius_core.catalog_promotions.batch_size', $config['catalog_promotions']['batch_size']);
 
         $env = $container->getParameter('kernel.environment');
         if ('test' === $env || 'test_cached' === $env) {

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -39,7 +39,6 @@
 
     <parameters>
         <parameter key="sylius.order_item_quantity_modifier.limit">9999</parameter>
-        <parameter key="sylius.messenger.product_variant.size_of_batches">100</parameter>
     </parameters>
 
     <services>
@@ -298,7 +297,7 @@
             class="Sylius\Bundle\CoreBundle\CommandDispatcher\BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher"
         >
             <argument type="service" id="sylius.command_bus" />
-            <argument>%sylius.messenger.product_variant.size_of_batches%</argument>
+            <argument>%sylius_core.catalog_promotions.batch_size%</argument>
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\CommandHandler\ApplyCatalogPromotionsOnVariantsHandler">

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -68,6 +68,30 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
         $this->testNotPrependingDoctrineMigrations('dev');
     }
 
+    /**
+     * @test
+     */
+    public function it_loads_batch_size_parameter_value_properly(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load(['catalog_promotions' => ['batch_size' => 200]]);
+
+        $this->assertContainerBuilderHasParameter('sylius_core.catalog_promotions.batch_size', 200);
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_default_batch_size_properly(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_core.catalog_promotions.batch_size', 100);
+    }
+
     protected function getContainerExtensions(): array
     {
         return [new SyliusCoreExtension()];

--- a/src/Sylius/Bundle/CoreBundle/spec/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcherSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcherSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\CommandDispatcher;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Command\ApplyCatalogPromotionsOnVariants;
+use Sylius\Bundle\CoreBundle\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class BatchedApplyCatalogPromotionsOnVariantsCommandDispatcherSpec extends ObjectBehavior
+{
+    public function let(MessageBusInterface $messageBus,): void
+    {
+        $this->beConstructedWith($messageBus, 2);
+    }
+
+    function it_implements_apply_catalog_promotions_on_variants_command_dispatcher_interface(): void
+    {
+        $this->shouldImplement(ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface::class);
+    }
+
+    public function it_dispatches_in_two_batches(MessageBusInterface $messageBus): void
+    {
+        $firstCommand = new ApplyCatalogPromotionsOnVariants(['example_variant1', 'example_variant2']);
+        $secondCommand = new ApplyCatalogPromotionsOnVariants(['example_variant3']);
+
+        $messageBus->dispatch($firstCommand)->willReturn(new Envelope($firstCommand))->shouldBeCalledOnce();
+        $messageBus->dispatch($secondCommand)->willReturn(new Envelope($secondCommand))->shouldBeCalledOnce();
+
+        $this->updateVariants(['example_variant1', 'example_variant2', 'example_variant3']);
+    }
+
+    public function it_dispatches_in_one_batch(MessageBusInterface $messageBus): void
+    {
+        $command = new ApplyCatalogPromotionsOnVariants(['example_variant1', 'example_variant2']);
+
+        $messageBus->dispatch($command)->willReturn(new Envelope($command))->shouldBeCalledOnce();
+
+        $this->updateVariants(['example_variant1', 'example_variant2']);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
In case of better management of batch sizes we decided to extract it to CatalogPromotion config, then we can resize it by modifying `_sylius.yaml` file 