### PR TITLE
[Documentation] Adjust installation guide for Plus on 1.11

### DIFF
--- a/docs/book/installation/sylius_plus_installation.rst
+++ b/docs/book/installation/sylius_plus_installation.rst
@@ -24,10 +24,10 @@ Installing Sylius Plus as a plugin to a Sylius application
 
 .. tip::
 
-    If it is a new project you are initiating, then first install Sylius-Standard in **version ^1.10** according to
+    If it is a new project you are initiating, then first install Sylius-Standard in **version ^1.11** according to
     :doc:`these instructions </book/installation/installation>`.
 
-    If you're installing Plus package to an existing project, then make sure you're upgraded to ``sylius/sylius ^1.10``.
+    If you're installing Plus package to an existing project, then make sure you're upgraded to ``sylius/sylius ^1.11``.
 
 **1.** Configure access to the private Packagist package in composer by using the Access Token you have been given with your license.
 
@@ -63,18 +63,6 @@ Installing Sylius Plus as a plugin to a Sylius application
     imports:
     # ...
         - { resource: "@SyliusPlusPlugin/Resources/config/config.yaml" }
-
-.. warning::
-
-    Recommended Sylius version to use with Sylius Plus is 1.11. If, for any reason, you need to use Sylius 1.10, it's required
-    to customise some API configurations. Run the following commands, to do it:
-
-    .. code-block:: bash
-
-        mkdir config/api_platform/
-        cp -R vendor/sylius/plus/etc/sylius-1.10/Resources/config/api_resources/* config/api_platform/
-        rm vendor/sylius/plus/src/Resources/config/api_resources/Customer.xml
-        rm vendor/sylius/plus/src/Resources/config/api_resources/Order.xml
 
 **5.** Configure Shop, Admin and Admin API routing:
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after #13650 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
