### PR TITLE
[WIP] Enabled variants serialization performance

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DataProvider/ProductItemDataProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/DataProvider/ProductItemDataProvider.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataProvider;
 
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\ProductWithEnabledVariantsExtension;
 use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -28,7 +31,9 @@ final class ProductItemDataProvider implements RestrictedDataProviderInterface, 
 {
     public function __construct(
         private ProductRepositoryInterface $productRepository,
-        private UserContextInterface $userContext
+        private UserContextInterface $userContext,
+        private ManagerRegistry $managerRegistry,
+        private iterable $itemExtensions
     ) {
     }
 
@@ -44,6 +49,17 @@ final class ProductItemDataProvider implements RestrictedDataProviderInterface, 
 
         /** @var ChannelInterface $channel */
         $channel = $context[ContextKeys::CHANNEL];
+
+        /*
+         * Creating custom queryBuilder here makes below findOneByChannelAndCode unusable ( I guess )
+         * https://api-platform.com/docs/core/data-providers/#injecting-extensions-pagination-filter-eagerloading-etc
+         *
+        foreach ($this->itemExtensions as $extension) {
+            if ($extension instanceof ProductWithEnabledVariantsExtension) {
+                $extension->applyToItem($queryBuilder, $queryNameGenerator, $resourceClass, $identifiers, $operationName, $context);
+            }
+        }
+        */
 
         return $this->productRepository->findOneByChannelAndCode($channel, $id);
     }

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/ProductWithEnabledVariantsExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/ProductWithEnabledVariantsExtension.php
@@ -11,39 +11,42 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;
+namespace Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension;
 
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\ContextAwareQueryCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
 /** @experimental */
-final class ProductsWithEnableFlagExtension implements ContextAwareQueryCollectionExtensionInterface
+final class ProductWithEnabledVariantsExtension implements QueryItemExtensionInterface
 {
     public function __construct(private UserContextInterface $userContext)
     {
     }
 
-    public function applyToCollection(
+    public function applyToItem(
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,
-        ?string $operationName = null,
+        array $identifiers,
+        string $operationName = null,
         array $context = []
-    ): void {
+    ) {
+        // spec class is TODO
         if (!is_a($resourceClass, ProductInterface::class, true)) {
             return;
         }
 
         $user = $this->userContext->getUser();
-        if ($user !== null && in_array('ROLE_API_ACCESS', $user->getRoles(), true)) {
+
+        if ($user instanceof AdminUserInterface && in_array('ROLE_API_ACCESS', $user->getRoles(), true)) {
             return;
         }
 
         $rootAlias = $queryBuilder->getRootAliases()[0];
-        $enabledParameterName = $queryNameGenerator->generateParameterName('enabled');
         $enabledVariantParameter = $queryNameGenerator->generateParameterName('enabledVariants');
 
         $queryBuilder
@@ -52,8 +55,5 @@ final class ProductsWithEnableFlagExtension implements ContextAwareQueryCollecti
             ->addSelect('variants')
             ->setParameter($enabledVariantParameter, true)
         ;
-
-        $queryBuilder->andWhere(sprintf('%s.enabled = :%s', $rootAlias, $enabledParameterName));
-        $queryBuilder->setParameter($enabledParameterName, true);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
@@ -41,12 +41,15 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
             <tag name="api_platform.item_data_provider" priority="10" />
         </service>
-
-        <service id="Sylius\Bundle\ApiBundle\DataProvider\ProductItemDataProvider">
-            <argument type="service" id="sylius.repository.product" />
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
-            <tag name="api_platform.item_data_provider" priority="10" />
-        </service>
+        
+<!--Disabled in order to make unit ProductTest passable ( to use an Extension instead of data provider ) -->
+<!--        <service id="Sylius\Bundle\ApiBundle\DataProvider\ProductItemDataProvider">-->
+<!--            <argument type="service" id="sylius.repository.product" />-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />-->
+<!--            <argument type="service" id="doctrine" />-->
+<!--            <argument key="$itemExtensions" type="tagged" tag="api_platform.doctrine.orm.query_extension.item" />-->
+<!--            <tag name="api_platform.item_data_provider" priority="10" />-->
+<!--        </service>-->
 
         <service id="Sylius\Bundle\ApiBundle\DataProvider\ProductAttributesSubresourceDataProvider">
             <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.collection" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -106,5 +106,10 @@
             <tag name="api_platform.doctrine.orm.query_extension.collection" />
             <tag name="api_platform.doctrine.orm.query_extension.item" />
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\ProductWithEnabledVariantsExtension">
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
@@ -44,11 +44,12 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
 
         $data = $this->normalizer->normalize($object, $format, $context);
 
-        $data['variants'] = $object
-            ->getEnabledVariants()
-            ->map(fn (ProductVariantInterface $variant): string => $this->iriConverter->getIriFromItem($variant))
-            ->getValues()
-        ;
+// Output is not to iterate over object list
+//        $data['variants'] = $object
+//            ->getEnabledVariants()
+//            ->map(fn (ProductVariantInterface $variant): string => $this->iriConverter->getIriFromItem($variant))
+//            ->getValues()
+//        ;
 
         $defaultVariant = $this->defaultProductVariantResolver->getVariant($object);
         $data['defaultVariant'] = $defaultVariant === null ? null : $this->iriConverter->getIriFromItem($defaultVariant);

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtensionSpec.php
@@ -65,11 +65,18 @@ class ProductsWithEnableFlagExtensionSpec extends ObjectBehavior
         $userContext->getUser()->willReturn($user);
         $user->getRoles()->willReturn([]);
 
-        $queryNameGenerator->generateParameterName('enabled')->shouldBeCalled()->willReturn('enabled');
+        $queryNameGenerator->generateParameterName('enabled')->willReturn('enabled');
+        $queryNameGenerator->generateParameterName('enabledVariants')->willReturn('enabledVariants');
 
         $queryBuilder->getRootAliases()->willReturn(['o']);
-        $queryBuilder->andWhere('o.enabled = :enabled')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->setParameter('enabled', true)->shouldBeCalled()->willReturn($queryBuilder);
+
+        $queryBuilder->innerJoin('o.variants', 'variants')->willReturn($queryBuilder);
+        $queryBuilder->andWhere('variants.enabled = :enabledVariants')->willReturn($queryBuilder);
+        $queryBuilder->addSelect('variants')->willReturn($queryBuilder);
+        $queryBuilder->setParameter('enabledVariants', true)->willReturn($queryBuilder);
+
+        $queryBuilder->andWhere('o.enabled = :enabled')->willReturn($queryBuilder);
+        $queryBuilder->setParameter('enabled', true)->willReturn($queryBuilder);
 
         $this->applyToCollection($queryBuilder, $queryNameGenerator, ProductInterface::class, 'get', [ContextKeys::CHANNEL => $channel, ContextKeys::LOCALE_CODE => 'en_US']);
     }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
@@ -83,7 +83,6 @@ final class ProductNormalizerSpec extends ObjectBehavior
         $iriConverter->getIriFromItem($variant)->willReturn('/api/v2/shop/product-variants/CODE');
 
         $this->normalize($product, null, [])->shouldReturn([
-            'variants' => ['/api/v2/shop/product-variants/CODE'],
             'defaultVariant' => '/api/v2/shop/product-variants/CODE',
         ]);
     }
@@ -104,7 +103,6 @@ final class ProductNormalizerSpec extends ObjectBehavior
         $defaultProductVariantResolver->getVariant($product)->willReturn(null);
 
         $this->normalize($product, null, [])->shouldReturn([
-            'variants' => ['/api/v2/shop/product-variants/CODE'],
             'defaultVariant' => null,
         ]);
     }

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -170,6 +170,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
 
     public function findOneByChannelAndCode(ChannelInterface $channel, string $code): ?ProductInterface
     {
+        // possible place to add logic from an extension with `innerJoin variants where variant is enabled`
         $product = $this->createQueryBuilder('o')
             ->where('o.code = :code')
             ->andWhere(':channel MEMBER OF o.channels')

--- a/tests/Api/DataFixtures/ORM/product/product_with_enabled_and_disabled_variant.yaml
+++ b/tests/Api/DataFixtures/ORM/product/product_with_enabled_and_disabled_variant.yaml
@@ -1,0 +1,112 @@
+Sylius\Component\Core\Model\Channel:
+    channel_web:
+        code: 'WEB'
+        name: 'Web Channel'
+        hostname: 'localhost'
+        description: 'Lorem ipsum'
+        baseCurrency: '@currency_usd'
+        defaultLocale: '@locale_en'
+        locales: ['@locale_en', '@locale_pl']
+        color: 'black'
+        enabled: true
+        taxCalculationStrategy: 'order_items_based'
+
+Sylius\Component\Currency\Model\Currency:
+    currency_usd:
+        code: 'USD'
+
+Sylius\Component\Locale\Model\Locale:
+    locale_en:
+        code: 'en_US'
+    locale_pl:
+        code: 'pl_PL'
+    locale_de:
+        code: 'de_DE'
+
+Sylius\Component\Core\Model\Product:
+    product_mug:
+        code: 'MUG'
+        channels: ['@channel_web']
+        currentLocale: 'en_US'
+        translations:
+            en_US: '@product_translation_mug'
+        options: ['@product_option_color']
+
+Sylius\Component\Core\Model\ProductTranslation:
+    product_translation_mug:
+        slug: 'mug'
+        locale: 'en_US'
+        name: 'Mug'
+        description: '<paragraph(2)>'
+        translatable: '@product_mug'
+
+Sylius\Component\Core\Model\ProductVariant:
+    product_variant_mug_blue:
+        code: 'MUG_BLUE'
+        product: '@product_mug'
+        currentLocale: 'en_US'
+        enabled: false
+        translations:
+            en_US: '@product_variant_translation_mug_blue'
+        optionValues: ['@product_option_value_color_blue']
+        channelPricings:
+            WEB: '@channel_pricing_product_variant_mug_blue_web'
+
+    product_variant_mug_red:
+        code: 'MUG_RED'
+        product: '@product_mug'
+        currentLocale: 'en_US'
+        translations:
+            en_US: '@product_variant_translation_mug_red'
+        optionValues: ['@product_option_value_color_red']
+        channelPricings:
+            WEB: '@channel_pricing_product_variant_mug_red_web'
+
+Sylius\Component\Product\Model\ProductVariantTranslation:
+    product_variant_translation_mug_blue:
+        locale: 'en_US'
+        name: 'Blue Mug'
+        translatable: '@product_variant_mug_blue'
+    product_variant_translation_mug_red:
+        locale: 'en_US'
+        name: 'Red Mug'
+        translatable: '@product_variant_mug_red'
+
+Sylius\Component\Core\Model\ChannelPricing:
+    channel_pricing_product_variant_mug_blue_web:
+        channelCode: 'WEB'
+        price: 2000
+        originalPrice: 3000
+    channel_pricing_product_variant_mug_red_web:
+        channelCode: 'WEB'
+        price: 2000
+
+Sylius\Component\Product\Model\ProductOption:
+    product_option_color:
+        code: 'COLOR'
+
+Sylius\Component\Product\Model\ProductOptionValue:
+    product_option_value_color_blue:
+        code: 'COLOR_BLUE'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_color'
+        translations:
+            - '@product_option_value_translation_blue'
+    product_option_value_color_red:
+        code: 'COLOR_RED'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_color'
+        translations:
+            - '@product_option_value_translation_red'
+
+Sylius\Component\Product\Model\ProductOptionValueTranslation:
+    product_option_value_translation_blue:
+        locale: 'en_US'
+        value: 'Blue'
+        translatable: '@product_option_value_color_blue'
+    product_option_value_translation_red:
+        locale: 'en_US'
+        value: 'Red'
+        translatable: '@product_option_value_color_red'

--- a/tests/Api/Responses/Expected/shop/product/get_product_response.json
+++ b/tests/Api/Responses/Expected/shop/product/get_product_response.json
@@ -1,0 +1,26 @@
+{
+  "@context": "\/api\/v2\/contexts\/Product",
+  "@id": "\/api\/v2\/shop\/products\/MUG",
+  "@type": "Product",
+  "productTaxons": [],
+  "mainTaxon": null,
+  "reviews": [],
+  "averageRating": @integer@,
+  "images": [],
+  "id": @integer@,
+  "code": "MUG",
+  "variants": [
+    "\/api\/v2\/shop\/product-variants\/MUG_RED"
+  ],
+  "options": [
+    "\/api\/v2\/shop\/product-options\/COLOR"
+  ],
+  "createdAt": @date@,
+  "updatedAt": @date@,
+  "shortDescription": null,
+  "name": "Mug",
+  "description": @string@,
+  "slug": "mug",
+  "associations": [],
+  "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_RED"
+}

--- a/tests/Api/Responses/Expected/shop/product/get_products_response.json
+++ b/tests/Api/Responses/Expected/shop/product/get_products_response.json
@@ -14,7 +14,6 @@
             "id": @integer@,
             "code": "MUG",
             "variants": [
-                "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
                 "\/api\/v2\/shop\/product-variants\/MUG_RED"
             ],
             "options": [
@@ -27,7 +26,7 @@
             "description": @string@,
             "slug": "mug",
             "associations": [],
-            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_RED"
         }
     ],
     "hydra:totalItems": 1,

--- a/tests/Api/Shop/ProductsTest.php
+++ b/tests/Api/Shop/ProductsTest.php
@@ -24,7 +24,12 @@ final class ProductsTest extends JsonApiTestCase
     {
         $this->loadFixturesFromFile('product/product_variant_with_original_price.yaml');
 
-        $this->client->request('GET', '/api/v2/shop/products-by-slug/mug?paramName=paramValue', [], [], self::CONTENT_TYPE_HEADER);
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/products-by-slug/mug?paramName=paramValue',
+            server: self::CONTENT_TYPE_HEADER
+        );
+
         $response = $this->client->getResponse();
 
         $this->assertEquals('/api/v2/shop/products/MUG?paramName=paramValue', $response->headers->get(('Location')));
@@ -39,11 +44,9 @@ final class ProductsTest extends JsonApiTestCase
         /** @var ProductInterface $product */
         $product = $fixtures['product_mug'];
         $this->client->request(
-            'GET',
-            sprintf('/api/v2/shop/products/%s', $product->getCode()),
-            [],
-            [],
-            self::CONTENT_TYPE_HEADER
+            method: 'GET',
+            uri: sprintf('/api/v2/shop/products/%s', $product->getCode()),
+            server: self::CONTENT_TYPE_HEADER
         );
 
         $this->assertResponse(
@@ -61,11 +64,13 @@ final class ProductsTest extends JsonApiTestCase
         /** @var ProductInterface $product */
         $product = $fixtures['product_mug'];
         $this->client->request(
-            'GET',
-            sprintf('/api/v2/shop/products/%s', $product->getCode()),
-            [],
-            [],
-            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json', 'HTTP_ACCEPT_LANGUAGE' => 'de_DE']
+            method: 'GET',
+            uri: sprintf('/api/v2/shop/products/%s', $product->getCode()),
+            server: [
+                'CONTENT_TYPE' => 'application/ld+json',
+                'HTTP_ACCEPT' => 'application/ld+json',
+                'HTTP_ACCEPT_LANGUAGE' => 'de_DE'
+            ]
         );
 
         $this->assertResponse(
@@ -76,21 +81,39 @@ final class ProductsTest extends JsonApiTestCase
     }
 
     /** @test */
-    public function it_returns_products_collection(): void
+    public function it_returns_product_with_enabled_variants(): void
     {
-        $this->loadFixturesFromFiles(['product/product_variant_with_original_price.yaml']);
+        $fixtures = $this->loadFixturesFromFile('product/product_with_enabled_and_disabled_variant.yaml');
 
+        /** @var ProductInterface $product */
+        $product = $fixtures['product_mug'];
         $this->client->request(
-            'GET',
-            '/api/v2/shop/products',
-            [],
-            [],
-            self::CONTENT_TYPE_HEADER
+            method: 'GET',
+            uri: sprintf('/api/v2/shop/products/%s', $product->getCode()),
+            server: ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_ACCEPT' => 'application/ld+json', 'HTTP_ACCEPT_LANGUAGE' => 'de_DE']
         );
 
         $this->assertResponse(
             $this->client->getResponse(),
-            'shop/product/get_products_collection_response',
+            'shop/product/get_product_response',
+            Response::HTTP_OK
+        );
+    }
+
+    /** @test */
+    public function it_returns_products_with_enabled_variants(): void
+    {
+        $this->loadFixturesFromFile('product/product_with_enabled_and_disabled_variant.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/products',
+            server: self::CONTENT_TYPE_HEADER
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/product/get_products_response',
             Response::HTTP_OK
         );
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master <!-- see the comment below -->          |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
WIP Additional info

When exists the dataProvider, extension responsible for querying enabled variants is omitted
When resigned from dataProvider in favor of extension
`src/Sylius/Component/Core/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php:514`
class member `$class->identifier` contains only the `id` field when we passing to that method an array `['code' => 'some_product_code']`
and
`features/cart/shopping_cart/adding_product_with_options_to_cart.feature` scenario fails after that change