### PR TITLE
Use semantic ui view instead of deprecated semantic_ui_translated

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -1,5 +1,23 @@
 # UPGRADE FROM `v1.10.X` TO `v1.11.0`
 
+### "pagerfanta/pagerfanta" semantic_ui_translated removed
+
+The `pagination.html.twig` has been changed to use the Twig view.
+
+There are differences in the markup between the PHP template and the Twig template.
+
+The wrapping container from 2.x branch of Pagerfanta in the PHP template was
+```html
+<div class="ui stackable fluid pagination menu">
+```
+
+while in the Twig template in 3.x branch it's 
+```html
+<div class="ui pagination menu">
+```
+
+The "stackable" class affects responsive display and "fluid" affects whether the pagination menu is full-width). 
+
 ### "polishsymfonycommunity/symfony-mocker-container" moved to dev-requirements
 
 This obvious dev dependency was part of Sylius requirements. In 1.11 we've moved it to proper place. However, it may lead to app break, as this container could be used in your Kernel, if you used Sylius-Standard as your template. In such a case, please update your `src/Kernel.php` class as follows:

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/pagination.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/pagination.html.twig
@@ -1,6 +1,6 @@
 {% macro simple(paginator, options) %}
     {% if paginator.haveToPaginate() %}
-        {{ pagerfanta(paginator, 'semantic_ui_translated', options|default({})) }}
+        {{ pagerfanta(paginator, 'semantic_ui', options|default({})) }}
     {% endif %}
 {% endmacro %}
 

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/pagination.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/pagination.html.twig
@@ -1,6 +1,6 @@
 {% macro simple(paginator, options) %}
     {% if paginator.haveToPaginate() %}
-        {{ pagerfanta(paginator, 'semantic_ui', options|default({})) }}
+        {{ pagerfanta(paginator, 'twig', options|default({'template': '@BabDevPagerfanta/semantic_ui.html.twig'})) }}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12462
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
