### PR TITLE
[behat]Extract Request creation to separate service

### DIFF
--- a/src/Sylius/Behat/Client/ApiClientInterface.php
+++ b/src/Sylius/Behat/Client/ApiClientInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface ApiClientInterface
 {
+    public function request(RequestInterface $request): Response;
+
     public function index(string $resource): Response;
 
     public function showByIri(string $iri): Response;
@@ -42,8 +44,6 @@ interface ApiClientInterface
 
     public function customAction(string $url, string $method): Response;
 
-    public function upload(): Response;
-
     public function resend(): Response;
 
     public function executeCustomRequest(RequestInterface $request): Response;
@@ -51,8 +51,6 @@ interface ApiClientInterface
     public function buildCreateRequest(string $resource): void;
 
     public function buildUpdateRequest(string $resource, string $id): void;
-
-    public function buildUploadRequest(string $resource): void;
 
     public function setRequestData(array $data): void;
 
@@ -66,8 +64,8 @@ interface ApiClientInterface
 
     public function addFile(string $key, UploadedFile $file): void;
 
-    /** @param string|int|array $value */
-    public function addRequestData(string $key, $value): void;
+    /** @param string|int|bool|array $value */
+    public function addRequestData(string $key, mixed $value): void;
 
     public function setSubResourceData(string $key, array $data): void;
 

--- a/src/Sylius/Behat/Client/ContentTypeGuide.php
+++ b/src/Sylius/Behat/Client/ContentTypeGuide.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Client;
+
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+class ContentTypeGuide implements ContentTypeGuideInterface
+{
+    private const JSON_CONTENT_TYPE = 'application/json';
+    private const PATCH_CONTENT_TYPE = 'application/merge-patch+json';
+    private const LINKED_DATA_JSON_CONTENT_TYPE = 'application/ld+json';
+
+    public function guide(string $method): string
+    {
+        if ($method === HttpRequest::METHOD_PATCH) {
+            return self::PATCH_CONTENT_TYPE;
+        }
+
+        if ($method === HttpRequest::METHOD_PUT) {
+            return self::LINKED_DATA_JSON_CONTENT_TYPE;
+        }
+
+        return self::JSON_CONTENT_TYPE;
+    }
+}

--- a/src/Sylius/Behat/Client/ContentTypeGuideInterface.php
+++ b/src/Sylius/Behat/Client/ContentTypeGuideInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Client;
+
+interface ContentTypeGuideInterface
+{
+    public function guide(string $method): string;
+}

--- a/src/Sylius/Behat/Client/Request.php
+++ b/src/Sylius/Behat/Client/Request.php
@@ -13,166 +13,16 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Client;
 
-use Symfony\Component\HttpFoundation\Request as HttpRequest;
-
 final class Request implements RequestInterface
 {
-    private string $url;
-
-    private string $method;
-
-    /** @var array */
-    private $headers = ['HTTP_ACCEPT' => 'application/ld+json'];
-
-    private array $content = [];
-
-    /** @var array */
-    private $parameters = [];
-
-    /** @var array */
-    private $files = [];
-
-    private function __construct(string $url, string $method, array $headers = [])
-    {
-        $this->url = $url;
-        $this->method = $method;
-        $this->headers = array_merge($this->headers, $headers);
-    }
-
-    public static function index(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
-
-        return new self(
-            sprintf('/api/v2/%s%s', self::prepareSection($section), $resource),
-            HttpRequest::METHOD_GET,
-            $headers
-        );
-    }
-
-    public static function subResourceIndex(?string $section, string $resource, string $id, string $subResource): RequestInterface
-    {
-        return new self(
-            sprintf('/api/v2/%s%s/%s/%s', self::prepareSection($section), $resource, $id, $subResource),
-            HttpRequest::METHOD_GET
-        );
-    }
-
-    public static function show(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
-
-        return new self(
-            sprintf('/api/v2/%s%s/%s', self::prepareSection($section), $resource, $id),
-            HttpRequest::METHOD_GET,
-            $headers
-        );
-    }
-
-    public static function create(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = ['CONTENT_TYPE' => 'application/ld+json'];
-        if ($token !== null) {
-            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
-        }
-
-        return new self(
-            sprintf('/api/v2/%s%s', self::prepareSection($section), $resource),
-            HttpRequest::METHOD_POST,
-            $headers
-        );
-    }
-
-    public static function update(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = ['CONTENT_TYPE' => 'application/ld+json'];
-        if ($token !== null) {
-            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
-        }
-
-        return new self(
-            sprintf('/api/v2/%s%s/%s', self::prepareSection($section), $resource, $id),
-            HttpRequest::METHOD_PUT,
-            $headers
-        );
-    }
-
-    public static function delete(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
-
-        return new self(
-            sprintf('/api/v2/%s%s/%s', self::prepareSection($section), $resource, $id),
-            HttpRequest::METHOD_DELETE,
-            $headers
-        );
-    }
-
-    public static function transition(?string $section, string $resource, string $id, string $transition): RequestInterface
-    {
-        return self::customItemAction($section, $resource, $id, HttpRequest::METHOD_PATCH, $transition);
-    }
-
-    public static function customItemAction(?string $section, string $resource, string $id, string $type, string $action): RequestInterface
-    {
-        return new self(
-            sprintf('/api/v2/%s%s/%s/%s', self::prepareSection($section), $resource, $id, $action),
-            $type,
-            ['CONTENT_TYPE' => self::resolveHttpMethod($type)]
-        );
-    }
-
-    public static function upload(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): RequestInterface {
-        $headers = ['CONTENT_TYPE' => 'multipart/form-data'];
-        if ($token !== null) {
-            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
-        }
-
-        return new self(
-            sprintf('/api/v2/%s%s', self::prepareSection($section), $resource),
-            HttpRequest::METHOD_POST,
-            $headers
-        );
-    }
-
-    public static function custom(string $url, string $method, array $additionalHeaders = [], ?string $token = null): RequestInterface
-    {
-        $headers = ['CONTENT_TYPE' => self::resolveHttpMethod($method)];
-        if ($token !== null) {
-            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
-        }
-
-        $headers = array_merge($headers, $additionalHeaders);
-
-        return new self($url, $method, $headers);
+    public function __construct(
+        private string $url,
+        private string $method,
+        private array $parameters = [],
+        private array $headers = [],
+        private array $content = [],
+        private array $files = [],
+    ) {
     }
 
     public function url(): string
@@ -271,19 +121,5 @@ final class Request implements RequestInterface
         }
 
         return $firstArray;
-    }
-
-    private static function prepareSection(?string $section): string
-    {
-        if ($section === null) {
-            return '';
-        }
-
-        return $section . '/';
-    }
-
-    private static function resolveHttpMethod(string $method): string
-    {
-        return $method === HttpRequest::METHOD_PATCH ? 'application/merge-patch+json' : 'application/json';
     }
 }

--- a/src/Sylius/Behat/Client/RequestBuilder.php
+++ b/src/Sylius/Behat/Client/RequestBuilder.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Client;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class RequestBuilder
+{
+    private string $uri;
+    private string $method;
+    private array $parameters = [];
+    private array $headers = [];
+    private array $content = [];
+    private array $files = [];
+
+    private function __construct(string $uri, string $method)
+    {
+        $this->uri = $uri;
+        $this->method = $method;
+    }
+
+    public static function create(string $uri, string $method): self
+    {
+        return new self($uri, $method);
+    }
+
+    public function withHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    public function withFile(string $key, UploadedFile $file): self
+    {
+        $this->files[$key] = $file;
+
+        return $this;
+    }
+
+    public function withContent(array $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function withParameter(string $key, string $value): self
+    {
+        $this->parameters[$key] = $value;
+
+        return $this;
+    }
+
+    public function build(): RequestInterface
+    {
+        return new Request(
+            $this->uri,
+            $this->method,
+            $this->parameters,
+            $this->headers,
+            $this->content,
+            $this->files,
+        );
+    }
+}

--- a/src/Sylius/Behat/Client/RequestFactory.php
+++ b/src/Sylius/Behat/Client/RequestFactory.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Client;
+
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+final class RequestFactory implements RequestFactoryInterface
+{
+    private const LINKED_DATA_JSON_CONTENT_TYPE = 'application/ld+json';
+    private const UPLOAD_FILE_CONTENT_TYPE = 'multipart/form-data';
+
+    public function __construct(
+        private ContentTypeGuideInterface $contentTypeGuide,
+    ) {
+    }
+
+    public function index(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s', $section, $resource),
+            HttpRequest::METHOD_GET,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        return $builder->build();
+    }
+
+    public function subResourceIndex(string $section, string $resource, string $id, string $subResource): RequestInterface
+    {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s/%s/%s', $section, $resource, $id, $subResource),
+            HttpRequest::METHOD_GET,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+
+        return $builder->build();
+    }
+
+    public function show(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            HttpRequest::METHOD_GET,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        return $builder->build();
+    }
+
+    public function create(
+        string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s', $section, $resource),
+            HttpRequest::METHOD_POST,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+        $builder->withHeader('CONTENT_TYPE', self::LINKED_DATA_JSON_CONTENT_TYPE);
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        return $builder->build();
+    }
+
+    public function update(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            HttpRequest::METHOD_PUT,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+        $builder->withHeader('CONTENT_TYPE', $this->contentTypeGuide->guide(HttpRequest::METHOD_PUT));
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        return $builder->build();
+    }
+
+    public function delete(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            HttpRequest::METHOD_DELETE,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        return $builder->build();
+    }
+
+    public function transition(string $section, string $resource, string $id, string $transition): RequestInterface
+    {
+        return self::customItemAction($section, $resource, $id, HttpRequest::METHOD_PATCH, $transition);
+    }
+
+    public function customItemAction(string $section, string $resource, string $id, string $type, string $action): RequestInterface
+    {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s/%s/%s', $section, $resource, $id, $action),
+            $type,
+        );
+        $builder->withHeader('CONTENT_TYPE', $this->contentTypeGuide->guide($type));
+
+        return $builder->build();
+    }
+
+    public function upload(
+        string $section,
+        string $resource,
+        array $files,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $builder = RequestBuilder::create(
+            sprintf('/api/v2/%s/%s', $section, $resource),
+            HttpRequest::METHOD_POST,
+        );
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+        $builder->withHeader('CONTENT_TYPE', self::UPLOAD_FILE_CONTENT_TYPE);
+
+        if ($token) {
+            $builder->withHeader('HTTP_' . $authorizationHeader, 'Bearer ' . $token);
+        }
+
+        foreach ($files as $name => $value) {
+            $builder->withFile($name, $value);
+        }
+
+        return $builder->build();
+    }
+
+    public function custom(string $url, string $method, array $additionalHeaders = [], ?string $token = null): RequestInterface
+    {
+        $builder = RequestBuilder::create($url, $method);
+        $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
+        $builder->withHeader('CONTENT_TYPE', $this->contentTypeGuide->guide($method));
+
+        if ($token) {
+            $builder->withHeader('HTTP_Authorization', 'Bearer ' . $token);
+        }
+
+        foreach ($additionalHeaders as $name => $value) {
+            $builder->withHeader($name, $value);
+        }
+
+        return $builder->build();
+    }
+}

--- a/src/Sylius/Behat/Client/RequestFactoryInterface.php
+++ b/src/Sylius/Behat/Client/RequestFactoryInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Client;
+
+interface RequestFactoryInterface
+{
+    public function index(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function subResourceIndex(
+        string $section,
+        string $resource,
+        string $id,
+        string $subResource
+    ): RequestInterface;
+
+    public function show(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function create(
+        string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function update(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function delete(
+        string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function upload(
+        string $section,
+        string $resource,
+        array $files,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface;
+
+    public function transition(
+        string $section,
+        string $resource,
+        string $id,
+        string $transition
+    ): RequestInterface;
+
+    public function customItemAction(
+        string $section,
+        string $resource,
+        string $id,
+        string $type,
+        string $action
+    ): RequestInterface;
+
+    public function custom(
+        string $url,
+        string $method,
+        array $additionalHeaders = [],
+        ?string $token = null
+    ): RequestInterface;
+}

--- a/src/Sylius/Behat/Client/RequestInterface.php
+++ b/src/Sylius/Behat/Client/RequestInterface.php
@@ -15,59 +15,6 @@ namespace Sylius\Behat\Client;
 
 interface RequestInterface
 {
-    public static function index(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function subResourceIndex(?string $section, string $resource, string $id, string $subResource): self;
-
-    public static function show(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function create(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function update(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function delete(
-        ?string $section,
-        string $resource,
-        string $id,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function transition(?string $section, string $resource, string $id, string $transition): self;
-
-    public static function customItemAction(?string $section, string $resource, string $id, string $type, string $action): self;
-
-    public static function upload(
-        ?string $section,
-        string $resource,
-        string $authorizationHeader,
-        ?string $token = null
-    ): self;
-
-    public static function custom(string $url, string $method, array $additionalHeaders = [], ?string $token = null): self;
-
     public function url(): string;
 
     public function method(): string;

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
-use Sylius\Behat\Client\Request;
+use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Context\Setup\ShopSecurityContext;
@@ -28,34 +28,17 @@ use Webmozart\Assert\Assert;
 
 final class CustomerContext implements Context
 {
-    private ApiClientInterface $client;
-
-    private SharedStorageInterface $sharedStorage;
-
-    private ResponseCheckerInterface $responseChecker;
-
-    private RegistrationContext $registrationContext;
-
-    private LoginContext $loginContext;
-
-    private ShopSecurityContext $shopApiSecurityContext;
-
     private ?string $verificationToken = '';
 
     public function __construct(
-        ApiClientInterface $client,
-        SharedStorageInterface $sharedStorage,
-        ResponseCheckerInterface $responseChecker,
-        RegistrationContext $registrationContext,
-        LoginContext $loginContext,
-        ShopSecurityContext $shopApiSecurityContext
+        private ApiClientInterface $client,
+        private SharedStorageInterface $sharedStorage,
+        private ResponseCheckerInterface $responseChecker,
+        private RegistrationContext $registrationContext,
+        private LoginContext $loginContext,
+        private ShopSecurityContext $shopApiSecurityContext,
+        private RequestFactoryInterface $requestFactory,
     ) {
-        $this->client = $client;
-        $this->sharedStorage = $sharedStorage;
-        $this->responseChecker = $responseChecker;
-        $this->registrationContext = $registrationContext;
-        $this->loginContext = $loginContext;
-        $this->shopApiSecurityContext = $shopApiSecurityContext;
     }
 
     /**
@@ -486,7 +469,7 @@ final class CustomerContext implements Context
 
     private function verifyAccount(string $token): void
     {
-        $request = Request::custom(
+        $request = $this->requestFactory->custom(
             \sprintf('/api/v2/shop/account-verification-requests/%s', $token),
             HttpRequest::METHOD_PATCH,
         );
@@ -496,7 +479,7 @@ final class CustomerContext implements Context
 
     private function registerAccount(?string $email = 'example@example.com', ?string $password = 'example'): void
     {
-        $request = Request::create('shop', Resources::CUSTOMERS, '');
+        $request = $this->requestFactory->create('shop', Resources::CUSTOMERS, '');
 
         $request->setContent([
             'firstName' => 'First',
@@ -510,7 +493,7 @@ final class CustomerContext implements Context
 
     private function resendVerificationEmail(string $email): void
     {
-        $request = Request::create('shop', 'account-verification-requests', 'Bearer');
+        $request = $this->requestFactory->create('shop', 'account-verification-requests', 'Bearer');
 
         $request->setContent(['email' => $email]);
 

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\RequestInterface;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ApiSecurityClientInterface;
-use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -30,34 +30,17 @@ use Webmozart\Assert\Assert;
 
 final class LoginContext implements Context
 {
-    private ApiSecurityClientInterface $apiSecurityClient;
-
-    private ApiClientInterface $client;
-
-    private IriConverterInterface $iriConverter;
-
-    private AbstractBrowser $shopAuthenticationTokenClient;
-
-    private ResponseCheckerInterface $responseChecker;
-
-    private SharedStorageInterface $sharedStorage;
-
     private ?RequestInterface $request = null;
 
     public function __construct(
-        ApiSecurityClientInterface $apiSecurityClient,
-        ApiClientInterface $client,
-        IriConverterInterface $iriConverter,
-        AbstractBrowser $shopAuthenticationTokenClient,
-        ResponseCheckerInterface $responseChecker,
-        SharedStorageInterface $sharedStorage
+        private ApiSecurityClientInterface $apiSecurityClient,
+        private ApiClientInterface $client,
+        private IriConverterInterface $iriConverter,
+        private AbstractBrowser $shopAuthenticationTokenClient,
+        private ResponseCheckerInterface $responseChecker,
+        private SharedStorageInterface $sharedStorage,
+        private RequestFactoryInterface $requestFactory,
     ) {
-        $this->apiSecurityClient = $apiSecurityClient;
-        $this->client = $client;
-        $this->iriConverter = $iriConverter;
-        $this->shopAuthenticationTokenClient = $shopAuthenticationTokenClient;
-        $this->responseChecker = $responseChecker;
-        $this->sharedStorage = $sharedStorage;
     }
 
     /**
@@ -101,7 +84,7 @@ final class LoginContext implements Context
      */
     public function iWantToResetPassword(): void
     {
-        $this->request = Request::create('shop', 'reset-password-requests', 'Bearer');
+        $this->request = $this->requestFactory->create('shop', 'reset-password-requests', 'Bearer');
     }
 
     /**
@@ -120,7 +103,7 @@ final class LoginContext implements Context
      */
     public function iFollowLinkOnMyEmailToResetPassword(ShopUserInterface $user): void
     {
-        $this->request = Request::custom(
+        $this->request = $this->requestFactory->custom(
             sprintf('api/v2/shop/reset-password-requests/%s', $user->getPasswordResetToken()),
             HttpRequest::METHOD_PATCH
         );

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -17,7 +17,7 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Behat\Client\ApiClientInterface;
-use Sylius\Behat\Client\Request;
+use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\Setter\ChannelContextSetterInterface;
@@ -38,6 +38,7 @@ final class ProductContext implements Context
         private SharedStorageInterface $sharedStorage,
         private IriConverterInterface $iriConverter,
         private ChannelContextSetterInterface $channelContextSetter,
+        private RequestFactoryInterface $requestFactory,
     ) {
     }
 
@@ -423,7 +424,8 @@ final class ProductContext implements Context
         $response = $this->client->getLastResponse();
 
         $productVariant = $this->responseChecker->getValue($response, 'variants');
-        $this->client->executeCustomRequest(Request::custom($productVariant[0], HttpRequest::METHOD_GET));
+        $request = $this->requestFactory->custom($productVariant[0], HttpRequest::METHOD_GET);
+        $this->client->executeCustomRequest($request);
 
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'name', $variantName));
     }
@@ -556,7 +558,8 @@ final class ProductContext implements Context
             }
 
             foreach ($product['variants'] as $variantIri) {
-                $response = $this->client->executeCustomRequest(Request::custom($variantIri, HttpRequest::METHOD_GET));
+                $request = $this->requestFactory->custom($variantIri, HttpRequest::METHOD_GET);
+                $response = $this->client->executeCustomRequest($request);
 
                 /** @var int $variantPrice */
                 $variantPrice = $this->responseChecker->getValue($response, $priceType);

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -15,11 +15,9 @@ namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
-use Sylius\Behat\Client\Request;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
-use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Webmozart\Assert\Assert;
 
 final class PromotionContext implements Context

--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -69,17 +69,21 @@
             <argument type="service" id="sylius.behat.mocker" />
             <argument type="service" id="sylius.behat.response_loader" />
         </service>
+
         <service id="sylius.behat.mocker" class="Sylius\Behat\Service\Mocker\Mocker" public="false">
             <argument type="service" id="service_container" />
         </service>
+
         <service id="sylius.behat.response_loader" class="Sylius\Behat\Service\ResponseLoader" public="false" />
 
         <service id="sylius.behat.notification_accessor" class="Sylius\Behat\Service\Accessor\NotificationAccessor" public="false">
             <argument type="service" id="behat.mink.default_session" />
         </service>
+
         <service id="sylius.behat.notification_checker" class="Sylius\Behat\Service\NotificationChecker" public="false">
             <argument type="service" id="sylius.behat.notification_accessor" />
         </service>
+
         <service id="sylius.behat.current_page_resolver" class="Sylius\Behat\Service\Resolver\CurrentPageResolver" public="false">
             <argument type="service" id="behat.mink.default_session" />
             <argument type="service" id="router" />

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -16,6 +16,7 @@
         <service id="sylius.behat.api_platform_client" class="Sylius\Behat\Client\ApiPlatformClient" abstract="true">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.behat.request_factory" />
             <argument>%sylius.api.authorization_header%</argument>
         </service>
 
@@ -41,6 +42,12 @@
             <argument type="service" id="test.client" />
             <argument>shop</argument>
             <argument type="service" id="sylius.behat.shared_storage" />
+        </service>
+
+        <service id="sylius.behat.content_type_guide" class="Sylius\Behat\Client\ContentTypeGuide" />
+
+        <service id="sylius.behat.request_factory" class="Sylius\Behat\Client\RequestFactory">
+            <argument type="service" id="sylius.behat.content_type_guide"/>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="behat.mink.parameters" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_channels" class="Sylius\Behat\Context\Api\Admin\ManagingChannelsContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -44,6 +44,7 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.shop.customer" class="Sylius\Behat\Context\Api\Shop\CustomerContext">
@@ -53,6 +54,7 @@
             <argument type="service" id="sylius.behat.context.api.shop.registration" />
             <argument type="service" id="sylius.behat.context.api.shop.login" />
             <argument type="service" id="sylius.behat.context.setup.shop_api_security" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.shop.promotion" class="Sylius\Behat\Context\Api\Shop\PromotionContext">
@@ -70,6 +72,7 @@
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.behat.request_factory" />
             <argument>%sylius.model.payment_method.class%</argument>
             <argument>%sylius.model.shipping_method.class%</argument>
         </service>
@@ -86,6 +89,7 @@
             <argument type="service" id="test.client" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.shop.product" class="Sylius\Behat\Context\Api\Shop\ProductContext">
@@ -94,6 +98,7 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.channel_context_setter" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.shop.product_variant" class="Sylius\Behat\Context\Api\Shop\ProductVariantContext">
@@ -124,6 +129,7 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.api_security" />
+            <argument type="service" id="sylius.behat.request_factory" />
         </service>
 
         <service id="sylius.behat.context.api.shop.order_item" class="Sylius\Behat\Context\Api\Shop\OrderItemContext">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

It is a part of improving Developer Experience in Behat tests. I removed factory methods out of the Request class, as the object has really grown up. Moved these methods to separate Factory required a lot of changes, that's why I decided to postpone here and merge current changes.

Created Request Builder and Factory will provide an additional layer for future developers to build their own Requests