### PR TITLE
[JS] Not render empty value in multi select autocompletes

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -40,10 +40,12 @@ $.fn.extend({
               value: item[choiceValue],
             }));
 
-            results.unshift({
-              name: '&nbsp;',
-              value: '',
-            });
+            if (!element.hasClass('multiple')){
+              results.unshift({
+                name: '&nbsp;',
+                value: '&nbsp;',
+              });
+            }
 
             return {
               success: true,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13734
| License         | MIT

After we fixed single autocompletes we have create a bug when we can add an empty value in multi-select autocompletes. Now we are not adding this empty value in multi-select.

In single autocompletes:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/28228691/160593065-23a438d1-dce2-49da-93b5-9fdfeb0b789d.png">
In multi-select autocompletes:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/28228691/160593157-e255824f-5ac3-4477-92d5-acc69e039d4d.png">


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
