### PR TITLE
[Catalog Promotions] State processing after fixtures load

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Listener/CatalogPromotionExecutorListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Listener/CatalogPromotionExecutorListener.php
@@ -15,20 +15,31 @@ namespace Sylius\Bundle\CoreBundle\Fixture\Listener;
 
 use Sylius\Bundle\CoreBundle\Fixture\CatalogPromotionFixture;
 use Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface;
+use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionStateProcessorInterface;
 use Sylius\Bundle\FixturesBundle\Listener\AbstractListener;
 use Sylius\Bundle\FixturesBundle\Listener\AfterFixtureListenerInterface;
 use Sylius\Bundle\FixturesBundle\Listener\FixtureEvent;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class CatalogPromotionExecutorListener extends AbstractListener implements AfterFixtureListenerInterface
 {
-    public function __construct(private AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor)
-    {
+    public function __construct(
+        private AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        private CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
+        private RepositoryInterface $catalogPromotionsRepository
+    ) {
     }
 
     public function afterFixture(FixtureEvent $fixtureEvent, array $options): void
     {
         if ($fixtureEvent->fixture() instanceof CatalogPromotionFixture) {
             $this->allCatalogPromotionsProcessor->process();
+
+            $catalogPromotions = $this->catalogPromotionsRepository->findAll();
+
+            foreach ($catalogPromotions as $catalogPromotion) {
+                $this->catalogPromotionStateProcessor->process($catalogPromotion);
+            }
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionStateProcessorInterface" />
             <argument type="service" id="Sylius\Bundle\PromotionBundle\Doctrine\ORM\CatalogPromotionRepository" />
+            <argument type="tagged_iterator" tag="sylius.catalog_promotion.criteria" />
             <tag name="sylius_fixtures.listener" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
@@ -17,6 +17,8 @@
 
         <service id="sylius_fixtures.listener.catalog_promotion_executor" class="Sylius\Bundle\CoreBundle\Fixture\Listener\CatalogPromotionExecutorListener" public="false">
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface" />
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionStateProcessorInterface" />
+            <argument type="service" id="Sylius\Bundle\PromotionBundle\Doctrine\ORM\CatalogPromotionRepository" />
             <tag name="sylius_fixtures.listener" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
@@ -22,20 +22,24 @@ use Sylius\Bundle\FixturesBundle\Listener\AfterFixtureListenerInterface;
 use Sylius\Bundle\FixturesBundle\Listener\FixtureEvent;
 use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
 use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
+use Sylius\Bundle\PromotionBundle\Criteria\CriteriaInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
 
 final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
 {
     function let(
         AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
         CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
-        RepositoryInterface $catalogPromotionRepository
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        CriteriaInterface $firstCriterion,
+        CriteriaInterface $secondCriterion
     ): void {
         $this->beConstructedWith(
             $allCatalogPromotionsProcessor,
             $catalogPromotionStateProcessor,
-            $catalogPromotionRepository
+            $catalogPromotionRepository,
+            [$firstCriterion, $secondCriterion]
         );
     }
 
@@ -54,11 +58,16 @@ final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
         CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
         SuiteInterface $suite,
         CatalogPromotionFixture $catalogPromotionFixture,
-        RepositoryInterface $catalogPromotionRepository,
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
         CatalogPromotionInterface $firstCatalogPromotion,
-        CatalogPromotionInterface $secondCatalogPromotion
+        CatalogPromotionInterface $secondCatalogPromotion,
+        CriteriaInterface $firstCriterion,
+        CriteriaInterface $secondCriterion
     ): void {
-        $catalogPromotionRepository->findAll()->willReturn([$firstCatalogPromotion, $secondCatalogPromotion]);
+        $catalogPromotionRepository
+            ->findByCriteria([$firstCriterion, $secondCriterion])
+            ->willReturn([$firstCatalogPromotion, $secondCatalogPromotion])
+        ;
 
         $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $catalogPromotionFixture->getWrappedObject(), []), []);
 
@@ -72,9 +81,11 @@ final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
         CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
         SuiteInterface $suite,
         FixtureInterface $fixture,
-        RepositoryInterface $catalogPromotionRepository
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        CriteriaInterface $firstCriterion,
+        CriteriaInterface $secondCriterion
     ): void {
-        $catalogPromotionRepository->findAll()->willReturn([]);
+        $catalogPromotionRepository->findByCriteria([$firstCriterion, $secondCriterion])->shouldNotBeCalled();
 
         $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $fixture->getWrappedObject(), []), []);
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/CatalogPromotionExecutorListenerSpec.php
@@ -16,17 +16,27 @@ namespace spec\Sylius\Bundle\CoreBundle\Fixture\Listener;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Fixture\CatalogPromotionFixture;
 use Sylius\Bundle\CoreBundle\Processor\AllProductVariantsCatalogPromotionsProcessorInterface;
+use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionStateProcessorInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Bundle\FixturesBundle\Listener\AfterFixtureListenerInterface;
 use Sylius\Bundle\FixturesBundle\Listener\FixtureEvent;
 use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
 use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
 {
-    function let(AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor): void
-    {
-        $this->beConstructedWith($allCatalogPromotionsProcessor);
+    function let(
+        AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
+        RepositoryInterface $catalogPromotionRepository
+    ): void {
+        $this->beConstructedWith(
+            $allCatalogPromotionsProcessor,
+            $catalogPromotionStateProcessor,
+            $catalogPromotionRepository
+        );
     }
 
     function it_implements_listener_interface(): void
@@ -41,21 +51,34 @@ final class CatalogPromotionExecutorListenerSpec extends ObjectBehavior
 
     function it_triggers_catalog_promotion_processing_after_catalog_promotion_fixture_execution(
         AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
         SuiteInterface $suite,
-        CatalogPromotionFixture $catalogPromotionFixture
+        CatalogPromotionFixture $catalogPromotionFixture,
+        RepositoryInterface $catalogPromotionRepository,
+        CatalogPromotionInterface $firstCatalogPromotion,
+        CatalogPromotionInterface $secondCatalogPromotion
     ): void {
+        $catalogPromotionRepository->findAll()->willReturn([$firstCatalogPromotion, $secondCatalogPromotion]);
+
         $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $catalogPromotionFixture->getWrappedObject(), []), []);
 
         $allCatalogPromotionsProcessor->process()->shouldBeCalled();
+        $catalogPromotionStateProcessor->process($firstCatalogPromotion)->shouldBeCalled();
+        $catalogPromotionStateProcessor->process($secondCatalogPromotion)->shouldBeCalled();
     }
 
     function it_does_not_trigger_catalog_promotion_processing_after_any_other_fixture_execution(
         AllProductVariantsCatalogPromotionsProcessorInterface $allCatalogPromotionsProcessor,
+        CatalogPromotionStateProcessorInterface $catalogPromotionStateProcessor,
         SuiteInterface $suite,
-        FixtureInterface $fixture
+        FixtureInterface $fixture,
+        RepositoryInterface $catalogPromotionRepository
     ): void {
+        $catalogPromotionRepository->findAll()->willReturn([]);
+
         $this->afterFixture(new FixtureEvent($suite->getWrappedObject(), $fixture->getWrappedObject(), []), []);
 
         $allCatalogPromotionsProcessor->process()->shouldNotBeCalled();
+        $catalogPromotionStateProcessor->process()->shouldNotBeCalled();
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

After our refactor of catalog promotions, fixtures don't work properly. With this fix, we process catalog promotions state after fixtures load.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
