### PR TITLE
Added customer to ShopUserToken schema

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
@@ -41,6 +41,11 @@ final class ShopAuthenticationTokenDocumentationNormalizer implements Normalizer
                     'type' => 'string',
                     'readOnly' => true,
                 ],
+                'customer' => [
+                    'type' => 'string',
+                    'readOnly' => true,
+                    'format' => 'iri-reference',
+                ]
             ],
         ];
 


### PR DESCRIPTION
I noticed that a Customer IRI is returned along with the token, and it was missing in the API docs.

| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | none
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
