### PR TITLE
[API] Sorting products by date

### DIFF
--- a/features/product/viewing_products/viewing_sorted_products.feature
+++ b/features/product/viewing_products/viewing_sorted_products.feature
@@ -20,16 +20,18 @@ Feature: Sorting listed products
         And this product belongs to "Fluffy Pets"
         And this product's price is "$13.27"
 
-    @ui
+    @api @ui
     Scenario: Sorting products by their dates with descending order
-        When I view newest products from taxon "Fluffy Pets"
+        When I browse products from taxon "Fluffy Pets"
+        And I sort products by the newest date first
         Then I should see 4 products in the list
         And I should see a product with name "Xtreme Pug"
         But the first product on the list should have name "Pug of Love"
 
-    @ui
+    @api @ui
     Scenario: Sorting products by their dates with ascending order
-        When I view oldest products from taxon "Fluffy Pets"
+        When I browse products from taxon "Fluffy Pets"
+        And I sort products by the oldest date first
         Then I should see 4 products in the list
         And I should see a product with name "Berserk Pug"
         But the first product on the list should have name "Xtreme Pug"

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -112,6 +112,16 @@ final class ProductContext implements Context
     }
 
     /**
+     * @When /^I sort products by the (oldest|newest) date first$/
+     */
+    public function iSortProductsByTheDateFirst(string $sortDirection): void
+    {
+        $sortDirection = 'oldest' === $sortDirection ? 'asc' : 'desc';
+
+        $this->client->sort(['createdAt' => $sortDirection]);
+    }
+
+    /**
      * @When I sort products by the lowest price first
      */
     public function iSortProductsByTheLowestPriceFirst(): void

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -266,6 +266,16 @@ final class ProductContext implements Context
     }
 
     /**
+     * @When /^I sort products by the (oldest|newest) date first$/
+     */
+    public function iSortProductsByTheDateFirst(string $sortDirection): void
+    {
+        $sortDirection = 'oldest' === $sortDirection ? 'Oldest first' : 'Newest first';
+
+        $this->indexPage->sort($sortDirection);
+    }
+
+    /**
      * @When I sort products by the lowest price first
      */
     public function iSortProductsByTheLowestPriceFirst(): void
@@ -276,7 +286,7 @@ final class ProductContext implements Context
     /**
      * @When I sort products by the highest price first
      */
-    public function iSortProductsByTheHighestPriceFisrt(): void
+    public function iSortProductsByTheHighestPriceFirst(): void
     {
         $this->indexPage->sort('Most expensive first');
     }
@@ -674,16 +684,6 @@ final class ProductContext implements Context
     public function iShouldSeeAMainImage(): void
     {
         Assert::true($this->showPage->isMainImageDisplayed());
-    }
-
-    /**
-     * @When /^I view (oldest|newest) products from (taxon "([^"]+)")$/
-     */
-    public function iViewSortedProductsFromTaxon($sortDirection, TaxonInterface $taxon): void
-    {
-        $sorting = ['createdAt' => 'oldest' === $sortDirection ? 'asc' : 'desc'];
-
-        $this->indexPage->open(['slug' => $taxon->getSlug(), 'sorting' => $sorting]);
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TaxonFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TaxonFilter.php
@@ -52,9 +52,12 @@ final class TaxonFilter extends AbstractContextAwareFilter
             ->innerJoin(sprintf('%s.productTaxons', $alias), 'productTaxon')
             ->innerJoin('productTaxon.taxon', 'taxon')
             ->andWhere('taxon.root = :taxonRoot')
-            ->addOrderBy('productTaxon.position')
             ->setParameter('taxonRoot', $taxon->getRoot())
         ;
+
+        if (empty($context['filters']['order'])) {
+            $queryBuilder->addOrderBy('productTaxon.position');
+        }
     }
 
     public function getDescription(string $resourceClass): array


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

1) Sorting shop products via API - test covered
2) Sorting products by `taxonPosition` if no other sorting parameter is specified
