### PR TITLE
[maintenance][docker]Increase opcache limits

### DIFF
--- a/.docker/test/php.ini
+++ b/.docker/test/php.ini
@@ -7,8 +7,8 @@ date.timezone=${PHP_DATE_TIMEZONE}
 [opcache]
 opcache.enable=1
 opcache.enable_cli=0
-opcache.memory_consumption=256
-opcache.max_accelerated_files=32531
+opcache.memory_consumption=1024
+opcache.max_accelerated_files=65407
 opcache.interned_strings_buffer=8
 opcache.validate_timestamps=0
 opcache.save_comments=1


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master          |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | none                      |
| License         | MIT                                                          |

We require almost 4GB in PHP memory, therefore 1GB of opcache memory shouldn't be that much in test environment and will reduce pipeline time
