### PR TITLE
[maintenance][docker]Use synchronous messenger transport

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     docker-compose:
-        name: Excute Tests on Docker Compose
+        name: Execute Tests on Docker Compose
         runs-on: ubuntu-latest
         env:
             COMPOSE_FILE: docker-compose.test.yml
@@ -18,7 +18,7 @@ jobs:
                 run: docker-compose run ci
 
     docker:
-        name: Excute Tests on Docker Containers
+        name: Execute Tests on Docker Containers
         runs-on: ubuntu-latest
         steps:
             -
@@ -48,6 +48,7 @@ jobs:
                         -e DATABASE_URL="mysql://root@mysql/sylius_test" \
                         -e APP_ENV="test" \
                         -e PHP_DATE_TIMEZONE="Europe/Warsaw" \
+                        -e MESSENGER_TRANSPORT_DSN="sync://" \
                         --net sylius_network \
                         --entrypoint="" \
                         -p 80:80/tcp \

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,6 +6,7 @@ services:
             APP_ENV: "test"
             DATABASE_URL: "mysql://root:mysql@mysql/sylius_test"
             PHP_DATE_TIMEZONE: "Europe/Warsaw"
+            MESSENGER_TRANSPORT_DSN: "sync://"
         volumes:
             - ./:/app:delegated
             - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master          |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | master                      |
| License         | MIT                                                          |

The test pipelines use synchronous messenger transport therefore docker test pipelines should too.
