### PR TITLE
[Admin] Fix for floating point amount on fixed action in catalog promotion.

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -646,7 +646,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
+     * @When I edit it to have empty amount of fixed discount in the :channel channel
      */
     public function iEditItToHaveEmptyFixedDiscountInTheChannel(ChannelInterface $channel): void
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -610,7 +610,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @When /^I edit it to have empty amount of fixed discount in the ("[^"]+" channel)$/
+     * @When I edit it to have empty amount of fixed discount in the :channel channel
      */
     public function iEditItToHaveEmptyFixedDiscountInChannel(ChannelInterface $channel): void
     {

--- a/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -59,9 +59,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
         $catalogPromotionAction = $form->getData();
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
-        $this->assertTrue($form->isSynchronized());
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(['WEB_US' => ['amount' => 20]], $catalogPromotionAction->getConfiguration());
+        $this->assertSame(['WEB_US' => ['amount' => 2000]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */
@@ -113,8 +112,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(['WEB_US' => ['amount' => 10]], $catalogPromotionAction->getConfiguration());
-        $this->assertSame(['WEB_US' => ['amount' => 10]], $catalogPromotionAction->getConfiguration());
+        $this->assertSame(['WEB_US' => ['amount' => 1000]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */
@@ -222,6 +220,33 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     }
 
     /** @test */
+    public function it_updates_fixed_discount_with_float_amount(): void
+    {
+        $fixedDiscount = $this->setupFixedDiscount();
+
+        $this->channelRepository->findAll(Argument::any())->willReturn(
+            [$this->channel->reveal()]
+        );
+
+        $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
+        $form->submit([
+            'type' => 'fixed_discount',
+            'configuration' => [
+                'WEB_US' => [
+                    'amount' => 20.54
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($form->isSynchronized());
+        $catalogPromotionAction = $form->getData();
+
+        $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
+        $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
+        $this->assertSame(['WEB_US' => ['amount' => 2054]], $catalogPromotionAction->getConfiguration());
+    }
+
+    /** @test */
     public function it_updates_percentage_discount_with_not_valid_amount(): void
     {
         $percentageDiscount = $this->setupPercentageDiscount();
@@ -251,7 +276,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
         $this->channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
 
         $currency = $this->prophesize(CurrencyInterface::class);
-        $currency->getCode()->willReturn('$');
+        $currency->getCode()->willReturn('USD');
 
         $channel = $this->prophesize(ChannelInterface::class);
         $channel->getCode()->willReturn('WEB_US');

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
@@ -34,7 +34,9 @@ final class FixedDiscountActionConfigurationType extends AbstractType
             ->get('amount')
             ->resetViewTransformers()
             ->resetModelTransformers()
-            ->addViewTransformer(new MoneyIntToLocalizedStringTransformer())
+            ->addViewTransformer(new MoneyIntToLocalizedStringTransformer(
+                divisor: $options['divisor']
+            ))
         ;
     }
 
@@ -43,6 +45,9 @@ final class FixedDiscountActionConfigurationType extends AbstractType
         $resolver
             ->setRequired('currency')
             ->setAllowedTypes('currency', 'string')
+            ->setDefaults([
+                'divisor' => 100,
+            ])
         ;
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #13651 
| License         | MIT

There was a problem with floating point value when updating catalog promotion.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
