### PR TITLE
[UI] Layout improvements and sticky columns

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_layout.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_layout.scss
@@ -1,0 +1,144 @@
+$layout-breakpoint: 768px;
+$layout-topbar-height: 80px;
+$layout-sidebar-width: 260px;
+
+.admin-layout {
+    min-height: 100vh;
+    background: #f9f9f9;
+
+    .admin-layout__sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 999;
+        width: 100%;
+        height: 100%;
+        overflow-y: auto;
+        background: #1e212b;
+
+        @media (min-width: $layout-breakpoint) {
+            width: $layout-sidebar-width;
+        }
+    }
+
+    .admin-layout__toggle {
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 18px;
+        cursor: pointer;
+        font-size: 16px;
+        color: rgba(255, 255, 255, .5);
+
+        @media (min-width: 768px) {
+            display: none;
+        }
+    }
+
+    .admin-layout__body {
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+    }
+
+    .admin-layout__topbar {
+        flex-shrink: 0;
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 998;
+        width: 100%;
+        height: $layout-topbar-height;
+    }
+
+    .admin-layout__content {
+        flex-grow: 1;
+        flex-shrink: 1;
+        padding: $layout-topbar-height 30px 0 30px;
+    }
+
+    .admin-layout__footer {
+        flex-shrink: 0;
+        padding: 30px;
+        margin-top: 40px;
+        border-top: 1px solid rgba(0, 0, 0, .1);
+        text-align: right;
+    }
+}
+
+.admin-layout {
+    .admin-layout__sidebar {
+        display: none;
+    }
+
+    &.admin-layout--open {
+        @media (max-width: $layout-breakpoint - 1) {
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        .admin-layout__sidebar {
+            display: block;
+        }
+
+        .admin-layout__body {
+            @media (min-width: $layout-breakpoint) {
+                margin-left: $layout-sidebar-width;
+            }
+        }
+
+        .admin-layout__topbar {
+            left: $layout-sidebar-width;
+            width: calc(100% - $layout-sidebar-width);
+        }
+    }
+}
+
+.admin-layout__nav {
+    > * {
+        display: block;
+    }
+
+    > a.item:first-child {
+        border-bottom: 1px solid rgba(255, 255, 255, .1);
+    }
+
+    > .item .input .icon {
+        right: 10px !important;
+    }
+
+    > .item .input {
+        display: block;
+        width: 100%;
+        padding: 8px 15px;
+        margin-bottom: 20px;
+    }
+
+    .sylius-admin-menu {
+        > .item {
+            margin: .7em 0 1.6em 0;
+        }
+
+        > .item > .header {
+            margin-bottom: 1em;
+            padding-left: 1.5em;
+            color: rgba(255, 255, 255, .9);
+            font-weight: 700;
+        }
+
+        > .item > .menu > .item {
+            display: block;
+            margin-right: 5px;
+            padding: .4em 1.3em;
+            color: rgba(255, 255, 255, .5);
+        }
+
+        > .item > .menu > .item.active {
+            color: #fff;
+        }
+
+        > .item > .menu > .item:hover {
+            color: rgba(255, 255, 255, .9);
+        }
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -343,3 +343,18 @@ div[id^="sylius_catalog_promotion_actions"] {
 .navigation-next {
     right: 0;
 }
+
+// ----------------------------------
+// ------------ Sticky columns
+// ----------------------------------
+
+@media (min-width: 1000px) {
+    .sticky-container {
+        align-items: flex-start !important;
+    }
+
+    .sticky-column {
+        position: sticky !important;
+        top: 60px
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -67,6 +67,7 @@ a {
 // ------------ Sidebar menu
 // ----------------------------------
 
+.admin-layout__nav,
 #sidebar.ui.sidebar.vertical.menu {
     > .item:first-child {
         margin-bottom: 10px;

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/main.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/main.scss
@@ -1,4 +1,5 @@
 @import "attributes";
+@import "layout";
 @import "taxonomy";
 @import "ui";
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_sidebarToggle.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_sidebarToggle.html.twig
@@ -1,3 +1,3 @@
-<a class="icon item" id="sidebar-toggle" title="{{ 'sylius.ui.toggle_sidebar'|trans }}">
+<a class="icon item" id="sidebar-toggle" title="{{ 'sylius.ui.toggle_sidebar'|trans }}" data-layout-toggle>
     <i class="sidebar icon"></i>
 </a>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/layout.html.twig
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title>{% block title %}Sylius{% endblock %}</title>
+
+    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+
+    {% block metatags %}
+    {% endblock %}
+
+    {% block stylesheets %}
+        <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+    {% endblock %}
+</head>
+
+<body>
+    <div class="admin-layout">
+        <script>
+            const layoutBreakpoint = 768;
+            const layoutContainer = document.querySelector('.admin-layout');
+
+            let layoutState = sessionStorage.getItem('sylius:layout');
+
+            const setLayoutState = () => {
+                layoutContainer.classList.toggle('admin-layout--open', layoutState);
+                sessionStorage.setItem('sylius:layout', layoutState);
+            };
+
+            if (layoutState === null) {
+                layoutState = window.innerWidth > layoutBreakpoint;
+            } else {
+                layoutState = window.innerWidth > layoutBreakpoint ? layoutState === 'true' : false;
+            }
+
+            setLayoutState();
+        </script>
+
+        <div class="admin-layout__sidebar">
+            <div class="admin-layout__nav">
+                {% block sidebar %}
+                {% endblock %}
+                <div class="admin-layout__toggle" data-layout-toggle>
+                    <i class="close icon"></i>
+                </div>
+            </div>
+        </div>
+
+        <div class="admin-layout__body">
+            <div class="admin-layout__topbar">
+                <div class="ui borderless menu">
+                    {% block topbar %}
+                    {% endblock %}
+                </div>
+            </div>
+
+            <div class="admin-layout__content">
+                {% block flash_messages %}
+                    {% include '@SyliusUi/_flashes.html.twig' %}
+                {% endblock %}
+
+                {% block pre_content %}
+                {% endblock %}
+
+                {% block content %}
+                {% endblock %}
+
+                {% block post_content %}
+                {% endblock %}
+            </div>
+
+            <div class="admin-layout__footer">
+                {% block footer %}
+                {% endblock %}
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const layoutToggleButton = document.querySelectorAll('[data-layout-toggle]');
+
+        layoutToggleButton.forEach((button) => {
+            button.addEventListener('click', () => {
+                layoutState = !layoutState;
+                setLayoutState();
+            });
+        });
+    </script>
+
+    {% include '@SyliusUi/Modal/_confirmation.html.twig' %}
+
+    {% block javascripts %}
+    {% endblock %}
+</body>
+</html>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_content.html.twig
@@ -1,5 +1,5 @@
-<div class="ui stackable grid">
-    <div class="twelve wide column">
+<div class="ui stackable grid sticky-container">
+    <div class="twelve wide column sticky-column">
         {{ sylius_template_event('sylius.admin.order.show.summary', _context) }}
     </div>
     <div class="four wide column">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_content.html.twig
@@ -1,5 +1,5 @@
-<div class="ui two column stackable grid">
-    <div class="sixteen wide mobile sixteen wide tablet three wide computer column">
+<div class="ui two column stackable grid sticky-container">
+    <div class="sixteen wide mobile sixteen wide tablet three wide computer column sticky-column">
         {{ sylius_template_event('sylius.admin.product.index.content.sidebar', _context) }}
     </div>
     <div class="sixteen wide mobile sixteen wide tablet thirteen wide computer column sylius-product-index">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
@@ -3,8 +3,8 @@
 {% block content %}
     {{ sylius_template_event('sylius.admin.taxon.create.before_content', {'resource': resource}) }}
 
-    <div class="ui grid">
-        <div class="sixteen wide mobile sixteen wide tablet four wide computer column">
+    <div class="ui grid sticky-container">
+        <div class="sixteen wide mobile sixteen wide tablet four wide computer column sticky-column">
             {{ sylius_template_event('sylius.admin.taxon.create.taxon_tree', {'resource': resource}) }}
         </div>
         <div class="sixteen wide mobile sixteen wide tablet twelve wide computer column">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
@@ -3,8 +3,8 @@
 {% block content %}
     {{ sylius_template_event('sylius.admin.taxon.update.before_content', {'resource': resource}) }}
 
-    <div class="ui grid">
-        <div class="sixteen wide mobile sixteen wide tablet four wide computer column">
+    <div class="ui grid sticky-container">
+        <div class="sixteen wide mobile sixteen wide tablet four wide computer column sticky-column">
             {{ sylius_template_event('sylius.admin.taxon.update.taxon_tree', {'resource': resource}) }}
         </div>
         <div class="sixteen wide mobile sixteen wide tablet twelve wide computer column">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends '@SyliusUi/Layout/sidebar.html.twig' %}
+{% extends '@SyliusAdmin/Layout/layout.html.twig' %}
 
 {% block title %} | Sylius{% endblock %}
 


### PR DESCRIPTION
Some minor UI improvements:

### Sticky columns in orders, taxons, and products
---
https://user-images.githubusercontent.com/15385420/155987944-8182038a-086b-4a80-a24e-70b15bbdf212.mov

### Improved sidebar: save menu state (open / close), remove heavy animation, full width mobile sidebar
---
https://user-images.githubusercontent.com/15385420/155988023-48b9f7f4-ec89-47ad-869e-8aba4c4ceffd.mov

![Zrzut ekranu 2022-02-28 o 14 06 02](https://user-images.githubusercontent.com/15385420/155988916-8bcae27d-4c18-42df-987d-8c61ca6b96b5.png)


