### PR TITLE
Validate existence of coupon

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -44,8 +44,18 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
             return;
         }
 
-        /** @var PromotionCouponInterface|null $promotionCoupon */
         $promotionCoupon = $this->promotionCouponRepository->findOneBy(['code' => $value->couponCode]);
+        
+        if (!$promotionCoupon instanceof PromotionCouponInterface) {
+            $this->context
+                ->buildViolation($constraint->message)
+                ->atPath('couponCode')
+                ->addViolation()
+            ;
+            
+            return;
+        }
+        
         /** @var OrderInterface $cart */
         $cart = $this->orderRepository->findCartByTokenValue($value->getOrderTokenValue());
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10, 1.11 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We see a lot of these messages:

```Uncaught PHP Exception TypeError: "Argument 2 passed to Sylius\Component\Promotion\Checker\Eligibility\CompositePromotionCouponEligibilityChecker::isEligible() must implement interface Sylius\Component\Promotion\Model\PromotionCouponInterface, null given, called in /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php on line 66" at /srv/sylius/vendor/sylius/sylius/src/Sylius/Component/Promotion/Checker/Eligibility/CompositePromotionCouponEligibilityChecker.php line 36```

This is because a null value can be fed into the promotionCouponChecker::isEligible. This PR will make sure that it is properly checked beforehand