### PR TITLE
[maintenance][mailer]Assert that email is not null

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/AdminBundle/EmailManager/OrderEmailManager.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\AdminBundle\EmailManager;
 use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
+use Webmozart\Assert\Assert;
 
 final class OrderEmailManager implements OrderEmailManagerInterface
 {
@@ -28,9 +29,12 @@ final class OrderEmailManager implements OrderEmailManagerInterface
 
     public function sendConfirmationEmail(OrderInterface $order): void
     {
+        $email = $order->getCustomer()->getEmail();
+        Assert::notNull($email);
+
         $this->emailSender->send(
             Emails::ORDER_CONFIRMATION_RESENT,
-            [$order->getCustomer()->getEmail()],
+            [$email],
             [
                 'order' => $order,
                 'channel' => $order->getChannel(),

--- a/src/Sylius/Bundle/AdminBundle/EmailManager/ShipmentEmailManager.php
+++ b/src/Sylius/Bundle/AdminBundle/EmailManager/ShipmentEmailManager.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
+use Webmozart\Assert\Assert;
 
 final class ShipmentEmailManager implements ShipmentEmailManagerInterface
 {
@@ -31,12 +32,18 @@ final class ShipmentEmailManager implements ShipmentEmailManagerInterface
     {
         /** @var OrderInterface $order */
         $order = $shipment->getOrder();
+        $email = $order->getCustomer()->getEmail();
+        Assert::notNull($email);
 
-        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, [$order->getCustomer()->getEmail()], [
-            'shipment' => $shipment,
-            'order' => $order,
-            'channel' => $order->getChannel(),
-            'localeCode' => $order->getLocaleCode(),
-        ]);
+        $this->emailSender->send(
+            Emails::SHIPMENT_CONFIRMATION,
+            [$email],
+            [
+                'shipment' => $shipment,
+                'order' => $order,
+                'channel' => $order->getChannel(),
+                'localeCode' => $order->getLocaleCode(),
+            ]
+        );
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/SendOrderConfirmationHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/SendOrderConfirmationHandler.php
@@ -19,6 +19,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Webmozart\Assert\Assert;
 
 /** @experimental */
 final class SendOrderConfirmationHandler implements MessageHandlerInterface
@@ -37,10 +38,12 @@ final class SendOrderConfirmationHandler implements MessageHandlerInterface
     {
         /** @var OrderInterface $order */
         $order = $this->orderRepository->findOneByTokenValue($sendOrderConfirmation->orderToken());
+        $email = $order->getCustomer()->getEmail();
+        Assert::notNull($email);
 
         $this->emailSender->send(
             Emails::ORDER_CONFIRMATION,
-            [$order->getCustomer()->getEmail()],
+            [$email],
             [
                 'order' => $order,
                 'channel' => $order->getChannel(),

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/SendShipmentConfirmationEmailHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/SendShipmentConfirmationEmailHandler.php
@@ -38,12 +38,15 @@ final class SendShipmentConfirmationEmailHandler implements MessageHandlerInterf
     {
         /** @var ShipmentInterface $shipment */
         $shipment = $this->shipmentRepository->find($sendShipmentConfirmationEmail->shipmentId);
+        $order = $shipment->getOrder();
+        Assert::notNull($order);
 
-        Assert::notNull($order = $shipment->getOrder());
+        $email = $order->getCustomer()->getEmail();
+        Assert::notNull($email);
 
         $this->emailSender->send(
             Emails::SHIPMENT_CONFIRMATION,
-            [$order->getCustomer()->getEmail()],
+            [$email],
             [
                 'shipment' => $shipment,
                 'order' => $order,

--- a/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
@@ -80,9 +80,12 @@ final class MailerListener
 
     private function sendEmail(UserInterface $user, string $emailCode): void
     {
+        $email = $user->getEmail();
+        Assert::notNull($email);
+
         $this->emailSender->send(
             $emailCode,
-            [$user->getEmail()],
+            [$email],
             [
                 'user' => $user,
                 'channel' => $this->channelContext->getChannel(),

--- a/src/Sylius/Bundle/CoreBundle/Mailer/OrderEmailManager.php
+++ b/src/Sylius/Bundle/CoreBundle/Mailer/OrderEmailManager.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\CoreBundle\Mailer;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
+use Webmozart\Assert\Assert;
 
 final class OrderEmailManager implements OrderEmailManagerInterface
 {
@@ -30,10 +31,12 @@ final class OrderEmailManager implements OrderEmailManagerInterface
     {
         /** @var CustomerInterface $customer */
         $customer = $order->getCustomer();
+        $email = $customer->getEmail();
+        Assert::notNull($email);
 
         $this->emailSender->send(
             Emails::ORDER_CONFIRMATION,
-            [$customer->getEmail()],
+            [$email],
             [
                 'order' => $order,
                 'channel' => $order->getChannel(),

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Bundle\CoreBundle\Mailer\OrderEmailManagerInterface as DecoratedOrderEmailManagerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
+use Webmozart\Assert\Assert;
 
 final class OrderEmailManager implements OrderEmailManagerInterface
 {
@@ -51,15 +52,17 @@ final class OrderEmailManager implements OrderEmailManagerInterface
             return;
         }
 
+        $email = $order->getCustomer()->getEmail();
+        Assert::notNull($email);
+
         $this->emailSender->send(
             Emails::ORDER_CONFIRMATION,
-            [$order->getCustomer()->getEmail()],
+            [$email],
             [
                 'order' => $order,
                 'channel' => $order->getChannel(),
                 'localeCode' => $order->getLocaleCode(),
             ]
-        )
-        ;
+        );
     }
 }

--- a/src/Sylius/Bundle/UserBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/MailerListener.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\UserBundle\Mailer\Emails;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Webmozart\Assert\Assert;
 
 class MailerListener
 {
@@ -45,6 +46,9 @@ class MailerListener
 
     protected function sendEmail(UserInterface $user, string $emailCode): void
     {
-        $this->emailSender->send($emailCode, [$user->getEmail()], ['user' => $user]);
+        $email = $user->getEmail();
+        Assert::notNull($email);
+
+        $this->emailSender->send($emailCode, [$email], ['user' => $user]);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

The latest Sylius Mailer update changed the email address type as not nullable. Therefore our psalm and phpstan pipelines recorded errors. This PR checks if the email is null. Similarly, as we did it in Sylius/Plus. There is no need to send a mail when the email address is null.