### PR TITLE
[API][Swagger] Accept language header in SwaggerUI

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -120,5 +120,14 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\PathHiderDocumentationNormalizer.inner" />
             <argument>%sylius.api.paths_to_hide%</argument>
         </service>
+
+        <service
+            id="Sylius\Bundle\ApiBundle\Swagger\AcceptLanguageHeaderDocumentationNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\AcceptLanguageHeaderDocumentationNormalizer.inner" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Swagger/AcceptLanguageHeaderDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/AcceptLanguageHeaderDocumentationNormalizer.php
@@ -22,12 +22,12 @@ final class AcceptLanguageHeaderDocumentationNormalizer implements NormalizerInt
     {
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $this->decoratedNormalizer->supportsNormalization($data, $format);
     }
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = [])
     {
         $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
 
@@ -35,7 +35,6 @@ final class AcceptLanguageHeaderDocumentationNormalizer implements NormalizerInt
             'name' => 'Accept-Language',
             'in' => 'header',
             'required' => false,
-            'default' => 'en_US',
             'schema' => [
                 'type' => 'string'
             ]

--- a/src/Sylius/Bundle/ApiBundle/Swagger/AcceptLanguageHeaderDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/AcceptLanguageHeaderDocumentationNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+final class AcceptLanguageHeaderDocumentationNormalizer implements NormalizerInterface
+{
+    public function __construct(private NormalizerInterface $decoratedNormalizer)
+    {
+    }
+
+    public function supportsNormalization($data, string $format = null)
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        $acceptLanguageHeader = [
+            'name' => 'Accept-Language',
+            'in' => 'header',
+            'required' => false,
+            'default' => 'en_US',
+            'schema' => [
+                'type' => 'string'
+            ]
+        ];
+
+        foreach ($docs['paths'] as $path => $methods) {
+            foreach ($methods as $methodName => $methodBody) {
+                if (is_object($methodBody)) {
+                    $methodBody = $methodBody->getArrayCopy();
+                    $methodBody['parameters'][] = $acceptLanguageHeader;
+
+                    $docs['paths'][$path][$methodName] = $methodBody;
+                }
+            }
+        }
+
+        return $docs;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Swagger/AcceptLanguageHeaderDocumentationNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Swagger/AcceptLanguageHeaderDocumentationNormalizerSpec.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Swagger;
+
+use ApiPlatform\Core\Documentation\Documentation;
+use ApiPlatform\Core\Metadata\Resource\ResourceNameCollection;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class AcceptLanguageHeaderDocumentationNormalizerSpec extends ObjectBehavior
+{
+    function let(NormalizerInterface $decoratedNormalizer): void
+    {
+        $this->beConstructedWith($decoratedNormalizer);
+    }
+
+    function it_supports_normalization(NormalizerInterface $decoratedNormalizer): void
+    {
+        $documentation = new Documentation(new ResourceNameCollection());
+
+        $decoratedNormalizer->supportsNormalization($documentation, null)->willReturn(true);
+
+        $this->supportsNormalization($documentation)->shouldReturn(true);
+    }
+
+    function it_does_not_support_normalization(NormalizerInterface $decoratedNormalizer): void
+    {
+        $decoratedNormalizer->supportsNormalization(null, null)->willReturn(false);
+
+        $this->supportsNormalization(null)->shouldReturn(false);
+    }
+
+    function it_does_not_add_accept_language_header_to_paths_which_are_not_objects(
+        NormalizerInterface $decoratedNormalizer,
+    ): void {
+        $docs = [
+            'paths' => [
+                '/api/v2/admin/addresses/{id}' => [
+                    'get' => [
+                        'parameters' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $documentation = new Documentation(new ResourceNameCollection());
+
+        $decoratedNormalizer
+            ->normalize($documentation, null, ['spec_version' => 3])
+            ->willReturn($docs)
+        ;
+
+        $this
+            ->normalize($documentation, null, ['spec_version' => 3])
+            ->shouldReturn([
+                'paths' => [
+                    '/api/v2/admin/addresses/{id}' => [
+                        'get' => [
+                            'parameters' => [],
+                        ],
+                    ],
+                ],
+            ])
+        ;
+    }
+
+    function it_adds_accept_language_header_to_paths_which_are_objects(NormalizerInterface $decoratedNormalizer,): void
+    {
+        $docs = [
+            'paths' => [
+                '/api/v2/admin/addresses/{id}' => [
+                    'get' => new \ArrayObject(
+                        [
+                            'parameters' => [],
+                        ],
+                    )
+                ],
+            ],
+        ];
+
+        $documentation = new Documentation(new ResourceNameCollection());
+
+        $decoratedNormalizer
+            ->normalize($documentation, null, ['spec_version' => 3])
+            ->willReturn($docs)
+        ;
+
+        $this
+            ->normalize($documentation, null, ['spec_version' => 3])
+            ->shouldReturn([
+                'paths' => [
+                    '/api/v2/admin/addresses/{id}' => [
+                        'get' => [
+                            'parameters' => [
+                                [
+                                    'name' => 'Accept-Language',
+                                    'in' => 'header',
+                                    'required' => false,
+                                    'schema' => [
+                                        'type' => 'string'
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+        ;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #13708
| License         | MIT

In the related ticket, we've added support for Accept-Language header but we can not use it in SwaggerUI. I provide a simple solution for that.

<img width="528" alt="image" src="https://user-images.githubusercontent.com/28228691/162196672-3fddd394-f7de-42fa-b94b-5512a1349e15.png">
<img width="662" alt="image" src="https://user-images.githubusercontent.com/28228691/162196770-32c35cac-fd8b-4233-b92e-7949b96bf359.png">


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
