### PR TITLE
[Maintenance] Relax conflict on liip imagine bundle - rebased version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
         "symfony/var-exporter": "^6.0",
         "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2",
-        "liip/imagine-bundle": "^2.7"
+        "liip/imagine-bundle": "2.7.0"
     },
     "require-dev": {
         "ext-json": "*",

--- a/src/Sylius/Bundle/CoreBundle/Twig/FilterExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/FilterExtension.php
@@ -17,6 +17,9 @@ use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Templating\FilterExtension as BaseFilterExtension;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+/**
+ * @psalm-suppress DeprecatedClass
+ */
 final class FilterExtension extends BaseFilterExtension
 {
     private string $imagesPath;
@@ -25,6 +28,7 @@ final class FilterExtension extends BaseFilterExtension
     {
         $this->imagesPath = $imagesPath;
 
+        /** @psalm-suppress DeprecatedClass */
         parent::__construct($cache);
     }
 
@@ -39,6 +43,7 @@ final class FilterExtension extends BaseFilterExtension
             return $this->imagesPath . $path;
         }
 
+        /** @psalm-suppress DeprecatedClass */
         return parent::filter($path, $filter, $config, $resolver, $referenceType);
     }
 


### PR DESCRIPTION
This commit removes support for liip imagine bundle 3.0 because we
extends a class that will not be in the bundle in its version 3.0.

| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Rebased version of #13602
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
