### PR TITLE
[Catalog Promotion][UI] Fixed error when trying to save catalog promotion with empty percentage discount value

### DIFF
--- a/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
@@ -98,3 +98,10 @@ Feature: Editing catalog promotion
         And I make it available in channel "Poland"
         And I save my changes
         Then I should be notified that not all channels are filled
+
+    @api @ui @javascript
+    Scenario: Receiving error message after not filling percentage value for percentage discount
+        When I want to modify a catalog promotion "Christmas sale"
+        And I edit it to have empty amount of percentage discount
+        And I save my changes
+        Then I should be notified that a discount amount should be a number and cannot be empty

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -631,6 +631,21 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I edit it to have empty amount of percentage discount
+     */
+    public function iEditItToHaveEmptyPercentageDiscount(): void
+    {
+        $content = $this->client->getContent();
+
+        $content['actions'] = [[
+            'type' => PercentageDiscountPriceCalculator::TYPE,
+            'configuration' => ['amount' => ''],
+        ]];
+
+        $this->client->setRequestData($content);
+    }
+
+    /**
      * @When I add catalog promotion scope with nonexistent type
      */
     public function iAddCatalogPromotionScopeWithNonexistentType(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -601,6 +601,15 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I edit it to have empty amount of percentage discount
+     */
+    public function iEditItToHaveEmptyPercentageDiscount(): void
+    {
+        $this->formElement->chooseActionType('Percentage discount');
+        $this->formElement->specifyLastActionDiscount('');
+    }
+
+    /**
      * @Then I should be notified that a discount amount should be between 0% and 100%
      */
     public function iShouldBeNotifiedThatADiscountAmountShouldBeBetween0And100Percent(): void

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PromotionBundle\Form\Type;
 
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\FixedDiscountPriceCalculator;
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -69,6 +70,12 @@ final class CatalogPromotionActionType extends AbstractResourceType
                             if ($channelConfiguration['amount'] === '') {
                                 return;
                             }
+                        }
+                    }
+
+                    if ($data['type'] === PercentageDiscountPriceCalculator::TYPE) {
+                        if ($data['configuration']['amount'] === '') {
+                            return;
                         }
                     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no

When trying to edit the percentage discount value and save it with an empty amount there was a 500 error. This PR provides only a workaround for this problem.

![image](https://user-images.githubusercontent.com/28228691/152782399-056c67c0-8fb8-4200-aba0-26b693a6f4ab.png)

![image](https://user-images.githubusercontent.com/28228691/152782475-00d5445a-c691-425e-9fbf-e6ed63d2e78f.png)


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
