### PR TITLE
[JS] add empty value to autocomplete selects

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -35,12 +35,19 @@ $.fn.extend({
             return settings;
           },
           onResponse(response) {
+            let results = response.map(item => ({
+              name: item[choiceName],
+              value: item[choiceValue],
+            }));
+
+            results.unshift({
+              name: '&nbsp;',
+              value: '',
+            });
+
             return {
               success: true,
-              results: response.map(item => ({
-                name: item[choiceName],
-                value: item[choiceValue],
-              })),
+              results: results,
             };
           },
         },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<img width="688" alt="image" src="https://user-images.githubusercontent.com/22825722/157185202-a7e49b9f-4826-4044-b68c-0a1a2e7d71af.png">

Adds empty field, which allows user to reset autoselect.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
