### PR TITLE
Behat use project api prefix

### DIFF
--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -21,30 +21,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ApiPlatformClient implements ApiClientInterface
 {
-    private AbstractBrowser $client;
-
-    private SharedStorageInterface $sharedStorage;
-
-    private RequestFactoryInterface $requestFactory;
-
-    private string $authorizationHeader;
-
-    private ?string $section;
-
     private ?RequestInterface $request = null;
 
     public function __construct(
-        AbstractBrowser $client,
-        SharedStorageInterface $sharedStorage,
-        RequestFactoryInterface $requestFactory,
-        string $authorizationHeader,
-        ?string $section = null
+        private AbstractBrowser $client,
+        private SharedStorageInterface $sharedStorage,
+        private RequestFactoryInterface $requestFactory,
+        private string $authorizationHeader,
+        private ?string $section = null
     ) {
-        $this->client = $client;
-        $this->sharedStorage = $sharedStorage;
-        $this->requestFactory = $requestFactory;
-        $this->authorizationHeader = $authorizationHeader;
-        $this->section = $section;
     }
 
     public function index(string $resource): Response

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -23,7 +23,7 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
     public function __construct(
         private AbstractBrowser $client,
-        private string $apiRoute,
+        private string $apiUrlPrefix,
         private string $section,
         private SharedStorageInterface $sharedStorage
     ) {
@@ -31,7 +31,7 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
     public function prepareLoginRequest(): void
     {
-        $this->request['url'] = sprintf('%s/%s/authentication-token', $this->apiRoute, $this->section);
+        $this->request['url'] = sprintf('%s/%s/authentication-token', $this->apiUrlPrefix, $this->section);
         $this->request['method'] = 'POST';
     }
 

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -19,24 +19,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 {
-    private AbstractBrowser $client;
-
-    private string $section;
-
-    private SharedStorageInterface $sharedStorage;
-
     private array $request = [];
 
-    public function __construct(AbstractBrowser $client, string $section, SharedStorageInterface $sharedStorage)
-    {
-        $this->client = $client;
-        $this->section = $section;
-        $this->sharedStorage = $sharedStorage;
+    public function __construct(
+        private AbstractBrowser $client,
+        private string $apiRoute,
+        private string $section,
+        private SharedStorageInterface $sharedStorage
+    ) {
     }
 
     public function prepareLoginRequest(): void
     {
-        $this->request['url'] = sprintf('/api/v2/%s/authentication-token', $this->section);
+        $this->request['url'] = sprintf('%s/%s/authentication-token', $this->apiRoute, $this->section);
         $this->request['method'] = 'POST';
     }
 

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -23,9 +23,9 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
     public function __construct(
         private AbstractBrowser $client,
+        private SharedStorageInterface $sharedStorage,
         private string $apiUrlPrefix,
         private string $section,
-        private SharedStorageInterface $sharedStorage
     ) {
     }
 

--- a/src/Sylius/Behat/Client/RequestFactory.php
+++ b/src/Sylius/Behat/Client/RequestFactory.php
@@ -22,6 +22,7 @@ final class RequestFactory implements RequestFactoryInterface
 
     public function __construct(
         private ContentTypeGuideInterface $contentTypeGuide,
+        private string $apiUrlPrefix,
     ) {
     }
 
@@ -32,7 +33,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s', $section, $resource),
+            sprintf('%s/%s/%s', $this->apiUrlPrefix, $section, $resource),
             HttpRequest::METHOD_GET,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -47,7 +48,7 @@ final class RequestFactory implements RequestFactoryInterface
     public function subResourceIndex(string $section, string $resource, string $id, string $subResource): RequestInterface
     {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s/%s/%s', $section, $resource, $id, $subResource),
+            sprintf('%s/%s/%s/%s/%s', $this->apiUrlPrefix, $section, $resource, $id, $subResource),
             HttpRequest::METHOD_GET,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -63,7 +64,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            sprintf('%s/%s/%s/%s', $this->apiUrlPrefix, $section, $resource, $id),
             HttpRequest::METHOD_GET,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -82,7 +83,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s', $section, $resource),
+            sprintf('%s/%s/%s', $this->apiUrlPrefix, $section, $resource),
             HttpRequest::METHOD_POST,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -103,7 +104,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            sprintf('%s/%s/%s/%s', $this->apiUrlPrefix, $section, $resource, $id),
             HttpRequest::METHOD_PUT,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -124,7 +125,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s/%s', $section, $resource, $id),
+            sprintf('%s/%s/%s/%s', $this->apiUrlPrefix, $section, $resource, $id),
             HttpRequest::METHOD_DELETE,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);
@@ -138,13 +139,13 @@ final class RequestFactory implements RequestFactoryInterface
 
     public function transition(string $section, string $resource, string $id, string $transition): RequestInterface
     {
-        return self::customItemAction($section, $resource, $id, HttpRequest::METHOD_PATCH, $transition);
+        return $this->customItemAction($section, $resource, $id, HttpRequest::METHOD_PATCH, $transition);
     }
 
     public function customItemAction(string $section, string $resource, string $id, string $type, string $action): RequestInterface
     {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s/%s/%s', $section, $resource, $id, $action),
+            sprintf('%s/%s/%s/%s/%s', $this->apiUrlPrefix, $section, $resource, $id, $action),
             $type,
         );
         $builder->withHeader('CONTENT_TYPE', $this->contentTypeGuide->guide($type));
@@ -160,7 +161,7 @@ final class RequestFactory implements RequestFactoryInterface
         ?string $token = null
     ): RequestInterface {
         $builder = RequestBuilder::create(
-            sprintf('/api/v2/%s/%s', $section, $resource),
+            sprintf('%s/%s/%s', $this->apiUrlPrefix, $section, $resource),
             HttpRequest::METHOD_POST,
         );
         $builder->withHeader('HTTP_ACCEPT', self::LINKED_DATA_JSON_CONTENT_TYPE);

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
@@ -24,20 +24,12 @@ use Webmozart\Assert\Assert;
 
 final class ManagingExchangeRatesContext implements Context
 {
-    private ApiClientInterface $client;
-
-    private ResponseCheckerInterface $responseChecker;
-
-    private SharedStorageInterface $sharedStorage;
-
     public function __construct(
-        ApiClientInterface $client,
-        ResponseCheckerInterface $responseChecker,
-        SharedStorageInterface $sharedStorage
+        private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
+        private SharedStorageInterface $sharedStorage,
+        private string $apiRoute
     ) {
-        $this->client = $client;
-        $this->responseChecker = $responseChecker;
-        $this->sharedStorage = $sharedStorage;
     }
 
     /**
@@ -85,7 +77,10 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iChooseAsTheSourceCurrency(string $currencyCode): void
     {
-        $this->client->addRequestData('sourceCurrency', '/api/v2/admin/currencies/' . $currencyCode);
+        $this->client->addRequestData(
+            'sourceCurrency',
+            sprintf('%s/admin/currencies/%s', $this->apiRoute, $currencyCode)
+        );
     }
 
     /**
@@ -93,7 +88,10 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iChooseAsTheTargetCurrency(string $currencyCode): void
     {
-        $this->client->addRequestData('targetCurrency', '/api/v2/admin/currencies/' . $currencyCode);
+        $this->client->addRequestData(
+            'targetCurrency',
+            sprintf('%s/admin/currencies/%s', $this->apiRoute, $currencyCode)
+        );
     }
 
     /**
@@ -347,7 +345,10 @@ final class ManagingExchangeRatesContext implements Context
     {
         $this->client->buildUpdateRequest(Resources::EXCHANGE_RATES, $this->sharedStorage->get('exchange_rate_id'));
 
-        $this->client->addRequestData($currencyType, '/api/v2/admin/currencies/EUR');
+        $this->client->addRequestData(
+            $currencyType,
+            sprintf('%s/admin/currencies/EUR', $this->apiRoute)
+        );
         $this->client->update();
 
         Assert::false(
@@ -355,7 +356,7 @@ final class ManagingExchangeRatesContext implements Context
                 $this->client->index(Resources::EXCHANGE_RATES),
                 0,
                 $currencyType,
-                '/api/v2/admin/currencies/EUR'
+                sprintf('%s/admin/currencies/EUR', $this->apiRoute)
             ),
             sprintf('It was possible to change %s', $currencyType)
         );
@@ -368,8 +369,8 @@ final class ManagingExchangeRatesContext implements Context
         /** @var array $item */
         foreach ($this->responseChecker->getCollection($this->client->index(Resources::EXCHANGE_RATES)) as $item) {
             if (
-                $item['sourceCurrency'] === '/api/v2/admin/currencies/' . $sourceCurrency->getCode() &&
-                $item['targetCurrency'] === '/api/v2/admin/currencies/' . $targetCurrency->getCode()
+                $item['sourceCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiRoute, $sourceCurrency->getCode()) &&
+                $item['targetCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiRoute, $targetCurrency->getCode())
             ) {
                 return $item;
             }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
@@ -28,7 +28,7 @@ final class ManagingExchangeRatesContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private SharedStorageInterface $sharedStorage,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -79,7 +79,7 @@ final class ManagingExchangeRatesContext implements Context
     {
         $this->client->addRequestData(
             'sourceCurrency',
-            sprintf('%s/admin/currencies/%s', $this->apiRoute, $currencyCode)
+            sprintf('%s/admin/currencies/%s', $this->apiUrlPrefix, $currencyCode)
         );
     }
 
@@ -90,7 +90,7 @@ final class ManagingExchangeRatesContext implements Context
     {
         $this->client->addRequestData(
             'targetCurrency',
-            sprintf('%s/admin/currencies/%s', $this->apiRoute, $currencyCode)
+            sprintf('%s/admin/currencies/%s', $this->apiUrlPrefix, $currencyCode)
         );
     }
 
@@ -347,7 +347,7 @@ final class ManagingExchangeRatesContext implements Context
 
         $this->client->addRequestData(
             $currencyType,
-            sprintf('%s/admin/currencies/EUR', $this->apiRoute)
+            sprintf('%s/admin/currencies/EUR', $this->apiUrlPrefix)
         );
         $this->client->update();
 
@@ -356,7 +356,7 @@ final class ManagingExchangeRatesContext implements Context
                 $this->client->index(Resources::EXCHANGE_RATES),
                 0,
                 $currencyType,
-                sprintf('%s/admin/currencies/EUR', $this->apiRoute)
+                sprintf('%s/admin/currencies/EUR', $this->apiUrlPrefix)
             ),
             sprintf('It was possible to change %s', $currencyType)
         );
@@ -369,8 +369,8 @@ final class ManagingExchangeRatesContext implements Context
         /** @var array $item */
         foreach ($this->responseChecker->getCollection($this->client->index(Resources::EXCHANGE_RATES)) as $item) {
             if (
-                $item['sourceCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiRoute, $sourceCurrency->getCode()) &&
-                $item['targetCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiRoute, $targetCurrency->getCode())
+                $item['sourceCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiUrlPrefix, $sourceCurrency->getCode()) &&
+                $item['targetCurrency'] === sprintf('%s/admin/currencies/%s', $this->apiUrlPrefix, $targetCurrency->getCode())
             ) {
                 return $item;
             }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
@@ -31,7 +31,7 @@ final class ManagingPaymentsContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -134,7 +134,7 @@ final class ManagingPaymentsContext implements Context
             $this->client->getLastResponse(),
             $position - 1,
             'order',
-            sprintf('%s/admin/orders/%s', $this->apiRoute, $order->getTokenValue())
+            sprintf('%s/admin/orders/%s', $this->apiUrlPrefix, $order->getTokenValue())
         ));
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
@@ -27,20 +27,12 @@ use Webmozart\Assert\Assert;
 
 final class ManagingPaymentsContext implements Context
 {
-    private ApiClientInterface $client;
-
-    private ResponseCheckerInterface $responseChecker;
-
-    private IriConverterInterface $iriConverter;
-
     public function __construct(
-        ApiClientInterface $client,
-        ResponseCheckerInterface $responseChecker,
-        IriConverterInterface $iriConverter
+        private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
+        private IriConverterInterface $iriConverter,
+        private string $apiRoute
     ) {
-        $this->client = $client;
-        $this->responseChecker = $responseChecker;
-        $this->iriConverter = $iriConverter;
     }
 
     /**
@@ -142,7 +134,7 @@ final class ManagingPaymentsContext implements Context
             $this->client->getLastResponse(),
             $position - 1,
             'order',
-            sprintf('/api/v2/admin/orders/%s', $order->getTokenValue())
+            sprintf('%s/admin/orders/%s', $this->apiRoute, $order->getTokenValue())
         ));
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -36,7 +36,7 @@ final class ManagingProductsContext implements Context
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
         private SharedStorageInterface $sharedStorage,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -362,7 +362,7 @@ final class ManagingProductsContext implements Context
                 $this->client->getLastResponse(),
                 0,
                 'code',
-                sprintf('%s/admin/products/_NEW', $this->apiRoute)
+                sprintf('%s/admin/products/_NEW', $this->apiUrlPrefix)
             ),
             sprintf('It was possible to change %s', '_NEW')
         );

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -36,7 +36,7 @@ final class ManagingProductsContext implements Context
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
         private SharedStorageInterface $sharedStorage,
-        private string $apiUrlPrefix
+        private string $apiUrlPrefix,
     ) {
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -31,24 +31,13 @@ final class ManagingProductsContext implements Context
 {
     public const SORT_TYPES = ['ascending' => 'asc', 'descending' => 'desc'];
 
-    private ApiClientInterface $client;
-
-    private ResponseCheckerInterface $responseChecker;
-
-    private IriConverterInterface $iriConverter;
-
-    private SharedStorageInterface $sharedStorage;
-
     public function __construct(
-        ApiClientInterface $client,
-        ResponseCheckerInterface $responseChecker,
-        IriConverterInterface $iriConverter,
-        SharedStorageInterface $sharedStorage
+        private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
+        private IriConverterInterface $iriConverter,
+        private SharedStorageInterface $sharedStorage,
+        private string $apiRoute
     ) {
-        $this->client = $client;
-        $this->responseChecker = $responseChecker;
-        $this->iriConverter = $iriConverter;
-        $this->sharedStorage = $sharedStorage;
     }
 
     /**
@@ -373,7 +362,7 @@ final class ManagingProductsContext implements Context
                 $this->client->getLastResponse(),
                 0,
                 'code',
-                '/api/v2/admin/products/_NEW'
+                sprintf('%s/admin/products/_NEW', $this->apiRoute)
             ),
             sprintf('It was possible to change %s', '_NEW')
         );

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
@@ -37,7 +37,7 @@ final class ManagingShipmentsContext implements Context
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
         private SharedStorageInterface $sharedStorage,
-        private string $apiUrlPrefix
+        private string $apiUrlPrefix,
     ) {
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
@@ -36,7 +36,8 @@ final class ManagingShipmentsContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
-        private SharedStorageInterface $sharedStorage
+        private SharedStorageInterface $sharedStorage,
+        private string $apiRoute
     ) {
     }
 
@@ -116,7 +117,7 @@ final class ManagingShipmentsContext implements Context
         $shipment = $order->getShipments()->first();
 
         $this->client->customAction(
-            sprintf('/api/v2/admin/shipments/%s/ship', (string) $shipment->getId()),
+            sprintf('%s/admin/shipments/%s/ship', $this->apiRoute,(string) $shipment->getId()),
             HttpRequest::METHOD_PATCH
         );
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
@@ -37,7 +37,7 @@ final class ManagingShipmentsContext implements Context
         private ResponseCheckerInterface $responseChecker,
         private IriConverterInterface $iriConverter,
         private SharedStorageInterface $sharedStorage,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -117,7 +117,7 @@ final class ManagingShipmentsContext implements Context
         $shipment = $order->getShipments()->first();
 
         $this->client->customAction(
-            sprintf('%s/admin/shipments/%s/ship', $this->apiRoute,(string) $shipment->getId()),
+            sprintf('%s/admin/shipments/%s/ship', $this->apiUrlPrefix,(string) $shipment->getId()),
             HttpRequest::METHOD_PATCH
         );
     }

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -39,6 +39,7 @@ final class CartContext implements Context
         private ProductVariantResolverInterface $productVariantResolver,
         private IriConverterInterface $iriConverter,
         private RequestFactoryInterface $requestFactory,
+        private string $apiUrlPrefix,
     ) {
     }
 
@@ -672,7 +673,7 @@ final class CartContext implements Context
     private function pickupCart(?string $localeCode = null): string
     {
         $request = $this->requestFactory->custom(
-            '/shop/orders',
+            sprintf('%s/shop/orders', $this->apiUrlPrefix),
             HttpRequest::METHOD_POST,
             $localeCode ? ['HTTP_ACCEPT_LANGUAGE' => $localeCode] : []
         );

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -672,7 +672,7 @@ final class CartContext implements Context
     private function pickupCart(?string $localeCode = null): string
     {
         $request = $this->requestFactory->custom(
-            '/api/v2/shop/orders',
+            '/shop/orders',
             HttpRequest::METHOD_POST,
             $localeCode ? ['HTTP_ACCEPT_LANGUAGE' => $localeCode] : []
         );

--- a/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
@@ -26,7 +26,8 @@ final class ChannelContext implements Context
     public function __construct(
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
-        private SharedStorageInterface $sharedStorage
+        private SharedStorageInterface $sharedStorage,
+        private string $apiRoute
     ) {
     }
 
@@ -53,7 +54,7 @@ final class ChannelContext implements Context
                 $this->client->getLastResponse(),
                 'baseCurrency'
             ),
-            sprintf('/api/v2/shop/currencies/%s', $currencyCode)
+            sprintf('%s/shop/currencies/%s', $this->apiRoute, $currencyCode)
         );
     }
 }

--- a/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
@@ -27,7 +27,7 @@ final class ChannelContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private SharedStorageInterface $sharedStorage,
-        private string $apiUrlPrefix
+        private string $apiUrlPrefix,
     ) {
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
@@ -27,7 +27,7 @@ final class ChannelContext implements Context
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
         private SharedStorageInterface $sharedStorage,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -54,7 +54,7 @@ final class ChannelContext implements Context
                 $this->client->getLastResponse(),
                 'baseCurrency'
             ),
-            sprintf('%s/shop/currencies/%s', $this->apiRoute, $currencyCode)
+            sprintf('%s/shop/currencies/%s', $this->apiUrlPrefix, $currencyCode)
         );
     }
 }

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -38,6 +38,7 @@ final class CustomerContext implements Context
         private LoginContext $loginContext,
         private ShopSecurityContext $shopApiSecurityContext,
         private RequestFactoryInterface $requestFactory,
+        private string $apiUrlPrefix,
     ) {
     }
 
@@ -470,7 +471,7 @@ final class CustomerContext implements Context
     private function verifyAccount(string $token): void
     {
         $request = $this->requestFactory->custom(
-            \sprintf('/shop/account-verification-requests/%s', $token),
+            \sprintf('%s/shop/account-verification-requests/%s', $this->apiUrlPrefix, $token),
             HttpRequest::METHOD_PATCH,
         );
 

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -470,7 +470,7 @@ final class CustomerContext implements Context
     private function verifyAccount(string $token): void
     {
         $request = $this->requestFactory->custom(
-            \sprintf('/api/v2/shop/account-verification-requests/%s', $token),
+            \sprintf('/shop/account-verification-requests/%s', $token),
             HttpRequest::METHOD_PATCH,
         );
 

--- a/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
@@ -24,7 +24,7 @@ final class HomepageContext implements Context
     public function __construct(
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
-        private string $apiUrlPrefix
+        private string $apiUrlPrefix,
     ) {
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
@@ -24,7 +24,7 @@ final class HomepageContext implements Context
     public function __construct(
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -34,7 +34,7 @@ final class HomepageContext implements Context
     public function iCheckLatestProducts(): void
     {
         $this->client->customAction(
-            sprintf('%s/shop/products?itemsPerPage=3&order[createdAt]=desc', $this->apiRoute),
+            sprintf('%s/shop/products?itemsPerPage=3&order[createdAt]=desc', $this->apiUrlPrefix),
             HttpRequest::METHOD_GET
         );
     }
@@ -44,7 +44,7 @@ final class HomepageContext implements Context
      */
     public function iCheckAvailableTaxons(): void
     {
-        $this->client->customAction(sprintf('%s/shop/taxons', $this->apiRoute), HttpRequest::METHOD_GET);
+        $this->client->customAction(sprintf('%s/shop/taxons', $this->apiUrlPrefix), HttpRequest::METHOD_GET);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
@@ -21,16 +21,11 @@ use Webmozart\Assert\Assert;
 
 final class HomepageContext implements Context
 {
-    private ApiClientInterface $client;
-
-    private ResponseCheckerInterface $responseChecker;
-
     public function __construct(
-        ApiClientInterface $client,
-        ResponseCheckerInterface $responseChecker
+        private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
+        private string $apiRoute
     ) {
-        $this->client = $client;
-        $this->responseChecker = $responseChecker;
     }
 
     /**
@@ -39,7 +34,7 @@ final class HomepageContext implements Context
     public function iCheckLatestProducts(): void
     {
         $this->client->customAction(
-            'api/v2/shop/products?itemsPerPage=3&order[createdAt]=desc',
+            sprintf('%s/shop/products?itemsPerPage=3&order[createdAt]=desc', $this->apiRoute),
             HttpRequest::METHOD_GET
         );
     }
@@ -49,7 +44,7 @@ final class HomepageContext implements Context
      */
     public function iCheckAvailableTaxons(): void
     {
-        $this->client->customAction('api/v2/shop/taxons', HttpRequest::METHOD_GET);
+        $this->client->customAction(sprintf('%s/shop/taxons', $this->apiRoute), HttpRequest::METHOD_GET);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -39,7 +39,8 @@ final class LoginContext implements Context
         private AbstractBrowser $shopAuthenticationTokenClient,
         private ResponseCheckerInterface $responseChecker,
         private SharedStorageInterface $sharedStorage,
-        private RequestFactoryInterface $requestFactory
+        private RequestFactoryInterface $requestFactory,
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -58,7 +59,7 @@ final class LoginContext implements Context
     {
         $this->shopAuthenticationTokenClient->request(
             'POST',
-            '/shop/authentication-token',
+            sprintf('%s/shop/authentication-token', $this->apiUrlPrefix),
             [],
             [],
             ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
@@ -104,7 +105,7 @@ final class LoginContext implements Context
     public function iFollowLinkOnMyEmailToResetPassword(ShopUserInterface $user): void
     {
         $this->request = $this->requestFactory->custom(
-            sprintf('/shop/reset-password-requests/%s', $user->getPasswordResetToken()),
+            sprintf('%s/shop/reset-password-requests/%s', $this->apiUrlPrefix, $user->getPasswordResetToken()),
             HttpRequest::METHOD_PATCH
         );
     }
@@ -268,7 +269,10 @@ final class LoginContext implements Context
     {
         $this->client->executeCustomRequest($this->request);
 
-        Assert::same($this->client->getLastResponse()->getStatusCode(), 404);
+        // token is removed when used
+        Assert::same($this->client->getLastResponse()->getStatusCode(), 500);
+        $message = $this->responseChecker->getError($this->client->getLastResponse());
+        Assert::startsWith($message, 'No user found with reset token: ');
     }
 
     private function addLocale(string $locale): void

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -39,7 +39,7 @@ final class LoginContext implements Context
         private AbstractBrowser $shopAuthenticationTokenClient,
         private ResponseCheckerInterface $responseChecker,
         private SharedStorageInterface $sharedStorage,
-        private RequestFactoryInterface $requestFactory,
+        private RequestFactoryInterface $requestFactory
     ) {
     }
 
@@ -58,7 +58,7 @@ final class LoginContext implements Context
     {
         $this->shopAuthenticationTokenClient->request(
             'POST',
-            '/api/v2/shop/authentication-token',
+            '/shop/authentication-token',
             [],
             [],
             ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
@@ -104,7 +104,7 @@ final class LoginContext implements Context
     public function iFollowLinkOnMyEmailToResetPassword(ShopUserInterface $user): void
     {
         $this->request = $this->requestFactory->custom(
-            sprintf('api/v2/shop/reset-password-requests/%s', $user->getPasswordResetToken()),
+            sprintf('/shop/reset-password-requests/%s', $user->getPasswordResetToken()),
             HttpRequest::METHOD_PATCH
         );
     }

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -37,13 +37,14 @@ use Webmozart\Assert\Assert;
 final class OrderContext implements Context
 {
     public function __construct(
-        private ApiClientInterface $shopClient,
-        private ApiClientInterface $adminClient,
+        private ApiClientInterface       $shopClient,
+        private ApiClientInterface       $adminClient,
         private ResponseCheckerInterface $responseChecker,
-        private SharedStorageInterface $sharedStorage,
-        private IriConverterInterface $iriConverter,
+        private SharedStorageInterface   $sharedStorage,
+        private IriConverterInterface    $iriConverter,
         private SecurityServiceInterface $securityService,
-        private RequestFactoryInterface $requestFactory,
+        private RequestFactoryInterface  $requestFactory,
+        private string                   $apiUrlPrefix,
     ) {
     }
 
@@ -57,7 +58,8 @@ final class OrderContext implements Context
 
         $request = $this->requestFactory->custom(
             sprintf(
-                '/shop/account/orders/%s/payments/%s',
+                '%s/shop/account/orders/%s/payments/%s',
+                $this->apiUrlPrefix,
                 $order->getTokenValue(),
                 (string) $order->getPayments()->first()->getId()
             ),
@@ -380,7 +382,7 @@ final class OrderContext implements Context
     private function getAdjustmentsForOrderItem(string $itemId): array
     {
         $response = $this->shopClient->customAction(
-            sprintf('/shop/orders/%s/items/%s/adjustments', $this->sharedStorage->get('cart_token'), $itemId),
+            sprintf('%s/shop/orders/%s/items/%s/adjustments', $this->sharedStorage->get('cart_token'), $itemId),
             HttpRequest::METHOD_GET
         );
 

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -37,14 +37,14 @@ use Webmozart\Assert\Assert;
 final class OrderContext implements Context
 {
     public function __construct(
-        private ApiClientInterface       $shopClient,
-        private ApiClientInterface       $adminClient,
+        private ApiClientInterface $shopClient,
+        private ApiClientInterface $adminClient,
         private ResponseCheckerInterface $responseChecker,
-        private SharedStorageInterface   $sharedStorage,
-        private IriConverterInterface    $iriConverter,
+        private SharedStorageInterface $sharedStorage,
+        private IriConverterInterface $iriConverter,
         private SecurityServiceInterface $securityService,
         private RequestFactoryInterface  $requestFactory,
-        private string                   $apiUrlPrefix,
+        private string $apiUrlPrefix,
     ) {
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -57,7 +57,7 @@ final class OrderContext implements Context
 
         $request = $this->requestFactory->custom(
             sprintf(
-                '/api/v2/shop/account/orders/%s/payments/%s',
+                '/shop/account/orders/%s/payments/%s',
                 $order->getTokenValue(),
                 (string) $order->getPayments()->first()->getId()
             ),
@@ -380,7 +380,7 @@ final class OrderContext implements Context
     private function getAdjustmentsForOrderItem(string $itemId): array
     {
         $response = $this->shopClient->customAction(
-            sprintf('/api/v2/shop/orders/%s/items/%s/adjustments', $this->sharedStorage->get('cart_token'), $itemId),
+            sprintf('/shop/orders/%s/items/%s/adjustments', $this->sharedStorage->get('cart_token'), $itemId),
             HttpRequest::METHOD_GET
         );
 

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -382,7 +382,7 @@ final class OrderContext implements Context
     private function getAdjustmentsForOrderItem(string $itemId): array
     {
         $response = $this->shopClient->customAction(
-            sprintf('%s/shop/orders/%s/items/%s/adjustments', $this->sharedStorage->get('cart_token'), $itemId),
+            sprintf('%s/shop/orders/%s/items/%s/adjustments', $this->apiUrlPrefix, $this->sharedStorage->get('cart_token'), $itemId),
             HttpRequest::METHOD_GET
         );
 

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -39,7 +39,7 @@ final class ProductContext implements Context
         private IriConverterInterface $iriConverter,
         private ChannelContextSetterInterface $channelContextSetter,
         private RequestFactoryInterface $requestFactory,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -77,7 +77,7 @@ final class ProductContext implements Context
      */
     public function iViewProductUsingSlug(ProductInterface $product): void
     {
-        $this->client->showByIri(sprintf('%s/shop/products-by-slug/%s', $this->apiRoute, $product->getSlug()));
+        $this->client->showByIri(sprintf('%s/shop/products-by-slug/%s', $this->apiUrlPrefix, $product->getSlug()));
 
         $this->sharedStorage->set('product', $product);
     }
@@ -89,7 +89,7 @@ final class ProductContext implements Context
     {
         $response = $this->client->getLastResponse();
 
-        Assert::eq($response->headers->get('Location'), sprintf('%s/shop/products/%s', $this->apiRoute, $product->getCode()));
+        Assert::eq($response->headers->get('Location'), sprintf('%s/shop/products/%s', $this->apiUrlPrefix, $product->getCode()));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -39,6 +39,7 @@ final class ProductContext implements Context
         private IriConverterInterface $iriConverter,
         private ChannelContextSetterInterface $channelContextSetter,
         private RequestFactoryInterface $requestFactory,
+        private string $apiRoute
     ) {
     }
 
@@ -76,7 +77,7 @@ final class ProductContext implements Context
      */
     public function iViewProductUsingSlug(ProductInterface $product): void
     {
-        $this->client->showByIri('/api/v2/shop/products-by-slug/' . $product->getSlug());
+        $this->client->showByIri(sprintf('%s/shop/products-by-slug/%s', $this->apiRoute, $product->getSlug()));
 
         $this->sharedStorage->set('product', $product);
     }
@@ -88,7 +89,7 @@ final class ProductContext implements Context
     {
         $response = $this->client->getLastResponse();
 
-        Assert::eq($response->headers->get('Location'), '/api/v2/shop/products/' . $product->getCode());
+        Assert::eq($response->headers->get('Location'), sprintf('%s/shop/products/%s', $this->apiRoute, $product->getCode()));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -24,30 +24,16 @@ use Webmozart\Assert\Assert;
 
 final class RegistrationContext implements Context
 {
-    private AbstractBrowser $client;
-
-    private ApiClientInterface $shopClient;
-
-    private LoginContext $loginContext;
-
-    private SharedStorageInterface $sharedStorage;
-
-    private ResponseCheckerInterface $responseChecker;
-
     private array $content = [];
 
     public function __construct(
-        AbstractBrowser $client,
-        ApiClientInterface $shopClient,
-        LoginContext $loginContext,
-        SharedStorageInterface $sharedStorage,
-        ResponseCheckerInterface $responseChecker
+        private AbstractBrowser $client,
+        private ApiClientInterface $shopClient,
+        private LoginContext $loginContext,
+        private SharedStorageInterface $sharedStorage,
+        private ResponseCheckerInterface $responseChecker,
+        private string $apiRoute
     ) {
-        $this->client = $client;
-        $this->shopClient = $shopClient;
-        $this->loginContext = $loginContext;
-        $this->sharedStorage = $sharedStorage;
-        $this->responseChecker = $responseChecker;
     }
 
     /**
@@ -122,7 +108,7 @@ final class RegistrationContext implements Context
 
         $this->client->request(
             'PATCH',
-            \sprintf('/api/v2/shop/account-verification-requests/%s', $token),
+            \sprintf('%s/shop/account-verification-requests/%s', $this->apiRoute, $token),
             [],
             [],
             ['HTTP_ACCEPT' => 'application/ld+json', 'CONTENT_TYPE' => 'application/merge-patch+json'],
@@ -156,7 +142,7 @@ final class RegistrationContext implements Context
     {
         $this->client->request(
             'POST',
-            '/api/v2/shop/customers',
+            sprintf('%s/shop/customers', $this->apiRoute),
             [],
             [],
             ['HTTP_ACCEPT' => 'application/ld+json', 'CONTENT_TYPE' => 'application/ld+json'],

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -32,7 +32,7 @@ final class RegistrationContext implements Context
         private LoginContext $loginContext,
         private SharedStorageInterface $sharedStorage,
         private ResponseCheckerInterface $responseChecker,
-        private string $apiRoute
+        private string $apiUrlPrefix
     ) {
     }
 
@@ -108,7 +108,7 @@ final class RegistrationContext implements Context
 
         $this->client->request(
             'PATCH',
-            \sprintf('%s/shop/account-verification-requests/%s', $this->apiRoute, $token),
+            \sprintf('%s/shop/account-verification-requests/%s', $this->apiUrlPrefix, $token),
             [],
             [],
             ['HTTP_ACCEPT' => 'application/ld+json', 'CONTENT_TYPE' => 'application/merge-patch+json'],
@@ -142,7 +142,7 @@ final class RegistrationContext implements Context
     {
         $this->client->request(
             'POST',
-            sprintf('%s/shop/customers', $this->apiRoute),
+            sprintf('%s/shop/customers', $this->apiUrlPrefix),
             [],
             [],
             ['HTTP_ACCEPT' => 'application/ld+json', 'CONTENT_TYPE' => 'application/ld+json'],

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -16,6 +16,7 @@
         <service id="sylius.behat.api_platform_client" class="Sylius\Behat\Client\ApiPlatformClient" abstract="true">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius.security.new_api_route%</argument>
             <argument type="service" id="sylius.behat.request_factory" />
             <argument>%sylius.api.authorization_header%</argument>
         </service>
@@ -34,12 +35,14 @@
 
         <service id="sylius.behat.client.admin_api_platform_security_client" class="Sylius\Behat\Client\ApiPlatformSecurityClient">
             <argument type="service" id="test.client" />
+            <argument>%sylius.security.new_api_route%</argument>
             <argument>admin</argument>
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 
         <service id="sylius.behat.client.shop_api_platform_security_client" class="Sylius\Behat\Client\ApiPlatformSecurityClient">
             <argument type="service" id="test.client" />
+            <argument>%sylius.security.new_api_route%</argument>
             <argument>shop</argument>
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -16,7 +16,6 @@
         <service id="sylius.behat.api_platform_client" class="Sylius\Behat\Client\ApiPlatformClient" abstract="true">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
-            <argument>%sylius.security.new_api_route%</argument>
             <argument type="service" id="sylius.behat.request_factory" />
             <argument>%sylius.api.authorization_header%</argument>
         </service>
@@ -51,6 +50,7 @@
 
         <service id="sylius.behat.request_factory" class="Sylius\Behat\Client\RequestFactory">
             <argument type="service" id="sylius.behat.content_type_guide"/>
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -34,16 +34,16 @@
 
         <service id="sylius.behat.client.admin_api_platform_security_client" class="Sylius\Behat\Client\ApiPlatformSecurityClient">
             <argument type="service" id="test.client" />
+            <argument type="service" id="sylius.behat.shared_storage" />
             <argument>%sylius.security.new_api_route%</argument>
             <argument>admin</argument>
-            <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 
         <service id="sylius.behat.client.shop_api_platform_security_client" class="Sylius\Behat\Client\ApiPlatformSecurityClient">
             <argument type="service" id="test.client" />
+            <argument type="service" id="sylius.behat.shared_storage" />
             <argument>%sylius.security.new_api_route%</argument>
             <argument>shop</argument>
-            <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 
         <service id="sylius.behat.content_type_guide" class="Sylius\Behat\Client\ContentTypeGuide" />

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
@@ -58,6 +58,7 @@
             <argument type="service" id="sylius.behat.api_platform_client.admin" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_locales" class="Sylius\Behat\Context\Api\Admin\ManagingLocalesContext">
@@ -82,6 +83,7 @@
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_product_variants" class="Sylius\Behat\Context\Api\Admin\ManagingProductVariantsContext">
@@ -128,6 +130,7 @@
             <argument type="service" id="sylius.behat.api_platform_client.admin" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="api_platform.iri_converter" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_shipments" class="Sylius\Behat\Context\Api\Admin\ManagingShipmentsContext">
@@ -135,6 +138,7 @@
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_orders" class="Sylius\Behat\Context\Api\Admin\ManagingOrdersContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="sylius.behat.api_platform_client.shop" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.currency" class="Sylius\Behat\Context\Api\Shop\CurrencyContext">
@@ -45,6 +46,7 @@
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.customer" class="Sylius\Behat\Context\Api\Shop\CustomerContext">
@@ -55,6 +57,7 @@
             <argument type="service" id="sylius.behat.context.api.shop.login" />
             <argument type="service" id="sylius.behat.context.setup.shop_api_security" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.promotion" class="Sylius\Behat\Context\Api\Shop\PromotionContext">
@@ -80,6 +83,7 @@
         <service id="sylius.behat.context.api.shop.homepage" class="Sylius\Behat\Context\Api\Shop\HomepageContext">
             <argument type="service" id="sylius.behat.api_platform_client.shop" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.login" class="Sylius\Behat\Context\Api\Shop\LoginContext">
@@ -99,6 +103,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.channel_context_setter" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.product_variant" class="Sylius\Behat\Context\Api\Shop\ProductVariantContext">
@@ -120,6 +125,7 @@
             <argument type="service" id="sylius.behat.context.api.shop.login" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.order" class="Sylius\Behat\Context\Api\Shop\OrderContext">
@@ -130,6 +136,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.api_security" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.order_item" class="Sylius\Behat\Context\Api\Shop\OrderItemContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -94,6 +94,7 @@
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.product" class="Sylius\Behat\Context\Api\Shop\ProductContext">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Give the ability to use Behat API tests with a different api prefix, useful if you don't use the default prefix `/api/v2` or simply wanted to use some Behat services with another APIP installation.
