### PR TITLE
[Behat] added context to manage non-collection subresources

### DIFF
--- a/src/Sylius/Behat/Client/ApiClientInterface.php
+++ b/src/Sylius/Behat/Client/ApiClientInterface.php
@@ -67,6 +67,8 @@ interface ApiClientInterface
     /** @param string|int|array $value */
     public function addRequestData(string $key, $value): void;
 
+    public function setSubResourceData(string $key, array $data): void;
+
     public function addSubResourceData(string $key, array $data): void;
 
     public function removeSubResource(string $subResource, string $id): void;

--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -226,6 +226,11 @@ final class ApiPlatformClient implements ApiClientInterface
         $this->request->updateContent($data);
     }
 
+    public function setSubResourceData(string $key, array $data): void
+    {
+        $this->request->setSubResource($key, $data);
+    }
+
     public function addSubResourceData(string $key, array $data): void
     {
         $this->request->addSubResource($key, $data);

--- a/src/Sylius/Behat/Client/Request.php
+++ b/src/Sylius/Behat/Client/Request.php
@@ -228,6 +228,11 @@ final class Request implements RequestInterface
         $this->files = array_merge($this->files, $newFiles);
     }
 
+    public function setSubresource(string $key, array $subResource): void
+    {
+        $this->content[$key] = $subResource;
+    }
+
     public function addSubResource(string $key, array $subResource): void
     {
         $this->content[$key][] = $subResource;

--- a/src/Sylius/Behat/Client/RequestInterface.php
+++ b/src/Sylius/Behat/Client/RequestInterface.php
@@ -90,6 +90,8 @@ interface RequestInterface
 
     public function updateFiles(array $newFiles): void;
 
+    public function setSubResource(string $key, array $subResource): void;
+
     public function addSubResource(string $key, array $subResource): void;
 
     public function removeSubResource(string $subResource, string $id): void;

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
@@ -183,7 +183,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iAddIt(): void
     {
-        $this->client->addSubResourceData('shopBillingData', $this->shopBillingData);
+        $this->client->setSubResourceData('shopBillingData', $this->shopBillingData);
 
         $this->client->create();
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

In order to use Sylius with the next API Platform release (2.7), I added the ability to test API resources which contains non-collection sub-resources (i.e. channel).
This patch seems to be useless with API Platform 2.6, but is mandatory for API Platform 2.7.