### PR TITLE
[Docs] Force user to login during checkout

### DIFF
--- a/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
+++ b/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
@@ -10,7 +10,7 @@ Firstly you need to add a new constraint class:
 
 .. code-block:: php
 
-    // # src/App/Validator/Constraints
+    // src/App/Validator/Constraints
 
     <?php
 
@@ -39,7 +39,7 @@ Then you need to add a validator class:
 
 .. code-block:: php
 
-    // # src/App/Validator/Constraints
+    // src/App/Validator/Constraints
 
     <?php
 
@@ -57,15 +57,10 @@ Then you need to add a validator class:
 
     final class UserAlreadyRegisteredValidator extends ConstraintValidator
     {
-        private CustomerRepositoryInterface $customerRepository;
-        private TokenStorageInterface $tokenStorage;
-
         public function __construct(
-            CustomerRepositoryInterface $customerRepository,
-            TokenStorageInterface $tokenStorage
+            private CustomerRepositoryInterface $customerRepository,
+            private TokenStorageInterface $tokenStorage
         ) {
-            $this->tokenStorage = $tokenStorage;
-            $this->customerRepository = $customerRepository;
         }
 
         public function validate($value, Constraint $constraint): void
@@ -113,4 +108,3 @@ As the last thing you need to do is enable this constraint validator in your app
         App\Validator\Constraints\UserAlreadyRegisteredValidator:
             class: App\Validator\Constraints\UserAlreadyRegisteredValidator
             tags: [ { name: validator.constraint_validator, alias: sylius_api_registered_user_validator } ]
-

--- a/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
+++ b/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
@@ -1,0 +1,116 @@
+How to force already registered user to login during checkout in Sylius API?
+============================================================================
+
+You can force the user to log in during checkout if he is already registered in your app.
+
+Create a new constraint validator
+---------------------------------
+
+Firstly you need to add a new constraint class:
+
+.. code-block:: php
+
+    // # src/App/Validator/Constraints
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Validator\Constraints;
+
+    use Symfony\Component\Validator\Constraint;
+
+    final class UserAlreadyRegistered extends Constraint
+    {
+        public string $message = 'This email is already registered. Please log in.';
+
+        public function validatedBy(): string
+        {
+            return 'sylius_api_registered_user_validator';
+        }
+
+        public function getTargets(): string
+        {
+            return self::CLASS_CONSTRAINT;
+        }
+    }
+
+Then you need to add a validator class:
+
+.. code-block:: php
+
+    // # src/App/Validator/Constraints
+
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Validator\Constraints;
+
+    use Sylius\Component\Core\Model\CustomerInterface;
+    use Sylius\Component\Core\Model\ShopUserInterface;
+    use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+    use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+    use Symfony\Component\Validator\Constraint;
+    use Symfony\Component\Validator\ConstraintValidator;
+    use Webmozart\Assert\Assert;
+
+    final class UserAlreadyRegisteredValidator extends ConstraintValidator
+    {
+        private CustomerRepositoryInterface $customerRepository;
+        private TokenStorageInterface $tokenStorage;
+
+        public function __construct(
+            CustomerRepositoryInterface $customerRepository,
+            TokenStorageInterface $tokenStorage
+        ) {
+            $this->tokenStorage = $tokenStorage;
+            $this->customerRepository = $customerRepository;
+        }
+
+        public function validate($value, Constraint $constraint): void
+        {
+            /** @var UserAlreadyRegistered $constraint */
+            Assert::isInstanceOf($constraint, UserAlreadyRegistered::class);
+
+            $token = $this->tokenStorage->getToken();
+
+            /** @var CustomerInterface|null $existingCustomer */
+            $existingCustomer = $this->customerRepository->findOneBy(['email' => $value->getEmail()]);
+            if (null !== $existingCustomer && !$token->getUser() instanceof ShopUserInterface) {
+                $this->context->addViolation($constraint->message);
+            }
+        }
+    }
+
+Enabling your validator
+-----------------------
+
+As the last thing you need to do is enable this constraint validator in your app and register it as a service in ``services.yaml``. You can do it this way:
+
+.. code-block:: xml
+
+    // # config/validator/validation.xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+
+    <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+        <class name="Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart">
+            <constraint name="App\Validator\Constraints\UserAlreadyRegistered">
+                <option name="groups">
+                    <value>sylius</value>
+                </option>
+            </constraint>
+        </class>
+    </constraint-mapping>
+
+.. code-block:: yaml
+
+    // # config/services.yaml
+
+    services:
+        # other definitions
+        App\Validator\Constraints\UserAlreadyRegisteredValidator:
+            class: App\Validator\Constraints\UserAlreadyRegisteredValidator
+            tags: [ { name: validator.constraint_validator, alias: sylius_api_registered_user_validator } ]
+

--- a/docs/cookbook/api/map.rst.inc
+++ b/docs/cookbook/api/map.rst.inc
@@ -1,1 +1,2 @@
 * :doc:`/cookbook/api/add_to_cart_product_chosen_by_product_options`
+* :doc:`/cookbook/api/how_force_login_already_registered_user_during_checkout`

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -167,5 +167,6 @@ API
     :hidden:
 
     api/add_to_cart_product_chosen_by_product_options
+    api/how_force_login_already_registered_user_during_checkout
 
 .. include:: /cookbook/api/map.rst.inc


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| License         | MIT

In API we should have the ability to force login during checkout if the user already has an account in our shop

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
