### PR TITLE
[Docs] Path fix for validator in API force login cookbook

### DIFF
--- a/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
+++ b/docs/cookbook/api/how_force_login_already_registered_user_during_checkout.rst
@@ -10,7 +10,7 @@ Firstly you need to add a new constraint class:
 
 .. code-block:: php
 
-    // src/App/Validator/Constraints
+    // src/Validator/Constraints
 
     <?php
 
@@ -39,7 +39,7 @@ Then you need to add a validator class:
 
 .. code-block:: php
 
-    // src/App/Validator/Constraints
+    // src/Validator/Constraints
 
     <?php
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #13691 
| License         | MIT

Small fix with a path to validator class in the cookbook.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
