### PR TITLE
[1.11][User] Reduce usage of deprecated `\Serializable` interface

### DIFF
--- a/src/Sylius/Behat/spec/Service/SecurityServiceSpec.php
+++ b/src/Sylius/Behat/spec/Service/SecurityServiceSpec.php
@@ -48,7 +48,7 @@ final class SecurityServiceSpec extends ObjectBehavior
     ) {
         $shopUser->getRoles()->willReturn(['ROLE_USER']);
         $shopUser->getPassword()->willReturn('xyz');
-        $shopUser->serialize()->willReturn('serialized_user');
+        $shopUser->__serialize()->willReturn(['serialized_user']);
 
         $session->set('_security_shop', Argument::any())->shouldBeCalled();
         $session->save()->shouldBeCalled();

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -391,12 +391,9 @@ class User implements UserInterface, \Stringable
         $this->encoderName = $encoderName;
     }
 
-    /**
-     * The serialized data have to contain the fields used by the equals method and the username.
-     */
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return serialize([
+        return [
             $this->password,
             $this->salt,
             $this->usernameCanonical,
@@ -405,29 +402,42 @@ class User implements UserInterface, \Stringable
             $this->enabled,
             $this->id,
             $this->encoderName,
-        ]);
+        ];
     }
 
     /**
-     * @param string $serialized
+     * The serialized data have to contain the fields used by the equals method and the username.
+     *
+     * @internal
+     */
+    public function serialize(): string
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->password = $data['password'] ?? null;
+        $this->salt = $data['salt'] ?? null;
+        $this->usernameCanonical = $data['usernameCanonical'] ?? null;
+        $this->username = $data['username'] ?? null;
+        $this->locked = $data['locked'] ?? null;
+        $this->enabled = $data['enabled'] ?? null;
+        $this->id = $data['id'] ?? null;
+        $this->encoderName = $data['encoderName'] ?? null;
+    }
+
+    /**
+     * @internal
      */
     public function unserialize($serialized): void
     {
-        $data = unserialize($serialized);
+        $data = (array) unserialize((string) $serialized);
         // add a few extra elements in the array to ensure that we have enough keys when unserializing
         // older data which does not include all properties.
         $data = array_merge($data, array_fill(0, 2, null));
 
-        [
-            $this->password,
-            $this->salt,
-            $this->usernameCanonical,
-            $this->username,
-            $this->locked,
-            $this->enabled,
-            $this->id,
-            $this->encoderName,
-        ] = $data;
+        $this->__unserialize($data);
     }
 
     protected function hasExpired(?\DateTimeInterface $date): bool

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -111,4 +111,8 @@ interface UserInterface extends
     public function addOAuthAccount(UserOAuthInterface $oauth): void;
 
     public function setEncoderName(?string $encoderName): void;
+
+    public function __serialize(): array;
+
+    public function __unserialize(array $data): void;
 }


### PR DESCRIPTION
Reduce usage of deprecated `\Serializable` interface which is reported in PHP 8.1.
```
Deprecated: Sylius\Component\User\Model\User implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /srv/acme/vendor/sylius/sylius/src/Sylius/Component/User/Model/User.php on line 21
```

Added new `__serialize/__unserialize` methods to cover serialization & made `serialize/unserialize` internal to prevent usage of them (we can remove in next version).

| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | yes for PHP 8.1
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | fixed
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
