### PR TITLE
Change sylius.behat.context.ui.email context to sylius.behat.context.api.email

### DIFF
--- a/src/Sylius/Behat/Context/Api/EmailContext.php
+++ b/src/Sylius/Behat/Context/Api/EmailContext.php
@@ -14,18 +14,27 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Test\Services\EmailCheckerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 
 final class EmailContext implements Context
 {
+    private SharedStorageInterface $sharedStorage;
+
     private EmailCheckerInterface $emailChecker;
 
     private TranslatorInterface $translator;
 
-    public function __construct(EmailCheckerInterface $emailChecker, TranslatorInterface $translator)
-    {
+    public function __construct(
+        SharedStorageInterface $sharedStorage,
+        EmailCheckerInterface $emailChecker,
+        TranslatorInterface $translator
+    ) {
+        $this->sharedStorage = $sharedStorage;
         $this->emailChecker = $emailChecker;
         $this->translator = $translator;
     }
@@ -51,6 +60,85 @@ final class EmailContext implements Context
     }
 
     /**
+     * @Then an email with the :method shipment's confirmation for the :orderNumber order should be sent to :email
+     */
+    public function anEmailWithShipmentsConfirmationForTheOrderShouldBeSentTo(string $method, string $orderNumber, string $recipient): void
+    {
+        Assert::true($this->emailChecker->hasMessageTo(
+            sprintf(
+                'Your order with number %s has been sent using %s.',
+                $orderNumber,
+                $method
+            ),
+            $recipient
+        ));
+    }
+
+    /**
+     * @Then /^an email with the summary of (order placed by "[^"]+") should be sent to him$/
+     * @Then /^an email with the summary of (order placed by "[^"]+") should be sent to him in ("([^"]+)" locale)$/
+     */
+    public function anEmailWithSummaryOfOrderPlacedByShouldBeSentTo(OrderInterface $order, string $localeCode = 'en_US'): void
+    {
+        $this->anEmailWithTheConfirmationOfTheOrderShouldBeSentTo($order, $order->getCustomer()->getEmailCanonical(), $localeCode);
+    }
+
+    /**
+     * @Then an email with the confirmation of the order :order should be sent to :email
+     * @Then an email with the confirmation of the order :order should be sent to :email in :localeCode locale
+     */
+    public function anEmailWithTheConfirmationOfTheOrderShouldBeSentTo(
+        OrderInterface $order,
+        string $recipient,
+        string $localeCode = 'en_US'
+    ): void {
+        $this->assertEmailContainsMessageTo(
+            sprintf(
+                '%s %s %s',
+                $this->translator->trans('sylius.email.order_confirmation.your_order_number', [], null, $localeCode),
+                $order->getNumber(),
+                $this->translator->trans('sylius.email.order_confirmation.has_been_successfully_placed', [], null, $localeCode)
+            ),
+            $recipient
+        );
+    }
+
+    /**
+     * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)"$/
+     * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)" in ("([^"]+)" locale)$/
+     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient
+     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient in :localeCode locale
+     */
+    public function anEmailWithShipmentDetailsOfOrderShouldBeSentTo(
+        OrderInterface $order,
+        string $recipient,
+        string $localeCode = 'en_US'
+    ): void {
+        $this->assertEmailContainsMessageTo(
+            sprintf(
+                '%s %s %s %s.',
+                $this->translator->trans('sylius.email.shipment_confirmation.your_order_with_number', [], null, $localeCode),
+                $order->getNumber(),
+                $this->translator->trans('sylius.email.shipment_confirmation.has_been_sent_using', [], null, $localeCode),
+                $this->getShippingMethodName($order)
+            ),
+            $recipient
+        );
+
+        if ($this->sharedStorage->has('tracking_code')) {
+            $this->assertEmailContainsMessageTo(
+                $this->translator->trans(
+                    'sylius.email.shipment_confirmation.you_can_check_its_location_with_the_tracking_code',
+                    ['%tracking_code%' => $this->sharedStorage->get('tracking_code')],
+                    null,
+                    $localeCode
+                ),
+                $recipient
+            );
+        }
+    }
+
+    /**
      * @Then it should be sent to :recipient
      * @Then the email with contact request should be sent to :recipient
      */
@@ -62,5 +150,16 @@ final class EmailContext implements Context
     private function assertEmailContainsMessageTo(string $message, string $recipient): void
     {
         Assert::true($this->emailChecker->hasMessageTo($message, $recipient));
+    }
+
+    private function getShippingMethodName(OrderInterface $order): string
+    {
+        /** @var ShipmentInterface|false $shipment */
+        $shipment = $order->getShipments()->first();
+        if (false === $shipment) {
+            throw new \LogicException('Order should have at least one shipment.');
+        }
+
+        return $shipment->getMethod()->getName();
     }
 }

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -163,7 +163,7 @@ final class EmailContext implements Context
 
     private function getShippingMethodName(OrderInterface $order): string
     {
-        /** @var ShipmentInterface $shipment */
+        /** @var ShipmentInterface|false $shipment */
         $shipment = $order->getShipments()->first();
         if (false === $shipment) {
             throw new \LogicException('Order should have at least one shipment.');

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/email.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/email.xml
@@ -15,6 +15,7 @@
     <services>
         <defaults public="true" />
         <service id="sylius.behat.context.api.email" class="Sylius\Behat\Context\Api\EmailContext">
+            <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.behat.email_checker" />
             <argument type="service" id="translator" />
         </service>

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -263,7 +263,6 @@
             <argument type="service" id="sylius.behat.current_page_resolver" />
             <argument type="service" id="sylius.behat.notification_checker" />
             <argument type="service" id="sylius.behat.java_script_test_helper" />
-            <argument type="service" id="behat.mink.default_session" />
         </service>
 
         <service id="sylius.behat.context.ui.admin.managing_tax_rate" class="Sylius\Behat\Context\Ui\Admin\ManagingTaxRateContext">

--- a/src/Sylius/Behat/Resources/config/suites/api/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/checkout/checkout.yml
@@ -54,7 +54,7 @@ default:
                 - sylius.behat.context.api.shop.login
                 - sylius.behat.context.api.shop.order
 
-                - sylius.behat.context.ui.email
+                - sylius.behat.context.api.email
 
             filters:
                 tags: "@checkout&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
@@ -37,7 +37,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
 
                 - sylius.behat.context.api.admin.managing_orders
-                - sylius.behat.context.ui.email
+                - sylius.behat.context.api.email
 
             filters:
                 tags: "@managing_orders&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/managing_shipments.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/managing_shipments.yml
@@ -30,7 +30,7 @@ default:
                 - sylius.behat.context.setup.shipping
                 - sylius.behat.context.setup.zone
 
-                - sylius.behat.context.ui.email
+                - sylius.behat.context.api.email
 
                 - sylius.behat.context.api.admin.managing_shipments
             filters:


### PR DESCRIPTION
I don't know why, but the API resources had `sylius.behat.context.ui.email` suites defined, not sure whether they are misconfiguration or feature. Could not find reason for it in the PRs.