### PR TITLE
Use the index of the last child of a collection to construct the element's form

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
@@ -24,7 +24,7 @@ class CollectionForm {
 
     this.$element = $(element);
     this.$list = this.$element.find('[data-form-collection="list"]:first');
-    this.count = this.$list.children().length;
+    this.nextIndexElement = this.$element.data('index');
     this.lastChoice = null;
     this.$element.on('click', '[data-form-collection="add"]:last', this.addItem);
     this.$element.on('click', '[data-form-collection="delete"]', this.deleteItem);
@@ -46,10 +46,10 @@ class CollectionForm {
     let prototype = this.$element.data('prototype');
     let prototypeName = new RegExp(this.$element.data('prototype-name'), 'g');
 
-    prototype = prototype.replace(prototypeName, this.count);
+    prototype = prototype.replace(prototypeName, this.nextIndexElement);
 
     this.$list.append(prototype);
-    this.count = this.count + 1;
+    this.nextIndexElement = this.nextIndexElement + 1;
 
     $(document).trigger('collection-form-add', [this.$list.children().last()]);
   }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -87,6 +87,7 @@
             {% if prototype is defined and allow_add %}
                 data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype.vars.name)|e }}'
                 data-prototype-name='{{ prototype.vars.name }}'
+                data-index='{{ form.children|length > 0 ? form.children|last.vars.name + 1 : 0 }}'
             {%- endif -%}
         >
             {{ error(form.vars.errors) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -87,12 +87,14 @@
             {% if prototype is defined and allow_add %}
                 data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype.vars.name)|e }}'
                 data-prototype-name='{{ prototype.vars.name }}'
-                {% set lastIndex = form.children|length > 0 ? form.children|last.vars.name : 0 %}
-                {% if lastIndex matches '/^\\d+$/' %}
+                {% set lastIndex = 0 %}
+                {% for child in form.children %}
+                    {% set name = child.vars.name %}
+                    {% if name matches '/^\\d+$/' %}
+                        {% set lastIndex = max(name, lastIndex) %}
+                    {% endif %}
+                {% endfor %}
                 data-index='{{ lastIndex + 1 }}'
-                {% else %}
-                data-index='0'
-                {% endif %}
             {%- endif -%}
         >
             {{ error(form.vars.errors) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -87,7 +87,12 @@
             {% if prototype is defined and allow_add %}
                 data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype.vars.name)|e }}'
                 data-prototype-name='{{ prototype.vars.name }}'
-                data-index='{{ form.children|length > 0 ? form.children|last.vars.name + 1 : 0 }}'
+                {% set lastIndex = form.children|length > 0 ? form.children|last.vars.name : 0 %}
+                {% if lastIndex matches '/^\\d+$/' %}
+                data-index='{{ lastIndex + 1 }}'
+                {% else %}
+                data-index='0'
+                {% endif %}
             {%- endif -%}
         >
             {{ error(form.vars.errors) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

When we have a CollectionType with children that have a numerical index, the "add" button can have a strange behaviour when deleting elements and adding new items.
For example, we have an array of items like this:
- 1 => [...]
- 3 => [...]
- 4 => [...]
- 5 => [...]

Previously, the JS code count the number of items, so 4, and add a new form with inputs name `my_beautiful_collection[items][4][XXXX]`. And when we submit the form, my "4" item is replace by the new "4"…

Like explained in Symfony doc, I use the last collection item to calculate the index of the new element: https://symfony.com/doc/5.4/form/form_collections.html#allowing-new-tags-with-the-prototype

This patch should be applied on all still maintained branches: 1.9, 1.10, 1.11 and master 
