### PR TITLE
Order overview throwings a NotFoundEception when order is still a cart

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -21,7 +21,7 @@ sylius_admin_order_show:
         _sylius:
             section: admin
             repository:
-              method: getOrderById
+              method: findOrderById
               arguments:
                 - '$id'
             permission: true
@@ -35,7 +35,7 @@ sylius_admin_order_history:
         _sylius:
             section: admin
             repository:
-              method: getOrderById
+              method: findOrderById
               arguments:
                 - '$id'
             permission: true
@@ -49,7 +49,7 @@ sylius_admin_order_update:
         _sylius:
             section: admin
             repository:
-              method: getOrderById
+              method: findOrderById
               arguments:
                 - '$id'
             permission: true
@@ -66,7 +66,7 @@ sylius_admin_order_cancel:
         _controller: sylius.controller.order:applyStateMachineTransitionAction
         _sylius:
             repository:
-              method: getOrderById
+              method: findOrderById
               arguments:
                 - '$id'
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -20,6 +20,10 @@ sylius_admin_order_show:
         _controller: sylius.controller.order:showAction
         _sylius:
             section: admin
+            repository:
+              method: getOrderById
+              arguments:
+                - '$id'
             permission: true
             template: "@SyliusAdmin/Order/show.html.twig"
 
@@ -30,6 +34,10 @@ sylius_admin_order_history:
         _controller: sylius.controller.order:showAction
         _sylius:
             section: admin
+            repository:
+              method: getOrderById
+              arguments:
+                - '$id'
             permission: true
             template: "@SyliusAdmin/Order/history.html.twig"
 
@@ -40,6 +48,10 @@ sylius_admin_order_update:
         _controller: sylius.controller.order:updateAction
         _sylius:
             section: admin
+            repository:
+              method: getOrderById
+              arguments:
+                - '$id'
             permission: true
             template: "@SyliusAdmin/Order/update.html.twig"
             form:
@@ -53,6 +65,10 @@ sylius_admin_order_cancel:
     defaults:
         _controller: sylius.controller.order:applyStateMachineTransitionAction
         _sylius:
+            repository:
+              method: getOrderById
+              arguments:
+                - '$id'
             permission: true
             state_machine:
                 graph: sylius_order

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -39,7 +39,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         $this->associationHydrator = new AssociationHydrator($entityManager, $class);
     }
 
-    public function getOrderById(string $id): ?OrderInterface
+    public function findOrderById(string $id): ?OrderInterface
     {
         return $this->createQueryBuilder('o')
             ->andWhere('o.id = :id')

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -39,6 +39,18 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         $this->associationHydrator = new AssociationHydrator($entityManager, $class);
     }
 
+    public function getOrderById(string $id): ?OrderInterface
+    {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.id = :id')
+            ->andWhere('o.state != :state')
+            ->setParameter('id', $id)
+            ->setParameter('state', OrderInterface::STATE_CART)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
     public function createListQueryBuilder(): QueryBuilder
     {
         return $this->createQueryBuilder('o')


### PR DESCRIPTION
If the order is in state cart the order show should not throw a 500. (It's like #13827 but github decided to close the other MR so I created a new one on a different branch.)

| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13826
| License         | MIT

When showing an order it should be checked before rendering the template if the order is actually completed or still in state cart.