### PR TITLE
[docs]Change python docker base version

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10.4-slim-buster
 
 WORKDIR /usr/src/app
 
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD [ "bash", "build.sh" ]
+CMD ["bash", "build.sh"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-slim-buster
+FROM python:3.10.4
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bugfix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

I scanned Sylius repository with Snyk (snyk.io) and he found out that there are vulnerabilities in the `python:3` base image repository. Therefore I would like to propose a change to update the image with a more secure version. I decided to not use Snyk's suggestion as the proposed image has tags which means they are working on it. Yet I had to use nor-slim image as it has not git installed in it :(

<img width="1410" alt="Screenshot 2022-03-30 at 10 55 23" src="https://user-images.githubusercontent.com/17534504/160793904-7a186938-6637-4bd5-83e4-5152b73a7e4b.png">
