### PR TITLE
[Maintenance] Specify the default path in the ECS configuration

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -37,6 +37,7 @@ TEXT
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PARALLEL, true);
+    $parameters->set(Option::PATHS, ['src/Sylius']);
     $parameters->set(Option::SKIP, [
         InlineDocCommentDeclarationSniff::class . '.MissingVariable',
         InlineDocCommentDeclarationSniff::class . '.NoAssignment',


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

It makes ECS execution a little bit easier :slightly_smiling_face: 

Before:
```bash
vendor/bin/ecs check --fix src/Sylius
```

After:
```bash
vendor/bin/ecs check --fix
```

Yet it is still possible to set any argument in the command, then `src/Sylius` will be overwritten.