### PR TITLE
[Admin][JS] Applying all the options selected for an attribute of type multiple select fixed

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -78,6 +78,10 @@ const copyValueToAllLanguages = function copyValueToAllLanguages() {
       $inputs.each((i, input) => {
         if (input.getAttribute('type') === 'checkbox') {
           input.checked = $masterAttributeInputs[i].checked;
+        } else if (input.nodeName === 'SELECT') {
+          for (let x = 0; x < $inputs[i].length; x++) {
+            input[x].selected = $masterAttributeInputs[i][x].selected;
+          }
         } else {
           input.value = $masterAttributeInputs[i].value;
         }


### PR DESCRIPTION

| Q               | A
| --------------- | -----
| Branch?         | 1.10 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | mentioned in [issue](https://github.com/Sylius/Sylius/issues/13326)
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
`Apply to all` button at admin product attribute edition page was working only for one option for select attribute, now it is possible to select all options.

https://user-images.githubusercontent.com/53942444/160408379-dd754e1e-5b44-4ce9-a4c5-19fb130c8ae1.mov


