### PR TITLE
Fix typo in sylius_order state machine callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-fileinfo": "*",
         "ext-gd": "*",
         "api-platform/core": "^2.6",
-        "babdev/pagerfanta-bundle": "^2.5",
+        "babdev/pagerfanta-bundle": "^2.5 || ^3.0",
         "behat/transliterator": "^1.3",
         "doctrine/collections": "^1.6",
         "doctrine/dbal": "^2.7",
@@ -39,7 +39,7 @@
         "fakerphp/faker": "^1.9",
         "friendsofsymfony/rest-bundle": "^3.0",
         "gedmo/doctrine-extensions": "^3.2",
-        "jms/serializer-bundle": "^3.5",
+        "jms/serializer-bundle": "^3.5 || ^4.0",
         "knplabs/gaufrette": "^0.8 || ^0.9 || ^0.10 || ^0.11",
         "knplabs/knp-gaufrette-bundle": "^0.7 || ^0.8",
         "knplabs/knp-menu": "^3.1",
@@ -47,6 +47,7 @@
         "laminas/laminas-stdlib": "^3.3.1",
         "lexik/jwt-authentication-bundle": "^2.11",
         "liip/imagine-bundle": "^2.3",
+        "pagerfanta/pagerfanta": "^3.0",
         "payum/payum": "^1.7",
         "payum/payum-bundle": "^2.4",
         "php-http/guzzle6-adapter": "^2.0",
@@ -113,7 +114,7 @@
         "webmozart/assert": "^1.9",
         "willdurand/hateoas": "^3.0",
         "willdurand/hateoas-bundle": "^2.0",
-        "winzou/state-machine-bundle": "^0.5"
+        "winzou/state-machine-bundle": "~0.5"
     },
     "replace": {
         "sylius/addressing": "self.version",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,9 +2,10 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
          colors="true"
          bootstrap="config/bootstrap.php"
+         convertDeprecationsToExceptions="true"
 >
     <testsuites>
         <testsuite name="Sylius Test Suite">

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Crud;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -70,6 +72,24 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     public function getMessageInvalidForm(): string
     {
         return $this->getDocument()->find('css', '.ui.icon.negative.message')->getText();
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
+use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Core\Model\AddressInterface;
 
@@ -70,5 +72,23 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
             'street' => '[data-test-street]',
             'province_validation_message' => '[data-test-validation-error]:contains("province")',
         ]);
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
+use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Service\JQueryHelper;
 
 class UpdatePage extends SymfonyPage implements UpdatePageInterface
@@ -90,6 +92,24 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
             'selected_province' => '[data-test-province-code] option[selected="selected"]',
             'street' => '[data-test-street]',
         ]);
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 
     private function waitForElement(int $timeout, string $elementName): void

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -104,6 +104,7 @@ class ProductTaxonController extends ResourceController
     {
         Assert::numeric($position, sprintf('The position "%s" is invalid.', $position));
 
+        /** @var ProductTaxonInterface $productTaxonFromBase */
         $productTaxonFromBase = $this->repository->findOneBy(['id' => $id]);
         $productTaxonFromBase->setPosition((int) $position);
     }

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
@@ -11,11 +11,15 @@ final class CancelOrderStateMachineCallbackPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->hasParameter('sm.configs')) {
+            return;
+        }
+
         /** @var array $smConfigs */
         $smConfigs = $container->getParameter('sm.configs');
 
         if (isset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'])) {
-            @trigger_error(
+            trigger_error(
                 sprintf('Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
                     'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
                     'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order'

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class CancelOrderStateMachineCallbackPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var array $smConfigs */
+        $smConfigs = $container->getParameter('sm.configs');
+
+        if (isset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'])) {
+            @trigger_error(
+                sprintf('Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
+                    'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
+                    'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order'
+                ),
+                \E_USER_DEPRECATED
+            );
+
+            $smConfigs['sylius_order']['callbacks']['after']['sylius_cancel_order'] = $smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'];
+            unset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order']);
+            $container->setParameter('sm.configs', $smConfigs);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
@@ -55,6 +55,7 @@ class AddressExampleFactory extends AbstractExampleFactory
             ->setDefault('city', fn (Options $options): string => $this->faker->city)
             ->setDefault('postcode', fn (Options $options): string => $this->faker->postcode)
             ->setDefault('country_code', function (Options $options): string {
+                /** @var CountryInterface[] $countries */
                 $countries = $this->countryRepository->findAll();
                 shuffle($countries);
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -18,6 +18,7 @@ use Faker\Generator;
 use Sylius\Bundle\CoreBundle\Fixture\OptionsResolver\LazyOption;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
 use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -212,6 +213,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
             }
             $productVariant->setTracked($options['tracked']);
 
+            /** @var ChannelInterface $channel */
             foreach ($this->channelRepository->findAll() as $channel) {
                 $this->createChannelPricings($productVariant, $channel->getCode());
             }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order.yml
@@ -92,7 +92,7 @@ winzou_state_machine:
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object", "event", "'cancel'", "'sylius_order_shipping'"]
                     priority: -300
-                sylis_cancel_order:
+                sylius_cancel_order:
                     on: ["cancel"]
                     do: ["@sylius.inventory.order_inventory_operator", "cancel"]
                     args: ["object"]

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -20,6 +20,7 @@ use Doctrine\Inflector\Rules\Substitution;
 use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Transformations;
 use Doctrine\Inflector\Rules\Word;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\CancelOrderStateMachineCallbackPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\ResolveShopUserTargetEntityPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBreakingErrorListenerPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBreakingExceptionListenerPass;
@@ -71,6 +72,7 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         $container->addCompilerPass(new ResolveShopUserTargetEntityPass());
         $container->addCompilerPass(new RegisterUriBasedSectionResolverPass());
         $container->addCompilerPass(new LiipImageFiltersPass());
+        $container->addCompilerPass(new CancelOrderStateMachineCallbackPass());
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\DependencyInjection\Compiler\BackwardsCompatibility;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\CancelOrderStateMachineCallbackPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CancelOrderStateMachineCallbackPassTest extends AbstractCompilerPassTestCase
+{
+    public array $smConfigs = [
+        'sylius_order' => [
+            'class' => 'Sylius\\Component\\Core\\Model\\Order',
+            'property_path' => 'state',
+            'graph' => 'sylius_order',
+            'state_machine_class' => 'Sylius\\Component\\Resource\\StateMachine\\StateMachine',
+            'states' => [
+                'cart',
+                'new',
+                'cancelled',
+                'fulfilled',
+            ],
+            'transitions' => [
+                'create' => [
+                    'from' => [
+                        'cart',
+                    ],
+                    'to' => 'new',
+                ],
+                'cancel' => [
+                    'from' => [
+                        'new',
+                    ],
+                    'to' => 'cancelled',
+                ],
+                'fulfill' => [
+                    'from' => [
+                        'new',
+                    ],
+                    'to' => 'fulfilled',
+                ],
+            ],
+            'callbacks' => [
+                'before' => [],
+                'after' => [
+                    'sylis_cancel_order' => [
+                        'on' => [
+                            'cancel',
+                        ],
+                        'do' => [
+                            '@sylius.inventory.order_inventory_operator',
+                            'cancel',
+                        ],
+                        'args' => [
+                            'object',
+                        ],
+                        'disabled' => false,
+                        'priority' => 0,
+                    ],
+                ],
+                'guard' => [],
+            ],
+        ],
+    ];
+
+    public function test_it_triggers_deprecation_error_when_old_callback_name_is_used(): void
+    {
+        $this->setParameter('sm.configs', $this->smConfigs);
+
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage(sprintf('Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
+            'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
+            'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order'
+        ));
+
+        $this->compile();
+    }
+
+    public function test_it_converts_from_old_name_to_new_name(): void
+    {
+        $this->setParameter('sm.configs', $this->smConfigs);
+        $this->expectDeprecation();
+        $this->compile();
+
+        $smConfigs = $this->container->getParameter('sm.configs');
+        $this->assertFalse(
+            isset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order']),
+            'State machine "sylius_order" should not have "sylis_cancel_order" callback configured.'
+        );
+        $this->assertTrue(
+            isset($smConfigs['sylius_order']['callbacks']['after']['sylius_cancel_order']),
+            'State machine "sylius_order" should have "sylius_cancel_order" callback configured.'
+        );
+        $this->assertEquals(
+            $this->smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'],
+            $smConfigs['sylius_order']['callbacks']['after']['sylius_cancel_order'],
+            'State machine "sylius_order" should have the "sylis_cancel_order" callback moved to "sylius_cancel_order".'
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new CancelOrderStateMachineCallbackPass());
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -30,7 +30,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "egulias/email-validator": "^3.0",
         "fakerphp/faker": "^1.10",
-        "jms/serializer-bundle": "^3.5",
+        "jms/serializer-bundle": "^3.5 || ^4.0",
         "knplabs/gaufrette": "^0.8 || ^0.9 || ^0.10 || ^0.11",
         "knplabs/knp-gaufrette-bundle": "^0.7 || ^0.8",
         "liip/imagine-bundle": "^2.3",
@@ -68,7 +68,7 @@
         "symfony/messenger": "^4.4 || ^5.4",
         "symfony/swiftmailer-bundle": "^3.4",
         "symfony/templating": "^4.4 || ^5.4",
-        "winzou/state-machine-bundle": "^0.5"
+        "winzou/state-machine-bundle": "~0.5"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",

--- a/src/Sylius/Bundle/CoreBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/CoreBundle/phpunit.xml.dist
@@ -4,6 +4,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
          colors="true"
+         convertDeprecationsToExceptions="true"
 >
     <testsuites>
         <testsuite name="Sylius Test Suite">

--- a/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionChecker.php
+++ b/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionChecker.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Addressing\Checker;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class CountryProvincesDeletionChecker implements CountryProvincesDeletionCheckerInterface
@@ -27,6 +28,7 @@ final class CountryProvincesDeletionChecker implements CountryProvincesDeletionC
 
     public function isDeletable(CountryInterface $country): bool
     {
+        /** @var ProvinceInterface[] $provinces */
         $provinces = $this->provinceRepository->findBy(['country' => $country]);
 
         $countryProvincesCodes = $country->getProvinces()


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13688, replaces #12762 and #12286
| License         | MIT

Credits to @DennisdeBest and @antiseptikk for the previous PRs and to @AymLaf for the reminder.