### PR TITLE
[Product][API][Bug] Fixed product sorting by translated names

### DIFF
--- a/features/product/viewing_products/viewing_sorted_products.feature
+++ b/features/product/viewing_products/viewing_sorted_products.feature
@@ -16,49 +16,52 @@ Feature: Sorting listed products
         And the store also has a product "Xtreme Pug" with code "X_PUG", created at "07-09-2016"
         And this product belongs to "Fluffy Pets"
         And this product's price is "$12.51"
+        And the store also has a product "Unreal Pug" with code "U_PUG", created at "04-10-2016"
+        And this product belongs to "Fluffy Pets"
+        And this product's price is "$13.27"
 
     @ui
     Scenario: Sorting products by their dates with descending order
         When I view newest products from taxon "Fluffy Pets"
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And I should see a product with name "Xtreme Pug"
         But the first product on the list should have name "Pug of Love"
 
     @ui
     Scenario: Sorting products by their dates with ascending order
         When I view oldest products from taxon "Fluffy Pets"
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And I should see a product with name "Berserk Pug"
         But the first product on the list should have name "Xtreme Pug"
 
-    @ui @api
-    Scenario: Sorting products by their prices with descending order
+    @api @ui
+    Scenario: Sorting products by their prices with ascending order
         When I browse products from taxon "Fluffy Pets"
         And I sort products by the lowest price first
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And I should see a product with name "Xtreme Pug"
         But the first product on the list should have name "Berserk Pug"
 
-    @ui @api
-    Scenario: Sorting products by their prices with ascending order
+    @api @ui
+    Scenario: Sorting products by their prices with descending order
         When I browse products from taxon "Fluffy Pets"
         And I sort products by the highest price first
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And I should see a product with name "Xtreme Pug"
         But the first product on the list should have name "Pug of Love"
 
-    @ui
+    @api @ui
     Scenario: Sorting products by their names from a to z
         When I browse products from taxon "Fluffy Pets"
         And I sort products alphabetically from a to z
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And the first product on the list should have name "Berserk Pug"
         And the last product on the list should have name "Xtreme Pug"
 
-    @ui
+    @api @ui
     Scenario: Sorting products by their names from z to a
         When I browse products from taxon "Fluffy Pets"
         And I sort products alphabetically from z to a
-        Then I should see 3 products in the list
+        Then I should see 4 products in the list
         And the first product on the list should have name "Xtreme Pug"
         And the last product on the list should have name "Berserk Pug"

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -27,7 +27,6 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
-use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
 final class ProductContext implements Context
@@ -125,6 +124,22 @@ final class ProductContext implements Context
     public function iSortProductsByTheHighestPriceFirst(): void
     {
         $this->client->sort(['price' => 'desc']);
+    }
+
+    /**
+     * @When I sort products alphabetically from a to z
+     */
+    public function iSortProductsAlphabeticallyFromAToZ(): void
+    {
+        $this->client->sort(['translation.name' => 'asc']);
+    }
+
+    /**
+     * @When I sort products alphabetically from z to a
+     */
+    public function iSortProductsAlphabeticallyFromZToA(): void
+    {
+        $this->client->sort(['translation.name' => 'desc']);
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TranslationOrderNameAndLocaleFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TranslationOrderNameAndLocaleFilter.php
@@ -54,9 +54,8 @@ final class TranslationOrderNameAndLocaleFilter extends AbstractContextAwareFilt
 
                 return;
             }
+            
             $queryBuilder
-                ->addSelect('translation')
-                ->innerJoin(sprintf('%s.translations', $rootAlias), 'translation')
                 ->orderBy('translation.name', $direction)
             ;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/12594
| License         | MIT

It resolves the issue with `500 status code` on products collection with `order[translation.name]` parameter.

![image](https://user-images.githubusercontent.com/40125720/155188505-bf19c712-c9e0-4355-b009-9dcbc859d50a.png)
