### PR TITLE
Limit the number of packages build run on 1.10

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -50,7 +50,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["7.4", "8.0", "8.1"]
+                php: ["7.4", "8.0"]
                 symfony: ["^4.4", "5.3.*", "5.4.*"]
                 package: "${{ fromJson(needs.list.outputs.packages) }}"
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It's not required on 1.11, as we test only 2 Symfony versions there, but on 1.10 there are 3 (`^4.4`, `5.3.*`, `5.4.*`), so the number of combinations exceeds the limit of 256 builds :dancer: