### PR TITLE
[Product] Render disabled main taxon without link in breadcrumb

### DIFF
--- a/features/product/viewing_products/viewing_product_with_disabled_main_taxon.feature
+++ b/features/product/viewing_products/viewing_product_with_disabled_main_taxon.feature
@@ -9,10 +9,10 @@ Feature: Viewing product with a disabled main taxon
         And the store classifies its products as "T-Shirts"
         And the "T-Shirts" taxon has children taxon "Men" and "Women"
         And the store has a product "T-Shirt Coconut" available in "Poland" channel
-        And this product belongs to "Men"
+        And this product has a main taxon "Men"
 
-    @ui
+    @ui @no-api
     Scenario: Seeing the breadcrumb with a disabled main taxon
-        When the "Men" taxon is disabled
-        Then I view product "T-Shirt Coconut"
-        Then I should not be able to click disabled main taxon "Men"
+        Given the "Men" taxon is disabled
+        When I view product "T-Shirt Coconut"
+        Then I should not be able to click disabled main taxon "Men" in the breadcrumb

--- a/features/product/viewing_products/viewing_product_with_disabled_main_taxon.feature
+++ b/features/product/viewing_products/viewing_product_with_disabled_main_taxon.feature
@@ -1,0 +1,18 @@
+@viewing_products
+Feature: Viewing product with a disabled main taxon
+    In order to only navigate to available taxons
+    As a Visitor
+    I want to have clickable links in the breadcrumb
+
+    Background:
+        Given the store operates on a channel named "Poland"
+        And the store classifies its products as "T-Shirts"
+        And the "T-Shirts" taxon has children taxon "Men" and "Women"
+        And the store has a product "T-Shirt Coconut" available in "Poland" channel
+        And this product belongs to "Men"
+
+    @ui
+    Scenario: Seeing the breadcrumb with a disabled main taxon
+        When the "Men" taxon is disabled
+        Then I view product "T-Shirt Coconut"
+        Then I should not be able to click disabled main taxon "Men"

--- a/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
@@ -45,6 +45,7 @@ final class ProductTaxonContext implements Context
 
     /**
      * @Given the product :product has a main taxon :taxon
+     * @Given /^(this product) has a main (taxon "[^"]+")$/
      */
     public function productHasMainTaxon(ProductInterface $product, TaxonInterface $taxon): void
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -937,11 +937,11 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Then I should not be able to click disabled main taxon :mainTaxon
+     * @Then I should not be able to click disabled main taxon :taxonName in the breadcrumb
      */
-    public function iShouldNotBeAbleToClickDisabledMainTaxon(string $mainTaxon): void
+    public function iShouldNotBeAbleToClickDisabledMainTaxonInTheBreacrumb(string $taxonName): void
     {
-        Assert::false($this->showPage->hasBreadcrumbLink($mainTaxon));
+        Assert::false($this->showPage->hasBreadcrumbLink($taxonName));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -937,6 +937,14 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then I should not be able to click disabled main taxon :mainTaxon
+     */
+    public function iShouldNotBeAbleToClickDisabledMainTaxon(string $mainTaxon): void
+    {
+        Assert::false($this->showPage->hasBreadcrumbLink($mainTaxon));
+    }
+
+    /**
      * @param string $productName
      * @param string $productAssociationName
      *

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -376,6 +376,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'validation_errors' => '[data-test-cart-validation-error]',
             'variant_radio' => '[data-test-product-variants] tbody tr:contains("%variantName%") input',
             'variants_rows' => '[data-test-product-variants-row]',
+            'breadcrumb' => '.breadcrumb',
         ]);
     }
 
@@ -385,5 +386,10 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             JQueryHelper::waitForAsynchronousActionsToFinish($this->getSession());
             $this->getDocument()->waitFor(3, fn (): bool => $this->summaryPage->isOpen());
         }
+    }
+
+    public function hasBreadcrumbLink(string $taxon): bool
+    {
+        return $this->getElement('breadcrumb')->findLink($taxon) != null;
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -357,6 +357,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'association' => '[data-test-product-association="%associationName%"]',
             'attributes' => '[data-test-product-attributes]',
             'average_rating' => '[data-test-average-rating]',
+            'breadcrumb' => '.breadcrumb',
             'catalog_promotion' => '.promotion_label',
             'current_variant_input' => '[data-test-product-variants] td input:checked',
             'details' => '[data-tab="details"]',
@@ -376,7 +377,6 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'validation_errors' => '[data-test-cart-validation-error]',
             'variant_radio' => '[data-test-product-variants] tbody tr:contains("%variantName%") input',
             'variants_rows' => '[data-test-product-variants-row]',
-            'breadcrumb' => '.breadcrumb',
         ]);
     }
 
@@ -388,8 +388,8 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         }
     }
 
-    public function hasBreadcrumbLink(string $taxon): bool
+    public function hasBreadcrumbLink(string $taxonName): bool
     {
-        return $this->getElement('breadcrumb')->findLink($taxon) != null;
+        return $this->getElement('breadcrumb')->findLink($taxonName) != null;
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
@@ -94,5 +94,5 @@ interface ShowPageInterface extends PageInterface
 
     public function getDescription(): string;
 
-    public function hasBreadcrumbLink(string $taxon): bool;
+    public function hasBreadcrumbLink(string $taxonName): bool;
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
@@ -93,4 +93,6 @@ interface ShowPageInterface extends PageInterface
     public function getOptionValues(string $optionName): array;
 
     public function getDescription(): string;
+
+    public function hasBreadcrumbLink(string $taxon): bool;
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
@@ -14,7 +14,11 @@
             <div class="divider"> / </div>
         {% endfor %}
 
-        <a href="{{ path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}) }}" class="section">{{ taxon.name }}</a>
+        {% if taxon.enabled %}
+            <a href="{{ path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}) }}" class="section">{{ taxon.name }}</a>
+        {% else %}
+            <div class="section">{{ taxon.name }}</div>
+        {% endif %}
         <div class="divider"> / </div>
     {% endif %}
     <div class="active section">{{ product.name }}</div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13713 
| License         | MIT

When a product's main taxon is disabled, the product page breadcrumb renders it as a link and throws a Not Found exception if it is clicked.
As suggested in #13713, with this PR the breadcrumb will render the main taxon without a link (as a simple `<div>`) when the taxon is disabled.
