### PR TITLE
Calculate tax with decimal precision and distribute proportionally across order items

### DIFF
--- a/docs/book/orders/taxation.rst
+++ b/docs/book/orders/taxation.rst
@@ -145,10 +145,23 @@ which has the services that implement the `OrderTaxesApplicatorInterface <https:
 Calculators
 '''''''''''
 
-For calculating Taxes **Sylius** is using the `DefaultCalculator <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Taxation/Calculator/DefaultCalculator.php>`_.
+For calculating Taxes **Sylius** is using tax calculators.
+
+To select a proper service we have a one that decides for us
+- the `DelegatingCalculator <https://github.com/Sylius/Sylius/blob/{current_version}/src/Sylius/Component/Taxation/Calculator/DelegatingCalculator.php>`_.
+Basing on the **TaxRate** assigned on the Product it will get its calculator type calculate the amount properly.
+
 You can create your custom calculator for taxes by creating a class that implements
-the `CalculatorInterface <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Taxation/Calculator/CalculatorInterface.php>`_
+the `CalculatorInterface <https://github.com/Sylius/Sylius/blob/{current_version}/src/Sylius/Component/Taxation/Calculator/CalculatorInterface.php>`_
 and registering it as a ``sylius.tax_calculator.your_calculator_name`` service.
+
+Built-in Calculators
+''''''''''''''''''''
+
+The already defined calculators in Sylius:
+
+* **DefaultCalculator** - calculates the ``amount`` with rounding.
+* **DecimalCalculator** - calculates the ``amount`` without rounding, which results in a distribution of decimal values among the items.
 
 Learn more
 ----------

--- a/features/taxation/applying_taxes/applying_correct_taxes_for_product_with_tax_rate_included_in_price.feature
+++ b/features/taxation/applying_taxes/applying_correct_taxes_for_product_with_tax_rate_included_in_price.feature
@@ -1,5 +1,5 @@
 @applying_taxes
-Feature: Apply correct taxes for items with tax rate included in price
+Feature: Applying correct taxes for items with tax rate included in price
     In order to pay proper amount when buying goods with tax rate included in price
     As a Visitor
     I want to have correct taxes applied to my order
@@ -7,14 +7,37 @@ Feature: Apply correct taxes for items with tax rate included in price
     Background:
         Given the store operates on a single channel in "United States"
         And default tax zone is "US"
-        And the store has included in price "VAT" tax rate of 23% for "Clothes" within the "US" zone
-        And the store has a product "PHP T-Shirt" priced at "$100.00"
+        And the store has included in price "VAT" tax rate of 20% for "Clothes" within the "US" zone
+        And the store has a product "PHP T-Shirt" priced at "$19.70"
+        And it belongs to "Clothes" tax category
+        And the store has a product "Symfony T-Shirt" priced at "$19.70"
         And it belongs to "Clothes" tax category
 
     @ui @api
-    Scenario: Proper taxes for taxed product
+    Scenario: Applying correct taxes for a single item with tax rate included in price
         When I add product "PHP T-Shirt" to the cart
-        Then my cart total should be "$100.00"
-        And my included in price taxes should be "$18.70"
+        Then my cart total should be "$19.70"
+        And my included in price taxes should be "$3.28"
         And there should be one item in my cart
-        And total price of "PHP T-Shirt" item should be "$100.00"
+        And total price of "PHP T-Shirt" item should be "$19.70"
+
+    @ui @api
+    Scenario: Applying correct taxes for a single item with multiple units with tax rate included in price
+        When I add 2 products "PHP T-Shirt" to the cart
+        Then my cart total should be "$39.40"
+        And my included in price taxes should be "$6.57"
+        And total price of "PHP T-Shirt" item should be "$39.40"
+
+    @ui @api
+    Scenario: Applying correct taxes for multiple items with tax rate included in price and default calculator
+        When I add products "PHP T-Shirt" and "Symfony T-Shirt" to the cart
+        Then my cart total should be "$39.40"
+        And my included in price taxes should be "$6.56"
+
+
+    @ui @api
+    Scenario: Applying correct taxes for multiple items with tax rate included in price and decimal calculator
+        Given the "VAT" tax rate has decimal calculator configured
+        When I add products "PHP T-Shirt" and "Symfony T-Shirt" to the cart
+        Then my cart total should be "$39.40"
+        And my included in price taxes should be "$6.57"

--- a/features/taxation/applying_taxes/applying_correct_taxes_for_product_with_tax_rate_included_in_price.feature
+++ b/features/taxation/applying_taxes/applying_correct_taxes_for_product_with_tax_rate_included_in_price.feature
@@ -34,7 +34,6 @@ Feature: Applying correct taxes for items with tax rate included in price
         Then my cart total should be "$39.40"
         And my included in price taxes should be "$6.56"
 
-
     @ui @api
     Scenario: Applying correct taxes for multiple items with tax rate included in price and decimal calculator
         Given the "VAT" tax rate has decimal calculator configured

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -89,6 +89,7 @@ final class CartContext implements Context
     }
 
     /**
+     * @When /^I add (products "([^"]+)" and "([^"]+)") to the cart$/
      * @When /^I add (products "([^"]+)", "([^"]+)" and "([^"]+)") to the cart$/
      */
     public function iAddMultipleProductsToTheCart(array $products): void

--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -157,6 +157,16 @@ final class TaxationContext implements Context
     }
 
     /**
+     * @Given the :taxRate tax rate has :calculator calculator configured
+     */
+    public function theTaxRateHasCalculatorConfigured(TaxRateInterface $taxRate, string $calculator): void
+    {
+        $taxRate->setCalculator($calculator);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @param string $taxCategoryName
      *
      * @return TaxCategoryInterface

--- a/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.tax_category
+                - sylius.behat.context.transform.tax_rate
                 - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.channel

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.tax_category
+                - sylius.behat.context.transform.tax_rate
                 - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.channel

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/taxation.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/taxation.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.integer_distributor" />
             <argument type="service" id="sylius.tax_rate_resolver" />
+            <argument type="service" id="sylius.proportional_integer_distributor" />
         </service>
         <service id="sylius.taxation.order_item_units_taxes_applicator" class="Sylius\Component\Core\Taxation\Applicator\OrderItemUnitsTaxesApplicator">
             <argument type="service" id="sylius.tax_calculator" />

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
@@ -36,7 +36,7 @@
         <service id="sylius.tax_calculator.default" class="Sylius\Component\Taxation\Calculator\DefaultCalculator">
             <tag name="sylius.tax_calculator" calculator="default" />
         </service>
-        <service id="sylius.tax_calculator.decimal" class="Sylius\Component\Taxation\Calculator\DefaultCalculator">
+        <service id="sylius.tax_calculator.decimal" class="Sylius\Component\Taxation\Calculator\DecimalCalculator">
             <tag name="sylius.tax_calculator" calculator="decimal" />
         </service>
 

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
@@ -36,6 +36,9 @@
         <service id="sylius.tax_calculator.default" class="Sylius\Component\Taxation\Calculator\DefaultCalculator">
             <tag name="sylius.tax_calculator" calculator="default" />
         </service>
+        <service id="sylius.tax_calculator.decimal" class="Sylius\Component\Taxation\Calculator\DefaultCalculator">
+            <tag name="sylius.tax_calculator" calculator="decimal" />
+        </service>
 
         <service id="sylius.tax_rate_resolver" class="Sylius\Component\Taxation\Resolver\TaxRateResolver">
             <argument type="service" id="sylius.repository.tax_rate" />

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -37,9 +37,7 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
     ) {
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     public function apply(OrderInterface $order, ZoneInterface $zone): void
     {
         $this->checkItemsQuantities($order);
@@ -72,7 +70,7 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
         $itemSplitTaxes = $this->proportionalIntegerDistributor->distribute($itemTaxWholeAmounts, $itemTotalTaxWholeAmount);
 
         foreach ($items as $index => $item) {
-            if (0 === $itemSplitTaxes[$index]) {
+            if (0 === $itemSplitTaxes[$index] || !isset($itemTaxRates[$index])) {
                 continue;
             }
 

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -69,14 +69,20 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
         $itemSplitTaxes = $this->proportionalIntegerDistributor->distribute($itemTaxWholeAmounts, $itemTotalTaxWholeAmount);
 
         foreach ($order->getItems() as $index => $item) {
+            $itemSplitTaxesIndex = $index;
+
+            if (!array_key_exists($itemSplitTaxesIndex, $itemSplitTaxes)) {
+                $itemSplitTaxesIndex = count($itemSplitTaxes) - 1;
+            }
+
             $quantity = $item->getQuantity();
             Assert::notSame($quantity, 0, 'Cannot apply tax to order item with 0 quantity.');
 
-            if (0 === $itemSplitTaxes[$index]) {
+            if (0 === $itemSplitTaxes[$itemSplitTaxesIndex]) {
                 continue;
             }
 
-            $this->distributeTaxesToUnits($itemSplitTaxes[$index], $quantity, $item, $itemTaxRates[$index]);
+            $this->distributeTaxesToUnits($itemSplitTaxes[$itemSplitTaxesIndex], $quantity, $item, $itemTaxRates[$index]);
         }
     }
 
@@ -122,6 +128,11 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
     ): void {
         $unitSplitTaxes = $this->distributor->distribute($totalTaxAmount, $quantity);
         foreach ($item->getUnits() as $index => $unit) {
+
+            if (!array_key_exists($index, $unitSplitTaxes)) {
+                $index = count($unitSplitTaxes) - 1;
+            }
+
             if (0 === $unitSplitTaxes[$index]) {
                 continue;
             }

--- a/src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemsTaxesApplicatorTest.php
+++ b/src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemsTaxesApplicatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Test\Tests\Taxation\Applicator;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Addressing\Model\Zone;
+use Sylius\Component\Core\Distributor\IntegerDistributor;
+use Sylius\Component\Core\Distributor\ProportionalIntegerDistributor;
+use Sylius\Component\Core\Model\Adjustment;
+use Sylius\Component\Core\Model\Order;
+use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnit;
+use Sylius\Component\Core\Model\ProductVariant;
+use Sylius\Component\Core\Model\TaxRate;
+use Sylius\Component\Core\Model\TaxRateInterface;
+use Sylius\Component\Core\Taxation\Applicator\OrderItemsTaxesApplicator;
+use Sylius\Component\Order\Factory\AdjustmentFactory;
+use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Taxation\Calculator\DecimalCalculator;
+use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+
+final class OrderItemsTaxesApplicatorTest extends TestCase
+{
+    public function test_it_calculates_tax_with_decimal_precision(): void
+    {
+        $applicator = new OrderItemsTaxesApplicator(
+            new DecimalCalculator(),
+            new AdjustmentFactory(new Factory(Adjustment::class)),
+            new IntegerDistributor(),
+            $this->createConfiguredMock(TaxRateResolverInterface::class, [
+                'resolve' => $this->createTaxRate(),
+            ]),
+            new ProportionalIntegerDistributor(),
+        );
+
+        $order = new Order();
+        for ($i = 0; $i < 20; $i++) {
+            $order->addItem($this->createOrderItem());
+        }
+
+        $applicator->apply($order, new Zone());
+
+        $this->assertEquals(39400, $order->getTotal());
+        $this->assertEquals(6567, $order->getTaxTotal());
+        $this->assertEquals(32833, $order->getTotal() - $order->getTaxTotal());
+    }
+
+    public function createOrderItem(): OrderItemInterface
+    {
+        $item = new OrderItem();
+        $item->setVariant(new ProductVariant());
+        $item->setUnitPrice(1970);
+        $item->addUnit(new OrderItemUnit($item));
+
+        return $item;
+    }
+
+    public function createTaxRate(): TaxRateInterface
+    {
+        $taxRate = new TaxRate();
+        $taxRate->setCode('standard');
+        $taxRate->setName('Standard');
+        $taxRate->setAmount(0.2);
+        $taxRate->setIncludedInPrice(true);
+
+        return $taxRate;
+    }
+}

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\Taxation\Applicator;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
+use Sylius\Component\Core\Distributor\ProportionalIntegerDistributorInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
@@ -35,7 +35,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
         IntegerDistributorInterface $distributor,
-        TaxRateResolverInterface $taxRateResolver,
+        TaxRateResolverInterface $taxRateResolver
     ): void {
         $this->beConstructedWith($calculator, $adjustmentsFactory, $distributor, $taxRateResolver);
     }
@@ -45,15 +45,13 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $this->shouldImplement(OrderTaxesApplicatorInterface::class);
     }
 
-    function it_applies_taxes_on_units_based_on_item_total_and_rate(
+    function it_applies_taxes_on_units_based_on_item_total_and_rate_without_distribution_on_items(
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
         IntegerDistributorInterface $distributor,
         TaxRateResolverInterface $taxRateResolver,
         AdjustmentInterface $taxAdjustment1,
         AdjustmentInterface $taxAdjustment2,
-        Collection $items,
-        Collection $units,
         OrderInterface $order,
         OrderItemInterface $orderItem,
         OrderItemUnitInterface $unit1,
@@ -62,10 +60,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         TaxRateInterface $taxRate,
         ZoneInterface $zone,
     ): void {
-        $order->getItems()->willReturn($items);
-
-        $items->count()->willReturn(1);
-        $items->getIterator()->willReturn(new \ArrayIterator([$orderItem->getWrappedObject()]));
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
         $orderItem->getQuantity()->willReturn(2);
 
@@ -81,8 +76,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $taxRate->getAmount()->willReturn(0.1);
         $taxRate->isIncludedInPrice()->willReturn(false);
 
-        $orderItem->getUnits()->willReturn($units);
-        $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
+        $orderItem->getUnits()->willReturn(new ArrayCollection([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
 
         $distributor->distribute(100, 2)->willReturn([50, 50]);
 
@@ -107,6 +101,108 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $this->apply($order, $zone);
     }
 
+    function it_applies_taxes_on_units_based_on_item_total_and_rate_with_distribution_on_items(
+        CalculatorInterface $calculator,
+        AdjustmentFactoryInterface $adjustmentsFactory,
+        IntegerDistributorInterface $distributor,
+        TaxRateResolverInterface $taxRateResolver,
+        ProportionalIntegerDistributorInterface $proportionalIntegerDistributor,
+        AdjustmentInterface $taxAdjustment1,
+        AdjustmentInterface $taxAdjustment2,
+        AdjustmentInterface $taxAdjustment3,
+        OrderInterface $order,
+        OrderItemInterface $orderItem1,
+        OrderItemInterface $orderItem2,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        OrderItemUnitInterface $unit3,
+        ProductVariantInterface $productVariant1,
+        ProductVariantInterface $productVariant2,
+        TaxRateInterface $taxRate,
+        ZoneInterface $zone,
+    ): void {
+        $this->beConstructedWith($calculator, $adjustmentsFactory, $distributor, $taxRateResolver, $proportionalIntegerDistributor);
+
+        $order->getItems()->willReturn(new ArrayCollection([
+            $orderItem1->getWrappedObject(),
+            $orderItem2->getWrappedObject(),
+        ]));
+
+        $orderItem1->getQuantity()->willReturn(2);
+        $orderItem1->getTotal()->willReturn(1000);
+        $orderItem1->getUnits()->willReturn(new ArrayCollection([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
+        $orderItem1->getVariant()->willReturn($productVariant1);
+        $taxRateResolver->resolve($productVariant1, ['zone' => $zone])->willReturn($taxRate);
+
+        $orderItem2->getQuantity()->willReturn(1);
+        $orderItem2->getTotal()->willReturn(1000);
+        $orderItem2->getUnits()->willReturn(new ArrayCollection([$unit3->getWrappedObject()]));
+        $orderItem2->getVariant()->willReturn($productVariant2);
+        $taxRateResolver->resolve($productVariant2, ['zone' => $zone])->willReturn($taxRate);
+
+        $calculator->calculate(1000, $taxRate)->willReturn(100.40);
+
+        $proportionalIntegerDistributor->distribute([100, 100], 201)->willReturn([101, 100]);
+
+        $taxRate->getLabel()->willReturn('Simple tax (10%)');
+        $taxRate->getCode()->willReturn('simple_tax');
+        $taxRate->getName()->willReturn('Simple tax');
+        $taxRate->getAmount()->willReturn(0.1);
+        $taxRate->isIncludedInPrice()->willReturn(false);
+
+        $distributor->distribute(101, 2)->willReturn([51, 50]);
+        $distributor->distribute(100, 1)->willReturn([100]);
+
+        $adjustmentsFactory
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                51,
+                false,
+                [
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ],
+            )
+            ->willReturn($taxAdjustment1)
+        ;
+        $adjustmentsFactory
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                50,
+                false,
+                [
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ],
+            )
+            ->willReturn($taxAdjustment2)
+        ;
+        $adjustmentsFactory
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                100,
+                false,
+                [
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ],
+            )
+            ->willReturn($taxAdjustment3)
+        ;
+
+        $unit1->addAdjustment($taxAdjustment1)->shouldBeCalled();
+        $unit2->addAdjustment($taxAdjustment2)->shouldBeCalled();
+        $unit3->addAdjustment($taxAdjustment3)->shouldBeCalled();
+
+        $this->apply($order, $zone);
+    }
+
     function it_throws_an_invalid_argument_exception_if_order_item_has_0_quantity(
         OrderInterface $order,
         OrderItemInterface $orderItem,
@@ -122,24 +218,13 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
 
     function it_does_nothing_if_tax_rate_cannot_be_resolved(
         TaxRateResolverInterface $taxRateResolver,
-        Collection $items,
-        \Iterator $iterator,
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $productVariant,
         ZoneInterface $zone,
     ): void {
-        $order->getItems()->willReturn($items);
-
-        $items->count()->willReturn(1);
-        $items->getIterator()->willReturn($iterator);
-        $iterator->rewind()->shouldBeCalled();
-        $iterator->valid()->willReturn(true, false)->shouldBeCalled();
-        $iterator->current()->willReturn($orderItem);
-        $iterator->next()->shouldBeCalled();
-
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $orderItem->getQuantity()->willReturn(5);
-
         $orderItem->getVariant()->willReturn($productVariant);
         $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn(null);
 
@@ -153,8 +238,6 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         AdjustmentFactoryInterface $adjustmentsFactory,
         IntegerDistributorInterface $distributor,
         TaxRateResolverInterface $taxRateResolver,
-        Collection $items,
-        Collection $units,
         OrderInterface $order,
         OrderItemInterface $orderItem,
         OrderItemUnitInterface $unit1,
@@ -163,10 +246,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         TaxRateInterface $taxRate,
         ZoneInterface $zone,
     ): void {
-        $order->getItems()->willReturn($items);
-
-        $items->count()->willReturn(1);
-        $items->getIterator()->willReturn(new \ArrayIterator([$orderItem->getWrappedObject()]));
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
         $orderItem->getQuantity()->willReturn(2);
         $orderItem->getVariant()->willReturn($productVariant);
@@ -179,8 +259,7 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $taxRate->getLabel()->willReturn('Simple tax (0%)');
         $taxRate->isIncludedInPrice()->willReturn(false);
 
-        $orderItem->getUnits()->willReturn($units);
-        $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
+        $orderItem->getUnits()->willReturn(new ArrayCollection([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
 
         $distributor->distribute(0, 2)->willReturn([0, 0]);
 

--- a/src/Sylius/Component/Taxation/Calculator/DecimalCalculator.php
+++ b/src/Sylius/Component/Taxation/Calculator/DecimalCalculator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Taxation\Calculator;
+
+use Sylius\Component\Taxation\Model\TaxRateInterface;
+
+final class DecimalCalculator implements CalculatorInterface
+{
+    public function calculate(float $base, TaxRateInterface $rate): float
+    {
+        if ($rate->isIncludedInPrice()) {
+            return $base - ($base / (1 + $rate->getAmount()));
+        }
+
+        return $base * $rate->getAmount();
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Attempt to solve the issue of decimal values being lost during tax calculation on item level which leads to a wrong tax total at the order level.

Issue reported by @ikamikaz3 via Slack ([full thread](https://sylius-devs.slack.com/archives/C3EGDG9LY/p1648827780599519)): 
![image](https://user-images.githubusercontent.com/7114562/161611854-734113d7-52a7-4b82-92b8-0031c6e7a120.png)