### PR TITLE
[Cache][Varnish][WIP] Invalidate shop cache if relevant admin resources are changed

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -583,6 +583,67 @@ jobs:
                     path: etc/build/
                     if-no-files-found: ignore
 
+    test-application-caching-mechanism:
+        name: PHP 8.0, Symfony 6, Varnish 6
+        runs-on: ubuntu-20.04
+        strategy:
+            fail-fast: false
+            matrix:
+                mysql: [ "5.7" ]
+                include:
+                    -   php: '8.0'
+                        symfony-version: '6.*'
+        env:
+            APP_ENV: test_cached
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?serverVersion=${{ matrix.mysql }}"
+            VARNISH_VERSION: '6.6'
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Shutdown default MySQL
+                run: sudo service mysql stop
+
+            -   name: Setup MySQL
+                uses: mirromutth/mysql-action@v1.1
+                with:
+                    mysql version: "${{ matrix.mysql }}"
+                    mysql root password: "root"
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    ini-values: date.timezone=Europe/Warsaw, opcache.enable=1, opcache.enable_cli=0, opcache.memory_consumption=512, opcache.max_accelerated_files=65407, opcache.interned_strings_buffer=8, opcache.validate_timestamps=0, opcache.save_comments=1, opcache.fast_shutdown=0
+                    extensions: intl, gd, opcache, mysql, pdo_mysql
+                    tools: symfony, composer-require-checker
+                    coverage: none
+
+            -   name: Copy configuration
+                run: |
+                    cp etc/varnish/docker-compose.yaml .
+                    cp etc/varnish/api_platform/config.yaml src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+
+            -   name: Setup Varnish
+                run: |
+                    docker-compose up --build -d
+
+            -   name: Install composer dependencies
+                run: |
+                    composer update --prefer-dist --no-interaction --no-progress
+
+            -   name: Prepare application database
+                run: |
+                    APP_DEBUG=1 bin/console doctrine:database:create -vvv
+                    bin/console doctrine:migrations:migrate -n -vvv
+
+            -   name: Run webserver
+                run: symfony server:start --port=8443 --dir=public --daemon --no-tls
+
+            -   name: Execute tests
+                run: vendor/bin/phpunit tests/Api/Admin/ProductVariantsCacheTest.php
+
     test-application-with-frontend:
         runs-on: ubuntu-latest
 

--- a/etc/varnish/api_platform/config.yaml
+++ b/etc/varnish/api_platform/config.yaml
@@ -1,0 +1,62 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+parameters:
+    env(SYLIUS_API_AUTHORIZATION_HEADER): Authorization
+    sylius.api.authorization_header: "%env(resolve:SYLIUS_API_AUTHORIZATION_HEADER)%"
+    sylius.api.paths_to_hide:
+        - "/api/v2/admin/catalog-promotion-actions/{id}"
+        - "/api/v2/admin/catalog-promotion-scopes/{id}"
+        - "/api/v2/admin/channel-pricings/{id}"
+    sylius.security.new_api_route: "/api/v2"
+    sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
+    sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
+    sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"
+    sylius.security.new_api_shop_route: "%sylius.security.new_api_route%/shop"
+    sylius.security.new_api_shop_regex: "^%sylius.security.new_api_shop_route%"
+    sylius.security.new_api_user_account_route: "%sylius.security.new_api_shop_route%/account"
+    sylius.security.new_api_user_account_regex: "^%sylius.security.new_api_user_account_route%"
+
+api_platform:
+    doctrine:
+        enabled: true
+    http_cache:
+        invalidation:
+            enabled: true
+            varnish_urls: [ 'http://localhost:8085/' ]
+            request_options:
+                base_uri: 'http://localhost:8085/'
+                verify: false
+        public: true
+    defaults:
+        cache_headers:
+            etag: true
+            max_age: 240 # 4 minutes
+            shared_max_age: 480 # 8 minutes
+            vary: [ 'Content-Type', 'Authorization', 'Accept-Language', 'Origin' ]
+    patch_formats:
+        json: ['application/merge-patch+json']
+    path_segment_name_generator: api_platform.path_segment_name_generator.dash
+    swagger:
+        versions: [3]
+        api_keys:
+            apiKey:
+                name: "%sylius.api.authorization_header%"
+                type: header
+    exception_to_status:
+        SM\SMException: 422
+        Sylius\Bundle\ApiBundle\Exception\CannotRemoveCurrentlyLoggedInUser: 422
+        Sylius\Bundle\ApiBundle\Exception\ShippingMethodCannotBeRemoved: 422
+        Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 400
+    collection:
+        pagination:
+            client_items_per_page: true
+    mapping:
+        paths: ['%kernel.project_dir%/config/api_platform']
+
+lexik_jwt_authentication:
+    token_extractors:
+        authorization_header:
+            enabled: true
+            prefix: Bearer
+            name: "%sylius.api.authorization_header%"

--- a/etc/varnish/default.vcl
+++ b/etc/varnish/default.vcl
@@ -1,0 +1,6 @@
+vcl 4.1;
+
+backend default {
+    .host = "localhost";
+    .port = "8443";
+}

--- a/etc/varnish/docker-compose.yaml
+++ b/etc/varnish/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+    varnish:
+        image: plopix/docker-varnish6
+        volumes:
+            - './etc/varnish/default.vcl:/etc/varnish/default.vcl:ro'
+        ports:
+            - '8085:80'

--- a/src/Sylius/Bundle/ApiBundle/Cache/VarnishPurger.php
+++ b/src/Sylius/Bundle/ApiBundle/Cache/VarnishPurger.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Cache;
+
+use ApiPlatform\Core\HttpCache\PurgerInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+
+final class VarnishPurger implements PurgerInterface
+{
+    public function __construct(
+        private PurgerInterface $basePurger,
+        private UrlMatcherInterface $urlMatcher
+    ) {
+    }
+
+    public function purge(array $iris)
+    {
+        $processedIris = [];
+        foreach ($iris as $iri) {
+            if ($this->isAdminIriReflectedInShop($iri)) {
+                $processedIris[] = $this->processAdminIriToShop($iri);
+            }
+
+            $processedIris[] = $iri;
+        }
+
+        $this->basePurger->purge($processedIris);
+    }
+
+    private function isAdminIriReflectedInShop(string $iri): bool
+    {
+        if (!str_contains($iri, 'admin')) {
+            return false;
+        }
+
+        try {
+            $this->urlMatcher->match(str_replace('admin/', 'shop/', $iri));
+        } catch (\Exception) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function processAdminIriToShop(string $iri): string
+    {
+        return str_replace('admin', 'shop', $iri);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Cache/VarnishPurgerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Cache/VarnishPurgerSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Cache;
+
+use ApiPlatform\Core\HttpCache\PurgerInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+
+final class VarnishPurgerSpec extends ObjectBehavior
+{
+    function let(PurgerInterface $basePurger, UrlMatcherInterface $urlMatcher): void
+    {
+        $this->beConstructedWith($basePurger, $urlMatcher);
+    }
+
+    function it_implements_purger_interface(): void
+    {
+        $this->shouldImplement(PurgerInterface::class);
+    }
+
+    function it_does_nothing_if_processing_iris_are_not_from_admin_section(
+        PurgerInterface $basePurger,
+        UrlMatcherInterface $urlMatcher
+    ): void {
+        $urlMatcher->match(Argument::any())->shouldNotBeCalled();
+
+        $basePurger->purge(['/shop/product-variants/MUG', '/shop/product-variants/T-SHIRT'])->shouldBeCalled();
+
+        $this->purge(['/shop/product-variants/MUG', '/shop/product-variants/T-SHIRT']);
+    }
+
+    function it_does_nothing_if_processing_admin_iris_does_not_manifest_in_shop(
+        PurgerInterface $basePurger,
+        UrlMatcherInterface $urlMatcher
+    ): void {
+        $urlMatcher->match('/shop/administrators')->willThrow(\Exception::class);
+
+        $basePurger->purge(['/admin/administrators', '/shop/product-variants/T-SHIRT']);
+
+        $this->purge(['/admin/administrators', '/shop/product-variants/T-SHIRT']);
+    }
+
+    function it_adds_shop_iris_to_purge_if_they_are_changed_in_admin(
+        PurgerInterface $basePurger,
+        UrlMatcherInterface $urlMatcher
+    ): void {
+        $urlMatcher->match('/shop/product-variants/MUG')->shouldBeCalled();
+        $urlMatcher->match('/shop/product-variants/T-SHIRT')->shouldBeCalled();
+
+        $basePurger
+            ->purge(['/shop/product-variants/MUG', '/admin/product-variants/MUG', '/shop/product-variants/T-SHIRT', '/admin/product-variants/T-SHIRT'])
+            ->shouldBeCalled()
+        ;
+
+        $this->purge(['/admin/product-variants/MUG', '/admin/product-variants/T-SHIRT']);
+    }
+}

--- a/tests/Api/Admin/ProductVariantsCacheTest.php
+++ b/tests/Api/Admin/ProductVariantsCacheTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Admin;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProductVariantsCacheTest extends JsonApiTestCase
+{
+    /** @test */
+    public function it_updates_channel_pricing_of_product_variant_in_both_admin_and_shop(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['channel.yaml', 'product/product_variant.yaml', 'authentication/api_administrator.yaml']);
+
+        $header = $this->authorizeAdministrator();
+
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $fixtures['product_variant'];
+        /** @var ChannelInterface $channel */
+        $channel = $fixtures['channel_web'];
+
+        $this->client->request(
+            'PUT',
+            sprintf('/api/v2/admin/product-variants/%s', $productVariant->getCode()),
+            [],
+            [],
+            array_merge($header, self::CONTENT_TYPE_HEADER),
+            json_encode([
+                'channelPricings' => ['WEB' => [
+                    '@id' => sprintf('/api/v2/admin/channel-pricings/%s', $productVariant->getChannelPricingForChannel($channel)->getId()),
+                    'price' => 3000,
+                    'originalPrice' => 4000,
+                ]]
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        $this->assertResponse($this->client->getResponse(), 'admin/put_product_variant_response', Response::HTTP_OK);
+
+        $this->client->request(
+            'GET',
+            sprintf('/api/v2/admin/product-variants/%s', $productVariant->getCode()),
+            [],
+            [],
+            array_merge($header, self::CONTENT_TYPE_HEADER)
+        );
+
+        $this->assertResponse($this->client->getResponse(), 'admin/get_product_variant_after_update_response', Response::HTTP_OK);
+
+        $this->client->request(
+            'GET',
+            sprintf('/api/v2/shop/product-variants/%s', $productVariant->getCode()),
+            [],
+            [],
+            self::CONTENT_TYPE_HEADER
+        );
+
+        $this->assertResponse($this->client->getResponse(), 'shop/product/get_product_variant_after_update_response', Response::HTTP_OK);
+    }
+
+    private function authorizeAdministrator(): array
+    {
+        $this->client->request(
+            'POST',
+            '/api/v2/admin/authentication-token',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+            json_encode(['email' => 'api@example.com', 'password' => 'sylius'])
+        );
+
+        $token = json_decode($this->client->getResponse()->getContent(), true)['token'];
+        $authorizationHeader = self::$container->getParameter('sylius.api.authorization_header');
+
+        $header['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
+
+        return $header;
+    }
+}

--- a/tests/Api/Responses/Expected/admin/get_product_variant_after_update_response.json
+++ b/tests/Api/Responses/Expected/admin/get_product_variant_after_update_response.json
@@ -1,0 +1,29 @@
+{
+    "@context":"\/api\/v2\/contexts\/ProductVariant",
+    "@id":"\/api\/v2\/admin\/product-variants\/MUG",
+    "@type":"ProductVariant",
+    "id":"@integer@",
+    "code":"MUG",
+    "product":"\/api\/v2\/admin\/products\/MUG_SW",
+    "channelPricings": {
+        "WEB": {
+            "@id": "/api/v2/admin/channel-pricings/@integer@",
+            "@type": "ChannelPricing",
+            "id": @integer@,
+            "channelCode": "WEB",
+            "price": 3000,
+            "originalPrice": 4000,
+            "minimumPrice": 0
+        }
+    },
+    "optionValues":[],
+    "translations": {
+        "en_US": {
+            "@id":"\/api\/v2\/admin\/product-variant-translation\/@integer@",
+            "@type":"ProductVariantTranslation",
+            "id":"@integer@",
+            "name":"Mug",
+            "locale":"en_US"
+        }
+    }
+}

--- a/tests/Api/Responses/Expected/shop/product/get_product_variant_after_update_response.json
+++ b/tests/Api/Responses/Expected/shop/product/get_product_variant_after_update_response.json
@@ -1,0 +1,13 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductVariant",
+    "@id": "\/api\/v2\/shop\/product-variants\/MUG",
+    "@type": "ProductVariant",
+    "id": @integer@,
+    "code": "MUG",
+    "product": "\/api\/v2\/shop\/products\/MUG_SW",
+    "optionValues": [],
+    "name": "Mug",
+    "price": 3000,
+    "originalPrice": 4000,
+    "inStock": true
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When using Varnish with Api Platform, when the e.g. product variant is updated in the admin API, its cache is refreshed for Admin **but not in the Shop**. With this quick fix, we force refreshing the cache for all resources updated in the admin panel that is also relevant in the shop. It's definitely not a perfect solution - but it should work.

BEWARE! 

It's not working for now :dancer: Because I cannot force varnish to work on Github actions :( I tried, but my knowledge and experience are limited in this area. So if anyone has some idea how to make Varnish work - please, check it out 🖖 cc @Sylius/core-team 