### PR TITLE
[Cart] Add Validator for localeCode

### DIFF
--- a/features/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
+++ b/features/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
@@ -14,3 +14,8 @@ Feature: Picking up the cart with the locale other than the default
         When I pick up cart in the "French (France)" locale
         And I check details of my cart
         Then my cart's locale should be "French (France)"
+
+    @api
+    Scenario: Picking up the cart with non valid locale
+        When I pick up cart using wrong locale
+        Then I should be notified that locale does not exist

--- a/features/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
+++ b/features/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
@@ -15,7 +15,7 @@ Feature: Picking up the cart with the locale other than the default
         And I check details of my cart
         Then my cart's locale should be "French (France)"
 
-    @api
+    @api @no-ui
     Scenario: Picking up the cart with non valid locale
         When I pick up cart using wrong locale
         Then I should be notified that locale does not exist

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -216,6 +216,16 @@ final class CartContext implements Context
     }
 
     /**
+     * @When I pick up cart using wrong locale
+     */
+    public function iPickUpMyCartUsingWrongLocale(): void
+    {
+        $this->cartsClient->buildCreateRequest();
+        $this->cartsClient->addRequestData('localeCode', 'en');
+        $this->cartsClient->create();
+    }
+
+    /**
      * @When I update my cart
      */
     public function iUpdateMyCart(): void
@@ -355,6 +365,19 @@ final class CartContext implements Context
         Assert::true(
             $this->responseChecker->isUpdateSuccessful($response),
             SprintfResponseEscaper::provideMessageWithEscapedResponseContent('Item has not been added.', $response)
+        );
+    }
+
+    /**
+     * @Then I should be notified that locale does not exist
+     */
+    public function iShouldBeNotifiedThatLocaleDoesNotExist(): void
+    {
+        $response = $this->cartsClient->getLastResponse();
+
+        Assert::false(
+            $this->responseChecker->isCreationSuccessful($response),
+            SprintfResponseEscaper::provideMessageWithEscapedResponseContent('The locale en does not exist.', $response)
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -377,8 +377,10 @@ final class CartContext implements Context
 
         Assert::false(
             $this->responseChecker->isCreationSuccessful($response),
-            SprintfResponseEscaper::provideMessageWithEscapedResponseContent('The locale en does not exist.', $response)
+            SprintfResponseEscaper::provideMessageWithEscapedResponseContent('The given locale exists but it should not', $response)
         );
+
+        Assert::same($this->responseChecker->getError($response), 'The locale en does not exist.');
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -39,7 +39,8 @@
                     <attribute name="groups">shop:order:create</attribute>
                 </attribute>
                 <attribute name="openapi_context">
-                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a particular channel.</attribute>                </attribute>
+                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a particular channel.</attribute>
+                </attribute>
             </collectionOperation>
 
             <collectionOperation name="shop_get">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
@@ -90,6 +90,11 @@
             <tag name="validator.constraint_validator" alias="sylius_api_confirm_reset_password" />
         </service>
 
+        <service id="sylius.api.validator.pickup_cart" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocaleValidator">
+            <argument type="service" id="sylius.repository.channel" />
+            <tag name="validator.constraint_validator" alias="sylius_api_pickup_cart" />
+        </service>
+
         <service id="sylius.api.validator.promotion_coupon_eligibility" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PromotionCouponEligibilityValidator">
             <argument type="service" id="sylius.repository.promotion_coupon" />
             <argument type="service" id="sylius.repository.order" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
@@ -90,9 +90,9 @@
             <tag name="validator.constraint_validator" alias="sylius_api_confirm_reset_password" />
         </service>
 
-        <service id="sylius.api.validator.pickup_cart" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocaleValidator">
+        <service id="sylius.api.validator.pickup_cart_locale" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocaleValidator">
             <argument type="service" id="sylius.repository.channel" />
-            <tag name="validator.constraint_validator" alias="sylius_api_pickup_cart" />
+            <tag name="validator.constraint_validator" alias="sylius_api_pickup_cart_locale" />
         </service>
 
         <service id="sylius.api.validator.promotion_coupon_eligibility" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PromotionCouponEligibilityValidator">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/validation/PickupCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/validation/PickupCart.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+
+    <class name="Sylius\Bundle\ApiBundle\Command\Cart\PickupCart">
+        <constraint name="Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocale">
+            <option name="groups">
+                <value>sylius</value>
+            </option>
+        </constraint>
+    </class>
+</constraint-mapping>

--- a/src/Sylius/Bundle/ApiBundle/Resources/translations/validators.en.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/translations/validators.en.yaml
@@ -7,6 +7,8 @@ sylius:
         without_country: 'The address without country cannot exist'
     country:
         not_exist: 'The country %countryCode% does not exist.'
+    locale:
+        not_exist: 'The locale %localeCode% does not exist.'
     order:
         not_empty: 'An empty order cannot be completed.'
     payment_method:

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocale.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocale.php
@@ -22,7 +22,7 @@ final class PickupCartLocale extends Constraint
 
     public function validatedBy(): string
     {
-        return 'sylius_api_pickup_cart';
+        return 'sylius_api_pickup_cart_locale';
     }
 
     public function getTargets(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocale.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocale.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/** @experimental */
+final class PickupCartLocale extends Constraint
+{
+    public string $notExist = 'sylius.locale.not_exist';
+
+    public function validatedBy(): string
+    {
+        return 'sylius_api_pickup_cart';
+    }
+
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocaleValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocaleValidator.php
@@ -35,16 +35,18 @@ class PickupCartLocaleValidator extends ConstraintValidator
         /** @var PickupCart $value */
         Assert::isInstanceOf($value, PickupCart::class);
 
+        if ($value->localeCode === null) {
+            return;
+        }
+
         /** @var ChannelInterface $channel */
         $channel = $this->channelRepository->findOneByCode($value->getChannelCode());
 
-        $locales = $channel->getLocales();
-
-        $locale = $locales->filter(function (LocaleInterface $locale) use ($value): bool {
+        $locales = $channel->getLocales()->filter(function (LocaleInterface $locale) use ($value): bool {
             return $locale->getCode() === $value->localeCode;
         });
 
-        if ($locale->isEmpty()) {
+        if ($locales->isEmpty()) {
             $this->context->addViolation($constraint->notExist, ['%localeCode%' => $value->localeCode]);
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocaleValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PickupCartLocaleValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
+
+use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Webmozart\Assert\Assert;
+
+class PickupCartLocaleValidator extends ConstraintValidator
+{
+    private ChannelRepositoryInterface $channelRepository;
+
+    public function __construct(ChannelRepositoryInterface $channelRepository)
+    {
+        $this->channelRepository = $channelRepository;
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        /** @var PickupCart $value */
+        Assert::isInstanceOf($value, PickupCart::class);
+
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneByCode($value->getChannelCode());
+
+        $locales = $channel->getLocales();
+
+        $locale = $locales->filter(function (LocaleInterface $locale) use ($value): bool {
+            return $locale->getCode() === $value->localeCode;
+        });
+
+        if ($locale->isEmpty()) {
+            $this->context->addViolation($constraint->notExist, ['%localeCode%' => $value->localeCode]);
+        }
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PickupCartLocaleValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PickupCartLocaleValidatorSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
+use Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocale;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+final class PickupCartLocaleValidatorSpec extends ObjectBehavior
+{
+    function let(ChannelRepositoryInterface $channelRepository): void
+    {
+        $this->beConstructedWith($channelRepository);
+    }
+
+    function it_is_a_constraint_validator(): void
+    {
+        $this->shouldImplement(ConstraintValidatorInterface::class);
+    }
+
+    function it_does_not_add_violation_if_locale_code_exists(
+        ExecutionContextInterface $executionContext,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelInterface $channel,
+        LocaleInterface $locale
+    ): void {
+        $constraint = new PickupCartLocale();
+        $this->initialize($executionContext);
+
+        $value = new PickupCart('token', 'en_US');
+        $value->setChannelCode('code');
+
+        $channelRepository->findOneByCode('code')->willReturn($channel);
+
+        $locale->getCode()->willReturn('en_US');
+        $channel->getLocales()->willReturn(new ArrayCollection([$locale->getWrappedObject()]));
+
+        $executionContext->addViolation('sylius.locale.not_exist', ["%localeCode%" => "en_US"])->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_adds_violation_if_locale_code_does_not_exist(
+        ExecutionContextInterface $executionContext,
+        ChannelRepositoryInterface $channelRepository,
+        ChannelInterface $channel,
+        LocaleInterface $locale
+    ): void {
+        $constraint = new PickupCartLocale();
+        $this->initialize($executionContext);
+
+        $value = new PickupCart('token', 'en');
+        $value->setChannelCode('code');
+
+        $channelRepository->findOneByCode('code')->willReturn($channel);
+
+        $locale->getCode()->willReturn('en_US');
+        $channel->getLocales()->willReturn(new ArrayCollection([$locale->getWrappedObject()]));
+
+        $executionContext->addViolation('sylius.locale.not_exist', ["%localeCode%" => "en"])->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PickupCartLocaleValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PickupCartLocaleValidatorSpec.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\ApiBundle\Validator\Constraints\PickupCartLocale;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -51,6 +52,23 @@ final class PickupCartLocaleValidatorSpec extends ObjectBehavior
 
         $locale->getCode()->willReturn('en_US');
         $channel->getLocales()->willReturn(new ArrayCollection([$locale->getWrappedObject()]));
+
+        $executionContext->addViolation('sylius.locale.not_exist', ["%localeCode%" => "en_US"])->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_does_not_add_violation_if_locale_code_is_not_set(
+        ExecutionContextInterface $executionContext,
+        ChannelRepositoryInterface $channelRepository
+    ): void {
+        $constraint = new PickupCartLocale();
+        $this->initialize($executionContext);
+
+        $value = new PickupCart('token', null);
+        $value->setChannelCode('code');
+
+        $channelRepository->findOneByCode('code')->shouldNotBeCalled();
 
         $executionContext->addViolation('sylius.locale.not_exist', ["%localeCode%" => "en_US"])->shouldNotBeCalled();
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Validate localeCode for picking up cart endpoint.
<img width="556" alt="image" src="https://user-images.githubusercontent.com/22825722/163052419-1072cd06-2841-4b29-9563-e1d80c5ab839.png">


<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
