### PR TITLE
[Maintenance]Run schema validation on mysql pipeline

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -256,9 +256,11 @@ jobs:
                 name: Prepare application database
                 run: |
                     APP_DEBUG=1 bin/console doctrine:database:create -vvv
-                    bin/console doctrine:schema:up --force -vvv
-                    bin/console doctrine:schema:validate
-                continue-on-error: true
+                    bin/console doctrine:schema:update --force -vvv
+
+            -
+                name: Validate Database Schema
+                run: bin/console doctrine:schema:validate -vvv
 
     test-application-without-frontend-mariadb:
         runs-on: ubuntu-latest
@@ -344,9 +346,11 @@ jobs:
                 run: |
                     bin/console doctrine:migrations:migrate first --no-interaction
                     bin/console doctrine:migrations:migrate latest --no-interaction
-                    bin/console doctrine:schema:validate --skip-mapping -vvv
-                continue-on-error: true
 
+            -
+                name: Validate Database Schema
+                run: bin/console doctrine:schema:validate -vvv
+            
             -
                 name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
@@ -476,6 +480,10 @@ jobs:
                 run: |
                     bin/console doctrine:migrations:migrate first --no-interaction
                     bin/console doctrine:migrations:migrate latest --no-interaction
+            
+            -
+                name: Validate Database Schema
+                run: bin/console doctrine:schema:validate -vvv
 
             -
                 name: Test installer
@@ -632,6 +640,10 @@ jobs:
                 run: |
                     APP_DEBUG=1 bin/console doctrine:database:create -vvv
                     bin/console doctrine:migrations:migrate -n -vvv
+
+            -
+                name: Validate Database Schema
+                run: bin/console doctrine:schema:validate -vvv
 
             -
                 name: Build assets

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,8 +7,4 @@ parameters:
 
 doctrine:
     dbal:
-        driver: 'pdo_mysql'
-        server_version: '5.7'
-        charset: utf8mb4
-
         url: '%env(resolve:DATABASE_URL)%'

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220407131547 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update messenger transport table: change queue_name length and add two indexes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        if ($schema->hasTable('messenger_messages')) {
+            $this->addSql('ALTER TABLE messenger_messages CHANGE queue_name queue_name VARCHAR(190) NOT NULL');
+            $this->addSql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
+            $this->addSql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        if ($schema->hasTable('messenger_messages')) {
+            $this->addSql('DROP INDEX IDX_75EA56E0FB7336F0 ON messenger_messages');
+            $this->addSql('DROP INDEX IDX_75EA56E0E3BD61CE ON messenger_messages');
+            $this->addSql('ALTER TABLE messenger_messages CHANGE queue_name queue_name VARCHAR(255) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220412144156.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220412144156.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Platforms\MariaDb1027Platform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220412144156 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Sync MariaDB schema';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof MariaDb1027Platform) {
+            $this->addSql('ALTER TABLE sylius_adjustment CHANGE details details LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+            $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+            $this->addSql('ALTER TABLE sylius_payment CHANGE details details LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+            $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json)\'');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($this->connection->getDatabasePlatform() instanceof MariaDb1027Platform) {
+            $this->addSql('ALTER TABLE sylius_adjustment CHANGE details details LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_bin`');
+            $this->addSql('ALTER TABLE sylius_gateway_config CHANGE config config LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_bin`');
+            $this->addSql('ALTER TABLE sylius_payment CHANGE details details LONGTEXT CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_bin`');
+            $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE json_value json_value LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_bin`');
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | [PR](https://github.com/Sylius/Sylius/pull/13846)
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


The PR should be failing, but after the https://github.com/Sylius/Sylius/pull/13846 it should be nice and green :)

This is what happened here. Cherry-pick the change from #13846 that all database pipelines were failing. What I found is that we actually test the schema, but accept failing steps. By not accepting that we were able to find out the problem with some extra things. Like our PostgreSQL schema is successfully validated, but our MariaDB schema is not. That's because of JSON type and the difference between MySQL and MariaDB. Now we have to decide whether we want these two schemas to be up to date or we turn off migrations on MariaDB

