### PR TITLE
[DX] Adding a helpful error message to the ResetPasswordHandler

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/ResetPasswordHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/ResetPasswordHandler.php
@@ -36,7 +36,7 @@ final class ResetPasswordHandler implements MessageHandlerInterface
         /** @var ShopUserInterface|null $user */
         $user = $this->userRepository->findOneBy(['passwordResetToken' => $command->resetPasswordToken]);
 
-        Assert::notNull($user);
+        Assert::notNull($user, 'No user found with reset token: ' . $command->resetPasswordToken);
 
         $resetting = $this->metadata->getParameter('resetting');
         $lifetime = new \DateInterval($resetting['token']['ttl']);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Before:
```
Uncaught PHP Exception Webmozart\Assert\InvalidArgumentException: "Expected a value other than null." at /var/www/sylius/vendor/webmozart/assert/src/Assert.php line 2060
```

After:
```
Uncaught PHP Exception Webmozart\Assert\InvalidArgumentException: "No user found with reset token: <TOKEN>" at /var/www/sylius/vendor/webmozart/assert/src/Assert.php line 2060
```

Maybe we also should have a check in the codestyle that finds all other occurrences, where a error message is missing. 