### PR TITLE
[Fixtures] Purge database trait

### DIFF
--- a/tests/DataFixtures/Factory/CountryFactoryTest.php
+++ b/tests/DataFixtures/Factory/CountryFactoryTest.php
@@ -15,14 +15,14 @@ namespace Sylius\Tests\DataFixtures\Factory;
 
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\CountryFactory;
 use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Intl\Countries;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class CountryFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/CurrencyFactoryTest.php
+++ b/tests/DataFixtures/Factory/CurrencyFactoryTest.php
@@ -15,14 +15,14 @@ namespace Sylius\Tests\DataFixtures\Factory;
 
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\CurrencyFactory;
 use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Intl\Currencies;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class CurrencyFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/CustomerGroupFactoryTest.php
+++ b/tests/DataFixtures/Factory/CustomerGroupFactoryTest.php
@@ -15,13 +15,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\CustomerGroupFactory;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class CustomerGroupFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/LocaleFactoryTest.php
+++ b/tests/DataFixtures/Factory/LocaleFactoryTest.php
@@ -15,13 +15,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\LocaleFactory;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class LocaleFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ProductAssociationTypeFactoryTest.php
+++ b/tests/DataFixtures/Factory/ProductAssociationTypeFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\LocaleFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ProductAssociationTypeFactory;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ProductAssociationTypeFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ProductAttributeFactoryTest.php
+++ b/tests/DataFixtures/Factory/ProductAttributeFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\LocaleFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ProductAttributeFactory;
 use Sylius\Component\Product\Model\ProductAttributeInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ProductAttributeFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ShippingCategoryFactoryTest.php
+++ b/tests/DataFixtures/Factory/ShippingCategoryFactoryTest.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\DataFixtures\Factory;
 
-use Sylius\Bundle\CoreBundle\DataFixtures\Factory\LocaleFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ShippingCategoryFactory;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ShippingCategoryFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ShopUserFactoryTest.php
+++ b/tests/DataFixtures/Factory/ShopUserFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\CustomerGroupFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ShopUserFactory;
 use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ShopUserFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/TaxCategoryFactoryTest.php
+++ b/tests/DataFixtures/Factory/TaxCategoryFactoryTest.php
@@ -15,13 +15,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\TaxCategoryFactory;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class TaxCategoryFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/TaxonFactoryTest.php
+++ b/tests/DataFixtures/Factory/TaxonFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\LocaleFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\TaxonFactory;
 use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class TaxonFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ZoneFactoryTest.php
+++ b/tests/DataFixtures/Factory/ZoneFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ZoneFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ZoneMemberFactory;
 use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ZoneFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/DataFixtures/Factory/ZoneMemberFactoryTest.php
+++ b/tests/DataFixtures/Factory/ZoneMemberFactoryTest.php
@@ -16,13 +16,13 @@ namespace Sylius\Tests\DataFixtures\Factory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ZoneFactory;
 use Sylius\Bundle\CoreBundle\DataFixtures\Factory\ZoneMemberFactory;
 use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Tests\PurgeDatabaseTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
-use Zenstruck\Foundry\Test\ResetDatabase;
 
 final class ZoneMemberFactoryTest extends KernelTestCase
 {
-    use ResetDatabase;
+    use PurgeDatabaseTrait;
     use Factories;
 
     /** @test */

--- a/tests/PurgeDatabaseTrait.php
+++ b/tests/PurgeDatabaseTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Tests;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @mixin KernelTestCase
+ */
+trait PurgeDatabaseTrait
+{
+    /**
+     * @internal
+     * @before
+     */
+    public static function _resetSchema(): void
+    {
+        if (!\is_subclass_of(static::class, KernelTestCase::class)) {
+            throw new \RuntimeException(\sprintf('The "%s" trait can only be used on TestCases that extend "%s".', __TRAIT__, KernelTestCase::class));
+        }
+
+        $kernel = static::createKernel();
+        $kernel->boot();
+
+        static::_purgeDatabase($kernel);
+
+        $kernel->shutdown();
+    }
+
+    public static function _purgeDatabase(KernelInterface $kernel)
+    {
+        if (!$kernel->getContainer()->has('doctrine')) {
+            return;
+        }
+
+        /** @var Registry $registry */
+        $registry = $kernel->getContainer()->get('doctrine');
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $registry->getManager();
+
+        $purger = new ORMPurger($entityManager);
+        $purger->purge();
+
+        $entityManager->clear();
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | foundry-fixtures
| Bug fix?        | yes, kind of, cause the ResetDatabase from Foundry is too low (it drops and recreates the database).
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #13621 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
