### PR TITLE
[UI][Swagger] AutoAuthorize on sending admin credentials

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Sylius/Bundle/ApiBundle/Resources/views/SwaggerUi/index.html.twig
@@ -91,6 +91,94 @@
         <script src="{{ asset('bundles/apiplatform/init-swagger-ui.js') }}"></script>
     {% endif %}
 {% endblock %}
+<script>
+    class ClassWatcher {
+        constructor(targetNode, classToWatch, classAddedCallback, classRemovedCallback) {
+            this.targetNode = targetNode
+            this.classToWatch = classToWatch
+            this.classAddedCallback = classAddedCallback
+            this.classRemovedCallback = classRemovedCallback
+            this.observer = null
+            this.lastClassState = targetNode.classList.contains(this.classToWatch)
+
+            this.init()
+        }
+
+        init() {
+            this.observer = new MutationObserver(this.mutationCallback)
+            this.observe()
+        }
+
+        observe() {
+            this.observer.observe(this.targetNode, { attributes: true })
+        }
+
+        disconnect() {
+            this.observer.disconnect()
+        }
+
+        mutationCallback = mutationsList => {
+            for(let mutation of mutationsList) {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                    let currentClassState = mutation.target.classList.contains(this.classToWatch)
+                    if(this.lastClassState !== currentClassState) {
+                        this.lastClassState = currentClassState
+                        if(currentClassState) {
+                            this.classAddedCallback()
+                        }
+                        else {
+                            this.classRemovedCallback()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let tokenRequestContainer = null;
+
+    function credentialsRequestReady() {
+        const tokenRequestContainer2 = document.querySelector('#operations-AdminUserToken-postCredentialsItem').getElementsByClassName('opblock-body')[0];
+
+        const executeWrapper = tokenRequestContainer2.getElementsByClassName('execute-wrapper')[0];
+        new ClassWatcher(executeWrapper, 'btn-group', credentialsRequestFinished, () => {});
+    }
+
+    function credentialsRequestFinished() {
+        const tokenElement = JSON.parse(tokenRequestContainer.querySelector('.highlight-code').getElementsByTagName('code')[0].innerText)
+
+        const buttonLogin = document.querySelector("#swagger-ui > section > div.swagger-ui > div:nth-child(2) > div.scheme-container > section > div > button");
+
+        const mouseEvent = new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true
+        });
+
+        buttonLogin.dispatchEvent(mouseEvent);
+
+        const authFormField = document.querySelector("#swagger-ui > section > div.swagger-ui > div:nth-child(2) > div.scheme-container > section > div > div > div.modal-ux > div > div > div.modal-ux-content > div > form > div:nth-child(1) > div > div:nth-child(5) > section > input[type=text]");
+
+        const authorizeSubmitButton = document.querySelector("#swagger-ui > section > div.swagger-ui > div:nth-child(2) > div.scheme-container > section > div > div > div.modal-ux > div > div > div.modal-ux-content > div > form > div.auth-btn-wrapper > button.btn.modal-btn.auth.authorize.button");
+
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+        nativeInputValueSetter.call(authFormField, `Bearer ${tokenElement.token}`);
+
+        authFormField.dispatchEvent(new Event('input', { bubbles: true }));
+
+        authorizeSubmitButton.dispatchEvent(mouseEvent);
+
+        const closeAuthFormButton = document.querySelector("#swagger-ui > section > div.swagger-ui > div:nth-child(2) > div.scheme-container > section > div > div > div.modal-ux > div > div > div.modal-ux-content > div > form > div.auth-btn-wrapper > button.btn.modal-btn.auth.btn-done.button");
+
+        closeAuthFormButton.dispatchEvent(mouseEvent);
+    }
+
+    window.addEventListener('load', event => {
+        tokenRequestContainer = document.querySelector('#operations-AdminUserToken-postCredentialsItem');
+
+        new ClassWatcher(tokenRequestContainer, 'is-open', credentialsRequestReady, function(){});
+    });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Automatically log in to swagger docs after authorization. Just to improve user/developer experience to avoid requesting and copy-pasting credentials every time you refresh page.

I had to hack React using vanilla js xD appreciate it.

https://user-images.githubusercontent.com/22825722/162623176-07768e6c-6ca0-468b-b99e-dc6217a24f42.mov



<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
