### PR TITLE
[API] Set createdByGuest to carts created via api

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/PickupCartHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/PickupCartHandler.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ApiBundle\CommandHandler\Cart;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Cart\Resolver\CreatedByGuestFlagResolverInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -36,7 +37,8 @@ final class PickupCartHandler implements MessageHandlerInterface
         private ChannelRepositoryInterface $channelRepository,
         private ObjectManager $orderManager,
         private RandomnessGeneratorInterface $generator,
-        private CustomerRepositoryInterface $customerRepository
+        private CustomerRepositoryInterface $customerRepository,
+        private CreatedByGuestFlagResolverInterface $createdByGuestFlagResolver
     ) {
     }
 
@@ -73,6 +75,7 @@ final class PickupCartHandler implements MessageHandlerInterface
         if ($customer !== null) {
             $cart->setCustomer($customer);
         }
+        $cart->setCreatedByGuest($this->createdByGuestFlagResolver->resolveFlag());
 
         $this->orderManager->persist($cart);
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -36,6 +36,7 @@
             <argument type="service" id="sylius.manager.order" />
             <argument type="service" id="sylius.random_generator" />
             <argument type="service" id="sylius.repository.customer" />
+            <argument type="service" id="Sylius\Component\Core\Cart\Resolver\CreatedByGuestFlagResolverInterface" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
             <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Cart/PickupCartHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Cart/PickupCartHandlerSpec.php
@@ -19,6 +19,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Cart\Resolver\CreatedByGuestFlagResolverInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -38,7 +39,8 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         ObjectManager $orderManager,
         RandomnessGeneratorInterface $generator,
-        CustomerRepositoryInterface $customerRepository
+        CustomerRepositoryInterface $customerRepository,
+        CreatedByGuestFlagResolverInterface $createdByGuestFlagResolver
     ): void {
         $this->beConstructedWith(
             $cartFactory,
@@ -46,7 +48,8 @@ final class PickupCartHandlerSpec extends ObjectBehavior
             $channelRepository,
             $orderManager,
             $generator,
-            $customerRepository
+            $customerRepository,
+            $createdByGuestFlagResolver
         );
     }
 
@@ -66,7 +69,8 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         OrderInterface $cart,
         ChannelInterface $channel,
         CurrencyInterface $currency,
-        LocaleInterface $locale
+        LocaleInterface $locale,
+        CreatedByGuestFlagResolverInterface $createdByGuestFlagResolver
     ): void {
         $pickupCart = new PickupCart();
         $pickupCart->setChannelCode('code');
@@ -86,12 +90,15 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $channel->getLocales()->willReturn(new ArrayCollection([$locale->getWrappedObject()]));
 
+        $createdByGuestFlagResolver->resolveFlag()->willReturn(false);
+
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer($customer)->shouldBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
         $cart->setTokenValue('urisafestr')->shouldBeCalled();
+        $cart->setCreatedByGuest(false)->shouldBeCalled();
 
         $orderManager->persist($cart)->shouldBeCalled();
 
@@ -136,7 +143,8 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         OrderInterface $cart,
         ChannelInterface $channel,
         CurrencyInterface $currency,
-        LocaleInterface $locale
+        LocaleInterface $locale,
+        CreatedByGuestFlagResolverInterface $createdByGuestFlagResolver
     ): void {
         $pickupCart = new PickupCart();
         $pickupCart->setChannelCode('code');
@@ -153,12 +161,15 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $channel->getLocales()->willReturn(new ArrayCollection([$locale->getWrappedObject()]));
 
+        $createdByGuestFlagResolver->resolveFlag()->willReturn(true);
+
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer(Argument::any())->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
         $cart->setTokenValue('urisafestr')->shouldBeCalled();
+        $cart->setCreatedByGuest(true)->shouldBeCalled();
 
         $orderManager->persist($cart)->shouldBeCalled();
 
@@ -174,7 +185,8 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         OrderInterface $cart,
         ChannelInterface $channel,
         CurrencyInterface $currency,
-        LocaleInterface $locale
+        LocaleInterface $locale,
+        CreatedByGuestFlagResolverInterface $createdByGuestFlagResolver
     ): void {
         $pickupCart = new PickupCart();
         $pickupCart->setChannelCode('code');
@@ -192,12 +204,15 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         $currency->getCode()->willReturn('USD');
         $locale->getCode()->willReturn('en_US');
 
+        $createdByGuestFlagResolver->resolveFlag()->willReturn(true);
+
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer(Argument::any())->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
         $cart->setTokenValue('urisafestr')->shouldBeCalled();
+        $cart->setCreatedByGuest(true)->shouldBeCalled();
 
         $orderManager->persist($cart)->shouldBeCalled();
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                                                         |
| Bug fix?        | yes                                                          |
| New feature?    | no                                                           |
| BC breaks?      | no                                                           |
| Deprecations?   | no                                                           |
| Related tickets |                                                              |
| License         | MIT                                                          |

The `PickupCartHandler` wasn't aware of the recently added `createdByGuest` flag. It uses the `findLatestNotEmptyCartByChannelAndCustomer` method of the cart repository, which is part of the `CoreBundle`, which excludes carts created by guests. In contrast to the `ShopBasedCartContext`, provided by the `CoreBundle`, it doesn't set the `createdByGuest` flag, so all carts, created via api, are defined as created by guests. Hence, the `PickupCartHandler` created a new cart every time the endpoint was called.