### PR TITLE
[Maintenance]Remove auto-scripts from composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -311,17 +311,5 @@
         "classmap": [
             "src/Kernel.php"
         ]
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "@auto-scripts"
-        ],
-        "post-update-cmd": [
-            "@auto-scripts"
-        ],
-        "auto-scripts": {
-            "cache:clear": "symfony-cmd",
-            "assets:install %PUBLIC_DIR%": "symfony-cmd"
-        }
     }
 }


### PR DESCRIPTION
In my opinion, using auto-scripts in the composer.json file is bad practice. Why?

1. **I lose my ability to define where and when commands are executed.** I would like to have all power of when, where, and what is executed. The auto-magic is the approach that may break installation or execution.

2. The Docker build that I'm working on cannot handle the auto-scripts approach, because of the **memory limitations**.

3. Default `cache:clear` command is very **costly when it comes to resources** and there are not many situations when you actually trigger that on dev or test environment. And you definitely don't want to trigger that default command on production without proper flags.

Maybe I will find more arguments, but for no that's it. Tell me why should we keep the composer auto-scripts.


| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT