### PR TITLE
[Docs] Drop warning about active, not applied promotions as states are handled in async manner as well

### DIFF
--- a/docs/book/products/catalog_promotions.rst
+++ b/docs/book/products/catalog_promotions.rst
@@ -313,8 +313,6 @@ After changes in CatalogPromotion, we dispatch proper message with delay calcula
     To enable asynchronous Catalog Promotion, remember about running messenger consumer in a separate process, use the command: ``php bin/console messenger:consume main``
     For more information check official `Symfony docs <https://symfony.com/doc/current/messenger.html#consuming-messages-running-the-worker>`_
 
-    Be aware that loading Catalog Promotion without enabled consumer, will change promotion's state to `active` but products will not be discounted.
-
 How the Catalog Promotions are applied?
 ---------------------------------------
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Reverts https://github.com/Sylius/Sylius/pull/13630/  because of https://github.com/Sylius/Sylius/pull/13624
| License         | MIT

This case does not exists anymore, as states are processed async as well 

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
