### PR TITLE
Don't redeclare field configured by extended form

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
@@ -19,7 +19,6 @@ use Sylius\Bundle\ProductBundle\Form\Type\ProductVariantMatchType;
 use Sylius\Component\Core\Model\Product;
 use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -33,11 +32,6 @@ final class CartItemTypeExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('quantity', IntegerType::class, [
-            'attr' => ['min' => 1],
-            'label' => 'sylius.ui.quantity',
-        ]);
-
         if (isset($options['product']) && $options['product']->hasVariants() && !$options['product']->isSimple()) {
             $type =
                 Product::VARIANT_SELECTION_CHOICE === $options['product']->getVariantSelectionMethod()


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

The core bundle's `CartItemTypeExtension` redeclares the quantity field, but the base `CartItemType` from the order bundle has already declares the field with the same configuration.  One less call to the Department of Redundancy Department is good for everybody.