### PR TITLE
Bump flex to ^1.17, v1.13 - old infrastructure shutdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -212,7 +212,7 @@
         "symfony/browser-kit": "^4.4 || ^5.2",
         "symfony/debug-bundle": "^4.4 || ^5.2",
         "symfony/dotenv": "^4.4 || ^5.2",
-        "symfony/flex": "^1.17",
+        "symfony/flex": "^1.17.1",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
         "vimeo/psalm": "^4.19"
     },

--- a/composer.json
+++ b/composer.json
@@ -212,7 +212,7 @@
         "symfony/browser-kit": "^4.4 || ^5.2",
         "symfony/debug-bundle": "^4.4 || ^5.2",
         "symfony/dotenv": "^4.4 || ^5.2",
-        "symfony/flex": "^1.7",
+        "symfony/flex": "^1.17",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
         "vimeo/psalm": "^4.19"
     },


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master          |
| Bug fix?        | yes                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes |
| Related tickets | -                     |
| License         | MIT                                                          |


https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down
