### PR TITLE
[API][Shop] Viewing only the enabled variants of a product

### DIFF
--- a/UPGRADE-API-1.12.md
+++ b/UPGRADE-API-1.12.md
@@ -98,3 +98,5 @@ Here is how the response looks like:
     ```
 
 1. The 2nd parameter `localeCode` has been removed from `src/Sylius/Bundle/ApiBundle/Command/Cart/PickupCart.php` and now is set automatically by `src/Sylius/Bundle/ApiBundle/DataTransformer/LocaleCodeAwareInputCommandDataTransformer.php`.
+
+1. The `api/v2/admin/products` and `api/v2/admin/products/{code}` have been changed and the `defaultVariant` field has been removed.

--- a/features/product/viewing_products/viewing_product_enabled_variants_only.feature
+++ b/features/product/viewing_products/viewing_product_enabled_variants_only.feature
@@ -11,7 +11,7 @@ Feature: Viewing product's enabled variants only
         And the product "Super Cool T-Shirt" has also an "Extra Large" variant
         And the "Extra Large" product variant is disabled
 
-    @ui
+    @ui @api
     Scenario: Seeing only enabled variants
         When I view product "Super Cool T-Shirt"
         Then I should be able to select between 3 variants

--- a/features/product/viewing_products/viewing_product_enabled_variants_options_only.feature
+++ b/features/product/viewing_products/viewing_product_enabled_variants_options_only.feature
@@ -12,7 +12,7 @@ Feature: Viewing product's enabled variants only
         And this product has all possible variants
         But all the product variants with the "Yellow" color are disabled
 
-    @ui
+    @ui @api
     Scenario: Seeing only enabled variants options
         When I view product "Super Cool T-Shirt"
         Then I should not be able to select the "Yellow" color option value

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/EnabledProductVariantsExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/EnabledProductVariantsExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\ContextAwareQueryCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/** @experimental */
+final class EnabledProductVariantsExtension implements ContextAwareQueryCollectionExtensionInterface
+{
+    public function __construct(private UserContextInterface $userContext)
+    {
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?string $operationName = null,
+        array $context = []
+    ): void {
+        if (!is_a($resourceClass, ProductVariantInterface::class, true)) {
+            return;
+        }
+
+        $user = $this->userContext->getUser();
+        if ($user !== null && in_array('ROLE_API_ACCESS', $user->getRoles(), true)) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $enabledParameterName = $queryNameGenerator->generateParameterName('enabled');
+
+        $queryBuilder->andWhere(sprintf('%s.enabled = :%s', $rootAlias, $enabledParameterName));
+        $queryBuilder->setParameter($enabledParameterName, true);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -48,6 +48,11 @@
             <tag name="api_platform.doctrine.orm.query_extension.collection" />
         </service>
 
+        <service id="Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension\EnabledProductVariantsExtension">
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+        </service>
+
         <service id="Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension\CountryCollectionExtension">
             <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" />

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Serializer;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
@@ -42,8 +43,12 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
         $context[self::ALREADY_CALLED] = true;
 
         $data = $this->normalizer->normalize($object, $format, $context);
-        $variant = $this->defaultProductVariantResolver->getVariant($object);
-        $data['defaultVariant'] = $variant === null ? null : $this->iriConverter->getIriFromItem($variant);
+
+        $variantsIris = array_map(fn(ProductVariantInterface $variant): string => $this->iriConverter->getIriFromItem($variant), $object->getEnabledVariants()->toArray());
+        $data['variants'] = array_values($variantsIris);
+
+        $defaultVariant = $this->defaultProductVariantResolver->getVariant($object);
+        $data['defaultVariant'] = $defaultVariant === null ? null : $this->iriConverter->getIriFromItem($defaultVariant);
 
         return $data;
     }
@@ -54,6 +59,18 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
             return false;
         }
 
-        return $data instanceof ProductInterface;
+        return $data instanceof ProductInterface && $this->isShopGetOperation($context);
+    }
+
+    private function isShopGetOperation(array $context): bool
+    {
+        if (isset($context['item_operation_name'])) {
+            return \str_starts_with($context['item_operation_name'], 'shop_get');
+        }
+        if (isset($context['collection_operation_name'])) {
+            return \str_starts_with($context['collection_operation_name'], 'shop_get');
+        }
+
+        return false;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/EnabledProductVariantsExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/EnabledProductVariantsExtensionSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class EnabledProductVariantsExtensionSpec extends ObjectBehavior
+{
+    function let(UserContextInterface $userContext)
+    {
+        $this->beConstructedWith($userContext);
+    }
+
+    function it_does_nothing_if_current_resource_is_not_a_product_variant(
+        UserContextInterface $userContext,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->shouldNotBeCalled();
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator, TaxonInterface::class, 'get', []);
+    }
+
+    function it_does_nothing_if_current_user_is_an_admin_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_API_ACCESS']);
+
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator, ProductVariantInterface::class, 'get', []);
+    }
+
+    function it_filters_products_by_enabled_flag_for_shop_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        ChannelInterface $channel
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn([]);
+
+        $queryNameGenerator->generateParameterName('enabled')->shouldBeCalled()->willReturn('enabled');
+
+        $queryBuilder->getRootAliases()->willReturn(['o']);
+        $queryBuilder->andWhere('o.enabled = :enabled')->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('enabled', true)->shouldBeCalled()->willReturn($queryBuilder);
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator,
+            ProductVariantInterface::class, 'get',
+            [ContextKeys::CHANNEL => $channel, ContextKeys::LOCALE_CODE => 'en_US']
+        );
+    }
+}

--- a/tests/Api/Admin/ProductTest.php
+++ b/tests/Api/Admin/ProductTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Admin;
+
+use Sylius\Component\Core\Model\ProductImageInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Sylius\Tests\Api\Utils\AdminUserLoginTrait;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ProductTest extends JsonApiTestCase
+{
+    use AdminUserLoginTrait;
+
+    /** @test */
+    public function it_returns_products_collection(): void
+    {
+        $this->loadFixturesFromFiles(['product/product_variant_with_original_price.yaml', 'authentication/api_administrator.yaml']);
+
+        $token = $this->logInAdminUser('api@example.com');
+        $authorizationHeader = self::$container->getParameter('sylius.api.authorization_header');
+        $header['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
+        $header = array_merge($header, self::CONTENT_TYPE_HEADER);
+
+        $this->client->request('GET',
+            '/api/v2/admin/products',
+            [],
+            [],
+            $header
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/get_products_collection_response',
+            Response::HTTP_OK
+        );
+    }
+
+    /** @test */
+    public function it_returns_product_item(): void
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yaml');
+        $fixtures = $this->loadFixturesFromFile('product/product_variant_with_original_price.yaml');
+
+        $token = $this->logInAdminUser('api@example.com');
+        $authorizationHeader = self::$container->getParameter('sylius.api.authorization_header');
+        $header['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
+        $header = array_merge($header, self::CONTENT_TYPE_HEADER);
+
+        /** @var ProductInterface $product */
+        $product = $fixtures['product_mug'];
+        $this->client->request('GET',
+            sprintf('/api/v2/admin/products/%s', $product->getCode()),
+            [],
+            [],
+            $header
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/get_product_response',
+            Response::HTTP_OK
+        );
+    }
+}

--- a/tests/Api/Responses/Expected/admin/get_product_response.json
+++ b/tests/Api/Responses/Expected/admin/get_product_response.json
@@ -1,0 +1,29 @@
+{
+    "@context": "\/api\/v2\/contexts\/Product",
+    "@id": "\/api\/v2\/admin\/products\/MUG",
+    "@type": "Product",
+    "productTaxons": [],
+    "mainTaxon": null,
+    "reviews": [],
+    "images": [],
+    "id": @integer@,
+    "code": "MUG",
+    "variants": [
+        "\/api\/v2\/admin\/product-variants\/MUG_BLUE",
+        "\/api\/v2\/admin\/product-variants\/MUG_RED"
+    ],
+    "options": [
+        "\/api\/v2\/admin\/product-options\/COLOR"
+    ],
+    "createdAt": @date@,
+    "updatedAt": @date@,
+    "translations": {
+        "en_US": {
+            "@id": "\/api\/v2\/admin\/product-translations\/@integer@",
+            "@type": "ProductTranslation",
+            "id": @integer@,
+            "name": "Mug",
+            "slug": "mug"
+        }
+    }
+}

--- a/tests/Api/Responses/Expected/admin/get_products_collection_response.json
+++ b/tests/Api/Responses/Expected/admin/get_products_collection_response.json
@@ -1,0 +1,85 @@
+{
+    "@context": "\/api\/v2\/contexts\/Product",
+    "@id": "\/api\/v2\/admin\/products",
+    "@type": "hydra:Collection",
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/admin\/products\/MUG",
+            "@type": "Product",
+            "productTaxons": [],
+            "mainTaxon": null,
+            "reviews": [],
+            "images": [],
+            "id": @integer@,
+            "code": "MUG",
+            "variants": [
+                "\/api\/v2\/admin\/product-variants\/MUG_BLUE",
+                "\/api\/v2\/admin\/product-variants\/MUG_RED"
+            ],
+            "options": [
+                "\/api\/v2\/admin\/product-options\/COLOR"
+            ],
+            "createdAt": @date@,
+            "updatedAt": @date@,
+            "translations": {
+                "en_US": {
+                    "@id": "\/api\/v2\/admin\/product-translations\/@integer@",
+                    "@type": "ProductTranslation",
+                    "id": @integer@,
+                    "name": "Mug",
+                    "slug": "mug"
+                }
+            }
+        }
+    ],
+    "hydra:totalItems": 1,
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/admin\/products{?translations.name,order[code],order[createdAt],productTaxons.taxon.code,productTaxons.taxon.code[],order[translation.name],localeCode for order[translation.name]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "translations.name",
+                "property": "translations.name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "order[code]",
+                "property": "code",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "order[createdAt]",
+                "property": "createdAt",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productTaxons.taxon.code",
+                "property": "productTaxons.taxon.code",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productTaxons.taxon.code[]",
+                "property": "productTaxons.taxon.code",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "order[translation.name]",
+                "property": "translation",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "localeCode for order[translation.name]",
+                "property": "localeCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/Expected/shop/product/get_products_collection_response.json
+++ b/tests/Api/Responses/Expected/shop/product/get_products_collection_response.json
@@ -1,0 +1,94 @@
+{
+    "@context": "\/api\/v2\/contexts\/Product",
+    "@id": "\/api\/v2\/shop\/products",
+    "@type": "hydra:Collection",
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/products\/MUG",
+            "@type": "Product",
+            "productTaxons": [],
+            "mainTaxon": null,
+            "reviews": [],
+            "averageRating": @integer@,
+            "images": [],
+            "id": @integer@,
+            "code": "MUG",
+            "variants": [
+                "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+                "\/api\/v2\/shop\/product-variants\/MUG_RED"
+            ],
+            "options": [
+                "\/api\/v2\/shop\/product-options\/COLOR"
+            ],
+            "createdAt": @date@,
+            "updatedAt": @date@,
+            "shortDescription": null,
+            "name": "Mug",
+            "description": @string@,
+            "slug": "mug",
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+        }
+    ],
+    "hydra:totalItems": 1,
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/products{?translations.name,order[code],order[createdAt],productTaxons.taxon.code,productTaxons.taxon.code[],order[price],order[translation.name],localeCode for order[translation.name],taxon}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "translations.name",
+              "property": "translations.name",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "order[code]",
+              "property": "code",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "order[createdAt]",
+              "property": "createdAt",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "productTaxons.taxon.code",
+              "property": "productTaxons.taxon.code",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "productTaxons.taxon.code[]",
+              "property": "productTaxons.taxon.code",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "order[price]",
+              "property": "price",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "order[translation.name]",
+              "property": "translation",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "localeCode for order[translation.name]",
+              "property": "localeCode",
+              "required": false
+          },
+          {
+              "@type": "IriTemplateMapping",
+              "variable": "taxon",
+              "property": null,
+              "required": false
+          }
+      ]
+    }
+}

--- a/tests/Api/Shop/ProductsTest.php
+++ b/tests/Api/Shop/ProductsTest.php
@@ -64,11 +64,30 @@ final class ProductsTest extends JsonApiTestCase
             [],
             [],
             ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json', 'HTTP_ACCEPT_LANGUAGE' => 'de_DE']
-    );
+        );
 
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/product/get_product_with_de_DE_locale_translation',
+            Response::HTTP_OK
+        );
+    }
+
+    /** @test */
+    public function it_returns_products_collection(): void
+    {
+        $this->loadFixturesFromFiles(['product/product_variant_with_original_price.yaml']);
+
+        $this->client->request('GET',
+            '/api/v2/shop/products',
+            [],
+            [],
+            self::CONTENT_TYPE_HEADER
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/product/get_products_collection_response',
             Response::HTTP_OK
         );
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
We haven't got any API scenarios for seeing only enabled variants in shop

