### PR TITLE
[CatalogPromotion][UI][Shop] Fixed label displaying after option change

### DIFF
--- a/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_products_with_options.feature
+++ b/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_products_with_options.feature
@@ -1,0 +1,40 @@
+@applying_catalog_promotions
+Feature: Seeing applied catalog promotions on products configured with the option selection method
+    In order to be informed about applied catalog promotion on products with given options
+    As a Customer
+    I want to see a discounted products with given options
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a "T-Shirt" configurable product
+        And this product has option "Size" with values "S", "M" and "L"
+        And this product has "T-Shirt-Variant-1" variant priced at "$20.00" configured with "S" option value
+        And this product has "T-Shirt-Variant-2" variant priced at "$25.00" configured with "M" option value
+        And this product has "T-Shirt-Variant-3" variant priced at "$50.00" configured with "L" option value
+        And this product is configured with the option matching selection method
+        And there is a catalog promotion "Winter sale" that reduces price by "50%" and applies on "T-Shirt-Variant-1" variant
+        And there is another catalog promotion "Surprise sale" that reduces price by "25%" and applies on "T-Shirt-Variant-3" variant
+
+    @ui @no-api @javascript
+    Scenario: Seeing applied catalog promotion on the product with default option
+        When I view product "T-Shirt"
+        Then I should see this product is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
+
+    @ui @no-api @javascript
+    Scenario: Seeing applied catalog promotion on the product with non default option
+        When I view product "T-Shirt"
+        And I select its "Size" as "L"
+        Then I should see this product is discounted from "$50.00" to "$37.50" with "Surprise sale" promotion
+
+    @ui @no-api @javascript
+    Scenario: Seeing applied catalog promotion on the product after changing the options multiple times
+        When I view product "T-Shirt"
+        And I select its "Size" as "L"
+        And I select its "Size" as "S"
+        Then I should see this product is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
+
+    @ui @no-api @javascript
+    Scenario: Seeing no applied catalog promotion on the product option without applied catalog promotion
+        When I view product "T-Shirt"
+        And I select its "Size" as "M"
+        Then I should see this product is not discounted

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -211,8 +211,8 @@ final class CatalogPromotionContext implements Context
     }
 
     /**
-     * @Given /^there is a catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" variant) and ("[^"]+" variant)$/
-     * @Given /^there is a catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
+     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" variant) and ("[^"]+" variant)$/
+     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
      */
     public function thereIsACatalogPromotionThatReducesPriceByAndAppliesOn(
         string $name,

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -321,6 +321,26 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^the (product "[^"]+") has(?:| a) "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/
+     * @Given /^(this product) has "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/
+     */
+    public function theProductHasVariantPricedAtConfiguredWithOptionValue(
+        ProductInterface $product,
+        string $productVariantName,
+        int $price,
+        ProductOptionValueInterface $optionValue
+    ) {
+        $this->createProductVariant(
+            $product,
+            $productVariantName,
+            $price,
+            StringInflector::nameToUppercaseCode($productVariantName),
+            $this->sharedStorage->get('channel'),
+            optionValue: $optionValue
+        );
+    }
+
+    /**
      * @Given /^("[^"]+" variant) priced at ("[^"]+") in ("[^"]+" channel)$/
      */
     public function variantPricedAtInChannel(
@@ -1067,6 +1087,16 @@ final class ProductContext implements Context
         $this->saveProduct($product);
     }
 
+    /**
+     * @Given /^(this product) is configured with the option matching selection method$/
+     */
+    public function thisProductIsConfiguredWithTheOptionMatchingSelectionMethod(ProductInterface $product): void
+    {
+        $product->setVariantSelectionMethod(ProductInterface::VARIANT_SELECTION_MATCH);
+
+        $this->saveProduct($product);
+    }
+
     private function getPriceFromString(string $price): int
     {
         return (int) round((float) str_replace(['€', '£', '$'], '', $price) * 100, 2);
@@ -1169,7 +1199,8 @@ final class ProductContext implements Context
         ChannelInterface $channel = null,
         $position = null,
         $shippingRequired = true,
-        int $currentStock = 0
+        int $currentStock = 0,
+        ?ProductOptionValueInterface $optionValue = null
     ) {
         $product->setVariantSelectionMethod(ProductInterface::VARIANT_SELECTION_CHOICE);
 
@@ -1183,6 +1214,9 @@ final class ProductContext implements Context
         $variant->addChannelPricing($this->createChannelPricingForChannel($price, $channel));
         $variant->setPosition((null === $position) ? null : (int) $position);
         $variant->setShippingRequired($shippingRequired);
+        if (null !== $optionValue) {
+            $variant->addOptionValue($optionValue);
+        }
 
         $product->addVariant($variant);
 

--- a/src/Sylius/Behat/Context/Transform/ProductOptionValueContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionValueContext.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Transform;
+
+use Behat\Behat\Context\Context;
+use Sylius\Component\Product\Model\ProductOptionValueInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final class ProductOptionValueContext implements Context
+{
+    public function __construct(private RepositoryInterface $productOptionValueRepository)
+    {
+    }
+
+    /**
+     * @Transform /^"([^"]+)" option value$/
+     */
+    public function getProductOptionValueByCode(string $code): ProductOptionValueInterface
+    {
+        $productOptionValues = $this->productOptionValueRepository->findBy(['code' => $code]);
+
+        Assert::eq(
+            count($productOptionValues),
+            1,
+            sprintf('%d product option values has been found with name "%s" but should be only one.', count($productOptionValues), $code)
+        );
+
+        return $productOptionValues[0];
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -411,6 +411,14 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then /^I should see this product is not discounted$/
+     */
+    public function iShouldSeeProductIsNotDiscounted(): void
+    {
+        Assert::null($this->showPage->getOriginalPrice());
+    }
+
+    /**
      * @Then /^I should see ("[^"]+" variant) is not discounted$/
      * @Then /^I should see (this variant) is not discounted$/
      */
@@ -507,6 +515,29 @@ final class ProductContext implements Context
     {
         $this->showPage->open(['slug' => $product->getTranslation('en_US')->getSlug(), '_locale' => 'en_US']);
         $this->showPage->selectVariant($variantName);
+    }
+
+    /**
+     * @Then /^I should see ("[^"]+" product) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
+     * @Then /^I should see (this product) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
+     * @Then /^I should see (this product) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" and "([^"]+)" promotions$/
+     * @Then /^I should see (this product) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/
+     * @Then /^I should see (this product) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/
+     */
+    public function iShouldSeeProductIsDiscountedFromToWithPromotions(
+        ProductInterface $product,
+        string $originalPrice,
+        string $price,
+        string ...$promotionsNames
+    ): void {
+        Assert::same($this->showPage->getPrice(), $price);
+        Assert::same($this->showPage->getOriginalPrice(), $originalPrice);
+        foreach ($promotionsNames as $promotionName) {
+            Assert::true(
+                $this->showPage->hasCatalogPromotionApplied($promotionName),
+                sprintf("Catalog promotion '%s' does not found ", $promotionName)
+            );
+        }
     }
 
     /**

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -20,7 +20,6 @@ use Behat\Mink\Session;
 use DMore\ChromeDriver\ChromeDriver;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
-use PhpSpec\Exception\Example\PendingException;
 use Sylius\Behat\Page\Shop\Cart\SummaryPageInterface;
 use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Product\Model\ProductInterface;
@@ -124,7 +123,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
 
     public function hasCatalogPromotionApplied(string $name): bool
     {
-        $catalogPromotions = $this->getDocument()->findAll('css', '.promotion_label');
+        $catalogPromotions = $this->getDocument()->findAll('css', '.column .promotion_label');
         foreach ($catalogPromotions as $catalogPromotion) {
             if (explode(' - ', $catalogPromotion->getText())[0] === $name) {
                 return true;

--- a/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
@@ -93,6 +93,10 @@
             <argument type="service" id="sylius.repository.product_option" />
         </service>
 
+        <service id="sylius.behat.context.transform.product_option_value" class="Sylius\Behat\Context\Transform\ProductOptionValueContext">
+            <argument type="service" id="sylius.repository.product_option_value" />
+        </service>
+
         <service id="sylius.behat.context.transform.product_review" class="Sylius\Behat\Context\Transform\ProductReviewContext">
             <argument type="service" id="sylius.repository.product_review" />
         </service>

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
@@ -18,6 +18,7 @@ default:
                 - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.product_option_value
                 - sylius.behat.context.transform.product_variant
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.taxon

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variantsPricing.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variantsPricing.html.twig
@@ -2,6 +2,12 @@
 
 <div id="sylius-variants-pricing" data-unavailable-text="{{ 'sylius.ui.unavailable'|trans }}">
 {% for price in pricing %}
-    <div {% for option, value in price %}data-{{ option }}="{% if option == 'value' or option == 'original-price' %}{{ money.convertAndFormat(value) }}{% elseif option == 'applied_promotions' %}{{ value|json_encode }}{% else %}{{ value|replace({'\"': '\''}) }}{% endif %}" {{ sylius_test_html_attribute('variant-price') }}{% endfor %}></div>
+    {% set catalog_promotions = [] %}
+    {% if price.applied_promotions is defined %}
+        {% for promotion in price.applied_promotions %}
+            {% set catalog_promotions = catalog_promotions|merge([{'label': promotion.name, 'description': promotion.description}]) %}
+        {% endfor %}
+    {% endif %}
+    <div {% for option, value in price %}data-{{ option }}="{% if option == 'value' or option == 'original-price' %}{{ money.convertAndFormat(value) }}{% elseif option == 'applied_promotions' %}{{ catalog_promotions|json_encode }}{% else %}{{ value|replace({'\"': '\''}) }}{% endif %}" {{ sylius_test_html_attribute('variant-price') }}{% endfor %}></div>
 {% endfor %}
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Displaying a proper catalog promotion labels while switching product's variants

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
