### PR TITLE
[Maintenance] Fix missing import in ECS config

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -10,6 +10,7 @@
  */
 
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\ValueObject\Option;


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no
| Related tickets | |
| License         | MIT                                                          |

`HeaderCommentFixer` was provided in https://github.com/Sylius/Sylius/pull/13890. Something went wrong during the upmerge I think and now ECS doesn't work on `1.11` and `master` branches.