### PR TITLE
[Maintenance] Add note to UPGRADE file about dropping Symfony 5.2 support

### DIFF
--- a/UPGRADE-1.10.md
+++ b/UPGRADE-1.10.md
@@ -1,4 +1,10 @@
+# UPGRADE FROM `v1.10.12` TO `v1.10.13`
+
+1. The support for Symfony 5.2 has been dropped, because it is not maintained version that has some security vulnerabilities. 
+   The recommended Symfony version to use with Sylius is 5.4 as it is the current long-term support version.
+
 # UPGRADE FROM `v1.10.x` TO `v1.10.12`
+
 1. Order Processors' priorities have changed and `sylius.order_processing.order_prices_recalculator` has now a higher priority than `sylius.order_processing.order_shipment_processor`.
 
 Previous priorities:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after #13837 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
