### PR TITLE
[Documentation] Remove section about CurrencyProvider that does not exist

### DIFF
--- a/docs/book/configuration/currencies.rst
+++ b/docs/book/configuration/currencies.rst
@@ -45,21 +45,6 @@ It allows you to convert money values from one currency to another.
 
 This solution is used for displaying an *approximate* value of price when the desired currency is different from the base currency of the current channel.
 
-Available Currencies Provider
------------------------------
-
-The default menu for selecting currency is using a service - **CurrencyProvider** - with the ``sylius.currency_provider`` id, which returns all enabled currencies.
-This is your entry point if you would like override this logic and return different currencies for various scenarios.
-
-.. code-block:: php
-
-    <?php
-
-    public function fooAction()
-    {
-        $currencies = $this->get('sylius.currency_provider')->getAvailableCurrencies();
-    }
-
 Switching Currency of a Channel
 -------------------------------
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

The mentioned `CurrencyProvider` does not exist since https://github.com/Sylius/Sylius/commit/16c50a96b6c369451993958e49cfe114dcfe585b from 2017 🎉 