### PR TITLE
Use api route prefix parameter instead of `/api/v2`

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -82,6 +82,7 @@
         >
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\ProductImageDocumentationNormalizer.inner" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service
@@ -91,6 +92,7 @@
             decoration-priority="20"
         >
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\ProductSlugDocumentationNormalizer.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductSlugDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductSlugDocumentationNormalizer.php
@@ -18,10 +18,10 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 /** @experimental */
 final class ProductSlugDocumentationNormalizer implements NormalizerInterface
 {
-    private const PRODUCT_SLUG_PATH = '/api/v2/shop/products-by-slug/{slug}';
-
-    public function __construct(private NormalizerInterface $decoratedNormalizer)
-    {
+    public function __construct(
+        private NormalizerInterface $decoratedNormalizer,
+        private string $apiRoute
+    ) {
     }
 
     public function supportsNormalization($data, $format = null): bool
@@ -33,11 +33,12 @@ final class ProductSlugDocumentationNormalizer implements NormalizerInterface
     {
         $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
 
-        $params = $docs['paths'][self::PRODUCT_SLUG_PATH]['get']['parameters'];
+        $shopProductBySlugPath = $this->apiRoute . '/shop/products-by-slug/{slug}';
+        $params = $docs['paths'][$shopProductBySlugPath]['get']['parameters'];
 
         foreach ($params as $index => $param) {
             if ($param['name'] === 'code') {
-                unset($docs['paths'][self::PRODUCT_SLUG_PATH]['get']['parameters'][$index]);
+                unset($docs['paths'][$shopProductBySlugPath]['get']['parameters'][$index]);
             }
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #13854
| License         | MIT

Small PR to be able to use another api route prefix while generating the swagger page.
