### PR TITLE
[Symfony 6] Fix specifications for register calculators pass

### DIFF
--- a/src/Sylius/Bundle/TaxationBundle/spec/DependencyInjection/Compiler/RegisterCalculatorsPassSpec.php
+++ b/src/Sylius/Bundle/TaxationBundle/spec/DependencyInjection/Compiler/RegisterCalculatorsPassSpec.php
@@ -42,7 +42,7 @@ final class RegisterCalculatorsPassSpec extends ObjectBehavior
         $calculator->addMethodCall(
             'register',
             Argument::type('array')
-        )->shouldBeCalled();
+        )->willReturn($calculator)->shouldBeCalled();
 
         $container->setParameter(
             'sylius.tax_calculators',


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6         |
| Bug fix?        | yes (for Symfony 6)                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | partially #13274                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Trying to fix https://github.com/Sylius/Sylius/runs/6420688720?check_suite_focus=true#step:11:10
And this is fixed here https://github.com/Sylius/Sylius/runs/6454899241?check_suite_focus=true#step:11:1
