### PR TITLE
[UI][CatalogPromotion] Fix to not displaying duplicated validation message for fixed discount action

### DIFF
--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -638,7 +638,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iShouldBeNotifiedThatADiscountAmountShouldBeConfiguredForAtLeasOneChannel(): void
     {
-        Assert::true($this->formElement->hasValidationMessage(
+        Assert::true($this->formElement->hasOnlyOneValidationMessage(
             'Configuration for one of the required channels is not provided.'
         ));
     }

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
@@ -170,6 +170,20 @@ final class FormElement extends Element implements FormElementInterface
         return false;
     }
 
+    public function hasOnlyOneValidationMessage(string $message): bool
+    {
+        $validationElements = $this->getDocument()->findAll('css', '.sylius-validation-error');
+
+        $counter = 0;
+        foreach ($validationElements as $validationElement) {
+            if ($validationElement->getText() === $message) {
+                ++$counter;
+            }
+        }
+
+        return $counter === 1;
+    }
+
     public function removeAllActions(): void
     {
         $deleteButtons = $this->getDocument()->findAll('css', '#actions [data-form-collection="delete"]');

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
@@ -8,7 +8,6 @@ use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 final class FixedDiscountActionConfigurationType extends AbstractType
 {
@@ -18,12 +17,6 @@ final class FixedDiscountActionConfigurationType extends AbstractType
             ->add('amount', MoneyType::class, [
                 'label' => 'sylius.ui.amount',
                 'currency' => $options['currency'],
-                'constraints' => [
-                    new NotBlank([
-                        'groups' => 'sylius',
-                        'message' => 'sylius.catalog_promotion_action.fixed_discount.channel_not_configured',
-                    ]),
-                ],
             ])
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Before:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/6140884/153552070-89469388-c557-49f1-9c0b-4d959c6e2079.png">

After:
<img width="655" alt="image" src="https://user-images.githubusercontent.com/6140884/153552001-205017e3-94ac-44e8-921d-320bac219154.png">

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
