### PR TITLE
[API][Shop] Viewing only the enabled variants of a product fixes

### DIFF
--- a/UPGRADE-API-1.12.md
+++ b/UPGRADE-API-1.12.md
@@ -99,4 +99,4 @@ Here is how the response looks like:
 
 1. The 2nd parameter `localeCode` has been removed from `src/Sylius/Bundle/ApiBundle/Command/Cart/PickupCart.php` and now is set automatically by `src/Sylius/Bundle/ApiBundle/DataTransformer/LocaleCodeAwareInputCommandDataTransformer.php`.
 
-1. The `api/v2/admin/products` and `api/v2/admin/products/{code}` have been changed and the `defaultVariant` field has been removed.
+1. The responses of endpoints `/api/v2/admin/products` and `/api/v2/admin/products/{code}` have been changed in such a way that the field `defaultVariant` has been removed.

--- a/features/product/viewing_product_variants/viewing_product_variant.feature
+++ b/features/product/viewing_product_variants/viewing_product_variant.feature
@@ -1,0 +1,18 @@
+@viewing_product_variants
+Feature: Viewing product's enabled variants only
+    In order to buy only available product variants
+    As a Customer
+    I want to see only enabled product variants
+
+    Background:
+        Given the store operates on a channel named "Web-US" in "USD" currency
+        And the store has a "Super Cool T-Shirt" configurable product
+        And this product has "Small", "Medium" and "Large" variants
+        And the product "Super Cool T-Shirt" has also an "Extra Large" variant
+        And the "Extra Large" product variant is disabled
+
+    @api @no-ui
+    Scenario: Viewing only enabled variants
+        When I view variants
+        Then I should see "Small", "Medium" and "Large" variants
+        But I should not see "Extra large" variant

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -601,14 +601,14 @@ final class ProductContext implements Context
         $productOptions = $this->responseChecker->getValue($response, 'options');
 
         foreach ($productOptions as $optionIri) {
-            if ($this->hasProductOptionWithName($optionIri, $optionName)) {
-                $variants = $this->responseChecker->getValue($response, 'variants');
+            if (!$this->hasProductOptionWithName($optionIri, $optionName)) {
+                continue;
+            }
 
-                foreach ($variants as $variantIri) {
-                    if ($this->variantHasProductOptionValue($variantIri, $optionValue))
-                    {
-                        return true;
-                    }
+            $variants = $this->responseChecker->getValue($response, 'variants');
+            foreach ($variants as $variantIri) {
+                if ($this->variantHasProductOptionValue($variantIri, $optionValue)) {
+                    return true;
                 }
             }
         }
@@ -628,11 +628,11 @@ final class ProductContext implements Context
         $variants = $this->client->showByIri($variantIri);
         $optionValues = $this->responseChecker->getValue($variants, 'optionValues');
 
-            foreach ($optionValues as $valueIri) {
-                if ($this->hasProductOptionWithValue($valueIri, $optionValue)) {
-                    return true;
-                }
+        foreach ($optionValues as $valueIri) {
+            if ($this->hasProductOptionWithValue($valueIri, $optionValue)) {
+                return true;
             }
+        }
 
         return false;
     }

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -252,6 +252,37 @@ final class ProductVariantContext implements Context
         }
     }
 
+    /**
+     * @Then I should not see :variant variant
+     */
+    public function iShouldNotSeeVariant(ProductVariantInterface $variant): void
+    {
+        $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
+        Assert::same(
+            $content['code'],
+            404,
+            sprintf('%s variant should be disabled', $variant->getName())
+        );
+    }
+
+    /**
+     * @Then /^I should see ("([^"]+)", "([^"]+)" and "([^"]+)" variants)$/
+     */
+    public function variantAndVariantShouldBeVisible(array $variants): void
+    {
+        $this->sharedStorage->set('token', null);
+
+        /** @var ProductVariantInterface $variant */
+        foreach ($variants as $variant) {
+            $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
+            Assert::same(
+                $content['name'],
+                $variant->getName(),
+                sprintf('%s variant should be visible', $variant->getName())
+            );
+        }
+    }
+
     private function findVariant(?ProductVariantInterface $variant): array
     {
         $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -96,6 +96,16 @@ final class ProductVariantContext implements Context
     }
 
     /**
+     * @Transform /^"([^"]+)", "([^"]+)" and "([^"]+)" variants$/
+     */
+    public function getVariantsByNames(string...$variantNames): array
+    {
+        return array_map(function ($variantName) {
+            return $this->getProductVariantByName($variantName);
+        }, $variantNames);
+    }
+
+    /**
      * @Transform /^variant with code "([^"]+)"$/
      */
     public function getProductVariantByCode($code)

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -34,6 +34,7 @@ imports:
     - suites/api/product/managing_products.yml
     - suites/api/product/viewing_products.yml
     - suites/api/product/viewing_product_reviews.yml
+    - suites/api/product/viewing_product_variants.yml
     - suites/api/promotion/applying_catalog_promotions.yml
     - suites/api/promotion/applying_promotion_coupon.yml
     - suites/api/promotion/applying_promotion_rules.yml

--- a/src/Sylius/Behat/Resources/config/suites/api/product/viewing_product_variants.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/product/viewing_product_variants.yml
@@ -1,0 +1,24 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        api_viewing_product_variants:
+            contexts:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.product_variant
+                - sylius.behat.context.transform.shared_storage
+
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.product
+
+                - sylius.behat.context.api.shop.channel
+                - sylius.behat.context.api.shop.product
+                - sylius.behat.context.api.shop.product_variant
+
+            filters:
+                tags: "@viewing_product_variants&&@api"
+            javascript: false

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/EnabledProductVariantItemExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/EnabledProductVariantItemExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+/** @experimental */
+final class EnabledProductVariantItemExtension implements QueryItemExtensionInterface
+{
+    public function __construct(private UserContextInterface $userContext)
+    {
+    }
+
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        string $operationName = null,
+        array $context = []
+    ) {
+        if (!is_a($resourceClass, ProductVariantInterface::class, true)) {
+            return;
+        }
+
+        $user = $this->userContext->getUser();
+        if ($user !== null && in_array('ROLE_API_ACCESS', $user->getRoles(), true)) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $enabled = $queryNameGenerator->generateParameterName('enabled');
+
+        $queryBuilder->andWhere(sprintf('%s.enabled = :%s', $rootAlias, $enabled));
+        $queryBuilder->setParameter($enabled, true);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -95,5 +95,10 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
             <tag name="api_platform.doctrine.orm.query_extension.item" />
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\EnabledProductVariantItemExtension">
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
@@ -44,8 +44,11 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
 
         $data = $this->normalizer->normalize($object, $format, $context);
 
-        $variantsIris = array_map(fn(ProductVariantInterface $variant): string => $this->iriConverter->getIriFromItem($variant), $object->getEnabledVariants()->toArray());
-        $data['variants'] = array_values($variantsIris);
+        $data['variants'] = $object
+            ->getEnabledVariants()
+            ->map(fn(ProductVariantInterface $variant): string => $this->iriConverter->getIriFromItem($variant))
+            ->getValues()
+        ;
 
         $defaultVariant = $this->defaultProductVariantResolver->getVariant($object);
         $data['defaultVariant'] = $defaultVariant === null ? null : $this->iriConverter->getIriFromItem($defaultVariant);
@@ -59,10 +62,10 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
             return false;
         }
 
-        return $data instanceof ProductInterface && $this->isShopGetOperation($context);
+        return $data instanceof ProductInterface && $this->isShopOperation($context);
     }
 
-    private function isShopGetOperation(array $context): bool
+    private function isShopOperation(array $context): bool
     {
         if (isset($context['item_operation_name'])) {
             return \str_starts_with($context['item_operation_name'], 'shop_get');

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductDocumentationNormalizer.php
@@ -38,7 +38,6 @@ final class ProductDocumentationNormalizer implements NormalizerInterface
             'readOnly' => true,
         ];
 
-        $docs['components']['schemas']['Product.jsonld-admin.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;
         $docs['components']['schemas']['Product.jsonld-shop.product.read']['properties']['defaultVariant'] = $defaultVariantSchema;
 
         return $docs;

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/EnabledProductVariantItemExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/EnabledProductVariantItemExtensionSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class EnabledProductVariantItemExtensionSpec extends ObjectBehavior
+{
+    function let(UserContextInterface $userContext)
+    {
+        $this->beConstructedWith($userContext);
+    }
+
+    function it_does_nothing_if_current_resource_is_not_a_product_variant(
+        UserContextInterface $userContext,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->shouldNotBeCalled();
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToItem($queryBuilder, $queryNameGenerator, TaxonInterface::class, [], 'get');
+    }
+
+    function it_does_nothing_if_current_user_is_an_admin_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_API_ACCESS']);
+
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToItem($queryBuilder, $queryNameGenerator, ProductVariantInterface::class, [], 'get');
+    }
+
+    function it_filters_products_by_enabled_flag_for_shop_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        ChannelInterface $channel
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn([]);
+
+        $queryNameGenerator->generateParameterName('enabled')->shouldBeCalled()->willReturn('enabled');
+
+        $queryBuilder->getRootAliases()->willReturn(['o']);
+        $queryBuilder->andWhere('o.enabled = :enabled')->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('enabled', true)->shouldBeCalled()->willReturn($queryBuilder);
+
+        $this->applyToItem($queryBuilder, $queryNameGenerator,
+            ProductVariantInterface::class, [],
+            'get',
+            [ContextKeys::CHANNEL => $channel, ContextKeys::LOCALE_CODE => 'en_US']
+        );
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
@@ -74,14 +74,12 @@ final class ProductNormalizerSpec extends ObjectBehavior
         IriConverterInterface $iriConverter,
         NormalizerInterface $normalizer,
         ProductInterface $product,
-        ProductVariantInterface $variant,
-        ArrayCollection $arrayCollection
+        ProductVariantInterface $variant
     ): void {
         $this->setNormalizer($normalizer);
 
         $normalizer->normalize($product, null, ['sylius_product_normalizer_already_called' => true])->willReturn([]);
-        $product->getEnabledVariants()->willReturn($arrayCollection);
-        $arrayCollection->toArray()->willReturn([$variant]);
+        $product->getEnabledVariants()->willReturn(new ArrayCollection([$variant->getWrappedObject()]));
         $defaultProductVariantResolver->getVariant($product)->willReturn($variant);
         $iriConverter->getIriFromItem($variant)->willReturn('/api/v2/shop/product-variants/CODE');
 
@@ -96,15 +94,13 @@ final class ProductNormalizerSpec extends ObjectBehavior
         IriConverterInterface $iriConverter,
         NormalizerInterface $normalizer,
         ProductVariantInterface $variant,
-        ProductInterface $product,
-        ArrayCollection $arrayCollection
+        ProductInterface $product
     ): void {
         $this->setNormalizer($normalizer);
 
         $normalizer->normalize($product, null, ['sylius_product_normalizer_already_called' => true])->willReturn([]);
         $iriConverter->getIriFromItem($variant)->willReturn('/api/v2/shop/product-variants/CODE');
-        $product->getEnabledVariants()->willReturn($arrayCollection);
-        $arrayCollection->toArray()->willReturn([$variant]);
+        $product->getEnabledVariants()->willReturn(new ArrayCollection([$variant->getWrappedObject()]));
 
         $defaultProductVariantResolver->getVariant($product)->willReturn(null);
 

--- a/tests/Api/Shop/ProductVariantsTest.php
+++ b/tests/Api/Shop/ProductVariantsTest.php
@@ -61,4 +61,20 @@ final class ProductVariantsTest extends JsonApiTestCase
             Response::HTTP_OK
         );
     }
+
+    /** @test */
+    public function it_returns_nothing_if_variant_not_found(): void
+    {
+        $this->loadFixturesFromFile('product/product_with_many_locales.yaml');
+
+        $this->client->request('GET',
+            '/api/v2/shop/product-variants/NON_EXISTING_VARIANT',
+            [],
+            [],
+            self::CONTENT_TYPE_HEADER
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes to [PR](https://github.com/Sylius/Sylius/pull/13863)
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
This PR contains missing QueryItemExtension for ProductVariants that shows only enabled variants and corrects comments from [this](https://github.com/Sylius/Sylius/pull/13863) PR