### PR TITLE
[Behat][API] Change the undefined step to create a configurable product instead of simple one

### DIFF
--- a/features/product/managing_products/editing_product_slug.feature
+++ b/features/product/managing_products/editing_product_slug.feature
@@ -18,7 +18,7 @@ Feature: Editing product's slug
 
     @ui @javascript @api
     Scenario: Creating a product with a custom slug
-        When I want to create a new simple product
+        When I want to create a new configurable product
         And I specify its code as "BOARD_MANSION_OF_MADNESS"
         And I name it "Mansion of Madness" in "English (United States)"
         And I set its slug to "mom-board-game" in "English (United States)"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The step was undefined in API context where we should create a configurable product, not a simple one. 
Build: https://github.com/Sylius/Sylius/runs/5559343143?check_suite_focus=true#step:24:85

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
