### PR TITLE
[Behat][API] Extract resources names from contexts to a separate class

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -55,7 +56,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iWantToEditThisAdministrator(AdminUserInterface $adminUser): void
     {
-        $this->client->buildUpdateRequest('administrators', (string) $adminUser->getId());
+        $this->client->buildUpdateRequest(Resources::ADMINISTRATORS, (string) $adminUser->getId());
     }
 
     /**
@@ -64,7 +65,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iBrowseAdministrators(): void
     {
-        $this->client->index('administrators');
+        $this->client->index(Resources::ADMINISTRATORS);
     }
 
     /**
@@ -72,7 +73,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iWantToCreateANewAdministrator(): void
     {
-        $this->client->buildCreateRequest('administrators');
+        $this->client->buildCreateRequest(Resources::ADMINISTRATORS);
     }
 
     /**
@@ -149,7 +150,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iDeleteAdministratorWithEmail(AdminUserInterface $adminUser): void
     {
-        $this->client->delete('administrators', (string) $adminUser->getId());
+        $this->client->delete(Resources::ADMINISTRATORS, (string) $adminUser->getId());
     }
 
     /**
@@ -157,7 +158,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iUploadTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
-        $this->client->buildUploadRequest('avatar-images');
+        $this->client->buildUploadRequest(Resources::AVATAR_IMAGES);
         $this->client->addParameter('owner', $this->iriConverter->getIriFromItem($administrator));
         $this->client->addFile('file', new UploadedFile($this->minkParameters['files_path'] . $avatar, basename($avatar)));
         $response = $this->client->upload();
@@ -175,7 +176,7 @@ final class ManagingAdministratorsContext implements Context
         $avatar = $administrator->getAvatar();
         Assert::notNull($avatar);
 
-        $this->client->delete('avatar-images', (string) $avatar->getId());
+        $this->client->delete(Resources::AVATAR_IMAGES, (string) $avatar->getId());
     }
 
     /**
@@ -194,7 +195,7 @@ final class ManagingAdministratorsContext implements Context
     public function theAdministratorShouldAppearInTheStore(string $email): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('administrators'), 'email', $email),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::ADMINISTRATORS), 'email', $email),
             sprintf('Administrator with email %s does not exist', $email)
         );
     }
@@ -205,7 +206,7 @@ final class ManagingAdministratorsContext implements Context
     public function thereShouldNotBeAdministratorAnymore(string $email): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('administrators'), 'email', $email),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::ADMINISTRATORS), 'email', $email),
             sprintf('Administrator with email %s exists, but it should not', $email)
         );
     }
@@ -216,7 +217,7 @@ final class ManagingAdministratorsContext implements Context
     public function thereShouldStillBeOnlyOneAdministratorWithAnEmail(string $email): void
     {
         Assert::count(
-            $this->responseChecker->getCollectionItemsWithValue($this->client->index('administrators'), 'email', $email),
+            $this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::ADMINISTRATORS), 'email', $email),
             1,
             sprintf('There is more than one administrator with email %s', $email)
         );
@@ -229,7 +230,7 @@ final class ManagingAdministratorsContext implements Context
     public function thisAdministratorWithNameShouldAppearInTheStore(string $username): void
     {
         Assert::count(
-            $this->responseChecker->getCollectionItemsWithValue($this->client->index('administrators'), 'username', $username),
+            $this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::ADMINISTRATORS), 'username', $username),
             1,
             sprintf('There is more than one administrator with username %s', $username)
         );
@@ -333,7 +334,7 @@ final class ManagingAdministratorsContext implements Context
     public function iShouldSeeTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
         Assert::true($this->responseChecker->hasValue(
-            $this->client->show('administrators', (string) $administrator->getId()),
+            $this->client->show(Resources::ADMINISTRATORS, (string) $administrator->getId()),
             'avatar',
             $this->sharedStorage->get(StringInflector::nameToCode($avatar))
         ));
@@ -348,7 +349,7 @@ final class ManagingAdministratorsContext implements Context
         $administrator = $this->sharedStorage->get('administrator');
 
         Assert::true($this->responseChecker->hasValue(
-            $this->client->show('administrators', (string) $administrator->getId()),
+            $this->client->show(Resources::ADMINISTRATORS, (string) $administrator->getId()),
             'avatar',
             null
         ));

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\FixedDiscountPriceCalculator;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\PercentageDiscountPriceCalculator;
@@ -64,7 +65,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iCreateANewCatalogPromotionWithCodeAndName(string $code, string $name): void
     {
-        $this->client->buildCreateRequest('catalog-promotions');
+        $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
         $this->client->addRequestData('code', $code);
         $this->client->addRequestData('name', $name);
         $this->client->create();
@@ -75,7 +76,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iCreateANewCatalogPromotionWithCodeAndNameAndPriority(string $code, string $name, int $priority): void
     {
-        $this->client->buildCreateRequest('catalog-promotions');
+        $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
         $this->client->addRequestData('code', $code);
         $this->client->addRequestData('name', $name);
         $this->client->addRequestData('priority', $priority);
@@ -87,7 +88,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iCreateANewCatalogPromotionWithoutSpecifyingItsCodeAndName(): void
     {
-        $this->client->buildCreateRequest('catalog-promotions');
+        $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
         $this->client->create();
     }
 
@@ -96,7 +97,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iWantToCreateNewCatalogPromotion(): void
     {
-        $this->client->buildCreateRequest('catalog-promotions');
+        $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
     }
 
     /**
@@ -167,7 +168,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iMakeItUnavailableInChannel(CatalogPromotionInterface $catalogPromotion, ChannelInterface $channel): void
     {
-        $channels = $this->responseChecker->getValue($this->client->show('catalog-promotions', $catalogPromotion->getCode()), 'channels');
+        $channels = $this->responseChecker->getValue($this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode()), 'channels');
 
         foreach (array_keys($channels, $this->iriConverter->getIriFromItem($channel)) as $key) {
             unset($channels[$key]);
@@ -190,7 +191,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iRenameTheCatalogPromotionTo(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
         $this->client->updateRequestData(['name' => $name]);
         $this->client->update();
     }
@@ -201,7 +202,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iWantToModifyACatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
@@ -351,7 +352,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iBrowseCatalogPromotions(): void
     {
-        $this->client->index('catalog-promotions');
+        $this->client->index(Resources::CATALOG_PROMOTIONS);
     }
 
     /**
@@ -508,7 +509,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant
     ): void {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
         $scopes = [[
             'type' => InForVariantsScopeVariantChecker::TYPE,
             'configuration' => [
@@ -529,7 +530,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         TaxonInterface $taxon
     ): void {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         $content = $this->client->getContent();
         unset($content['scopes'][0]['configuration']['variants']);
@@ -548,7 +549,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ProductInterface $product
     ): void {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         $content = $this->client->getContent();
         unset($content['scopes'][0]['configuration']['variants']);
@@ -581,7 +582,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iEditCatalogPromotionToHaveDiscount(CatalogPromotionInterface $catalogPromotion, float $amount): void
     {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
         $scopes = [[
             'type' => PercentageDiscountPriceCalculator::TYPE,
             'configuration' => [
@@ -601,7 +602,7 @@ final class ManagingCatalogPromotionsContext implements Context
         int $amount,
         ChannelInterface $channel
     ): void {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
         $content = $this->client->getContent();
 
         $content['actions'] = [[
@@ -782,7 +783,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $catalogPromotionCode = $catalogPromotion->getCode();
         Assert::notNull($catalogPromotionCode);
 
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotionCode);
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotionCode);
         $content = $this->client->getContent();
         foreach (array_keys($content['channels'], $this->iriConverter->getIriFromItem($channel)) as $key) {
             unset($content['channels'][$key]);
@@ -800,7 +801,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel
     ): void {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
         $content = $this->client->getContent();
         $content['channels'][] = $this->iriConverter->getIriFromItem($channel);
         $this->client->updateRequestData(['channels' => $content['channels']]);
@@ -819,7 +820,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $catalogPromotionCode = $catalogPromotion->getCode();
         Assert::notNull($catalogPromotionCode);
 
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotionCode);
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotionCode);
         $content = $this->client->getContent();
         foreach (array_keys($content['channels'], $this->iriConverter->getIriFromItem($removedChannel)) as $key) {
             unset($content['channels'][$key]);
@@ -835,7 +836,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iViewDetailsOfTheCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
-        $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
@@ -855,7 +856,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thereShouldBeNewCatalogPromotionOnTheList(int $amount = 0): void
     {
-        Assert::count($this->responseChecker->getCollection($this->client->index('catalog-promotions')), $amount);
+        Assert::count($this->responseChecker->getCollection($this->client->index(Resources::CATALOG_PROMOTIONS)), $amount);
     }
 
     /**
@@ -931,7 +932,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function itShouldHaveCodeAndName(string $code, string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValues($this->client->index('catalog-promotions'), ['code' => $code, 'name' => $name]),
+            $this->responseChecker->hasItemWithValues($this->client->index(Resources::CATALOG_PROMOTIONS), ['code' => $code, 'name' => $name]),
             sprintf('Cannot find catalog promotions with code "%s" and name "%s" in the list', $code, $name)
         );
     }
@@ -942,7 +943,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function itShouldHavePriorityEqualTo(int $priority): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValues($this->client->index('catalog-promotions'), ['priority' => $priority]),
+            $this->responseChecker->hasItemWithValues($this->client->index(Resources::CATALOG_PROMOTIONS), ['priority' => $priority]),
             sprintf('Cannot find catalog promotions with priority "%d"', $priority)
         );
     }
@@ -954,7 +955,7 @@ final class ManagingCatalogPromotionsContext implements Context
     {
         foreach ($names as $name) {
             Assert::true(
-                $this->responseChecker->hasItemWithValue($this->client->index('catalog-promotions'), 'name', $name),
+                $this->responseChecker->hasItemWithValue($this->client->index(Resources::CATALOG_PROMOTIONS), 'name', $name),
                 sprintf('Cannot find catalog promotions with name "%s" in the list', $name)
             );
         }
@@ -971,7 +972,7 @@ final class ManagingCatalogPromotionsContext implements Context
         string $startDate,
         string $endDate
     ): void {
-        $response = $this->client->index('catalog-promotions');
+        $response = $this->client->index(Resources::CATALOG_PROMOTIONS);
 
         Assert::true(
             $this->responseChecker->hasItemWithValues(
@@ -992,7 +993,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         int $priority
     ): void {
-        $response = $this->client->index('catalog-promotions');
+        $response = $this->client->index(Resources::CATALOG_PROMOTIONS);
 
         Assert::true(
             $this->responseChecker->hasItemWithValues(
@@ -1012,7 +1013,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function theCatalogPromotionsNamedShouldOperateBetweenYesterdayAndTomorrow(
         CatalogPromotionInterface $catalogPromotion
     ): void {
-        $response = $this->client->index('catalog-promotions');
+        $response = $this->client->index(Resources::CATALOG_PROMOTIONS);
 
         Assert::true(
             $this->responseChecker->hasItemWithValues(
@@ -1057,7 +1058,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thisCatalogPromotionShouldBe(CatalogPromotionInterface $catalogPromotion, string $state): void
     {
-        $response = $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $response = $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true($this->responseChecker->hasValue($response, 'state', $state));
     }
@@ -1116,7 +1117,7 @@ final class ManagingCatalogPromotionsContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasValueInCollection(
-                $this->client->show('catalog-promotions', $catalogPromotion->getCode()),
+                $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode()),
                 'channels',
                 $this->iriConverter->getIriFromItem($channel)
             ),
@@ -1135,7 +1136,7 @@ final class ManagingCatalogPromotionsContext implements Context
     ): void {
         Assert::false(
             $this->responseChecker->hasValueInCollection(
-                $this->client->show('catalog-promotions', $catalogPromotion->getCode()),
+                $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode()),
                 'channels',
                 $this->iriConverter->getIriFromItem($channel)
             ),
@@ -1180,7 +1181,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thisCatalogPromotionNameShouldBe(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
-        $response = $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $response = $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true(
             $this->responseChecker->hasValue($response, 'name', $name),
@@ -1202,7 +1203,7 @@ final class ManagingCatalogPromotionsContext implements Context
             'described' => 'description',
         ];
 
-        $response = $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $response = $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true($this->responseChecker->hasTranslation($response, $localeCode, $fieldsMapping[$field], $value));
     }
@@ -1214,7 +1215,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant
     ): void {
-        $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true($this->catalogPromotionAppliesOnVariants($productVariant));
     }
@@ -1242,7 +1243,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         TaxonInterface $taxon
     ): void {
-        $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true($this->catalogPromotionAppliesOnTaxons($taxon));
     }
@@ -1254,7 +1255,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant
     ): void {
-        $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::false($this->catalogPromotionAppliesOnVariants($productVariant));
     }
@@ -1266,7 +1267,7 @@ final class ManagingCatalogPromotionsContext implements Context
         CatalogPromotionInterface $catalogPromotion,
         ProductInterface $product
     ): void {
-        $this->client->show('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         Assert::true($this->catalogPromotionAppliesOnProducts($product));
     }
@@ -1303,7 +1304,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thereShouldStillBeOnlyOneCatalogPromotionWithCode(string $code): void
     {
-        Assert::count($this->responseChecker->getCollectionItemsWithValue($this->client->index('catalog-promotions'), 'code', $code), 1);
+        Assert::count($this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::CATALOG_PROMOTIONS), 'code', $code), 1);
     }
 
     /**
@@ -1562,7 +1563,7 @@ final class ManagingCatalogPromotionsContext implements Context
 
     private function toggleCatalogPromotion(CatalogPromotionInterface $catalogPromotion, bool $enabled): void
     {
-        $this->client->buildUpdateRequest('catalog-promotions', $catalogPromotion->getCode());
+        $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
 
         $this->client->updateRequestData(['enabled' => $enabled]);
         $this->client->update();
@@ -1578,7 +1579,7 @@ final class ManagingCatalogPromotionsContext implements Context
         float $discount,
         ChannelInterface $channel
     ): void {
-        $this->client->buildCreateRequest('catalog-promotions');
+        $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
 
         $this->client->updateRequestData([
             'code' => StringInflector::nameToCode($name),

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -50,7 +51,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iWantToCreateANewChannel(): void
     {
-        $this->client->buildCreateRequest('channels');
+        $this->client->buildCreateRequest(Resources::CHANNELS);
     }
 
     /**
@@ -193,7 +194,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iWantToBrowseChannels(): void
     {
-        $this->client->index('channels');
+        $this->client->index(Resources::CHANNELS);
     }
 
     /**
@@ -214,7 +215,7 @@ final class ManagingChannelsContext implements Context
     public function theChannelShouldAppearInTheRegistry(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('channels'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::CHANNELS), 'name', $name),
             sprintf('Channel with name %s does not exist', $name)
         );
     }
@@ -225,7 +226,7 @@ final class ManagingChannelsContext implements Context
     public function theChannelShouldHaveAsAMenuTaxon(ChannelInterface $channel, TaxonInterface $taxon): void
     {
         Assert::same(
-            $this->responseChecker->getValue($this->client->show('channels', $channel->getCode()), 'menuTaxon'),
+            $this->responseChecker->getValue($this->client->show(Resources::CHANNELS, $channel->getCode()), 'menuTaxon'),
             $this->iriConverter->getIriFromItem($taxon),
             sprintf('Channel %s does not have %s menu taxon', $channel->getName(), $taxon->getName())
         );

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
@@ -50,7 +51,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iWantToAddANewCountry(): void
     {
-        $this->client->buildCreateRequest('countries');
+        $this->client->buildCreateRequest(Resources::COUNTRIES);
     }
 
     /**
@@ -75,7 +76,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iWantToEditThisCountry(CountryInterface $country): void
     {
-        $this->client->buildUpdateRequest('countries', $country->getCode());
+        $this->client->buildUpdateRequest(Resources::COUNTRIES, $country->getCode());
     }
 
     /**
@@ -154,7 +155,7 @@ final class ManagingCountriesContext implements Context
     {
         $iri = $this->iriConverter->getItemIriFromResourceClass(get_class($province), ['code' => $province->getCode()]);
 
-        $provinces = $this->responseChecker->getValue($this->client->show('countries', $country->getCode()), 'provinces');
+        $provinces = $this->responseChecker->getValue($this->client->show(Resources::COUNTRIES, $country->getCode()), 'provinces');
         foreach ($provinces as $countryProvince) {
             if ($iri === $countryProvince) {
                 $this->client->removeSubResource('provinces', $countryProvince);
@@ -176,7 +177,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iRemoveProvinceName(ProvinceInterface $province): void
     {
-        $this->client->buildUpdateRequest('provinces', $province->getCode());
+        $this->client->buildUpdateRequest(Resources::PROVINCES, $province->getCode());
         $this->client->addRequestData('name', '');
         $this->client->update();
     }
@@ -198,7 +199,7 @@ final class ManagingCountriesContext implements Context
     public function theCountryShouldAppearInTheStore(CountryInterface $country): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('countries'), 'code', $country->getCode()),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::COUNTRIES), 'code', $country->getCode()),
             sprintf('There is no country with name "%s"', $country->getName())
         );
     }
@@ -210,7 +211,7 @@ final class ManagingCountriesContext implements Context
     public function theCountryShouldHaveTheProvince(CountryInterface $country, ProvinceInterface $province): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('countries', 'provinces', $country->getCode()),
+            $this->client->subResourceIndex(Resources::COUNTRIES, 'provinces', $country->getCode()),
             'code',
             $province->getCode()
         ));
@@ -224,7 +225,7 @@ final class ManagingCountriesContext implements Context
         /** @var CountryInterface $country */
         $country = $this->sharedStorage->get('country');
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('countries', 'provinces', $country->getCode()),
+            $this->client->subResourceIndex(Resources::COUNTRIES, 'provinces', $country->getCode()),
             'code',
             $province->getCode()
         ));
@@ -262,7 +263,7 @@ final class ManagingCountriesContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasValue(
-                $this->client->show('countries', $country->getCode()),
+                $this->client->show(Resources::COUNTRIES, $country->getCode()),
                 'enabled',
                 $enabled === 'enabled'
             ),
@@ -358,7 +359,7 @@ final class ManagingCountriesContext implements Context
 
     private function getProvincesOfCountry(CountryInterface $country): iterable
     {
-        $response = $this->client->show('countries', $country->getCode());
+        $response = $this->client->show(Resources::COUNTRIES, $country->getCode());
         $countryFromResponse = $this->responseChecker->getResponseContent($response);
 
         foreach ($countryFromResponse['provinces'] as $provinceFromResponse) {

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Webmozart\Assert\Assert;
 
 final class ManagingCurrenciesContext implements Context
@@ -35,7 +36,7 @@ final class ManagingCurrenciesContext implements Context
      */
     public function iWantToSeeAllCurrenciesInStore(): void
     {
-        $this->client->index('currencies');
+        $this->client->index(Resources::CURRENCIES);
     }
 
     /**
@@ -43,7 +44,7 @@ final class ManagingCurrenciesContext implements Context
      */
     public function iWantToAddNewCurrency(): void
     {
-        $this->client->buildCreateRequest('currencies');
+        $this->client->buildCreateRequest(Resources::CURRENCIES);
     }
 
     /**
@@ -79,7 +80,7 @@ final class ManagingCurrenciesContext implements Context
     public function currencyShouldAppearInTheStore(string $currencyName): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('currencies'), 'name', $currencyName),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::CURRENCIES), 'name', $currencyName),
             sprintf('There is no currency with name "%s"', $currencyName)
         );
     }
@@ -89,7 +90,7 @@ final class ManagingCurrenciesContext implements Context
      */
     public function thereShouldStillBeOnlyOneCurrencyWithCode(string $code): void
     {
-        $response = $this->client->index('currencies');
+        $response = $this->client->index(Resources::CURRENCIES);
         Assert::same($this->responseChecker->countCollectionItems($response), 1);
         Assert::true(
             $this->responseChecker->hasItemWithValue($response, 'code', $code),

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCustomerGroupsContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
 use Webmozart\Assert\Assert;
 
@@ -36,7 +37,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iWantToCreateANewCustomerGroup(): void
     {
-        $this->client->buildCreateRequest('customer-groups');
+        $this->client->buildCreateRequest(Resources::CUSTOMER_GROUPS);
     }
 
     /**
@@ -72,7 +73,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iWantToEditThisCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
-        $this->client->buildUpdateRequest('customer-groups', $customerGroup->getCode());
+        $this->client->buildUpdateRequest(Resources::CUSTOMER_GROUPS, $customerGroup->getCode());
     }
 
     /**
@@ -89,7 +90,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iWantToBrowseCustomerGroups(): void
     {
-        $this->client->index('customer-groups');
+        $this->client->index(Resources::CUSTOMER_GROUPS);
     }
 
     /**
@@ -97,7 +98,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iDeleteTheCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
-        $this->client->delete('customer-groups', $customerGroup->getCode());
+        $this->client->delete(Resources::CUSTOMER_GROUPS, $customerGroup->getCode());
     }
 
     /**
@@ -106,7 +107,7 @@ final class ManagingCustomerGroupsContext implements Context
     public function theCustomerGroupShouldAppearInTheStore(CustomerGroupInterface $customerGroup): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('customer-groups'), 'code', $customerGroup->getCode()),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::CUSTOMER_GROUPS), 'code', $customerGroup->getCode()),
             sprintf('Customer group with code %s does not exist', $customerGroup->getCode())
         );
     }
@@ -118,7 +119,7 @@ final class ManagingCustomerGroupsContext implements Context
     public function thisCustomerGroupWithNameShouldAppearInTheStore(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('customer-groups'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::CUSTOMER_GROUPS), 'name', $name),
             sprintf('Customer group with name %s does not exist', $name)
         );
     }
@@ -129,7 +130,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iShouldSeeCustomerGroupsInTheList(int $amountOfCustomerGroups = 1): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('customer-groups')), $amountOfCustomerGroups);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::CUSTOMER_GROUPS)), $amountOfCustomerGroups);
     }
 
     /**
@@ -138,7 +139,7 @@ final class ManagingCustomerGroupsContext implements Context
     public function thisCustomerGroupShouldStillBeNamed(CustomerGroupInterface $customerGroup, string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('customer-groups', $customerGroup->getCode()), 'name', $name),
+            $this->responseChecker->hasValue($this->client->show(Resources::CUSTOMER_GROUPS, $customerGroup->getCode()), 'name', $name),
             'Customer groups name is not ' . $name
         );
     }
@@ -232,6 +233,6 @@ final class ManagingCustomerGroupsContext implements Context
 
     private function isItemOnIndex(string $property, string $value): bool
     {
-        return $this->responseChecker->hasItemWithValue($this->client->index('customer-groups'), $property, $value);
+        return $this->responseChecker->hasItemWithValue($this->client->index(Resources::CUSTOMER_GROUPS), $property, $value);
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Currency\Model\ExchangeRateInterface;
@@ -45,7 +46,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iWantToEditThisExchangeRate(ExchangeRateInterface $exchangeRate): void
     {
-        $this->client->buildUpdateRequest('exchange-rates', (string) $exchangeRate->getId());
+        $this->client->buildUpdateRequest(Resources::EXCHANGE_RATES, (string) $exchangeRate->getId());
 
         $this->sharedStorage->set('exchange_rate_id', (string) $exchangeRate->getId());
     }
@@ -57,7 +58,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iBrowseExchangeRatesOfTheStore(): void
     {
-        $this->client->index('exchange-rates',);
+        $this->client->index(Resources::EXCHANGE_RATES);
     }
 
     /**
@@ -65,7 +66,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iWantToAddNewExchangeRate(): void
     {
-        $this->client->buildCreateRequest('exchange-rates',);
+        $this->client->buildCreateRequest(Resources::EXCHANGE_RATES);
     }
 
     /**
@@ -124,7 +125,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iDeleteTheExchangeRateBetweenAnd(ExchangeRateInterface $exchangeRate): void
     {
-        $this->client->delete('exchange-rates', (string) $exchangeRate->getId());
+        $this->client->delete(Resources::EXCHANGE_RATES, (string) $exchangeRate->getId());
     }
 
     /**
@@ -157,7 +158,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldSeeASingleExchangeRateInTheList(): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('exchange-rates')), 1);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::EXCHANGE_RATES)), 1);
     }
 
     /**
@@ -199,7 +200,7 @@ final class ManagingExchangeRatesContext implements Context
     public function itShouldHaveARatioOf(float $ratio): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('exchange-rates'), 'ratio', $ratio),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::EXCHANGE_RATES), 'ratio', $ratio),
             sprintf('ExchangeRate with ratio %s does not exist', $ratio)
         );
     }
@@ -231,7 +232,7 @@ final class ManagingExchangeRatesContext implements Context
         CurrencyInterface $sourceCurrency,
         CurrencyInterface $targetCurrency
     ): void {
-        $this->client->index('exchange-rates');
+        $this->client->index(Resources::EXCHANGE_RATES);
 
         Assert::null($this->getExchangeRateFromResponse($sourceCurrency, $targetCurrency));
     }
@@ -344,14 +345,14 @@ final class ManagingExchangeRatesContext implements Context
 
     private function assertIfNotBeAbleToEditItCurrency(string $currencyType): void
     {
-        $this->client->buildUpdateRequest('exchange-rates', $this->sharedStorage->get('exchange_rate_id'));
+        $this->client->buildUpdateRequest(Resources::EXCHANGE_RATES, $this->sharedStorage->get('exchange_rate_id'));
 
         $this->client->addRequestData($currencyType, '/api/v2/admin/currencies/EUR');
         $this->client->update();
 
         Assert::false(
             $this->responseChecker->hasItemOnPositionWithValue(
-                $this->client->index('exchange-rates'),
+                $this->client->index(Resources::EXCHANGE_RATES),
                 0,
                 $currencyType,
                 '/api/v2/admin/currencies/EUR'
@@ -365,7 +366,7 @@ final class ManagingExchangeRatesContext implements Context
         CurrencyInterface $targetCurrency
     ): ?array {
         /** @var array $item */
-        foreach ($this->responseChecker->getCollection($this->client->index('exchange-rates')) as $item) {
+        foreach ($this->responseChecker->getCollection($this->client->index(Resources::EXCHANGE_RATES)) as $item) {
             if (
                 $item['sourceCurrency'] === '/api/v2/admin/currencies/' . $sourceCurrency->getCode() &&
                 $item['targetCurrency'] === '/api/v2/admin/currencies/' . $targetCurrency->getCode()

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingLocalesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingLocalesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Webmozart\Assert\Assert;
 
 final class ManagingLocalesContext implements Context
@@ -37,7 +38,7 @@ final class ManagingLocalesContext implements Context
      */
     public function iWantToAddNewLocale(): void
     {
-        $this->client->buildCreateRequest('locales');
+        $this->client->buildCreateRequest(Resources::LOCALES);
     }
 
     /**
@@ -73,7 +74,7 @@ final class ManagingLocalesContext implements Context
      */
     public function theStoreShouldBeAvailableInTheLanguage(string $localeCode): void
     {
-        $response = $this->client->index('locales');
+        $response = $this->client->index(Resources::LOCALES);
         Assert::true(
             $this->responseChecker->hasItemWithValue($response, 'code', $localeCode),
             sprintf('There is no locale with code "%s"', $localeCode)

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SecurityServiceInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -59,7 +60,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iSeeTheOrder(OrderInterface $order): void
     {
-        $this->client->show('orders', $order->getTokenValue());
+        $this->client->show(Resources::ORDERS, $order->getTokenValue());
     }
 
     /**
@@ -67,7 +68,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iBrowseOrders(): void
     {
-        $this->client->index('orders');
+        $this->client->index(Resources::ORDERS);
     }
 
     /**
@@ -76,8 +77,8 @@ final class ManagingOrdersContext implements Context
     public function iCancelThisOrder(OrderInterface $order): void
     {
         $this->client->applyTransition(
-            'orders',
-            $this->responseChecker->getValue($this->client->show('orders', $order->getTokenValue()), 'tokenValue'),
+            Resources::ORDERS,
+            $this->responseChecker->getValue($this->client->show(Resources::ORDERS, $order->getTokenValue()), 'tokenValue'),
             OrderTransitions::TRANSITION_CANCEL
         );
     }
@@ -88,7 +89,7 @@ final class ManagingOrdersContext implements Context
     public function iMarkThisOrderAsAPaid(OrderInterface $order): void
     {
         $this->client->applyTransition(
-            'payments',
+            Resources::PAYMENTS,
             (string) $order->getLastPayment()->getId(),
             PaymentTransitions::TRANSITION_COMPLETE
         );
@@ -100,7 +101,7 @@ final class ManagingOrdersContext implements Context
     public function iShipThisOrder(OrderInterface $order): void
     {
         $this->client->applyTransition(
-            'shipments',
+            Resources::SHIPMENTS,
             (string) $order->getShipments()->first()->getId(),
             ShipmentTransitions::TRANSITION_SHIP
         );
@@ -158,7 +159,7 @@ final class ManagingOrdersContext implements Context
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
-        $orderState = $this->responseChecker->getValue($this->client->show('orders', $order->getTokenValue()), 'state');
+        $orderState = $this->responseChecker->getValue($this->client->show(Resources::ORDERS, $order->getTokenValue()), 'state');
 
         Assert::same($orderState, strtolower($state));
     }
@@ -169,7 +170,7 @@ final class ManagingOrdersContext implements Context
     public function itShouldHaveShipmentState(string $state): void
     {
         $shipmentIri = $this->responseChecker->getValue(
-            $this->client->show('orders', $this->sharedStorage->get('order')->getTokenValue()),
+            $this->client->show(Resources::ORDERS, $this->sharedStorage->get('order')->getTokenValue()),
             'shipments'
         )[0];
 
@@ -185,7 +186,7 @@ final class ManagingOrdersContext implements Context
     public function itShouldHavePaymentState($state): void
     {
         $paymentIri = $this->responseChecker->getValue(
-            $this->client->show('orders', $this->sharedStorage->get('order')->getTokenValue()),
+            $this->client->show(Resources::ORDERS, $this->sharedStorage->get('order')->getTokenValue()),
             'payments'
         )[0];
 
@@ -201,7 +202,7 @@ final class ManagingOrdersContext implements Context
     public function theOrderShouldHaveNumberOfPayments(int $number): void
     {
         Assert::count(
-            $this->responseChecker->getValue($this->client->show('orders', $this->sharedStorage->get('order')->getTokenValue()), 'payments'),
+            $this->responseChecker->getValue($this->client->show(Resources::ORDERS, $this->sharedStorage->get('order')->getTokenValue()), 'payments'),
             $number
         );
     }
@@ -212,7 +213,7 @@ final class ManagingOrdersContext implements Context
     public function theOrderShouldHavePaymentState(OrderInterface $order, string $paymentState): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('orders', $order->getTokenValue()), 'paymentState', strtolower($paymentState)),
+            $this->responseChecker->hasValue($this->client->show(Resources::ORDERS, $order->getTokenValue()), 'paymentState', strtolower($paymentState)),
             sprintf('Order %s does not have %s payment state', $order->getTokenValue(), $paymentState)
         );
     }
@@ -321,7 +322,7 @@ final class ManagingOrdersContext implements Context
     ): void {
         $this->adminSecurityService->logIn($user);
 
-        $currencyCode = $this->responseChecker->getValue($this->client->show('orders', $order->getTokenValue()), 'currencyCode');
+        $currencyCode = $this->responseChecker->getValue($this->client->show(Resources::ORDERS, $order->getTokenValue()), 'currencyCode');
 
         Assert::same($currencyCode, $currency);
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -48,7 +49,7 @@ final class ManagingPaymentsContext implements Context
      */
     public function iAmBrowsingPayments(): void
     {
-        $this->client->index('payments');
+        $this->client->index(Resources::PAYMENTS);
     }
 
     /**
@@ -60,7 +61,7 @@ final class ManagingPaymentsContext implements Context
         Assert::notNull($payment);
 
         $this->client->applyTransition(
-            'payments',
+            Resources::PAYMENTS,
             (string) $payment->getId(),
             PaymentTransitions::TRANSITION_COMPLETE
         );
@@ -162,7 +163,7 @@ final class ManagingPaymentsContext implements Context
         Assert::notNull($payment);
 
         Assert::true($this->responseChecker->hasValue(
-            $this->client->show('payments', (string) $payment->getId()),
+            $this->client->show(Resources::PAYMENTS, (string) $payment->getId()),
             'state',
             StringInflector::nameToLowercaseCode($paymentState)
         ));

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 use Webmozart\Assert\Assert;
@@ -43,7 +44,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iWantToCreateANewProductAssociationType(): void
     {
-        $this->client->buildCreateRequest('product-association-types');
+        $this->client->buildCreateRequest(Resources::PRODUCT_ASSOCIATION_TYPES);
     }
 
     /**
@@ -95,7 +96,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function theProductAssociationTypeShouldAppearInTheStore(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-association-types'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES), 'name', $name),
             sprintf('There is no product association type with name "%s"', $name)
         );
     }
@@ -106,7 +107,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iBrowseProductAssociationTypes(): void
     {
-        $this->client->index('product-association-types');
+        $this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES);
     }
 
     /**
@@ -115,7 +116,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iShouldSeeProductAssociationTypesInTheList(int $count = 1): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('product-association-types')), $count);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES)), $count);
     }
 
     /**
@@ -125,7 +126,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function iShouldSeeTheProductAssociationTypeInTheList(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-association-types'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES), 'name', $name),
             sprintf('There is no product association type with name "%s"', $name)
         );
     }
@@ -135,7 +136,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iDeleteTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
-        $this->client->delete('product-association-types', $productAssociationType->getCode());
+        $this->client->delete(Resources::PRODUCT_ASSOCIATION_TYPES, $productAssociationType->getCode());
     }
 
     /**
@@ -157,7 +158,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function thisProductAssociationTypeShouldNoLongerExistInTheRegistry(ProductAssociationTypeInterface $productAssociationType): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-association-types'), 'code', $productAssociationType->getCode()),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES), 'code', $productAssociationType->getCode()),
             sprintf('Product association type with code %s exist', $productAssociationType->getCode())
         );
     }
@@ -167,7 +168,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iWantToModifyTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
-        $this->client->buildUpdateRequest('product-association-types', $productAssociationType->getCode());
+        $this->client->buildUpdateRequest(Resources::PRODUCT_ASSOCIATION_TYPES, $productAssociationType->getCode());
     }
 
     /**
@@ -203,7 +204,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function thisProductAssociationTypeNameShouldBe(ProductAssociationTypeInterface $productAssociationType, string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('product-association-types', $productAssociationType->getCode()), 'name', $name),
+            $this->responseChecker->hasValue($this->client->show(Resources::PRODUCT_ASSOCIATION_TYPES, $productAssociationType->getCode()), 'name', $name),
             sprintf('Product association type name is not %s', $name)
         );
     }
@@ -240,7 +241,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function iDeleteThem(): void
     {
         foreach ($this->sharedStorage->get('product_association_type_to_delete') as $code) {
-            $this->client->delete('product-association-types', $code);
+            $this->client->delete(Resources::PRODUCT_ASSOCIATION_TYPES, $code);
         }
     }
 
@@ -287,7 +288,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function thereShouldStillBeOnlyOneProductAssociationTypeWithACode(string $code): void
     {
         Assert::count(
-            $this->responseChecker->getCollectionItemsWithValue($this->client->index('product-association-types'), 'code', $code),
+            $this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES), 'code', $code),
             1,
             sprintf('More then one Product association type have code %s.', $code)
         );
@@ -318,7 +319,7 @@ final class ManagingProductAssociationTypesContext implements Context
     public function theProductAssociationTypeWithNameShouldNotBeAdded(string $type, string $value): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-association-types'), $type, $value),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES), $type, $value),
             sprintf('Product association type with %s %s exist', $type, $value)
         );
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Product\Model\ProductOptionInterface;
 use Webmozart\Assert\Assert;
@@ -43,7 +44,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iWantToCreateANewProductOption(): void
     {
-        $this->client->buildCreateRequest('product-options');
+        $this->client->buildCreateRequest(Resources::PRODUCT_OPTIONS);
     }
 
     /**
@@ -51,7 +52,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iBrowseProductOptions(): void
     {
-        $this->client->index('product-options');
+        $this->client->index(Resources::PRODUCT_OPTIONS);
     }
 
     /**
@@ -60,7 +61,7 @@ final class ManagingProductOptionsContext implements Context
     public function iWantToModifyProductOption(ProductOptionInterface $productOption): void
     {
         $this->sharedStorage->set('product_option', $productOption);
-        $this->client->buildUpdateRequest('product-options', $productOption->getCode());
+        $this->client->buildUpdateRequest(Resources::PRODUCT_OPTIONS, $productOption->getCode());
     }
 
     /**
@@ -158,7 +159,7 @@ final class ManagingProductOptionsContext implements Context
         $this->sharedStorage->set('product_option', $productOption);
 
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-options'), 'name', $productOption->getName()),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_OPTIONS), 'name', $productOption->getName()),
             sprintf('Product option should have name "%s", but it does not.', $productOption->getName())
         );
     }
@@ -193,7 +194,7 @@ final class ManagingProductOptionsContext implements Context
     public function theProductOptionWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('product-options'), $element, $value),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_OPTIONS), $element, $value),
             sprintf('Product option should not have %s "%s", but it does,', $element, $value)
         );
     }
@@ -203,7 +204,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function thereShouldStillBeOnlyOneProductOptionWith(string $element, string $value): void
     {
-        $response = $this->client->index('product-options');
+        $response = $this->client->index(Resources::PRODUCT_OPTIONS);
         $itemsCount = $this->responseChecker->countCollectionItems($response);
 
         Assert::same($itemsCount, 1, sprintf('Expected 1 product options, but got %d', $itemsCount));
@@ -216,7 +217,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function thisProductOptionNameShouldBe(ProductOptionInterface $productOption, string $name): void
     {
-        Assert::true($this->responseChecker->hasValue($this->client->show('product-options', $productOption->getCode()), 'name', $name));
+        Assert::true($this->responseChecker->hasValue($this->client->show(Resources::PRODUCT_OPTIONS, $productOption->getCode()), 'name', $name));
     }
 
     /**
@@ -228,7 +229,7 @@ final class ManagingProductOptionsContext implements Context
         string $optionValueName
     ): void {
         Assert::true($this->responseChecker->hasItemWithTranslation(
-            $this->client->subResourceIndex('product-options', 'values', $productOption->getCode()),
+            $this->client->subResourceIndex(Resources::PRODUCT_OPTIONS, 'values', $productOption->getCode()),
             'en_US',
             'value',
             $optionValueName

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductReviewsContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
 use Webmozart\Assert\Assert;
@@ -43,7 +44,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iWantToBrowseProductReviews(): void
     {
-        $this->client->index('product-reviews');
+        $this->client->index(Resources::PRODUCT_REVIEWS);
     }
 
     /**
@@ -51,7 +52,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iWantToModifyTheProductReview(ReviewInterface $productReview): void
     {
-        $this->client->buildUpdateRequest('product-reviews', (string) $productReview->getId());
+        $this->client->buildUpdateRequest(Resources::PRODUCT_REVIEWS, (string) $productReview->getId());
     }
 
     /**
@@ -93,7 +94,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iChangeStateTheProductReview(string $state, ReviewInterface $productReview): void
     {
-        $this->client->applyTransition('product-reviews', (string) $productReview->getId(), $state);
+        $this->client->applyTransition(Resources::PRODUCT_REVIEWS, (string) $productReview->getId(), $state);
     }
 
     /**
@@ -103,7 +104,7 @@ final class ManagingProductReviewsContext implements Context
     {
         $this->sharedStorage->set('product_review_id', $productReview->getId());
 
-        $this->client->delete('product-reviews', (string) $productReview->getId());
+        $this->client->delete(Resources::PRODUCT_REVIEWS, (string) $productReview->getId());
     }
 
     /**
@@ -221,14 +222,14 @@ final class ManagingProductReviewsContext implements Context
 
     private function isItemOnIndex(string $property, string $value): bool
     {
-        return $this->responseChecker->hasItemWithValue($this->client->index('product-reviews'), $property, $value);
+        return $this->responseChecker->hasItemWithValue($this->client->index(Resources::PRODUCT_REVIEWS), $property, $value);
     }
 
     /** @param string|int $value */
     private function assertIfReviewHasElementWithValue(ReviewInterface $productReview, string $element, $value): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('product-reviews', (string) $productReview->getId()), $element, $value),
+            $this->responseChecker->hasValue($this->client->show(Resources::PRODUCT_REVIEWS, (string) $productReview->getId()), $element, $value),
             sprintf('Product review %s is not %s', $element, $value)
         );
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -46,7 +47,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function iWantToCreateANewProductVariant(ProductInterface $product): void
     {
-        $this->client->buildCreateRequest('product-variants');
+        $this->client->buildCreateRequest(Resources::PRODUCT_VARIANTS);
         $this->client->addRequestData('product', $this->iriConverter->getIriFromItem($product));
     }
 
@@ -150,7 +151,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theProductVariantShouldAppearInTheShop(string $productVariantCode, ProductInterface $product): void
     {
-        $response = $this->client->index('product-variants');
+        $response = $this->client->index(Resources::PRODUCT_VARIANTS);
 
         Assert::true($this->responseChecker->hasItemWithValue($response, 'code', $productVariantCode));
     }
@@ -160,7 +161,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theVariantWithCodeShouldBePricedAtForChannel(ProductVariantInterface $productVariant, int $price, ChannelInterface $channel): void
     {
-        $response = $this->responseChecker->getCollection($this->client->index('product-variants'));
+        $response = $this->responseChecker->getCollection($this->client->index(Resources::PRODUCT_VARIANTS));
 
         Assert::same($response[0]['channelPricings'][$channel->getCode()]['price'], $price);
     }
@@ -170,7 +171,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theVariantWithCodeShouldHaveMinimumPriceForChannel(ProductVariantInterface $productVariant, int $minimumPrice, ChannelInterface $channel): void
     {
-        $response = $this->responseChecker->getCollection($this->client->index('product-variants'));
+        $response = $this->responseChecker->getCollection($this->client->index(Resources::PRODUCT_VARIANTS));
 
         Assert::same($response[0]['channelPricings'][$channel->getCode()]['minimumPrice'], $minimumPrice);
     }
@@ -181,7 +182,7 @@ final class ManagingProductVariantsContext implements Context
         ?int $price,
         string $field
     ): void {
-        $this->client->buildUpdateRequest('product-variants', $variant->getCode());
+        $this->client->buildUpdateRequest(Resources::PRODUCT_VARIANTS, $variant->getCode());
 
         $content = $this->client->getContent();
         $content['channelPricings'][$channel->getCode()][$field] = $price;
@@ -196,7 +197,7 @@ final class ManagingProductVariantsContext implements Context
         ProductInterface $product,
         ChannelInterface $channel
     ): void {
-        $this->client->buildCreateRequest('product-variants');
+        $this->client->buildCreateRequest(Resources::PRODUCT_VARIANTS);
         $this->client->addRequestData('product', $this->iriConverter->getIriFromItem($product));
         $this->client->addRequestData('code', StringInflector::nameToCode($name));
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -73,7 +74,7 @@ final class ManagingProductsContext implements Context
      */
     public function iWantToBrowseProducts(): void
     {
-        $this->client->index('products');
+        $this->client->index(Resources::PRODUCTS);
 
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
@@ -86,7 +87,7 @@ final class ManagingProductsContext implements Context
         /** @var AdminUserInterface $adminUser */
         $adminUser = $this->sharedStorage->get('administrator');
 
-        $this->client->buildUpdateRequest('administrators', (string) $adminUser->getId());
+        $this->client->buildUpdateRequest(Resources::ADMINISTRATORS, (string) $adminUser->getId());
 
         $this->client->updateRequestData(['localeCode' => $localeCode]);
         $this->client->update();
@@ -97,7 +98,7 @@ final class ManagingProductsContext implements Context
      */
     public function iWantToCreateANewConfigurableProduct(): void
     {
-        $this->client->buildCreateRequest('products');
+        $this->client->buildCreateRequest(Resources::PRODUCTS);
     }
 
     /**
@@ -160,7 +161,7 @@ final class ManagingProductsContext implements Context
         /** @var ProductInterface $product */
         $product = $this->sharedStorage->get('product');
 
-        $productOptions = $this->responseChecker->getValue($this->client->show('products', $product->getCode()), 'options');
+        $productOptions = $this->responseChecker->getValue($this->client->show(Resources::PRODUCTS, $product->getCode()), 'options');
 
         $productOptions[] = $this->iriConverter->getIriFromItem($productOption);
 
@@ -208,7 +209,7 @@ final class ManagingProductsContext implements Context
      */
     public function iDeleteProduct(ProductInterface $product): void
     {
-        $this->client->delete('products', $product->getCode());
+        $this->client->delete(Resources::PRODUCTS, $product->getCode());
     }
 
     /**
@@ -217,7 +218,7 @@ final class ManagingProductsContext implements Context
      */
     public function iWantToModifyAProduct(ProductInterface $product): void
     {
-        $this->client->buildUpdateRequest('products', $product->getCode());
+        $this->client->buildUpdateRequest(Resources::PRODUCTS, $product->getCode());
     }
 
     /**
@@ -239,7 +240,7 @@ final class ManagingProductsContext implements Context
      */
     public function theProductShouldAppearInTheShop(string $productName): void
     {
-        $response = $this->client->index('products');
+        $response = $this->client->index(Resources::PRODUCTS);
 
         Assert::true(
             $this->responseChecker->hasItemWithTranslation($response, 'en_US', 'name', $productName)
@@ -365,7 +366,7 @@ final class ManagingProductsContext implements Context
     {
         $this->client->addRequestData('code', '_NEW');
         $this->client->update();
-        $this->client->index('products');
+        $this->client->index(Resources::PRODUCTS);
 
         Assert::false(
             $this->responseChecker->hasItemOnPositionWithValue(
@@ -384,7 +385,7 @@ final class ManagingProductsContext implements Context
      */
     public function thisProductMainTaxonShouldBe(ProductInterface $product, TaxonInterface $taxon): void
     {
-        $response = $this->client->show('products', $product->getCode());
+        $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         $mainTaxon = $this->responseChecker->getValue($response, 'mainTaxon');
 
@@ -396,7 +397,7 @@ final class ManagingProductsContext implements Context
      */
     public function thisProductNameShouldBe(ProductInterface $product, string $name): void
     {
-        $response = $this->client->show('products', $product->getCode());
+        $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         Assert::true(
             $this->responseChecker->hasTranslation($response, 'en_US', 'name', $name),
@@ -409,7 +410,7 @@ final class ManagingProductsContext implements Context
      */
     public function productShouldNotExist(ProductInterface $product): void
     {
-        $response = $this->client->index('products');
+        $response = $this->client->index(Resources::PRODUCTS);
 
         Assert::false(
             $this->responseChecker->hasItemWithValue($response, 'code', $product->getCode()),
@@ -422,7 +423,7 @@ final class ManagingProductsContext implements Context
      */
     public function thisProductShouldHaveOption(ProductInterface $product, ProductOptionInterface $productOption): void
     {
-        $response = $this->client->show('products', $product->getCode());
+        $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         $productFromResponse = $this->responseChecker->getResponseContent($response);
 
@@ -450,7 +451,7 @@ final class ManagingProductsContext implements Context
      */
     public function productSlugShouldBe(ProductInterface $product, string $slug, $localeCode = 'en_US'): void
     {
-        $response = $this->client->show('products', $product->getCode());
+        $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         Assert::true(
             $this->responseChecker->hasTranslation($response, $localeCode, 'slug', $slug),
@@ -463,7 +464,7 @@ final class ManagingProductsContext implements Context
      */
     public function thereAreNoProductReviews(ProductInterface $product): void
     {
-        $response = $this->client->index('product-reviews');
+        $response = $this->client->index(Resources::PRODUCT_REVIEWS);
 
         Assert::isEmpty(
             $this->responseChecker->getCollectionItemsWithValue(
@@ -480,7 +481,7 @@ final class ManagingProductsContext implements Context
      */
     public function productShouldExistInTheProductCatalog(ProductInterface $product): void
     {
-        $response = $this->client->index('products');
+        $response = $this->client->index(Resources::PRODUCTS);
         $code = $product->getCode();
 
         Assert::true(
@@ -494,7 +495,7 @@ final class ManagingProductsContext implements Context
      */
     public function productShouldStillHaveAnAccessibleImage(ProductInterface $product): void
     {
-        $response = $this->client->show('products', $product->getCode());
+        $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         Assert::true($this->hasProductImage($response, $product), 'Image does not exists');
     }
@@ -504,7 +505,7 @@ final class ManagingProductsContext implements Context
      */
     public function productWithNameShouldNotBeAdded(string $field, string $value): void
     {
-        Assert::false($this->hasProductWithFieldValue($this->client->index('products'), $field, $value));
+        Assert::false($this->hasProductWithFieldValue($this->client->index(Resources::PRODUCTS), $field, $value));
     }
 
     private function getAdminLocaleCode(): string
@@ -512,7 +513,7 @@ final class ManagingProductsContext implements Context
         /** @var AdminUserInterface $adminUser */
         $adminUser = $this->sharedStorage->get('administrator');
 
-        $response = $this->client->show('administrators', (string) $adminUser->getId());
+        $response = $this->client->show(Resources::ADMINISTRATORS, (string) $adminUser->getId());
 
         return $this->responseChecker->getValue($response, 'localeCode');
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -338,7 +338,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldSeeProductWith(string $field, string $value): void
     {
-        $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
+        $response = $this->getLastResponse();
 
         Assert::true(
             $this->hasProductWithFieldValue($response, $field, $value),
@@ -351,7 +351,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldNotSeeAnyProductWith(string $field, string $value): void
     {
-        $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
+        $response = $this->getLastResponse();
 
         Assert::false(
             $this->responseChecker->hasItemWithTranslation($response, 'en_US', $field, $value),
@@ -438,7 +438,7 @@ final class ManagingProductsContext implements Context
      */
     public function theFirstProductOnTheListShouldHave(string $field, string $value): void
     {
-        $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
+        $response = $this->getLastResponse();
 
         $products = $this->responseChecker->getCollection($response);
 
@@ -552,5 +552,10 @@ final class ManagingProductsContext implements Context
         }
 
         return false;
+    }
+
+    private function getLastResponse(): Response
+    {
+        return $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Core\Model\PromotionInterface;
 use Webmozart\Assert\Assert;
 
@@ -39,7 +40,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iWantToBrowsePromotions(): void
     {
-        $this->client->index('promotions');
+        $this->client->index(Resources::PROMOTIONS);
     }
 
     /**
@@ -47,7 +48,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iWantToCreateANewPromotion(): void
     {
-        $this->client->buildCreateRequest('promotions');
+        $this->client->buildCreateRequest(Resources::PROMOTIONS);
     }
 
     /**
@@ -138,7 +139,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iDeletePromotion(PromotionInterface $promotion): void
     {
-        $this->client->delete('promotions', $promotion->getCode());
+        $this->client->delete(Resources::PROMOTIONS, $promotion->getCode());
     }
 
     /**
@@ -157,7 +158,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function promotionShouldNotExistInTheRegistry(PromotionInterface $promotion): void
     {
-        $response = $this->client->index('promotions');
+        $response = $this->client->index(Resources::PROMOTIONS);
         $promotionName = (string) $promotion->getName();
 
         Assert::false(
@@ -180,7 +181,7 @@ final class ManagingPromotionsContext implements Context
     public function thePromotionShouldNotAppliesToDiscountedItems(PromotionInterface $promotion): void
     {
         Assert::false(
-            $this->responseChecker->getValue($this->client->show('promotions', $promotion->getCode()), 'appliesToDiscounted')
+            $this->responseChecker->getValue($this->client->show(Resources::PROMOTIONS, $promotion->getCode()), 'appliesToDiscounted')
         );
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
@@ -18,6 +18,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -44,7 +45,7 @@ final class ManagingShipmentsContext implements Context
      */
     public function iBrowseShipments(): void
     {
-        $this->client->index('shipments');
+        $this->client->index(Resources::SHIPMENTS);
     }
 
     /**
@@ -84,7 +85,7 @@ final class ManagingShipmentsContext implements Context
      */
     public function iViewTheShipmentOfTheOrder(OrderInterface $order): void
     {
-        $response = $this->client->show('shipments', (string) $order->getShipments()->first()->getId());
+        $response = $this->client->show(Resources::SHIPMENTS, (string) $order->getShipments()->first()->getId());
 
         $this->sharedStorage->set('response', $response);
     }
@@ -103,7 +104,7 @@ final class ManagingShipmentsContext implements Context
      */
     public function iShipShipmentOfOrder(OrderInterface $order): void
     {
-        $this->client->applyTransition('shipments', (string) $order->getShipments()->first()->getId(), ShipmentTransitions::TRANSITION_SHIP);
+        $this->client->applyTransition(Resources::SHIPMENTS, (string) $order->getShipments()->first()->getId(), ShipmentTransitions::TRANSITION_SHIP);
     }
 
     /**
@@ -126,7 +127,7 @@ final class ManagingShipmentsContext implements Context
     public function iShipTheShipmentOfOrderWithTrackingCode(OrderInterface $order, string $trackingCode): void
     {
         $this->client->applyTransition(
-            'shipments',
+            Resources::SHIPMENTS,
             (string) $order->getShipments()->first()->getId(),
             ShipmentTransitions::TRANSITION_SHIP,
             ['tracking' => $trackingCode]
@@ -159,7 +160,7 @@ final class ManagingShipmentsContext implements Context
     public function iShouldSeeTheShipmentOfOrderAs(OrderInterface $order, string $shippingState): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValues($this->client->index('shipments'), [
+            $this->responseChecker->hasItemWithValues($this->client->index(Resources::SHIPMENTS), [
                 'order' => $this->iriConverter->getIriFromItem($order),
                 'state' => strtolower($shippingState),
             ]),
@@ -189,7 +190,7 @@ final class ManagingShipmentsContext implements Context
     public function iShouldSeeTheShippingDateAs(OrderInterface $order, string $dateTime): void
     {
         Assert::eq(
-            new \DateTime($this->responseChecker->getValue($this->client->show('shipments', (string) $order->getShipments()->first()->getId()), 'shippedAt')),
+            new \DateTime($this->responseChecker->getValue($this->client->show(Resources::SHIPMENTS, (string) $order->getShipments()->first()->getId()), 'shippedAt')),
             new \DateTime($dateTime),
             'Shipment was shipped in different date'
         );
@@ -205,7 +206,7 @@ final class ManagingShipmentsContext implements Context
         CustomerInterface $customer,
         ChannelInterface $channel = null
     ): void {
-        $this->client->index('shipments');
+        $this->client->index(Resources::SHIPMENTS);
 
         foreach ($this->responseChecker->getCollectionItemsWithValue(
             $this->client->getLastResponse(),

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShippingCategoriesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Webmozart\Assert\Assert;
 
@@ -36,7 +37,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iWantToCreateANewShippingCategory(): void
     {
-        $this->client->buildCreateRequest('shipping-categories');
+        $this->client->buildCreateRequest(Resources::SHIPPING_CATEGORIES);
     }
 
     /**
@@ -44,7 +45,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iWantToModifyAShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
-        $this->client->buildUpdateRequest('shipping-categories', $shippingCategory->getCode());
+        $this->client->buildUpdateRequest(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
     /**
@@ -60,7 +61,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iDeleteShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
-        $this->client->delete('shipping-categories', $shippingCategory->getCode());
+        $this->client->delete(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
     /**
@@ -68,7 +69,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iBrowseShippingCategories(): void
     {
-        $this->client->index('shipping-categories');
+        $this->client->index(Resources::SHIPPING_CATEGORIES);
     }
 
     /**
@@ -99,7 +100,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iModifyAShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
-        $this->client->buildUpdateRequest('shipping-categories', $shippingCategory->getCode());
+        $this->client->buildUpdateRequest(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
     /**
@@ -146,7 +147,7 @@ final class ManagingShippingCategoriesContext implements Context
      */
     public function iShouldSeeShippingCategoriesInTheList(int $count = 1): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('shipping-categories')), $count);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::SHIPPING_CATEGORIES)), $count);
     }
 
     /**
@@ -204,7 +205,7 @@ final class ManagingShippingCategoriesContext implements Context
     public function thereShouldStillBeOnlyOneShippingCategoryWith(string $code): void
     {
         Assert::same(
-            count($this->responseChecker->getCollectionItemsWithValue($this->client->index('shipping-categories'), 'code', $code)),
+            count($this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::SHIPPING_CATEGORIES), 'code', $code)),
             1
         );
     }
@@ -255,7 +256,7 @@ final class ManagingShippingCategoriesContext implements Context
 
     private function isItemOnIndex(string $property, string $value): bool
     {
-        $this->client->index('shipping-categories');
+        $this->client->index(Resources::SHIPPING_CATEGORIES);
 
         return $this->responseChecker->hasItemWithValue($this->client->getLastResponse(), $property, $value);
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -54,7 +55,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iAmBrowsingArchivalShippingMethods(): void
     {
-        $this->client->index('shipping-methods');
+        $this->client->index(Resources::SHIPPING_METHODS);
         $this->client->addFilter('exists[archivedAt]', true);
         $this->client->filter();
     }
@@ -80,7 +81,7 @@ final class ManagingShippingMethodsContext implements Context
         /** @var AdminUserInterface $adminUser */
         $adminUser = $this->sharedStorage->get('administrator');
 
-        $this->client->buildUpdateRequest('administrators', (string) $adminUser->getId());
+        $this->client->buildUpdateRequest(Resources::ADMINISTRATORS, (string) $adminUser->getId());
 
         $this->client->updateRequestData(['localeCode' => $localeCode]);
         $this->client->update();
@@ -94,7 +95,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iBrowseShippingMethods(): void
     {
-        $response = $this->client->index('shipping-methods');
+        $response = $this->client->index(Resources::SHIPPING_METHODS);
 
         $this->sharedStorage->set('response', $response);
     }
@@ -104,7 +105,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iDeleteShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
-        $this->client->delete('shipping-methods', $shippingMethod->getCode());
+        $this->client->delete(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
     /**
@@ -113,7 +114,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iWantToCreateANewShippingMethod(): void
     {
-        $this->client->buildCreateRequest('shipping-methods');
+        $this->client->buildCreateRequest(Resources::SHIPPING_METHODS);
     }
 
     /**
@@ -121,7 +122,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iTryToCreateANewShippingMethodWithValidData(): void
     {
-        $this->client->buildCreateRequest('shipping-methods');
+        $this->client->buildCreateRequest(Resources::SHIPPING_METHODS);
         $this->client->setRequestData([
             'code' => 'FED_EX_CARRIER',
             'position' => 0,
@@ -137,7 +138,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iTryToShowShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
-        $this->client->show('shipping-methods', $shippingMethod->getCode());
+        $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
     /**
@@ -235,8 +236,8 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iArchiveTheShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
-        $this->client->customItemAction('shipping-methods', $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'archive');
-        $this->client->index('shipping-methods');
+        $this->client->customItemAction(Resources::SHIPPING_METHODS, $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'archive');
+        $this->client->index(Resources::SHIPPING_METHODS);
     }
 
     /**
@@ -244,7 +245,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iTryToRestoreTheShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
-        $this->client->customItemAction('shipping-methods', $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'restore');
+        $this->client->customItemAction(Resources::SHIPPING_METHODS, $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'restore');
     }
 
     /**
@@ -262,7 +263,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iWantToModifyShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
-        $this->client->buildUpdateRequest('shipping-methods', $shippingMethod->getCode());
+        $this->client->buildUpdateRequest(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
     /**
@@ -322,7 +323,7 @@ final class ManagingShippingMethodsContext implements Context
     public function theShippingMethodShouldAppearInTheRegistry(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithTranslation($this->client->index('shipping-methods'), 'en_US', 'name', $name),
+            $this->responseChecker->hasItemWithTranslation($this->client->index(Resources::SHIPPING_METHODS), 'en_US', 'name', $name),
             sprintf('Shipping method with name %s does not exists', $name)
         );
     }
@@ -335,7 +336,7 @@ final class ManagingShippingMethodsContext implements Context
         $name = $shippingMethod->getName();
 
         Assert::true(
-            $this->responseChecker->hasItemWithTranslation($this->client->index('shipping-methods'), 'en_US', 'name', $name),
+            $this->responseChecker->hasItemWithTranslation($this->client->index(Resources::SHIPPING_METHODS), 'en_US', 'name', $name),
             sprintf('Shipping method with name %s does not exists', $name)
         );
     }
@@ -359,7 +360,7 @@ final class ManagingShippingMethodsContext implements Context
         $shippingMethodName = $shippingMethod->getName();
 
         Assert::false(
-            $this->responseChecker->hasItemWithTranslation($this->client->index('shipping-methods'), 'en_US', 'name', $shippingMethodName),
+            $this->responseChecker->hasItemWithTranslation($this->client->index(Resources::SHIPPING_METHODS), 'en_US', 'name', $shippingMethodName),
             sprintf('Shipping method with name %s does not exists', $shippingMethodName)
         );
     }
@@ -390,7 +391,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasValueInCollection(
-                $this->client->show('shipping-methods', $shippingMethod->getCode()),
+                $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode()),
                 'channels',
                 $this->iriConverter->getIriFromItem($channel)
             ),
@@ -406,7 +407,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasTranslation(
-                $this->client->show('shipping-methods', $shippingMethod->getCode()),
+                $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode()),
                 'en_US',
                 'name',
                 $name
@@ -422,7 +423,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasValue(
-                $this->client->show('shipping-methods', $shippingMethod->getCode()),
+                $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode()),
                 'enabled',
                 false
             ),
@@ -437,7 +438,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasValue(
-                $this->client->show('shipping-methods', $shippingMethod->getCode()),
+                $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode()),
                 'enabled',
                 true
             ),
@@ -490,7 +491,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function thereShouldStillBeOnlyOneShippingMethodWith(string $value): void
     {
-        $response = $this->client->index('shipping-methods');
+        $response = $this->client->index(Resources::SHIPPING_METHODS);
         $itemsCount = $this->responseChecker->countCollectionItems($response);
 
         Assert::same($itemsCount, 1, sprintf('Expected 1 shipping method, but got %d', $itemsCount));
@@ -514,7 +515,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iShouldSeeShippingMethodOnTheList(int $amount): void
     {
-        $this->client->index('shipping-methods');
+        $this->client->index(Resources::SHIPPING_METHODS);
 
         $response = $this->client->getLastResponse();
         $itemsCount = $this->responseChecker->countCollectionItems($response);
@@ -561,7 +562,7 @@ final class ManagingShippingMethodsContext implements Context
     public function theShippingMethodWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('shipping-methods'), $element, $value),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::SHIPPING_METHODS), $element, $value),
             sprintf('Shipping method should not have %s "%s", but it does,', $element, $value)
         );
     }
@@ -611,7 +612,7 @@ final class ManagingShippingMethodsContext implements Context
         /** @var AdminUserInterface $adminUser */
         $adminUser = $this->sharedStorage->get('administrator');
 
-        $response = $this->client->show('administrators', (string) $adminUser->getId());
+        $response = $this->client->show(Resources::ADMINISTRATORS, (string) $adminUser->getId());
 
         return $this->responseChecker->getValue($response, 'localeCode');
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxCategoriesContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Admin;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 use Webmozart\Assert\Assert;
 
@@ -36,7 +37,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iWantToCreateNewTaxCategory(): void
     {
-        $this->client->buildCreateRequest('tax-categories');
+        $this->client->buildCreateRequest(Resources::TAX_CATEGORIES);
     }
 
     /**
@@ -45,7 +46,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iWantToModifyTaxCategory(TaxCategoryInterface $taxCategory): void
     {
-        $this->client->buildUpdateRequest('tax-categories', $taxCategory->getCode());
+        $this->client->buildUpdateRequest(Resources::TAX_CATEGORIES, $taxCategory->getCode());
     }
 
     /**
@@ -53,7 +54,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iDeleteTaxCategory(TaxCategoryInterface $taxCategory): void
     {
-        $this->client->delete('tax-categories', $taxCategory->getCode());
+        $this->client->delete(Resources::TAX_CATEGORIES, $taxCategory->getCode());
     }
 
     /**
@@ -116,7 +117,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iWantToBrowseTaxCategories(): void
     {
-        $this->client->index('tax-categories');
+        $this->client->index(Resources::TAX_CATEGORIES);
     }
 
     /**
@@ -163,7 +164,7 @@ final class ManagingTaxCategoriesContext implements Context
     public function thisTaxCategoryNameShouldBe(TaxCategoryInterface $taxCategory, string $taxCategoryName): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('tax-categories', $taxCategory->getCode()), 'name', $taxCategoryName),
+            $this->responseChecker->hasValue($this->client->show(Resources::TAX_CATEGORIES, $taxCategory->getCode()), 'name', $taxCategoryName),
             sprintf('Tax category name is not %s', $taxCategoryName)
         );
     }
@@ -185,7 +186,7 @@ final class ManagingTaxCategoriesContext implements Context
     public function thereShouldStillBeOnlyOneTaxCategoryWith(string $element, string $value): void
     {
         Assert::same(
-            count($this->responseChecker->getCollectionItemsWithValue($this->client->index('tax-categories'), $element, $value)),
+            count($this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::TAX_CATEGORIES), $element, $value)),
             1
         );
     }
@@ -252,6 +253,6 @@ final class ManagingTaxCategoriesContext implements Context
 
     private function isItemOnIndex(string $property, string $value): bool
     {
-        return $this->responseChecker->hasItemWithValue($this->client->index('tax-categories'), $property, $value);
+        return $this->responseChecker->hasItemWithValue($this->client->index(Resources::TAX_CATEGORIES), $property, $value);
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
@@ -55,7 +56,7 @@ final class ManagingZonesContext implements Context
      */
     public function iWantToCreateANewZoneConsistingOfCountry(string $memberType): void
     {
-        $this->client->buildCreateRequest('zones');
+        $this->client->buildCreateRequest(Resources::ZONES);
         $this->client->addRequestData('type', $memberType);
     }
 
@@ -137,7 +138,7 @@ final class ManagingZonesContext implements Context
      */
     public function iWantToSeeAllZonesInStore(): void
     {
-        $this->client->index('zones');
+        $this->client->index(Resources::ZONES);
     }
 
     /**
@@ -145,7 +146,7 @@ final class ManagingZonesContext implements Context
      */
     public function iDeleteZoneNamed(ZoneInterface $zone): void
     {
-        $this->client->delete('zones', $zone->getCode());
+        $this->client->delete(Resources::ZONES, $zone->getCode());
     }
 
     /**
@@ -167,7 +168,7 @@ final class ManagingZonesContext implements Context
     public function iDeleteThem(): void
     {
         foreach ($this->sharedStorage->get('zone_to_delete') as $code) {
-            $this->client->delete('zones', $code);
+            $this->client->delete(Resources::ZONES, $code);
         }
     }
 
@@ -176,7 +177,7 @@ final class ManagingZonesContext implements Context
      */
     public function iWantToModifyTheZoneNamed(ZoneInterface $zone): void
     {
-        $this->client->buildUpdateRequest('zones', $zone->getCode());
+        $this->client->buildUpdateRequest(Resources::ZONES, $zone->getCode());
     }
 
     /**
@@ -219,7 +220,7 @@ final class ManagingZonesContext implements Context
         CountryInterface $country
     ): void {
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('zones', 'members', $zone->getCode()),
+            $this->client->subResourceIndex(Resources::ZONES, 'members', $zone->getCode()),
             'code',
             $country->getCode()
         ));
@@ -261,7 +262,7 @@ final class ManagingZonesContext implements Context
         ProvinceInterface $province
     ): void {
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('zones', 'members', $zone->getCode()),
+            $this->client->subResourceIndex(Resources::ZONES, 'members', $zone->getCode()),
             'code',
             $province->getCode()
         ));
@@ -275,7 +276,7 @@ final class ManagingZonesContext implements Context
         ZoneInterface $otherZone
     ): void {
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('zones', 'members', $zone->getCode()),
+            $this->client->subResourceIndex(Resources::ZONES, 'members', $zone->getCode()),
             'code',
             $otherZone->getCode()
         ));
@@ -287,7 +288,7 @@ final class ManagingZonesContext implements Context
     public function itsScopeShouldBe(string $scope): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('zones', 'EU'), 'scope', $scope),
+            $this->responseChecker->hasValue($this->client->show(Resources::ZONES, 'EU'), 'scope', $scope),
             sprintf('Its Zone does not have %s scope', $scope)
         );
     }
@@ -298,7 +299,7 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldSeeZonesInTheList(int $count = 1): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('zones')), $count);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::ZONES)), $count);
     }
 
     /**
@@ -308,7 +309,7 @@ final class ManagingZonesContext implements Context
     public function iShouldSeeTheZoneNamedInTheList(string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasItemWithValue($this->client->index('zones'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::ZONES), 'name', $name),
             sprintf('There is no zone with name "%s"', $name)
         );
     }
@@ -319,7 +320,7 @@ final class ManagingZonesContext implements Context
     public function thereShouldStillBeOnlyOneZoneWithCode(string $code): void
     {
         Assert::count(
-            $this->responseChecker->getCollectionItemsWithValue($this->client->index('zones'), 'code', $code),
+            $this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::ZONES), 'code', $code),
             1,
             sprintf('There should be only one zone with code "%s"', $code)
         );
@@ -331,7 +332,7 @@ final class ManagingZonesContext implements Context
     public function theZoneNamedShouldNoLongerExistInTheRegistry(string $name): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('zones'), 'name', $name),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::ZONES), 'name', $name),
             sprintf('Zone with name %s exists', $name)
         );
     }
@@ -342,7 +343,7 @@ final class ManagingZonesContext implements Context
     public function zoneShouldNotBeAdded(string $field, string $value): void
     {
         Assert::false(
-            $this->responseChecker->hasItemWithValue($this->client->index('zones'), $field, $value),
+            $this->responseChecker->hasItemWithValue($this->client->index(Resources::ZONES), $field, $value),
             sprintf('Zone with %s %s exists', $field, $value)
         );
     }
@@ -353,13 +354,13 @@ final class ManagingZonesContext implements Context
     public function thisZoneShouldHaveOnlyTheProvinceMember(ZoneInterface $zone, ZoneMemberInterface $zoneMember): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(
-            $this->client->subResourceIndex('zones', 'members', $zone->getCode()),
+            $this->client->subResourceIndex(Resources::ZONES, 'members', $zone->getCode()),
             'code',
             $zoneMember->getCode()
         ));
 
         Assert::same(
-            $this->responseChecker->countCollectionItems($this->client->subResourceIndex('zones', 'members', $zone->getCode())),
+            $this->responseChecker->countCollectionItems($this->client->subResourceIndex(Resources::ZONES, 'members', $zone->getCode())),
             1
         );
     }
@@ -370,7 +371,7 @@ final class ManagingZonesContext implements Context
     public function thisZoneNameShouldBe(ZoneInterface $zone, string $name): void
     {
         Assert::true(
-            $this->responseChecker->hasValue($this->client->show('zones', $zone->getCode()), 'name', $name),
+            $this->responseChecker->hasValue($this->client->show(Resources::ZONES, $zone->getCode()), 'name', $name),
             sprintf('Its Zone does not have name %s.', $name)
         );
     }

--- a/src/Sylius/Behat/Context/Api/Resources.php
+++ b/src/Sylius/Behat/Context/Api/Resources.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Api;
+
+final class Resources
+{
+    public const ADDRESSES = 'addresses';
+    public const ADMINISTRATORS = 'administrators';
+    public const AVATAR_IMAGES = 'avatar-images';
+    public const CATALOG_PROMOTIONS = 'catalog-promotions';
+    public const CHANNELS = 'channels';
+    public const COUNTRIES = 'countries';
+    public const CURRENCIES = 'currencies';
+    public const CUSTOMER_GROUPS = 'customer-groups';
+    public const CUSTOMERS = 'customers';
+    public const EXCHANGE_RATES = 'exchange-rates';
+    public const LOCALES = 'locales';
+    public const ORDER_ITEM_UNITS = 'order-item-units';
+    public const ORDER_ITEMS = 'order-item-units';
+    public const ORDERS = 'orders';
+    public const PAYMENT_METHODS = 'payment-methods';
+    public const PAYMENTS = 'payments';
+    public const PRODUCT_ASSOCIATION_TYPES = 'product-association-types';
+    public const PRODUCT_OPTIONS = 'product-options';
+    public const PRODUCT_REVIEWS = 'product-reviews';
+    public const PRODUCT_VARIANTS = 'product-variants';
+    public const PRODUCTS = 'products';
+    public const PROMOTIONS = 'promotions';
+    public const PROVINCES = 'provinces';
+    public const SHIPMENTS = 'shipments';
+    public const SHIPPING_CATEGORIES = 'shipping-categories';
+    public const SHIPPING_METHODS = 'shipping-methods';
+    public const TAX_CATEGORIES = 'tax-categories';
+    public const ZONES = 'zones';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Sylius/Behat/Context/Api/Shop/AddressContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/AddressContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Core\Model\AddressInterface;
@@ -49,7 +50,7 @@ final class AddressContext implements Context
      */
     public function iAmEditingTheAddressOf(AddressInterface $address): void
     {
-        $this->client->buildUpdateRequest('addresses', (string) $address->getId());
+        $this->client->buildUpdateRequest(Resources::ADDRESSES, (string) $address->getId());
     }
 
     /**
@@ -57,7 +58,7 @@ final class AddressContext implements Context
      */
     public function iWantToAddANewAddressToMyAddressBook(): void
     {
-        $this->client->buildCreateRequest('addresses');
+        $this->client->buildCreateRequest(Resources::ADDRESSES);
     }
 
     /**
@@ -130,7 +131,7 @@ final class AddressContext implements Context
      */
     public function iBrowseMyAddresses(): void
     {
-        $this->client->index('addresses');
+        $this->client->index(Resources::ADDRESSES);
     }
 
     /**
@@ -140,7 +141,7 @@ final class AddressContext implements Context
     {
         $id = $this->getAddressIdFromAddressBookByFullName($fullName);
 
-        $this->client->delete('addresses', $id);
+        $this->client->delete(Resources::ADDRESSES, $id);
     }
 
     /**
@@ -148,7 +149,7 @@ final class AddressContext implements Context
      */
     public function iDeleteTheAddressBelongsTo(AddressInterface $address): void
     {
-        $this->client->delete('addresses', (string) $address->getId());
+        $this->client->delete(Resources::ADDRESSES, (string) $address->getId());
     }
 
     /**
@@ -158,7 +159,7 @@ final class AddressContext implements Context
     {
         $addressIri = $this->getAddressIriFromAddressBookByFullName($fullName);
 
-        $this->client->buildUpdateRequest('customers', (string) $this->sharedStorage->get('user')->getCustomer()->getId());
+        $this->client->buildUpdateRequest(Resources::CUSTOMERS, (string) $this->sharedStorage->get('user')->getCustomer()->getId());
         $this->client->addRequestData('defaultAddress', $addressIri);
         $this->client->update();
     }
@@ -168,7 +169,7 @@ final class AddressContext implements Context
      */
     public function iTryToEditTheAddressOf(AddressInterface $address): void
     {
-        $this->client->buildUpdateRequest('addresses', (string) $address->getId());
+        $this->client->buildUpdateRequest(Resources::ADDRESSES, (string) $address->getId());
     }
 
     /**
@@ -286,7 +287,7 @@ final class AddressContext implements Context
      */
     public function iShouldHaveAddresses(int $count = 1): void
     {
-        Assert::same(count($this->responseChecker->getCollection($this->client->index('addresses'))), $count);
+        Assert::same(count($this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES))), $count);
     }
 
     /**
@@ -319,7 +320,7 @@ final class AddressContext implements Context
      */
     public function thereShouldBeNoAddresses(): void
     {
-        Assert::same(count($this->responseChecker->getCollection($this->client->index('addresses'))), 0);
+        Assert::same(count($this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES))), 0);
     }
 
     /**
@@ -344,7 +345,7 @@ final class AddressContext implements Context
      */
     public function addressShouldBeMarkedAsMyDefaultAddress(AddressInterface $address): void
     {
-        $customerResponse = $this->client->show('customers', (string) $this->sharedStorage->get('user')->getCustomer()->getId());
+        $customerResponse = $this->client->show(Resources::CUSTOMERS, (string) $this->sharedStorage->get('user')->getCustomer()->getId());
         $addressResponse = $this->client->showByIri($this->responseChecker->getValue($customerResponse, 'defaultAddress'));
 
         Assert::true($this->responseChecker->hasValue($addressResponse, 'city', $address->getCity()));
@@ -408,7 +409,7 @@ final class AddressContext implements Context
      */
     public function iShouldHaveNoDefaultAddress(): void
     {
-        $userShowResponse = $this->client->show('customers', (string) $this->sharedStorage->get('user')->getCustomer()->getId());
+        $userShowResponse = $this->client->show(Resources::CUSTOMERS, (string) $this->sharedStorage->get('user')->getCustomer()->getId());
         Assert::null(
             $this->responseChecker->getValue($userShowResponse, 'defaultAddress'),
             'Default address should be null'
@@ -499,7 +500,7 @@ final class AddressContext implements Context
         Assert::notNull($fullName);
         [$firstName, $lastName] = explode(' ', $fullName);
 
-        $addresses = $this->responseChecker->getCollection($this->client->index('addresses'));
+        $addresses = $this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES));
         /** @var AddressInterface $address */
         foreach ($addresses as $address) {
             if ($firstName === $address['firstName'] && $lastName === $address['lastName']) {

--- a/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Webmozart\Assert\Assert;
@@ -39,7 +40,7 @@ final class ChannelContext implements Context
         $this->sharedStorage->set('hostname', $channel->getHostname());
         $this->sharedStorage->remove('current_locale_code');
 
-        $this->client->show('channels', $channel->getCode());
+        $this->client->show(Resources::CHANNELS, $channel->getCode());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -18,6 +18,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -147,7 +148,7 @@ final class CheckoutContext implements Context
      */
     public function iChooseForBillingAddress(string $street, string $addressType): void
     {
-        $addressBook = $this->responseChecker->getCollection($this->client->index('addresses'));
+        $addressBook = $this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES));
 
         $addressType .= 'Address';
 
@@ -345,7 +346,7 @@ final class CheckoutContext implements Context
 
         Assert::notSame($response->getStatusCode(), 200);
 
-        $this->client->show('orders', $this->sharedStorage->get('cart_token'));
+        $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
     }
 
     /**
@@ -391,7 +392,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $this->sharedStorage->get('cart_token'),
             HTTPRequest::METHOD_PATCH,
             sprintf('shipments/%s', $this->getCart()['shipments'][0]['id'])
@@ -409,7 +410,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $this->sharedStorage->get('cart_token'),
             HTTPRequest::METHOD_PATCH,
             sprintf('payments/%s', $this->getCart()['payments'][0]['id'])
@@ -480,7 +481,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $this->sharedStorage->get('cart_token'),
             HTTPRequest::METHOD_PATCH,
             \sprintf('payments/%s', $this->getCart()['payments'][0]['id'])
@@ -895,7 +896,7 @@ final class CheckoutContext implements Context
     {
         if ($this->sharedStorage->has('cart_token')) {
             $discountTotal = $this->responseChecker->getValue(
-                $this->client->show('orders', $this->sharedStorage->get('cart_token')),
+                $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token')),
                 'orderPromotionTotal'
             );
 
@@ -912,7 +913,7 @@ final class CheckoutContext implements Context
      */
     public function thereShouldBeNoTaxesCharged(): void
     {
-        $this->client->show('orders', $this->sharedStorage->get('cart_token'));
+        $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
 
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'taxTotal'), 0);
     }
@@ -1081,7 +1082,7 @@ final class CheckoutContext implements Context
 
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $tokenValue,
             HTTPRequest::METHOD_POST,
             'items'
@@ -1198,14 +1199,14 @@ final class CheckoutContext implements Context
             $content['email'] = null;
         }
 
-        $this->client->buildUpdateRequest('orders', $this->getCartTokenValue());
+        $this->client->buildUpdateRequest(Resources::ORDERS, $this->getCartTokenValue());
         $this->client->setRequestData($content);
         $this->client->update();
     }
 
     private function getCart(): array
     {
-        return $this->responseChecker->getResponseContent($this->client->show('orders', $this->getCartTokenValue()));
+        return $this->responseChecker->getResponseContent($this->client->show(Resources::ORDERS, $this->getCartTokenValue()));
     }
 
     private function getCartTokenValue(): ?string
@@ -1223,7 +1224,7 @@ final class CheckoutContext implements Context
 
     private function getCheckoutState(): string
     {
-        $this->client->show('orders', $this->sharedStorage->get('cart_token'));
+        $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
 
         $response = $this->client->getLastResponse();
 
@@ -1232,7 +1233,7 @@ final class CheckoutContext implements Context
 
     private function getCartShippingMethods(array $cart): array
     {
-        $this->client->index('shipping-methods');
+        $this->client->index(Resources::SHIPPING_METHODS);
         $this->client->addFilter('tokenValue', $cart['tokenValue']);
         $this->client->addFilter('shipmentId', $cart['shipments'][0]['id']);
         $this->client->filter();
@@ -1275,7 +1276,7 @@ final class CheckoutContext implements Context
             return [];
         }
 
-        $this->client->index('payment-methods');
+        $this->client->index(Resources::PAYMENT_METHODS);
         $this->client->addFilter('paymentId', $order->getLastPayment()->getId());
         $this->client->addFilter('tokenValue', $order->getTokenValue());
         $this->client->filter();
@@ -1381,7 +1382,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $tokenValue,
             HTTPRequest::METHOD_POST,
             'items'
@@ -1399,7 +1400,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $tokenValue,
             HttpRequest::METHOD_DELETE,
             \sprintf('items/%s', $orderItemId)
@@ -1439,7 +1440,7 @@ final class CheckoutContext implements Context
 
     private function addressShouldBeFilledAs(AddressInterface $address, string $addressType): void
     {
-        $response = $this->client->show('orders', $this->sharedStorage->get('cart_token'));
+        $response = $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
 
         $addressFromResponse = $this->responseChecker->getValue($response, $addressType . 'Address');
 
@@ -1452,7 +1453,7 @@ final class CheckoutContext implements Context
 
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $this->sharedStorage->get('cart_token'),
             HTTPRequest::METHOD_PATCH,
             'complete'
@@ -1467,7 +1468,7 @@ final class CheckoutContext implements Context
     {
         $request = Request::customItemAction(
             'shop',
-            'orders',
+            Resources::ORDERS,
             $this->sharedStorage->get('cart_token'),
             HTTPRequest::METHOD_PATCH,
             sprintf('shipments/%s', $this->getCart()['shipments'][0]['id'])

--- a/src/Sylius/Behat/Context/Api/Shop/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CurrencyContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Webmozart\Assert\Assert;
 
@@ -38,7 +39,7 @@ final class CurrencyContext implements Context
      */
     public function iBrowseCurrencies(): void
     {
-        $this->client->index('currencies');
+        $this->client->index(Resources::CURRENCIES);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -17,6 +17,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Context\Setup\ShopSecurityContext;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -66,7 +67,7 @@ final class CustomerContext implements Context
         $shopUser = $this->sharedStorage->get('user');
         $customer = $shopUser->getCustomer();
 
-        $this->client->buildUpdateRequest('customers', (string) $customer->getId());
+        $this->client->buildUpdateRequest(Resources::CUSTOMERS, (string) $customer->getId());
     }
 
     /**
@@ -79,7 +80,7 @@ final class CustomerContext implements Context
         /** @var CustomerInterface $customer */
         $customer = $shopUser->getCustomer();
 
-        $this->client->buildCustomUpdateRequest('customers', (string) $customer->getId(), 'password');
+        $this->client->buildCustomUpdateRequest(Resources::CUSTOMERS, (string) $customer->getId(), 'password');
     }
 
     /**
@@ -245,7 +246,7 @@ final class CustomerContext implements Context
 
         $this->shopApiSecurityContext->iAmLoggedInAs($email);
 
-        $response = $this->client->show('customers', (string) $shopUser->getCustomer()->getId());
+        $response = $this->client->show(Resources::CUSTOMERS, (string) $shopUser->getCustomer()->getId());
 
         Assert::true($this->responseChecker->hasValue($response, 'email', $email));
     }
@@ -259,7 +260,7 @@ final class CustomerContext implements Context
         /** @var ShopUserInterface $shopUser */
         $shopUser = $this->sharedStorage->get('user');
 
-        $response = $this->client->show('customers', (string) $shopUser->getCustomer()->getId());
+        $response = $this->client->show(Resources::CUSTOMERS, (string) $shopUser->getCustomer()->getId());
 
         Assert::true($this->responseChecker->hasValue($response, 'fullName', $name));
     }
@@ -335,7 +336,7 @@ final class CustomerContext implements Context
      */
     public function iBrowseMyOrders(): void
     {
-        $this->client->index('orders');
+        $this->client->index(Resources::ORDERS);
     }
 
     /**
@@ -356,7 +357,7 @@ final class CustomerContext implements Context
      */
     public function iShouldSeeASingleOrderInTheList(): void
     {
-        Assert::same($this->responseChecker->countCollectionItems($this->client->index('orders')), 1);
+        Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::ORDERS)), 1);
     }
 
     /**
@@ -495,7 +496,7 @@ final class CustomerContext implements Context
 
     private function registerAccount(?string $email = 'example@example.com', ?string $password = 'example'): void
     {
-        $request = Request::create('shop', 'customers', '');
+        $request = Request::create('shop', Resources::CUSTOMERS, '');
 
         $request->setContent([
             'firstName' => 'First',
@@ -522,6 +523,6 @@ final class CustomerContext implements Context
         $user = $this->sharedStorage->get('user');
         $this->loginContext->iLogInAsWithPassword($user->getEmail(), 'sylius');
 
-        return $this->client->show('customers', (string) $user->getCustomer()->getId());
+        return $this->client->show(Resources::CUSTOMERS, (string) $user->getCustomer()->getId());
     }
 }

--- a/src/Sylius/Behat/Context/Api/Shop/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LocaleContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Webmozart\Assert\Assert;
@@ -34,7 +35,7 @@ final class LocaleContext implements Context
      */
     public function iGetAvailableLocales(): void
     {
-       $this->client->index('locales');
+       $this->client->index(Resources::LOCALES);
     }
 
     /**
@@ -42,7 +43,7 @@ final class LocaleContext implements Context
      */
     public function iGetLocale(LocaleInterface $locale): void
     {
-        $this->client->show('locales', $locale->getCode());
+        $this->client->show(Resources::LOCALES, $locale->getCode());
     }
 
     /**
@@ -101,7 +102,7 @@ final class LocaleContext implements Context
      */
     public function iShouldShopUsingTheLocale(string $localeCode): void
     {
-        $this->client->buildCreateRequest('orders');
+        $this->client->buildCreateRequest(Resources::ORDERS);
 
         Assert::same($this->responseChecker->getValue($this->client->create(), 'localeCode'), $localeCode);
     }

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -18,6 +18,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SecurityServiceInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
@@ -92,7 +93,7 @@ final class OrderContext implements Context
      */
     public function iViewTheSummaryOfMyOrder(OrderInterface $order): void
     {
-        $this->shopClient->show('orders', $order->getTokenValue());
+        $this->shopClient->show(Resources::ORDERS, $order->getTokenValue());
     }
 
     /**
@@ -112,7 +113,7 @@ final class OrderContext implements Context
      */
     public function iShouldBeAbleToAccessThisOrderDetails(): void
     {
-        $response = $this->shopClient->show('orders', $this->sharedStorage->get('cart_token'));
+        $response = $this->shopClient->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
 
         Assert::same($response->getStatusCode(), Response::HTTP_OK);
         Assert::same(
@@ -320,7 +321,7 @@ final class OrderContext implements Context
     {
         $payment = $this
             ->responseChecker
-            ->getValue($this->shopClient->show('orders', $this->sharedStorage->get('cart_token')), 'payments')[0]
+            ->getValue($this->shopClient->show(Resources::ORDERS, $this->sharedStorage->get('cart_token')), 'payments')[0]
         ;
 
         Assert::same($this->iriConverter->getIriFromItem($paymentMethod), $payment['method']);
@@ -367,7 +368,7 @@ final class OrderContext implements Context
 
         Assert::same(
             $notes,
-            $this->responseChecker->getValue($this->adminClient->show('orders', $order->getTokenValue()), 'notes')
+            $this->responseChecker->getValue($this->adminClient->show(Resources::ORDERS, $order->getTokenValue()), 'notes')
         );
     }
 
@@ -383,13 +384,13 @@ final class OrderContext implements Context
 
         Assert::same(
             $currency,
-            $this->responseChecker->getValue($this->adminClient->show('orders', $order->getTokenValue()), 'currencyCode')
+            $this->responseChecker->getValue($this->adminClient->show(Resources::ORDERS, $order->getTokenValue()), 'currencyCode')
         );
     }
 
     private function getAdjustmentsForOrder(): array
     {
-        $response = $this->shopClient->subResourceIndex('orders', 'adjustments', $this->sharedStorage->get('cart_token'));
+        $response = $this->shopClient->subResourceIndex(Resources::ORDERS, 'adjustments', $this->sharedStorage->get('cart_token'));
 
         return $this->responseChecker->getCollection($response);
     }
@@ -406,7 +407,7 @@ final class OrderContext implements Context
 
     private function geOrderItemIdForProductInCart(ProductInterface $product, string $tokenValue): ?string
     {
-        $items = $this->responseChecker->getValue($this->shopClient->show('orders', $tokenValue), 'items');
+        $items = $this->responseChecker->getValue($this->shopClient->show(Resources::ORDERS, $tokenValue), 'items');
 
         foreach ($items as $item) {
             $response = $this->getProductForItem($item);

--- a/src/Sylius/Behat/Context/Api/Shop/OrderItemContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderItemContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -53,7 +54,7 @@ final class OrderItemContext implements Context
         /** @var OrderItemInterface $orderItem */
         $orderItem = $order->getItems()->first();
 
-        $this->client->show('order-items', (string) $orderItem->getId());
+        $this->client->show(Resources::ORDER_ITEMS, (string) $orderItem->getId());
     }
 
     /**
@@ -68,7 +69,7 @@ final class OrderItemContext implements Context
         /** @var OrderItemUnitInterface $orderItemUnit */
         $orderItemUnit = $order->getItemUnits()->first();
 
-        $this->client->show('order-item-units', (string) $orderItemUnit->getId());
+        $this->client->show(Resources::ORDER_ITEM_UNITS, (string) $orderItemUnit->getId());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PaymentContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -52,7 +53,7 @@ final class PaymentContext implements Context
         /** @var PaymentInterface $payment */
         $payment = $order->getPayments()->first();
 
-        $this->client->show('payments', (string) $payment->getId());
+        $this->client->show(Resources::PAYMENTS, (string) $payment->getId());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -19,6 +19,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\Setter\ChannelContextSetterInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -63,7 +64,7 @@ final class ProductContext implements Context
      */
     public function iViewProduct(ProductInterface $product): void
     {
-        $this->client->show('products', $product->getCode());
+        $this->client->show(Resources::PRODUCTS, $product->getCode());
 
         /** @var ProductVariantInterface $productVariant */
         $productVariant = $product->getVariants()->first();
@@ -111,7 +112,7 @@ final class ProductContext implements Context
      */
     public function iBrowseProductsFromTaxon(?TaxonInterface $taxon = null): void
     {
-        $this->client->index('products');
+        $this->client->index(Resources::PRODUCTS);
 
         if ($taxon !== null) {
             $this->client->addFilter('taxon', $this->iriConverter->getIriFromItem($taxon));
@@ -481,7 +482,7 @@ final class ProductContext implements Context
         $this->channelContextSetter->setChannel($channel);
 
         Assert::true($this->hasProductWithPrice(
-            [$this->responseChecker->getResponseContent($this->client->show('products', $product->getCode()))],
+            [$this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCTS, $product->getCode()))],
             $price,
             null,
             StringInflector::nameToCamelCase($priceType)

--- a/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
@@ -52,7 +53,7 @@ final class ProductReviewContext implements Context
         /** @var ProductInterface $product */
         $product = $this->sharedStorage->get('product');
 
-        $this->client->index('product-reviews');
+        $this->client->index(Resources::PRODUCT_REVIEWS);
         $this->client->addFilter('reviewSubject', $this->iriConverter->getIriFromItem($product));
         $this->client->filter();
     }
@@ -71,7 +72,7 @@ final class ProductReviewContext implements Context
      */
     public function iWantToReviewProduct(ProductInterface $product): void
     {
-        $this->client->buildCreateRequest('product-reviews');
+        $this->client->buildCreateRequest(Resources::PRODUCT_REVIEWS);
         $this->client->addRequestData('product', $this->iriConverter->getIriFromItem($product));
     }
 
@@ -113,7 +114,7 @@ final class ProductReviewContext implements Context
         /** @var ProductInterface $product */
         $product = $this->sharedStorage->get('product');
 
-        $this->client->index('product-reviews');
+        $this->client->index(Resources::PRODUCT_REVIEWS);
         $this->client->addFilter('reviewSubject', $this->iriConverter->getIriFromItem($product));
         $this->client->addFilter('itemsPerPage', 3);
         $this->client->addFilter('order[createdAt]', 'desc');

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -47,7 +48,7 @@ final class ProductVariantContext implements Context
     public function iSelectVariant(ProductVariantInterface $variant): void
     {
         $this->sharedStorage->set('variant', $variant);
-        $this->client->show('product-variants', $variant->getCode());
+        $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
     }
 
     /**
@@ -56,7 +57,7 @@ final class ProductVariantContext implements Context
     public function visitorViewVariant(ProductVariantInterface $variant): void
     {
         $this->sharedStorage->set('token', null);
-        $this->client->show('product-variants', $variant->getCode());
+        $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
     }
 
     /**
@@ -64,7 +65,7 @@ final class ProductVariantContext implements Context
      */
     public function iViewVariants(): void
     {
-        $response = $this->client->index('product-variants');
+        $response = $this->client->index(Resources::PRODUCT_VARIANTS);
 
         $this->sharedStorage->set('response', $response);
     }
@@ -160,7 +161,7 @@ final class ProductVariantContext implements Context
         string $promotionName
     ): void {
         $this->sharedStorage->set('token', null);
-        $this->client->show('product-variants', $productVariant->getCode());
+        $this->client->show(Resources::PRODUCT_VARIANTS, $productVariant->getCode());
 
         $this->iShouldSeeVariantIsDiscountedFromToWithPromotions($productVariant, $originalPrice, $price, $promotionName);
     }
@@ -175,7 +176,7 @@ final class ProductVariantContext implements Context
         int $numberOfPromotions
     ): void {
         $this->sharedStorage->set('token', null);
-        $this->client->show('product-variants', $variant->getCode());
+        $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
 
         $this->iShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions($variant, $originalPrice, $price, $numberOfPromotions);
     }
@@ -208,7 +209,7 @@ final class ProductVariantContext implements Context
      */
     public function iShouldSeeThisVariantIsNotDiscounted(ProductVariantInterface $variant): void
     {
-        $content = $this->responseChecker->getResponseContent($this->client->show('product-variants', $variant->getCode()));
+        $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
 
         Assert::keyNotExists($content, 'appliedPromotions');
     }
@@ -223,7 +224,7 @@ final class ProductVariantContext implements Context
 
         /** @var ProductVariantInterface $variant */
         foreach ($variants as $variant) {
-            $content = $this->responseChecker->getResponseContent($this->client->show('product-variants', $variant->getCode()));
+            $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
             Assert::keyExists(
                 $content,
                 'appliedPromotions',
@@ -242,7 +243,7 @@ final class ProductVariantContext implements Context
 
         /** @var ProductVariantInterface $variant */
         foreach ($variants as $variant) {
-            $content = $this->responseChecker->getResponseContent($this->client->show('product-variants', $variant->getCode()));
+            $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
             Assert::keyNotExists(
                 $content,
                 'appliedPromotions',

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -17,6 +17,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Webmozart\Assert\Assert;
@@ -70,7 +71,7 @@ final class PromotionContext implements Context
 
     private function useCouponCode(?string $couponCode): void
     {
-        $this->client->buildUpdateRequest('orders', $this->getCartTokenValue());
+        $this->client->buildUpdateRequest(Resources::ORDERS, $this->getCartTokenValue());
         $this->client->setRequestData(['couponCode' => $couponCode]);
         $this->client->update();
     }

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
@@ -266,7 +267,7 @@ final class RegistrationContext implements Context
     {
         $customer = $this->sharedStorage->get('customer');
 
-        $response = $this->shopClient->show('customers', (string) $customer->getId());
+        $response = $this->shopClient->show(Resources::CUSTOMERS, (string) $customer->getId());
 
         Assert::true($this->responseChecker->getResponseContent($response)['subscribedToNewsletter']);
     }

--- a/src/Sylius/Behat/Context/Api/Shop/ShipmentContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ShipmentContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -52,7 +53,7 @@ final class ShipmentContext implements Context
         /** @var ShipmentInterface $shipment */
         $shipment = $order->getShipments()->first();
 
-        $this->client->show('shipments', (string) $shipment->getId());
+        $this->client->show(Resources::SHIPMENTS, (string) $shipment->getId());
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after #13832
| License         | MIT

To avoid potential problems with defining resources names using API client, I've extracted available resources to one class in Behat.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
