### PR TITLE
[Maintenance]Ignore phpstan.neon file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@
 /.php_cs.cache
 ###< friendsofphp/php-cs-fixer ###
 
+###> phpstan/phpstan ###
+/phpstan.neon
+###< phpstan/phpstan ###
+
 ###> phpunit/phpunit ###
 /phpunit.xml
 /.phpunit.result.cache


### PR DESCRIPTION
Due to the presence of the `phpstan.neon.dist` file, I would like to propose adding the `phpstan.neon` config file to the gitignore as the phpunit, phpspec are ignored.


| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
