### PR TITLE
[Maintenance] Run the build on tags rather than on releases

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -2,6 +2,8 @@ name: Application
 
 on:
     push:
+        tags:
+            - v1.*
         branches-ignore:
             - 'dependabot/**'
         paths-ignore:
@@ -13,8 +15,6 @@ on:
             - "adr/**"
             - "docs/**"
             - "*.md"
-    release:
-        types: [created]
     schedule:
         -
             cron: "0 1 * * 6" # Run at 1am every Saturday


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no 
| Related tickets | 
| License         | MIT

The tag push is an actual moment when the new version of Sylius is done, the release is just the icing on the cake 🍰 So it makes more sense to run the workflow when the real thing is happening, not when it's nicely served 🖖 