### PR TITLE
[Psalm] Configuration - totallyTyped replaced according to docs to avoid deprecation problem

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="2"
+    reportMixedIssues="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

`Error: psalm.xml:3:5: ConfigIssue: Attribute "totallyTyped" is deprecated and is going to be removed in the next major version (see https://psalm.dev/271)`

According to Psalm docs: 
**totallyTyped**
(Deprecated) Setting `totallyTyped` to "true" is equivalent to setting `errorLevel` to "1". Setting `totallyTyped` to "false" is equivalent to setting `errorLevel` to "2" and `reportMixedIssues` to "false"

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
