### PR TITLE
[Maintenance] Remove 1.10 branch from scheduled ECS refactor

### DIFF
--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                branch: ["1.10", "1.11", "master"]
+                branch: ["1.11", "master"]
         
         steps:
             -

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -56,7 +56,5 @@ return [
     Sylius\Behat\Application\SyliusTestPlugin\SyliusTestPlugin::class => ['test' => true, 'test_cached' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
-    Sonata\Doctrine\Bridge\Symfony\SonataDoctrineSymfonyBundle::class => ['all' => true],
-    Sonata\Twig\Bridge\Symfony\SonataTwigSymfonyBundle::class => ['all' => true],
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10 |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets |                      |
| License         | MIT                                                          |

As we no longer maintain support for version 1.10 (except security fixes), I would like to remove 1.10 branch from the scheduled ECS refactor.
