### PR TITLE
[Symfony] fix error that causes problem with opening swagger ui in some cases

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/DisablePhpstanPropertyExtractorPass.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/DisablePhpstanPropertyExtractorPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @see https://github.com/symfony/symfony/issues/45517
+ */
+class DisablePhpstanPropertyExtractorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('property_info.phpstan_extractor')) {
+            $container->removeDefinition('property_info.phpstan_extractor');
+            $def = $container->getDefinition('property_info');
+            /** @var IteratorArgument $typeExtractors */
+            $typeExtractors = $def->getArgument(1);
+            $newExtractors = [];
+
+            foreach ($typeExtractors->getValues() as $extractor) {
+                $extractorId = (string) $extractor;
+                if ('property_info.phpstan_extractor' !== $extractorId) {
+                    $newExtractors[] = $extractor;
+                }
+            }
+
+            $def->setArgument(1, new IteratorArgument($newExtractors));
+        }
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
+++ b/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle;
 
 use Sylius\Bundle\ApiBundle\DependencyInjection\Compiler\CommandDataTransformerPass;
+use Sylius\Bundle\ApiBundle\DependencyInjection\Compiler\DisablePhpstanPropertyExtractorPass;
 use Sylius\Bundle\ApiBundle\DependencyInjection\Compiler\ReflectionExtractorHotfixPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,5 +26,6 @@ final class SyliusApiBundle extends Bundle
     {
         $builder->addCompilerPass(new CommandDataTransformerPass());
         $builder->addCompilerPass(new ReflectionExtractorHotfixPass());
+        $builder->addCompilerPass(new DisablePhpstanPropertyExtractorPass());
     }
 }


### PR DESCRIPTION

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fix error where symfony couldnt load namespace when opening swagger docs.
Symfony issue: https://github.com/symfony/symfony/issues/45517

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
