### PR TITLE
Avoid passing empty needle to strpos()

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -47,7 +47,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
         $propertyPath = $this->context->getPropertyPath();
 
         foreach (iterator_to_array($this->context->getViolations()) as $violation) {
-            if (0 === strpos($violation->getPropertyPath(), $propertyPath)) {
+            if ('' === $propertyPath || 0 === strpos($violation->getPropertyPath(), $propertyPath)) {
                 return;
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Extraction of https://github.com/Sylius/Sylius/pull/13431
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

It may happen that `propertyPath` is empty if the object is root object which may lead to php warning being triggered. It is better to omit such situation