### PR TITLE
[docker][maintenance]Extend Makefile possibilities and compose tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,53 +4,34 @@ on:
     push:
 
 jobs:
-    docker-compose:
-        name: Execute Tests on Docker Compose
+    static-analyze:
+        name: Execute Static Analyze on Docker Compose
         runs-on: ubuntu-latest
         env:
             COMPOSE_FILE: docker-compose.test.yml
 
         steps:
-            -   name: Checkout code
+            -
+                name: Checkout Code
                 uses: actions/checkout@v2
 
-            -   name: Run PHPUnit, PHPSpec and Behat tests
-                run: docker-compose run ci
+            -
+                name: Run PHPUnit, PHPSpec and Psalm
+                # docker-compose -f docker-compose.test.yml --profile static-analyze run static
+                run: docker compose --profile static-analyze run static
 
-    docker:
-        name: Execute Tests on Docker Containers
+    integration:
+        name: Execute Behat Tests on Docker Compose
         runs-on: ubuntu-latest
+        env:
+            COMPOSE_FILE: docker-compose.test.yml
+        
         steps:
             -
-                name: Checkout
+                name: Checkout Code
                 uses: actions/checkout@v2
+
             -
-                name: Shutdown default MySQL
-                run: sudo service mysql stop
-            -
-                name: Setup MySQL
-                run: |
-                    docker network create sylius_network
-                    docker run \
-                        --platform linux/amd64 \
-                        -e MYSQL_ALLOW_EMPTY_PASSWORD=true \
-                        -p 3306:3306/tcp \
-                        --name mysql \
-                        --net sylius_network \
-                        -d mysql:5.7
-            -
-                name: Run PHPUnit, PHPSpec and Behat tests
-                run: |
-                    docker run \
-                        -v "$(pwd)"/:/app:delegated \
-                        -v "$(pwd)"/.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated \
-                        -v "$(pwd)"/.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated \
-                        -e DATABASE_URL="mysql://root@mysql/sylius_test" \
-                        -e APP_ENV="test" \
-                        -e PHP_DATE_TIMEZONE="Europe/Warsaw" \
-                        -e MESSENGER_TRANSPORT_DSN="sync://" \
-                        --net sylius_network \
-                        --entrypoint="" \
-                        -p 80:80/tcp \
-                        -i sylius/standard:1.11-traditional \
-                        make ci
+                name: Run Behat
+                # docker-compose -f docker-compose.test.yml --profile integration run behat
+                run: docker-compose --profile integration run behat

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,19 +1,31 @@
 services:
-    ci:
+    static:
         image: sylius/standard:1.11-traditional
-        entrypoint: ["make", "ci"]
+        entrypoint: ["make", "static"]
+        profiles: ["static-analyze"]
         environment:
             APP_ENV: "test_cached"
-            APP_DEBUG: 0
-            DATABASE_URL: "mysql://root:mysql@mysql/sylius_%kernel.environment%?charset=utf8mb4"
+            PHP_DATE_TIMEZONE: "Europe/Warsaw"
+        volumes:
+            - ./:/app:delegated
+            - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
+            - ./.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated
+        networks:
+            - sylius
+    
+    behat:
+        image: sylius/standard:1.11-traditional
+        entrypoint: ["make", "integration"]
+        profiles: ["integration"]
+        environment:
+            APP_ENV: "test_cached"
+            DATABASE_URL: "mysql://root:mysql@mysql/sylius_%kernel.environment%"
             PHP_DATE_TIMEZONE: "Europe/Warsaw"
             MESSENGER_TRANSPORT_DSN: "sync://"
         volumes:
             - ./:/app:delegated
             - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
             - ./.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated
-        ports:
-            - 80:80
         depends_on:
             - mysql
         networks:
@@ -21,11 +33,10 @@ services:
 
     mysql:
         image: mysql:5.7
+        profiles: ["integration"]
         platform: linux/amd64
         environment:
             MYSQL_ROOT_PASSWORD: mysql
-        ports:
-            - 3306:3306
         networks:
             - sylius
 


### PR DESCRIPTION
1. Removed inline-docker pipeline - it is exactly like docker-compose but uglier
2. Separated tests for static analysis and behat (integration tests)
3. Created special docker profiles (https://docs.docker.com/compose/profiles/)