### PR TITLE
Use API Url prefix on sylius.api.paths_to_hide

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -5,9 +5,9 @@ parameters:
     env(SYLIUS_API_AUTHORIZATION_HEADER): Authorization
     sylius.api.authorization_header: "%env(resolve:SYLIUS_API_AUTHORIZATION_HEADER)%"
     sylius.api.paths_to_hide: 
-        - "/api/v2/admin/catalog-promotion-actions/{id}"
-        - "/api/v2/admin/catalog-promotion-scopes/{id}"
-        - "/api/v2/admin/channel-pricings/{id}"
+        - "%sylius.security.new_api_route%/admin/catalog-promotion-actions/{id}"
+        - "%sylius.security.new_api_route%/admin/catalog-promotion-scopes/{id}"
+        - "%sylius.security.new_api_route%/admin/channel-pricings/{id}"
     sylius.security.new_api_route: "/api/v2"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
     sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes (in case you are not using the default api url prefix)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

If you are using another url prefix, different from `/api/v2` then those paths are not processed, this PR fix this issue.
