### PR TITLE
[Admin][API] Catalog promotion actions validation fixed

### DIFF
--- a/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
@@ -113,3 +113,10 @@ Feature: Editing catalog promotion
         And I edit it to have empty amount of percentage discount
         And I save my changes
         Then I should be notified that a discount amount should be a number and cannot be empty
+
+    @api @ui @javascript
+    Scenario: Editing catalog promotion action to be a fixed discount and not filling amount
+        When I want to modify a catalog promotion "Christmas sale"
+        And I edit it to have empty amount of fixed discount in the "United States" channel
+        And I save my changes
+        Then I should be notified that a discount amount should be configured for at least one channel

--- a/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
@@ -105,3 +105,11 @@ Feature: Editing catalog promotion
         And I edit it to have empty amount of percentage discount
         And I save my changes
         Then I should be notified that a discount amount should be a number and cannot be empty
+
+    @api @ui @javascript
+    Scenario: Editing catalog promotion action to be a percentage discount and not filling amount
+        Given there is a catalog promotion "Winter sale" that reduces price by fixed "$10.00" in the "United States" channel and applies on "T-Shirt" product
+        When I want to modify a catalog promotion "Christmas sale"
+        And I edit it to have empty amount of percentage discount
+        And I save my changes
+        Then I should be notified that a discount amount should be a number and cannot be empty

--- a/features/promotion/managing_catalog_promotions/validating_catalog_promotion_creation.feature
+++ b/features/promotion/managing_catalog_promotions/validating_catalog_promotion_creation.feature
@@ -111,7 +111,7 @@ Feature: Validating a catalog promotion creation
         And I add scope that applies on variants "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
         And I add invalid percentage discount action with non number in amount
         And I try to add it
-        Then I should be notified that a discount amount is not valid
+        Then I should be notified that a discount amount should be a number and cannot be empty
         And there should be an empty list of catalog promotions
 
     @api @ui @javascript

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -648,9 +648,8 @@ final class ManagingCatalogPromotionsContext implements Context
     /**
      * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
      */
-    public function iEditItToHaveEmptyFixedDiscountInTheChannel(
-        ChannelInterface $channel
-    ): void {
+    public function iEditItToHaveEmptyFixedDiscountInTheChannel(ChannelInterface $channel): void
+    {
         $content = $this->client->getContent();
 
         $content['actions'] = [[

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -646,6 +646,22 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
+     */
+    public function iEditItToHaveEmptyFixedDiscountInTheChannel(
+        ChannelInterface $channel
+    ): void {
+        $content = $this->client->getContent();
+
+        $content['actions'] = [[
+            'type' => FixedDiscountPriceCalculator::TYPE,
+            'configuration' => [$channel->getCode() => ['amount' => '']],
+        ]];
+
+        $this->client->setRequestData($content);
+    }
+
+    /**
      * @When I add catalog promotion scope with nonexistent type
      */
     public function iAddCatalogPromotionScopeWithNonexistentType(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -610,6 +610,17 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
+     */
+    public function iEditItToHaveEmptyFixedDiscountInChannel(
+        ChannelInterface $channel
+    ): void
+    {
+        $this->formElement->chooseActionType('Fixed discount');
+        $this->formElement->specifyLastActionDiscountForChannel('', $channel);
+    }
+
+    /**
      * @Then I should be notified that a discount amount should be between 0% and 100%
      */
     public function iShouldBeNotifiedThatADiscountAmountShouldBeBetween0And100Percent(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -612,9 +612,7 @@ final class ManagingCatalogPromotionsContext implements Context
     /**
      * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
      */
-    public function iEditItToHaveEmptyFixedDiscountInChannel(
-        ChannelInterface $channel
-    ): void
+    public function iEditItToHaveEmptyFixedDiscountInChannel(ChannelInterface $channel): void
     {
         $this->formElement->chooseActionType('Fixed discount');
         $this->formElement->specifyLastActionDiscountForChannel('', $channel);

--- a/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Form\Type\CatalogPromotion;
+
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Prophecy\Prophecy\ProphecyInterface;
+use Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotionAction\ChannelBasedFixedDiscountActionConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction\PercentageDiscountActionConfigurationType;
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionActionType;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionAction;
+use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+
+final class CatalogPromotionActionTypeTest extends TypeTestCase
+{
+    private ProphecyInterface|ChannelInterface $channel;
+
+    private ObjectProphecy $channelRepository;
+
+    /** @test */
+    public function it_updates_amount_of_fixed_discount(): void
+    {
+        $fixedDiscount = $this->setupFixedDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
+        $form->submit([
+            'type' => 'fixed_discount',
+            'configuration' => [
+                'WEB_US' => [
+                    'amount' => 20
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
+        $this->assertSame(
+            [
+                'WEB_US' => [
+                    'amount' => 20
+                ]
+            ],
+            $catalogPromotionAction->getConfiguration()
+        );
+    }
+
+    /** @test */
+    public function it_updates_amount_of_percentage_discount(): void
+    {
+        $percentageDiscount = $this->setupPercentageDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
+        $form->submit([
+            'type' => 'percentage_discount',
+            'configuration' => [
+                'amount' => 10
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('percentage_discount', $catalogPromotionAction->getType());
+        $this->assertSame(['amount' => 0.1], $catalogPromotionAction->getConfiguration());
+    }
+
+    /** @test */
+    public function it_changes_action_to_fixed_discount(): void
+    {
+        $percentageDiscount = $this->setupPercentageDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
+        $form->submit([
+            'type' => 'fixed_discount',
+            'configuration' => [
+                'WEB_US' => [
+                    'amount' => 10
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
+        $this->assertSame(
+            [
+                'WEB_US' => [
+                    'amount' => 10
+                ]
+            ],
+            $catalogPromotionAction->getConfiguration()
+        );
+    }
+
+    /** @test */
+    public function it_changes_action_to_percentage_discount(): void
+    {
+        $fixedDiscount = $this->setupFixedDiscount();
+
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
+        $form->submit([
+            'type' => 'percentage_discount',
+            'configuration' => [
+                'amount' => 10
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('percentage_discount', $catalogPromotionAction->getType());
+        $this->assertSame(['amount' => 0.1], $catalogPromotionAction->getConfiguration());
+    }
+
+    /** @test */
+    public function it_changes_action_to_percentage_discount_with_empty_amount(): void
+    {
+        $fixedDiscount = $this->setupFixedDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
+        $form->submit([
+            'type' => 'percentage_discount',
+            'configuration' => [
+                'amount' => ''
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('percentage_discount', $catalogPromotionAction->getType());
+        $this->assertSame(['amount' => null], $catalogPromotionAction->getConfiguration());
+    }
+
+    /** @test */
+    public function it_changes_action_to_fixed_discount_with_empty_amount(): void
+    {
+        $percentageDiscount = $this->setupPercentageDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
+        $form->submit([
+            'type' => 'fixed_discount',
+            'configuration' => [
+                'WEB_US' => [
+                    'amount' => ''
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
+        $this->assertSame(
+            [
+                'WEB_US' => [
+                    'amount' => null
+                ]
+            ],
+            $catalogPromotionAction->getConfiguration()
+        );
+    }
+
+    /** @test */
+    public function it_updates_fixed_discount_with_not_valid_amount(): void
+    {
+        $fixedDiscount = $this->setupFixedDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
+        $form->submit([
+            'type' => 'fixed_discount',
+            'configuration' => [
+                'WEB_US' => [
+                    'amount' => 'Not valid amount'
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
+        $this->assertSame(
+            [
+                'WEB_US' => [
+                    'amount' => null
+                ]
+            ],
+            $catalogPromotionAction->getConfiguration()
+        );
+    }
+
+    /** @test */
+    public function it_updates_percentage_discount_with_not_valid_amount(): void
+    {
+        $percentageDiscount = $this->setupPercentageDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
+        $form->submit([
+            'type' => 'percentage_discount',
+            'configuration' => [
+                'amount' => 'Not valid amount'
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('percentage_discount', $catalogPromotionAction->getType());
+        $this->assertSame(['amount' => null], $catalogPromotionAction->getConfiguration());
+    }
+
+    protected function setUp(): void
+    {
+        $this->channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
+
+        $currency = $this->prophesize(CurrencyInterface::class);
+        $currency->getCode()->willReturn('$');
+
+        $channel = $this->prophesize(ChannelInterface::class);
+        $channel->getCode()->willReturn('WEB_US');
+        $channel->getName()->willReturn('United States');
+        $channel->getBaseCurrency()->willReturn($currency->reveal());
+        $this->channel = $channel;
+
+        parent::setUp();
+    }
+
+    protected function getExtensions(): array
+    {
+        $catalogPromotionActionType = new CatalogPromotionActionType(
+            CatalogPromotionActionInterface::class,
+            ['sylius'],
+            [
+                'percentage_discount' => new PercentageDiscountActionConfigurationType(),
+                'fixed_discount' => new ChannelBasedFixedDiscountActionConfigurationType()
+            ]
+        );
+
+        $channelCollectionType = new ChannelCollectionType(
+            $this->channelRepository->reveal()
+        );
+
+        $validator = Validation::createValidatorBuilder()->getValidator();
+
+        return [
+            new PreloadedExtension([$catalogPromotionActionType, $channelCollectionType], []),
+            new ValidatorExtension($validator)
+        ];
+    }
+
+    private function setupPercentageDiscount(): CatalogPromotionActionInterface
+    {
+        $percentageDiscount = new CatalogPromotionAction();
+        $percentageDiscount->setType('percentage_discount');
+        $percentageDiscount->setCatalogPromotion(null);
+        $percentageDiscount->setConfiguration(['amount' => 0.1]);
+
+        return $percentageDiscount;
+    }
+
+    private function setupFixedDiscount(): CatalogPromotionActionInterface
+    {
+        $fixedDiscount = new CatalogPromotionAction();
+        $fixedDiscount->setType('percentage_discount');
+        $fixedDiscount->setCatalogPromotion(null);
+        $fixedDiscount->setConfiguration(['WEB_US' => ['amount' => 10]]);
+
+        return $fixedDiscount;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -61,14 +61,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertTrue($form->isSynchronized());
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(
-            [
-                'WEB_US' => [
-                    'amount' => 20
-                ]
-            ],
-            $catalogPromotionAction->getConfiguration()
-        );
+        $this->assertSame(['WEB_US' => ['amount' => 20]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */
@@ -120,21 +113,14 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(
-            [
-                'WEB_US' => [
-                    'amount' => 10
-                ]
-            ],
-            $catalogPromotionAction->getConfiguration()
-        );
+        $this->assertSame(['WEB_US' => ['amount' => 10]], $catalogPromotionAction->getConfiguration());
+        $this->assertSame(['WEB_US' => ['amount' => 10]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */
     public function it_changes_action_to_percentage_discount(): void
     {
         $fixedDiscount = $this->setupFixedDiscount();
-
 
         $this->channelRepository->findAll(Argument::any())->willReturn(
             [$this->channel->reveal()]
@@ -205,14 +191,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(
-            [
-                'WEB_US' => [
-                    'amount' => null
-                ]
-            ],
-            $catalogPromotionAction->getConfiguration()
-        );
+        $this->assertSame(['WEB_US' => ['amount' => null]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */
@@ -239,14 +218,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(
-            [
-                'WEB_US' => [
-                    'amount' => null
-                ]
-            ],
-            $catalogPromotionAction->getConfiguration()
-        );
+        $this->assertSame(['WEB_US' => ['amount' => null]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */

--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
@@ -14,19 +14,19 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PromotionBundle\Form\DataTransformer;
 
 use Symfony\Component\Form\Exception\TransformationFailedException;
-use Symfony\Component\Form\Extension\Core\DataTransformer\PercentToLocalizedStringTransformer;
+use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 
-final class PercentFloatToLocalizedStringTransformer extends PercentToLocalizedStringTransformer
+final class MoneyIntToLocalizedStringTransformer extends MoneyToLocalizedStringTransformer
 {
     /**
-     * Transforms between a percentage value into a float
+     * Transforms a localized money string into a normalized format.
      *
-     * @param string $value Percentage value
+     * @param string $value Localized money string
      *
-     * @return float Normalized value
+     * @return int|float|null
      *
-     * @throws TransformationFailedException if the given value is not a string or
-     *                                       if the value could not be transformed
+     * @throws TransformationFailedException if the given value is not a string
+     *                                       or if the value cannot be transformed
      */
     public function reverseTransform($value)
     {
@@ -34,18 +34,15 @@ final class PercentFloatToLocalizedStringTransformer extends PercentToLocalizedS
             return;
         }
 
-        return (float) parent::reverseTransform($value);
+        return (int) parent::reverseTransform($value);
     }
 
-    /**
-     * @param float|string $value
-     */
     public function transform($value)
     {
         if (!is_numeric($value)) {
             return;
         }
 
-        return parent::transform((float) $value);
+        return parent::transform($value);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
@@ -13,21 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 
 final class MoneyIntToLocalizedStringTransformer extends MoneyToLocalizedStringTransformer
 {
-    /**
-     * Transforms a localized money string into a normalized format.
-     *
-     * @param string $value Localized money string
-     *
-     * @return int|float|null
-     *
-     * @throws TransformationFailedException if the given value is not a string
-     *                                       or if the value cannot be transformed
-     */
     public function reverseTransform($value)
     {
         if (!is_numeric($value)) {

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
@@ -36,7 +36,6 @@ final class FixedDiscountActionConfigurationType extends AbstractType
             ->resetModelTransformers()
             ->addViewTransformer(new MoneyIntToLocalizedStringTransformer())
         ;
-
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction;
 
 use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
+use Sylius\Bundle\PromotionBundle\Form\DataTransformer\MoneyIntToLocalizedStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,6 +29,14 @@ final class FixedDiscountActionConfigurationType extends AbstractType
                 'currency' => $options['currency'],
             ])
         ;
+
+        $builder
+            ->get('amount')
+            ->resetViewTransformers()
+            ->resetModelTransformers()
+            ->addViewTransformer(new MoneyIntToLocalizedStringTransformer())
+        ;
+
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction;
 
+use Sylius\Bundle\PromotionBundle\Form\DataTransformer\PercentFloatToLocalizedStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\GreaterThan;
-use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
-use Symfony\Component\Validator\Constraints\Type;
 
 final class PercentageDiscountActionConfigurationType extends AbstractType
 {
@@ -33,6 +31,13 @@ final class PercentageDiscountActionConfigurationType extends AbstractType
                     ]),
                 ],
             ])
+        ;
+
+        $builder
+            ->get('amount')
+            ->resetViewTransformers()
+            ->resetModelTransformers()
+            ->addViewTransformer(new PercentFloatToLocalizedStringTransformer())
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionActionType.php
@@ -1,11 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type;
 
-use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\FixedDiscountPriceCalculator;
-use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\PercentageDiscountPriceCalculator;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -65,27 +72,10 @@ final class CatalogPromotionActionType extends AbstractResourceType
                     $formData->setType($data['type']);
                     $formData->setConfiguration($data['configuration']);
 
-                    if ($data['type'] === FixedDiscountPriceCalculator::TYPE) {
-                        foreach ($data['configuration'] as $channelConfiguration) {
-                            if ($channelConfiguration['amount'] === '') {
-                                return;
-                            }
-                        }
-                    }
-
-                    if ($data['type'] === PercentageDiscountPriceCalculator::TYPE) {
-                        if ($data['configuration']['amount'] === '') {
-                            return;
-                        }
-                    }
-
                     $form->setData($formData);
                 }
 
-                $actionConfigurationType = $this->actionConfigurationTypes[$data['type']];
-                $form->add('configuration', $actionConfigurationType, [
-                    'label' => false,
-                ]);
+                $this->addConfigurationTypeToForm($event);
             })
         ;
     }
@@ -97,7 +87,6 @@ final class CatalogPromotionActionType extends AbstractResourceType
 
     private function addConfigurationTypeToForm(FormEvent $event): void
     {
-        /** @var CatalogPromotionActionInterface|null $data */
         $data = $event->getData();
         if ($data === null) {
             return;
@@ -105,7 +94,9 @@ final class CatalogPromotionActionType extends AbstractResourceType
 
         $form = $event->getForm();
 
-        $actionConfigurationType = $this->actionConfigurationTypes[$data->getType()];
+        $dataType = $data instanceof CatalogPromotionActionInterface ? $data->getType() : $data['type'];
+
+        $actionConfigurationType = $this->actionConfigurationTypes[$dataType];
         $form->add('configuration', $actionConfigurationType, [
             'label' => false,
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

There was a validation problem when changing actions in the catalog promotion. 

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
