### PR TITLE
Commnad to show order details

### DIFF
--- a/features/cli/show_order.feature
+++ b/features/cli/show_order.feature
@@ -20,3 +20,5 @@ Feature: Showing an order
             | Customer: john.doe@gmail.com |
             | Channel: WEB-US              |
             | PHP T-Shirt                  |
+            | Offline                      |
+            | Free                         |

--- a/features/cli/show_order.feature
+++ b/features/cli/show_order.feature
@@ -12,6 +12,6 @@ Feature: Showing an order
         And there is a customer "john.doe@gmail.com" that placed an order "#00000025"
 
     Scenario: Show order information
-        When I run show order command for order "#00000026"
+        When I run show order command for order "#00000025"
         Then I should see the following information:
-            | Number\s+00000026 |
+            | Order #00000025 |

--- a/features/cli/show_order.feature
+++ b/features/cli/show_order.feature
@@ -14,4 +14,4 @@ Feature: Showing an order
     Scenario: Show order information
         When I run show order command for order "#00000026"
         Then I should see the following information:
-            | 1234 |
+            | Number\s+00000026 |

--- a/features/cli/show_order.feature
+++ b/features/cli/show_order.feature
@@ -10,8 +10,13 @@ Feature: Showing an order
         And the store ships everywhere for free
         And the store allows paying offline
         And there is a customer "john.doe@gmail.com" that placed an order "#00000025"
+        And the customer bought a single "PHP T-Shirt"
+        And the customer chose "Free" shipping method to "United States" with "Offline" payment
 
     Scenario: Show order information
         When I run show order command for order "#00000025"
         Then I should see the following information:
-            | Order #00000025 |
+            | Order #00000025              |
+            | Customer: john.doe@gmail.com |
+            | Channel: WEB-US              |
+            | PHP T-Shirt                  |

--- a/features/cli/show_order.feature
+++ b/features/cli/show_order.feature
@@ -1,0 +1,17 @@
+@show_order @cli
+Feature: Showing an order
+    In order to be efficiently debug an order
+    As a Developer
+    I want to be be able to quickly show order information in the CLI
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$10.00" in "United States" channel
+        And the store ships everywhere for free
+        And the store allows paying offline
+        And there is a customer "john.doe@gmail.com" that placed an order "#00000025"
+
+    Scenario: Show order information
+        When I run show order command for order "#00000026"
+        Then I should see the following information:
+            | 1234 |

--- a/features/cli/showing_available_plugins.feature
+++ b/features/cli/showing_available_plugins.feature
@@ -5,5 +5,5 @@ Feature: Showing available Sylius plugins
     I want to be informed about available plugins
 
     Scenario: Showing available Sylius plugins
-        When I run show available plugins command
+        When I run show order command
         Then I should see output "Available official plugins and selected community plugins" with listed plugins

--- a/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
+++ b/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
@@ -52,12 +52,15 @@ final class ShowOrderContext implements Context
     public function runShowOrderCommand(string $number): void
     {
         $this->application = new Application($this->kernel);
-        $this->application->add(new ShowOrderCommand());
+        $this->application->add(new ShowOrderCommand($this->orderRepository));
 
         $this->command = $this->application->find('sylius:order:show');
         $this->tester = new CommandTester($this->command);
 
-        $this->tester->execute(['command' => 'sylius:order:show']);
+        $this->tester->execute([
+            'command' => 'sylius:order:show',
+            'number' => ltrim($number, '#'),
+        ]);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
+++ b/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
@@ -44,7 +44,7 @@ final class ShowOrderContext implements Context
     }
 
     /**
-     * @When I run show order command for order :arg1
+     * @When I run show order command for order :number
      */
     public function runShowOrderCommand(string $number): void
     {

--- a/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
+++ b/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
@@ -15,8 +15,6 @@ namespace Sylius\Behat\Context\Cli;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
-use PhpSpec\Exception\Example\PendingException;
-use Sylius\Bundle\CoreBundle\Command\SetupCommand;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
 use Sylius\Bundle\OrderBundle\Command\ShowOrderCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -40,8 +38,7 @@ final class ShowOrderContext implements Context
     public function __construct(
         KernelInterface $kernel,
         OrderRepository $orderRepository,
-    )
-    {
+    ) {
         $this->kernel = $kernel;
         $this->orderRepository = $orderRepository;
     }
@@ -68,7 +65,7 @@ final class ShowOrderContext implements Context
      */
     public function iShouldSeeTheFollowingInformation(TableNode $table): void
     {
-        $output =  $this->tester->getDisplay();
+        $output = $this->tester->getDisplay();
         foreach ($table->getColumn(0) as $regex) {
             Assert::regex($output, '{' . $regex . '}');
         }

--- a/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
+++ b/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Cli;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use PhpSpec\Exception\Example\PendingException;
+use Sylius\Bundle\CoreBundle\Command\SetupCommand;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
+use Sylius\Bundle\OrderBundle\Command\ShowOrderCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Webmozart\Assert\Assert;
+
+final class ShowOrderContext implements Context
+{
+    private KernelInterface $kernel;
+
+    private ?Application $application = null;
+
+    private ?CommandTester $tester = null;
+
+    private ?Command $command = null;
+
+    private OrderRepository $orderRepository;
+
+    public function __construct(
+        KernelInterface $kernel,
+        OrderRepository $orderRepository,
+    )
+    {
+        $this->kernel = $kernel;
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
+     * @When I run show order command for order :arg1
+     */
+    public function runShowOrderCommand(string $number): void
+    {
+        $this->application = new Application($this->kernel);
+        $this->application->add(new ShowOrderCommand());
+
+        $this->command = $this->application->find('sylius:order:show');
+        $this->tester = new CommandTester($this->command);
+
+        $this->tester->execute(['command' => 'sylius:order:show']);
+    }
+
+    /**
+     * @Then I should see the following information:
+     */
+    public function iShouldSeeTheFollowingInformation(TableNode $table): void
+    {
+        throw new PendingException();
+    }
+}

--- a/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
+++ b/src/Sylius/Behat/Context/Cli/ShowOrderContext.php
@@ -65,6 +65,9 @@ final class ShowOrderContext implements Context
      */
     public function iShouldSeeTheFollowingInformation(TableNode $table): void
     {
-        throw new PendingException();
+        $output =  $this->tester->getDisplay();
+        foreach ($table->getColumn(0) as $regex) {
+            Assert::regex($output, '{' . $regex . '}');
+        }
     }
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
@@ -27,5 +27,10 @@
             <argument type="service" id="kernel" />
             <argument type="service" id="sylius.repository.order" />
         </service>
+
+        <service id="sylius.behat.context.cli.show_order" class="Sylius\Behat\Context\Cli\ShowOrderContext">
+            <argument type="service" id="kernel" />
+            <argument type="service" id="sylius.repository.order" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -54,6 +54,7 @@ imports:
     - suites/api/user/managing_customer_groups.yml
 
     - suites/cli/canceling_unpaid_orders.yml
+    - suites/cli/show_order.yml
     - suites/cli/installer.yml
     - suites/cli/showing_available_plugins.yml
 

--- a/src/Sylius/Behat/Resources/config/suites/cli/show_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/cli/show_order.yml
@@ -1,0 +1,27 @@
+default:
+    suites:
+        # todo: remove unused contexts
+        cli_show_order:
+            contexts:
+                - sylius.behat.context.cli.show_order
+
+                - sylius.behat.context.hook.doctrine_orm
+                    
+                - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.customer
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.payment
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.shipping_method
+                - sylius.behat.context.transform.order
+                
+                - sylius.behat.context.setup.order
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shipping
+                - sylius.behat.context.setup.payment
+
+            filters:
+                tags: "@show_order&&@cli"
+

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sylius\Bundle\OrderBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+class ShowOrderCommand extends Command
+{
+}

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Sylius\Bundle\OrderBundle\Command;
 
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
@@ -19,9 +30,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ShowOrderCommand extends Command
 {
-    const ARG_NUMBER = 'number';
-    const DATE_FORMAT = 'Y-m-d H:i:s';
+    public const ARG_NUMBER = 'number';
 
+    public const DATE_FORMAT = 'Y-m-d H:i:s';
 
     protected static $defaultName = 'sylius:order:show';
 
@@ -40,13 +51,14 @@ class ShowOrderCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $number = (string)$input->getArgument(self::ARG_NUMBER);
+        $number = (string) $input->getArgument(self::ARG_NUMBER);
 
         // do not use findOneByNumber as we want also to get cart orders
         $order = $this->orderRepository->findOneBy(['number' => $number]);
         $style = new SymfonyStyle($input, $output);
         if (null === $order) {
             $style->error(sprintf('Order with number "%s" not found', $number));
+
             return self::FAILURE;
         }
 
@@ -99,6 +111,7 @@ class ShowOrderCommand extends Command
             ],
         ]);
     }
+
     private function fieldValueTable(OutputInterface $output, array $fieldValues): void
     {
         $table = new Table($output);
@@ -139,7 +152,7 @@ class ShowOrderCommand extends Command
                 ['id', $customer->getId()],
                 ['email', $customer->getEmail()],
                 ['group', $customer->getGroup()?->getCode()],
-            ]
+            ],
         ]);
     }
 
@@ -148,6 +161,7 @@ class ShowOrderCommand extends Command
         if (null === $address) {
             $output->writeln('No address');
             $output->writeln('');
+
             return;
         }
 
@@ -164,7 +178,7 @@ class ShowOrderCommand extends Command
                 ['City', $address->getFirstName()],
                 ['Postcode', $address->getLastName()],
                 ['Province', sprintf('%s (%s)', $address->getProvinceName(), $address->getProvinceCode())],
-            ]
+            ],
         ]);
     }
 
@@ -189,12 +203,12 @@ class ShowOrderCommand extends Command
             ]);
         }
         $table->setStyle('default');
-        $table->addRow(new TableSeparator()) ;
+        $table->addRow(new TableSeparator());
         $table->addRows(array_map(
             fn (array $pair) => [
                 new TableCell(
                     $pair[0],
-                    ['colspan' => 4, 'style' => new TableCellStyle(['align' => 'right']), ]
+                    ['colspan' => 4, 'style' => new TableCellStyle(['align' => 'right'])]
                 ),
                 $pair[1],
             ],
@@ -206,5 +220,4 @@ class ShowOrderCommand extends Command
         ));
         $table->render();
     }
-
 }

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\Command;
 
+use Doctrine\Common\Collections\Collection;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Customer\Model\CustomerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -79,6 +81,8 @@ class ShowOrderCommand extends Command
         $this->renderItems($output, $order);
         $style->section('Payments');
         $this->renderPayments($output, $order->getPayments());
+        $style->section('Shipments');
+        $this->renderShipments($output, $order->getShipments());
     }
 
     private function renderAttributes(OutputInterface $output, Order $order)
@@ -252,6 +256,36 @@ class ShowOrderCommand extends Command
                 $payment->getUpdatedAt()?->format(self::DATE_FORMAT),
                 $payment->getAmount(),
                 $payment->getCurrencyCode(),
+            ]);
+        }
+        $table->render();
+        $output->writeln('');
+    }
+
+    /**
+     * @param Traversable<ShipmentInterface> $shipments
+     */
+    private function renderShipments(OutputInterface $output, Traversable $shipments): void
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            'ID',
+            'Method',
+            'State',
+            'Tracking',
+            'Created',
+            'Updated',
+            'Adjustments',
+        ]);
+        foreach ($shipments as $shipment) {
+            $table->addRow([
+                $shipment->getId(),
+                $shipment->getMethod()?->getName() ?? 'n/a',
+                $shipment->getState(),
+                $shipment->getTracking(),
+                $shipment->getCreatedAt()?->format(self::DATE_FORMAT),
+                $shipment->getUpdatedAt()?->format(self::DATE_FORMAT),
+                $shipment->getAdjustmentsTotal(),
             ]);
         }
         $table->render();

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -2,17 +2,54 @@
 
 namespace Sylius\Bundle\OrderBundle\Command;
 
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
+use Sylius\Component\Core\Model\Order;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ShowOrderCommand extends Command
 {
+    const ARG_NUMBER = 'number';
+
     protected static $defaultName = 'sylius:order:show';
+
+    private OrderRepository $orderRepository;
+
+    protected function configure(): void
+    {
+        $this->addArgument(self::ARG_NUMBER, InputArgument::REQUIRED, 'Order number');
+    }
+
+    public function __construct(OrderRepository $orderRepository)
+    {
+        parent::__construct();
+        $this->orderRepository = $orderRepository;
+    }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        return 0;
+        $number = (string)$input->getArgument(self::ARG_NUMBER);
+
+        // do not use findOneByNumber as we want also to get cart orders
+        $order = $this->orderRepository->findOneBy(['number' => $number]);
+        $style = new SymfonyStyle($input, $output);
+        if (null === $order) {
+            $style->error(sprintf('Order with number "%s" not found', $number));
+            return self::FAILURE;
+        }
+
+        $this->renderOrder($style, $order);
+
+        return self::FAILURE;
+    }
+
+    private function renderOrder(SymfonyStyle $style, Order $order): void
+    {
+        $style->title(sprintf('Order #%s', $order->getNumber()));
     }
 
 }

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\Command;
 
-use Doctrine\Common\Collections\Collection;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderRepository;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\Order;
@@ -145,7 +144,7 @@ class ShowOrderCommand extends Command
     {
         return [
             sprintf('<fg=#aaa>%s:</>', $field),
-            new TableCell((string)($value ?? 'n/a'), [
+            new TableCell((string) ($value ?? 'n/a'), [
                 'colspan' => $span,
             ]),
         ];

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -3,7 +3,16 @@
 namespace Sylius\Bundle\OrderBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ShowOrderCommand extends Command
 {
+    protected static $defaultName = 'sylius:order:show';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return 0;
+    }
+
 }

--- a/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/ShowOrderCommand.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Traversable;
 
-class ShowOrderCommand extends Command
+final class ShowOrderCommand extends Command
 {
     public const ARG_NUMBER = 'number';
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -25,6 +25,11 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Sylius\Bundle\OrderBundle\Command\ShowOrderCommand">
+            <argument type="service" id="sylius.repository.order" />
+            <tag name="console.command" />
+        </service>
+
         <service id="sylius.context.cart.new" class="Sylius\Component\Order\Context\CartContext">
             <argument type="service" id="sylius.factory.order" />
             <tag name="sylius.context.cart" priority="-999" />


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master                                                       |
| Bug fix?        | no                                                           |
| New feature?    | yes                                                          |
| BC breaks?      | no                                                           |
| Deprecations?   | no                                                           |
| Related tickets |                                                              |
| License         | MIT                                                          |


This PR adds a command to show details of an order.

![image](https://user-images.githubusercontent.com/530801/170731540-8f6424de-c362-47fd-8dca-a95dcbaefd26.png)

I've previously found it useful for local development and on production to quickly check the state of an order on the CLI without looking into the admin interface. Not sure how useful this would be for others.

Shows:

- Order attributes
- Order Items
- Payments
- Shipments

TODO?

- Add an option to retrieve an oder by ID or token instead of number ?

---

tests seem to be currently failing in master