### PR TITLE
[Symfony 6] Fix Taxonomy bundle test app

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
@@ -36,12 +36,12 @@ class AppKernel extends Kernel
         $loader->load(__DIR__ . '/config/config.yml');
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir() . '/SyliusTaxonomyBundle/cache/' . $this->getEnvironment();
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return sys_get_temp_dir() . '/SyliusTaxonomyBundle/logs';
     }

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/config/config.yml
@@ -16,7 +16,7 @@ framework:
     default_locale: "%locale%"
     session:
         handler_id: ~
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     http_method_override: true
     test: ~
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6          |
| Bug fix?        | yes (for Symfony 6)                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | partially #13274                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Trying to fix https://github.com/Sylius/Sylius/runs/6420620909?check_suite_focus=true#step:11:7
This is fixed here https://github.com/Sylius/Sylius/runs/6455042292?check_suite_focus=true