### PR TITLE
[UI][Swagger] Add info to swagger paths about iri reference

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -120,5 +120,14 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\PathHiderDocumentationNormalizer.inner" />
             <argument>%sylius.api.paths_to_hide%</argument>
         </service>
+
+        <service
+            id="Sylius\Bundle\ApiBundle\Swagger\IriReferenceExampleNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            autoconfigure="false"
+            decoration-priority="0"
+        >
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\IriReferenceExampleNormalizer.inner" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -125,7 +125,7 @@
             id="Sylius\Bundle\ApiBundle\Swagger\IriReferenceExampleNormalizer"
             decorates="api_platform.swagger.normalizer.documentation"
             autoconfigure="false"
-            decoration-priority="0"
+            decoration-priority="5"
         >
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\IriReferenceExampleNormalizer.inner" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Swagger/IriReferenceExampleNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/IriReferenceExampleNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+class IriReferenceExampleNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private NormalizerInterface $decoratedNormalizer
+    ) { }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        foreach ($docs['components']['schemas'] as $schema) {
+            if (!isset($schema['properties'])) {
+                continue;
+            }
+
+            foreach ($schema['properties'] as $property) {
+                if (isset($property['type']) && isset($property['format']) && $property['format'] === 'iri-reference' && !isset($property['example'])) {
+                    $property['example'] = 'iri-reference';
+                }
+
+                if (isset($property['type']) && $property['type'] === 'array' && isset($property['items']['format']) && !isset($property['items']['example'])) {
+                    $property['items']['example'] = 'iri-reference';
+                }
+            }
+        }
+
+        return $docs;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductDocumentationNormalizer.php
@@ -31,12 +31,12 @@ final class ProductDocumentationNormalizer implements NormalizerInterface
     {
         $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
 
-        $defaultVariantSchema = [
+        $defaultVariantSchema = new \ArrayObject([
             'type' => 'string',
             'format' => 'iri-reference',
             'nullable' => true,
-            'readOnly' => true,
-        ];
+            'readOnly' => true
+        ]);
 
         $docs['components']['schemas']['Product.jsonld-admin.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;
         $docs['components']['schemas']['Product.jsonld-shop.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Its sometimes hard to tell if you should send iri or string reference in different endpoints, with this normalizer it will be easy to tell if you need to send string or actual iri.

Before:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/22825722/162625251-235d37da-dbf6-47f5-879b-a4e7c50e5dd4.png">

After:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/22825722/162625262-7134ae86-8879-43f6-adee-2d5a6a549f0d.png">


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
