### PR TITLE
[Catalog Promotion] Fix priorities fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/promotion.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/promotion.yaml
@@ -49,6 +49,7 @@ sylius_fixtures:
                                 name: 'Winter sale'
                                 channels:
                                     - 'FASHION_WEB'
+                                priority: 1
                                 scopes:
                                     -   type: 'for_variants'
                                         configuration:
@@ -65,7 +66,7 @@ sylius_fixtures:
                                 name: 'Spring sale'
                                 channels:
                                     - 'FASHION_WEB'
-                                priority: 100
+                                priority: 3
                                 scopes:
                                     -   type: 'for_taxons'
                                         configuration:
@@ -82,7 +83,7 @@ sylius_fixtures:
                                 channels:
                                     - 'FASHION_WEB'
                                 exclusive: true
-                                priority: 30
+                                priority: 4
                                 scopes:
                                     -   type: 'for_variants'
                                         configuration:
@@ -99,6 +100,7 @@ sylius_fixtures:
                                 end_date: '10 days'
                                 channels:
                                     - 'FASHION_WEB'
+                                priority: 2
                                 scopes:
                                     -   type: 'for_products'
                                         configuration:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | .11
| License         | MIT

we shouldn't have two promotions with the same priority, previously config make 2 catalog promotions with priority equal 0.
<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
