### PR TITLE
[Dependencies] Removed unused registered Sonata bundles

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -57,7 +57,5 @@ return [
     Sylius\Behat\Application\SyliusTestPlugin\SyliusTestPlugin::class => ['test' => true, 'test_cached' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
-    Sonata\Doctrine\Bridge\Symfony\SonataDoctrineSymfonyBundle::class => ['all' => true],
-    Sonata\Twig\Bridge\Symfony\SonataTwigSymfonyBundle::class => ['all' => true],
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
 ];

--- a/symfony.lock
+++ b/symfony.lock
@@ -558,9 +558,6 @@
             "ref": "8273133183506fe6ec66895e8890227b0dfba1c7"
         }
     },
-    "sonata-project/twig-extensions": {
-        "version": "1.4.1"
-    },
     "squizlabs/php_codesniffer": {
         "version": "3.3.1"
     },


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master <!-- see the comment below -->          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                   |
| BC breaks?      | no                                                       |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Ones `sonata-project/block-bundle` had update to 4.13 probably that's the reason why composer update was broken
<img width="342" alt="image" src="https://user-images.githubusercontent.com/40125720/170490670-c65b9a63-6e65-42ad-8eca-e4b3f38702cc.png">

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/40125720/170490343-b7909cb4-f81e-4798-a800-05a42537bc94.png">
