### PR TITLE
[Order] Fix getters and setters to use a proper flag name after upmerge issue

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -477,12 +477,12 @@ class Order extends BaseOrder implements OrderInterface
         return $total;
     }
 
-    public function getByGuest(): bool
+    public function getCreatedByGuest(): bool
     {
         return $this->createdByGuest;
     }
 
-    public function setByGuest(bool $createdByGuest): void
+    public function setCreatedByGuest(bool $createdByGuest): void
     {
         $this->createdByGuest = $createdByGuest;
     }

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -113,9 +113,9 @@ interface OrderInterface extends
 
     public function setCustomerIp(?string $customerIp): void;
 
-    public function getByGuest(): bool;
+    public function getCreatedByGuest(): bool;
 
-    public function setByGuest(bool $guest): void;
+    public function setCreatedByGuest(bool $createdByGuest): void;
 
     /**
      * @return Collection|OrderItemInterface[]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after https://github.com/Sylius/Sylius/pull/13695
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
