### PR TITLE
 [1.11][User] Reduce usage of deprecated `\Serializable` interface #13642 

### DIFF
--- a/src/Sylius/Behat/spec/Service/SecurityServiceSpec.php
+++ b/src/Sylius/Behat/spec/Service/SecurityServiceSpec.php
@@ -48,7 +48,7 @@ final class SecurityServiceSpec extends ObjectBehavior
     ) {
         $shopUser->getRoles()->willReturn(['ROLE_USER']);
         $shopUser->getPassword()->willReturn('xyz');
-        $shopUser->serialize()->willReturn('serialized_user');
+        $shopUser->__serialize()->willReturn(['serialized_user']);
 
         $session->set('_security_shop', Argument::any())->shouldBeCalled();
         $session->save()->shouldBeCalled();

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -381,9 +381,9 @@ class User implements UserInterface, \Stringable
     /**
      * The serialized data have to contain the fields used by the equals method and the username.
      */
-    public function serialize(): string
+    public function __serialize(): array
     {
-        return serialize([
+        return [
             $this->password,
             $this->salt,
             $this->usernameCanonical,
@@ -392,18 +392,23 @@ class User implements UserInterface, \Stringable
             $this->enabled,
             $this->id,
             $this->encoderName,
-        ]);
+        ];
     }
 
     /**
-     * @param string $serialized
+     * @internal
+     * @deprecated since 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__serialize() or \serialize($user) in PHP 8.1 instead
      */
-    public function unserialize($serialized): void
+    public function serialize(): string
     {
-        $data = unserialize($serialized);
+        return serialize($this->__serialize());
+    }
+
+    public function __unserialize(array $serialized): void
+    {
         // add a few extra elements in the array to ensure that we have enough keys when unserializing
         // older data which does not include all properties.
-        $data = array_merge($data, array_fill(0, 2, null));
+        $serialized = array_merge($serialized, array_fill(0, 2, null));
 
         [
             $this->password,
@@ -414,7 +419,18 @@ class User implements UserInterface, \Stringable
             $this->enabled,
             $this->id,
             $this->encoderName,
-        ] = $data;
+        ] = $serialized;
+    }
+
+    /**
+     * @param string $serialized
+     *
+     * @internal
+     * @deprecated since 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__unserialize() or \unserialize($serialized) in PHP 8.1 instead
+     */
+    public function unserialize($serialized): void
+    {
+        $this->__unserialize(unserialize($serialized));
     }
 
     protected function hasExpired(?\DateTimeInterface $date): bool

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -111,4 +111,8 @@ interface UserInterface extends
     public function addOAuthAccount(UserOAuthInterface $oauth): void;
 
     public function setEncoderName(?string $encoderName): void;
+
+    public function __serialize(): array;
+
+    public function __unserialize(array $data): void;
 }


### PR DESCRIPTION
Remove deprecated message of `\Serializable` interface in `User` entity which is reported in PHP 8.1.

```
Deprecated: Sylius\Component\User\Model\User implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in /srv/acme/vendor/sylius/sylius/src/Sylius/Component/User/Model/User.php on line 21
```

- Added new `__serialize` and `__unserialize` methods to cover serialization
- Made `serialize` and `unserialize` internal to prevent usage of them (we can remove in next version).

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11         |
| Bug fix?        | no                                                      |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no/yes |
| Related tickets | https://github.com/Sylius/Sylius/pull/13642                      |
| License         | MIT                                                          |

