### PR TITLE
[Addressing] Prevent deleting zones and provinces that are zone members

### DIFF
--- a/features/addressing/managing_countries/managing_provinces_of_country.feature
+++ b/features/addressing/managing_countries/managing_provinces_of_country.feature
@@ -26,6 +26,24 @@ Feature: Managing provinces of a country
         And this country should not have the "Northern Ireland" province
 
     @ui @javascript @api
+    Scenario: Removing a province that is a zone member should not be possible
+        Given this country has the "Northern Ireland" province with "GB-NIR" code
+        And this country also has the "Scotland" province with "GB-SCT" code
+        And this country also has the "England" province with "GB-ENG" code
+        And the store has a zone "Great Britain" with code "GB"
+        And it has the "Northern Ireland" province member
+        And it also has the "Scotland" province member
+        And it also has the "England" province member
+        When I want to edit this country
+        And I delete the "Northern Ireland" province of this country
+        And I also delete the "Scotland" province of this country
+        And I save my changes
+        Then I should be notified that provinces that are in use cannot be deleted
+        And this country should still have the "Northern Ireland" province
+        And this country should still have the "Scotland" province
+        And this country should still have the "England" province
+
+    @ui @javascript @api
     Scenario: Removing and adding a new province to an existing country
         Given this country has the "Northern Ireland" province with "GB-NIR" code
         When I want to edit this country

--- a/features/addressing/managing_zones/deleting_zone.feature
+++ b/features/addressing/managing_zones/deleting_zone.feature
@@ -7,18 +7,27 @@ Feature: Deleting a zone
     Background:
         Given the store has a zone "North America" with code "NA"
         And the store also has a zone "South America" with code "SA"
+        And the store also has a zone "Central and Eastern Europe" with code "CEE"
+        And the store also has a zone "Europe" with code "EU"
+        And it has the zone named "Central and Eastern Europe"
         And the store has a tax category "Sports gear"
         And the store has "Sales Tax" tax rate of 20% for "Sports gear" within the "SA" zone
         And I am logged in as an administrator
 
     @ui @api
     Scenario: Deleted zone should disappear from the registry
-        When I delete zone named "North America"
+        When I delete the zone named "North America"
         Then I should be notified that it has been successfully deleted
         And the zone named "North America" should no longer exist in the registry
 
     @ui @api
     Scenario: Deleting zone with associated tax rates should not be possible
-        When I delete zone named "South America"
+        When I try to delete the zone named "South America"
         Then I should be notified that this zone cannot be deleted
         And I should still see the zone named "South America" in the list
+
+    @ui @api
+    Scenario: Deleting zone that is a zone member should not be possible
+        When I try to delete the zone named "Central and Eastern Europe"
+        Then I should be notified that this zone cannot be deleted
+        And I should still see the zone named "Central and Eastern Europe" in the list

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -152,7 +152,7 @@ final class ManagingCountriesContext implements Context
     }
 
     /**
-     * @When /^I delete the ("[^"]+" province) of (this country)$/
+     * @When /^I(?:| also) delete the ("[^"]+" province) of (this country)$/
      */
     public function iDeleteTheProvinceOfThisCountry(ProvinceInterface $province, CountryInterface $country): void
     {
@@ -209,7 +209,7 @@ final class ManagingCountriesContext implements Context
 
     /**
      * @Then the country :country should have the :province province
-     * @Then /^(this country) should have the ("[^"]*" province)$/
+     * @Then /^(this country) should(?:| still) have the ("[^"]*" province)$/
      */
     public function theCountryShouldHaveTheProvince(CountryInterface $country, ProvinceInterface $province): void
     {
@@ -345,6 +345,17 @@ final class ManagingCountriesContext implements Context
         Assert::contains(
             $this->responseChecker->getError($this->provincesClient->getLastResponse()),
             'Please enter province name.'
+        );
+    }
+
+    /**
+     * @Then I should be notified that provinces that are in use cannot be deleted
+     */
+    public function iShouldBeNotifiedThatProvincesThatAreInUseCannotBeDeleted(): void
+    {
+        Assert::contains(
+            $this->responseChecker->getError($this->client->getLastResponse()),
+            'Provinces that are in use cannot be deleted.'
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -355,7 +355,7 @@ final class ManagingCountriesContext implements Context
     {
         Assert::contains(
             $this->responseChecker->getError($this->client->getLastResponse()),
-            'Provinces that are in use cannot be deleted.'
+            'Cannot delete, the province is in use.'
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
@@ -141,7 +141,7 @@ final class ManagingZonesContext implements Context
     }
 
     /**
-     * @When I delete zone named :zone
+     * @When /^I(?:| try to) delete the (zone named "([^"]*)")$/
      */
     public function iDeleteZoneNamed(ZoneInterface $zone): void
     {

--- a/src/Sylius/Behat/Context/Setup/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Setup/ZoneContext.php
@@ -31,28 +31,13 @@ use Symfony\Component\Intl\Countries;
 
 final class ZoneContext implements Context
 {
-    private SharedStorageInterface $sharedStorage;
-
-    private RepositoryInterface $zoneRepository;
-
-    private ObjectManager $objectManager;
-
-    private ZoneFactoryInterface $zoneFactory;
-
-    private FactoryInterface $zoneMemberFactory;
-
     public function __construct(
-        SharedStorageInterface $sharedStorage,
-        RepositoryInterface $zoneRepository,
-        ObjectManager $objectManager,
-        ZoneFactoryInterface $zoneFactory,
-        FactoryInterface $zoneMemberFactory
+        private SharedStorageInterface $sharedStorage,
+        private RepositoryInterface $zoneRepository,
+        private ObjectManager $objectManager,
+        private ZoneFactoryInterface $zoneFactory,
+        private FactoryInterface $zoneMemberFactory
     ) {
-        $this->sharedStorage = $sharedStorage;
-        $this->zoneRepository = $zoneRepository;
-        $this->objectManager = $objectManager;
-        $this->zoneFactory = $zoneFactory;
-        $this->zoneMemberFactory = $zoneMemberFactory;
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -77,7 +77,7 @@ final class ManagingZonesContext implements Context
     }
 
     /**
-     * @When /^I delete (zone named "([^"]*)")$/
+     * @When /^I(?:| try to) delete the (zone named "([^"]*)")$/
      */
     public function iDeleteZoneNamed(ZoneInterface $zone)
     {

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -72,6 +72,7 @@
             <argument type="service" id="sylius.behat.page.admin.country.create" />
             <argument type="service" id="sylius.behat.page.admin.country.update" />
             <argument type="service" id="sylius.behat.current_page_resolver" />
+            <argument type="service" id="sylius.behat.notification_checker" />
         </service>
 
         <service id="sylius.behat.context.ui.admin.managing_currencies" class="Sylius\Behat\Context\Ui\Admin\ManagingCurrenciesContext">

--- a/src/Sylius/Behat/Resources/config/suites/api/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/addressing/managing_countries.yml
@@ -15,6 +15,7 @@ default:
 
                 - sylius.behat.context.setup.admin_api_security
                 - sylius.behat.context.setup.geographical
+                - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.api.admin.managing_countries
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
@@ -8,10 +8,12 @@ default:
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.country
+                - sylius.behat.context.transform.province
                 - sylius.behat.context.transform.shared_storage
 
-                - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.admin_security
+                - sylius.behat.context.setup.geographical
+                - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.ui.admin.managing_countries
                 - sylius.behat.context.ui.admin.notification

--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AddressingBundle\EventListener;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Webmozart\Assert\Assert;
+
+final class ZoneMemberIntegrityListener
+{
+    public function __construct(
+        private SessionInterface $session,
+        private RepositoryInterface $zoneMemberRepository,
+        private RepositoryInterface $provinceRepository,
+    ) {
+    }
+
+    public function protectFromRemovingZone(GenericEvent $event): void
+    {
+        $zone = $event->getSubject();
+        Assert::isInstanceOf($zone, ZoneInterface::class);
+
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $zone->getCode()]);
+
+        if (null !== $zoneMember) {
+            /** @var FlashBagInterface $flashes */
+            $flashes = $this->session->getBag('flashes');
+            $flashes->add('error', [
+                'message' => 'sylius.resource.delete_error',
+                'parameters' => ['%resource%' => 'zone'],
+            ]);
+
+            $event->stopPropagation();
+        }
+    }
+
+    public function protectFromRemovingProvinceWithinCountry(GenericEvent $event): void
+    {
+        /** @var CountryInterface $country */
+        $country = $event->getSubject();
+        Assert::isInstanceOf($country, CountryInterface::class);
+        $provinces = $this->provinceRepository->findBy(['country' => $country]);
+
+        $countryProvinceCodes = $country->getProvinces()->map(fn ($province): string => $province->getCode())->getValues();
+        $provinceCodes = (new ArrayCollection($provinces))->map(fn ($province): string => $province->getCode())->getValues();
+
+        $provincesToDelete = array_diff($provinceCodes, $countryProvinceCodes);
+
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $provincesToDelete]);
+
+        if (null !== $zoneMember) {
+            /** @var FlashBagInterface $flashes */
+            $flashes = $this->session->getBag('flashes');
+            $flashes->add('error', [
+                'message' => 'sylius.resource.delete_error',
+                'parameters' => ['%resource%' => 'province'],
+            ]);
+
+            $event->stopPropagation();
+        }
+    }
+}

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/checkers.xml" />
         <import resource="services/form.xml" />
         <import resource="services/listeners.xml" />
     </imports>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -14,6 +14,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
         <import resource="services/form.xml" />
+        <import resource="services/listeners.xml" />
     </imports>
 
     <services>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services/checkers.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface" class="Sylius\Component\Addressing\Checker\ZoneDeletionChecker">
+            <argument type="service" id="sylius.repository.zone_member" />
+        </service>
+
+        <service id="Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface" class="Sylius\Component\Addressing\Checker\CountryProvincesDeletionChecker">
+            <argument type="service" id="sylius.repository.zone_member" />
+            <argument type="service" id="sylius.repository.province" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services/listeners.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.listener.zone_member_integrity" class="Sylius\Bundle\AddressingBundle\EventListener\ZoneMemberIntegrityListener">
+            <argument type="service" id="session" />
+            <argument type="service" id="sylius.repository.zone_member" />
+            <argument type="service" id="sylius.repository.province" />
+            <tag name="kernel.event_listener" event="sylius.zone.pre_delete" method="protectFromRemovingZone" />
+            <tag name="kernel.event_listener" event="sylius.country.pre_update" method="protectFromRemovingProvinceWithinCountry" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services/listeners.xml
@@ -17,8 +17,8 @@
 
         <service id="sylius.listener.zone_member_integrity" class="Sylius\Bundle\AddressingBundle\EventListener\ZoneMemberIntegrityListener">
             <argument type="service" id="session" />
-            <argument type="service" id="sylius.repository.zone_member" />
-            <argument type="service" id="sylius.repository.province" />
+            <argument type="service" id="Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface" />
+            <argument type="service" id="Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface" />
             <tag name="kernel.event_listener" event="sylius.zone.pre_delete" method="protectFromRemovingZone" />
             <tag name="kernel.event_listener" event="sylius.country.pre_update" method="protectFromRemovingProvinceWithinCountry" />
         </service>

--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\AddressingBundle\EventListener;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AddressingBundle\EventListener\ZoneMemberIntegrityListener;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
+{
+    function let(
+        SessionInterface $session,
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository,
+    ): void {
+        $this->beConstructedWith($session, $zoneMemberRepository, $provinceRepository);
+    }
+
+    function it_does_not_allow_to_remove_zone_if_it_exists_as_a_zone_member(
+        SessionInterface $session,
+        RepositoryInterface $zoneMemberRepository,
+        GenericEvent $event,
+        ZoneInterface $zone,
+        ZoneMemberInterface $zoneMember,
+        FlashBagInterface $flashes,
+    ): void {
+        $event->getSubject()->willReturn($zone);
+        $zone->getCode()->willReturn('MUG');
+
+        $zoneMemberRepository->findOneBy(['code' => 'MUG'])->willReturn($zoneMember);
+
+        $session->getBag('flashes')->willReturn($flashes);
+
+        $flashes
+            ->add('error', [
+                'message' => 'sylius.resource.delete_error',
+                'parameters' => ['%resource%' => 'zone'],
+            ])
+            ->shouldBeCalled()
+        ;
+
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->protectFromRemovingZone($event);
+    }
+
+    function it_does_nothing_if_zone_does_not_exist_as_a_zone_member(
+        SessionInterface $session,
+        RepositoryInterface $zoneMemberRepository,
+        GenericEvent $event,
+        ZoneInterface $zone,
+    ): void {
+        $event->getSubject()->willReturn($zone);
+        $zone->getCode()->willReturn('MUG');
+
+        $zoneMemberRepository->findOneBy(['code' => 'MUG'])->willReturn(null);
+
+        $session->getBag('flashes')->shouldNotBeCalled();
+        $event->stopPropagation()->shouldNotBeCalled();
+
+        $this->protectFromRemovingZone($event);
+    }
+
+    function it_throws_an_error_if_an_event_subject_is_not_a_zone(GenericEvent $event): void
+    {
+        $event->getSubject()->willReturn('wrongSubject');
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('protectFromRemovingZone', [$event])
+        ;
+    }
+
+    function it_does_not_allow_to_remove_province_if_it_exists_as_a_zone_member(
+        SessionInterface $session,
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository,
+        GenericEvent $event,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince,
+        ZoneMemberInterface $zoneMember,
+        FlashBagInterface $flashes,
+    ): void {
+        $event->getSubject()->willReturn($country);
+
+        $firstProvince->getCode()->willReturn('FIRST_PROVINCE');
+        $secondProvince->getCode()->willReturn('SECOND_PROVINCE');
+        $thirdProvince->getCode()->willReturn('THIRD_PROVINCE');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'FIRST_PROVINCE', 2 => 'THIRD_PROVINCE']])
+            ->willReturn($zoneMember)
+        ;
+
+        $session->getBag('flashes')->willReturn($flashes);
+
+        $flashes
+            ->add('error', [
+                'message' => 'sylius.resource.delete_error',
+                'parameters' => ['%resource%' => 'province'],
+            ])
+            ->shouldBeCalled()
+        ;
+
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->protectFromRemovingProvinceWithinCountry($event);
+    }
+
+    function it_does_nothing_if_province_does_not_exist_as_a_zone_member(
+        SessionInterface $session,
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository,
+        GenericEvent $event,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince,
+    ): void {
+        $event->getSubject()->willReturn($country);
+
+        $firstProvince->getCode()->willReturn('FIRST_PROVINCE');
+        $secondProvince->getCode()->willReturn('SECOND_PROVINCE');
+        $thirdProvince->getCode()->willReturn('THIRD_PROVINCE');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'FIRST_PROVINCE', 2 => 'THIRD_PROVINCE']])
+            ->willReturn(null)
+        ;
+
+        $session->getBag('flashes')->shouldNotBeCalled();
+        $event->stopPropagation()->shouldNotBeCalled();
+
+        $this->protectFromRemovingProvinceWithinCountry($event);
+    }
+
+    function it_throws_an_error_if_an_event_subject_is_not_a_province(GenericEvent $event): void
+    {
+        $event->getSubject()->willReturn('wrongSubject');
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('protectFromRemovingProvinceWithinCountry', [$event])
+        ;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/DataPersister/CountryDataPersister.php
+++ b/src/Sylius/Bundle/ApiBundle/DataPersister/CountryDataPersister.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Bundle\ApiBundle\Exception\ProvinceCannotBeRemoved;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/** @experimental */
+final class CountryDataPersister implements ContextAwareDataPersisterInterface
+{
+    public function __construct(
+        private ContextAwareDataPersisterInterface $decoratedDataPersister,
+        private RepositoryInterface $provinceRepository,
+        private RepositoryInterface $zoneMemberRepository
+    ) {
+    }
+
+    public function supports($data, array $context = []): bool
+    {
+        return $data instanceof CountryInterface;
+    }
+
+    public function persist($data, array $context = [])
+    {
+        $provinces = $this->provinceRepository->findBy(['country' => $data]);
+
+        $countryProvinceCodes = $data->getProvinces()->map(fn ($province): string => $province->getCode())->getValues();
+        $provinceCodes = (new ArrayCollection($provinces))->map(fn ($province): string => $province->getCode())->getValues();
+
+        $provincesToDelete = array_diff($provinceCodes, $countryProvinceCodes);
+
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $provincesToDelete]);
+
+        if (null !== $zoneMember) {
+            throw new ProvinceCannotBeRemoved();
+        }
+
+        return $this->decoratedDataPersister->persist($data, $context);
+    }
+
+    public function remove($data, array $context = [])
+    {
+        return $this->decoratedDataPersister->remove($data, $context);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/DataPersister/ZoneDataPersister.php
+++ b/src/Sylius/Bundle/ApiBundle/DataPersister/ZoneDataPersister.php
@@ -15,15 +15,15 @@ namespace Sylius\Bundle\ApiBundle\DataPersister;
 
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use Sylius\Bundle\ApiBundle\Exception\ZoneCannotBeRemoved;
+use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /** @experimental */
 final class ZoneDataPersister implements ContextAwareDataPersisterInterface
 {
     public function __construct(
         private ContextAwareDataPersisterInterface $decoratedDataPersister,
-        private RepositoryInterface $zoneMemberRepository
+        private ZoneDeletionCheckerInterface $zoneDeletionChecker
     ) {
     }
 
@@ -39,9 +39,7 @@ final class ZoneDataPersister implements ContextAwareDataPersisterInterface
 
     public function remove($data, array $context = [])
     {
-        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $data->getCode()]);
-
-        if (null !== $zoneMember) {
+        if (!$this->zoneDeletionChecker->isDeletable($data)) {
             throw new ZoneCannotBeRemoved();
         }
 

--- a/src/Sylius/Bundle/ApiBundle/DataPersister/ZoneDataPersister.php
+++ b/src/Sylius/Bundle/ApiBundle/DataPersister/ZoneDataPersister.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use Sylius\Bundle\ApiBundle\Exception\ZoneCannotBeRemoved;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/** @experimental */
+final class ZoneDataPersister implements ContextAwareDataPersisterInterface
+{
+    public function __construct(
+        private ContextAwareDataPersisterInterface $decoratedDataPersister,
+        private RepositoryInterface $zoneMemberRepository
+    ) {
+    }
+
+    public function supports($data, array $context = []): bool
+    {
+        return $data instanceof ZoneInterface;
+    }
+
+    public function persist($data, array $context = [])
+    {
+        return $this->decoratedDataPersister->persist($data, $context);
+    }
+
+    public function remove($data, array $context = [])
+    {
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $data->getCode()]);
+
+        if (null !== $zoneMember) {
+            throw new ZoneCannotBeRemoved();
+        }
+
+        return $this->decoratedDataPersister->remove($data, $context);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Exception/ProvinceCannotBeRemoved.php
+++ b/src/Sylius/Bundle/ApiBundle/Exception/ProvinceCannotBeRemoved.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Exception;
+
+/** @experimental */
+final class ProvinceCannotBeRemoved extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Cannot delete, the province is in use.');
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Exception/ZoneCannotBeRemoved.php
+++ b/src/Sylius/Bundle/ApiBundle/Exception/ZoneCannotBeRemoved.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Exception;
+
+/** @experimental */
+final class ZoneCannotBeRemoved extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Cannot delete, the zone is in use.');
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -39,6 +39,8 @@ api_platform:
         SM\SMException: 422
         Sylius\Bundle\ApiBundle\Exception\CannotRemoveCurrentlyLoggedInUser: 422
         Sylius\Bundle\ApiBundle\Exception\ShippingMethodCannotBeRemoved: 422
+        Sylius\Bundle\ApiBundle\Exception\ZoneCannotBeRemoved: 422
+        Sylius\Bundle\ApiBundle\Exception\ProvinceCannotBeRemoved: 422
         Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 400
     collection:
         pagination:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
@@ -31,8 +31,21 @@
             <tag name="api_platform.data_persister" />
         </service>
 
+        <service id="Sylius\Bundle\ApiBundle\DataPersister\CountryDataPersister">
+            <argument type="service" id="api_platform.doctrine.orm.data_persister" />
+            <argument type="service" id="sylius.repository.province" />
+            <argument type="service" id="sylius.repository.zone_member" />
+            <tag name="api_platform.data_persister" />
+        </service>
+
         <service id="Sylius\Bundle\ApiBundle\DataPersister\ShippingMethodDataPersister">
             <argument type="service" id="api_platform.doctrine.orm.data_persister" />
+            <tag name="api_platform.data_persister" />
+        </service>
+
+        <service id="Sylius\Bundle\ApiBundle\DataPersister\ZoneDataPersister">
+            <argument type="service" id="api_platform.doctrine.orm.data_persister" />
+            <argument type="service" id="sylius.repository.zone_member" />
             <tag name="api_platform.data_persister" />
         </service>
     </services>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
@@ -33,8 +33,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\DataPersister\CountryDataPersister">
             <argument type="service" id="api_platform.doctrine.orm.data_persister" />
-            <argument type="service" id="sylius.repository.province" />
-            <argument type="service" id="sylius.repository.zone_member" />
+            <argument type="service" id="Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface" />
             <tag name="api_platform.data_persister" />
         </service>
 
@@ -45,7 +44,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\DataPersister\ZoneDataPersister">
             <argument type="service" id="api_platform.doctrine.orm.data_persister" />
-            <argument type="service" id="sylius.repository.zone_member" />
+            <argument type="service" id="Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface" />
             <tag name="api_platform.data_persister" />
         </service>
     </services>

--- a/src/Sylius/Bundle/ApiBundle/spec/DataPersister/CountryDataPersisterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataPersister/CountryDataPersisterSpec.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace spec\Sylius\Bundle\ApiBundle\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Exception\ProvinceCannotBeRemoved;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+class CountryDataPersisterSpec extends ObjectBehavior
+{
+    function let(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $provinceRepository,
+        RepositoryInterface $zoneMemberRepository,
+    ): void {
+        $this->beConstructedWith($decoratedDataPersister, $provinceRepository, $zoneMemberRepository);
+    }
+
+    function it_supports_only_zone_entity(CountryInterface $country, ProductInterface $product): void
+    {
+        $this->supports($country)->shouldReturn(true);
+        $this->supports($product)->shouldReturn(false);
+    }
+
+    function it_uses_decorated_data_persister_to_remove_country(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        CountryInterface $country,
+    ): void {
+        $decoratedDataPersister->remove($country, [])->shouldBeCalled();
+
+        $this->remove($country, []);
+    }
+
+    function it_uses_decorated_data_persister_to_persist_country(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $provinceRepository,
+        RepositoryInterface $zoneMemberRepository,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince
+    ): void {
+        $firstProvince->getCode()->willReturn('FIRST_PROVINCE');
+        $secondProvince->getCode()->willReturn('SECOND_PROVINCE');
+        $thirdProvince->getCode()->willReturn('THIRD_PROVINCE');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'FIRST_PROVINCE', 2 => 'THIRD_PROVINCE']])
+            ->willReturn(null)
+        ;
+
+        $decoratedDataPersister->persist($country, [])->shouldBeCalled();
+
+        $this->persist($country, []);
+    }
+
+    function it_throws_an_error_if_the_province_within_a_country_is_in_use(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $provinceRepository,
+        RepositoryInterface $zoneMemberRepository,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince,
+        ZoneMemberInterface $zoneMember
+    ): void {
+        $firstProvince->getCode()->willReturn('FIRST_PROVINCE');
+        $secondProvince->getCode()->willReturn('SECOND_PROVINCE');
+        $thirdProvince->getCode()->willReturn('THIRD_PROVINCE');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'FIRST_PROVINCE', 2 => 'THIRD_PROVINCE']])
+            ->willReturn($zoneMember)
+        ;
+
+        $decoratedDataPersister->persist($country, [])->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(ProvinceCannotBeRemoved::class)
+            ->during('persist', [$country, []])
+        ;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/DataPersister/ZoneDataPersisterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataPersister/ZoneDataPersisterSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace spec\Sylius\Bundle\ApiBundle\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Exception\ZoneCannotBeRemoved;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+class ZoneDataPersisterSpec extends ObjectBehavior
+{
+    function let(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $zoneMemberRepository,
+    ): void {
+        $this->beConstructedWith($decoratedDataPersister, $zoneMemberRepository);
+    }
+
+    function it_supports_only_zone_entity(ZoneInterface $zone, ProductInterface $product): void
+    {
+        $this->supports($zone)->shouldReturn(true);
+        $this->supports($product)->shouldReturn(false);
+    }
+
+    function it_uses_decorated_data_persister_to_persist_zone(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        ZoneInterface $zone,
+    ): void {
+        $decoratedDataPersister->persist($zone, [])->shouldBeCalled();
+
+        $this->persist($zone, []);
+    }
+
+    function it_uses_decorated_data_persister_to_remove_zone(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $zoneMemberRepository,
+        ZoneInterface $zone,
+    ): void {
+        $zone->getCode()->willReturn('US');
+        $zoneMemberRepository->findOneBy(['code' => 'US'])->willReturn(null);
+
+        $decoratedDataPersister->remove($zone, [])->shouldBeCalled();
+
+        $this->remove($zone, []);
+    }
+
+    function it_throws_an_error_if_the_zone_is_in_use(
+        ContextAwareDataPersisterInterface $decoratedDataPersister,
+        RepositoryInterface $zoneMemberRepository,
+        ZoneInterface $zone,
+        ZoneMemberInterface $zoneMember,
+    ): void {
+        $zone->getCode()->willReturn('US');
+        $zoneMemberRepository->findOneBy(['code' => 'US'])->willReturn($zoneMember);
+
+        $decoratedDataPersister->remove($zone, [])->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(ZoneCannotBeRemoved::class)
+            ->during('remove', [$zone, []])
+        ;
+    }
+}

--- a/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionChecker.php
+++ b/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Addressing\Checker;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class CountryProvincesDeletionChecker implements CountryProvincesDeletionCheckerInterface
+{
+    public function __construct(
+        private RepositoryInterface $zoneMemberRepository,
+        private RepositoryInterface $provinceRepository
+    ) {
+    }
+
+    public function isDeletable(CountryInterface $country): bool
+    {
+        $provinces = $this->provinceRepository->findBy(['country' => $country]);
+
+        $countryProvincesCodes = $country->getProvinces()
+            ->map(fn ($province): string => $province->getCode())
+            ->getValues()
+        ;
+
+        $provincesCodes = (new ArrayCollection($provinces))
+            ->map(fn ($province): string => $province->getCode())
+            ->getValues()
+        ;
+
+        $provincesCodesToDelete = array_diff($provincesCodes, $countryProvincesCodes);
+
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $provincesCodesToDelete]);
+
+        return null === $zoneMember;
+    }
+}

--- a/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionCheckerInterface.php
+++ b/src/Sylius/Component/Addressing/Checker/CountryProvincesDeletionCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Addressing\Checker;
+
+use Sylius\Component\Addressing\Model\CountryInterface;
+
+interface CountryProvincesDeletionCheckerInterface
+{
+    public function isDeletable(CountryInterface $country): bool;
+}

--- a/src/Sylius/Component/Addressing/Checker/ZoneDeletionChecker.php
+++ b/src/Sylius/Component/Addressing/Checker/ZoneDeletionChecker.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Addressing\Checker;
+
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class ZoneDeletionChecker implements ZoneDeletionCheckerInterface
+{
+    public function __construct(private RepositoryInterface $zoneMemberRepository) {
+    }
+
+    public function isDeletable(ZoneInterface $zone): bool
+    {
+        $zoneMember = $this->zoneMemberRepository->findOneBy(['code' => $zone->getCode()]);
+
+        return null === $zoneMember;
+    }
+}

--- a/src/Sylius/Component/Addressing/Checker/ZoneDeletionCheckerInterface.php
+++ b/src/Sylius/Component/Addressing/Checker/ZoneDeletionCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Addressing\Checker;
+
+use Sylius\Component\Addressing\Model\ZoneInterface;
+
+interface ZoneDeletionCheckerInterface
+{
+    public function isDeletable(ZoneInterface $zone): bool;
+}

--- a/src/Sylius/Component/Addressing/spec/Checker/CountryProvincesDeletionCheckerSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Checker/CountryProvincesDeletionCheckerSpec.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Addressing\Checker;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AddressingBundle\EventListener\ZoneMemberIntegrityListener;
+use Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface;
+use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class CountryProvincesDeletionCheckerSpec extends ObjectBehavior
+{
+    function let(
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository
+    ): void
+    {
+        $this->beConstructedWith($zoneMemberRepository, $provinceRepository);
+    }
+
+    function it_implements_country_provinces_deletion_checker_interface(): void
+    {
+        $this->shouldImplement(CountryProvincesDeletionCheckerInterface::class);
+    }
+
+    function it_says_provinces_within_a_country_are_not_deletable_if_there_is_a_province_that_exists_as_a_zone_member(
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince,
+        ZoneMemberInterface $zoneMember
+    ): void {
+        $firstProvince->getCode()->willReturn('US-AK');
+        $secondProvince->getCode()->willReturn('US-TX');
+        $thirdProvince->getCode()->willReturn('US-KY');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'US-AK', 2 => 'US-KY']])
+            ->willReturn($zoneMember)
+        ;
+
+        $this->isDeletable($country)->shouldReturn(false);
+    }
+
+    function it_says_provinces_within_a_country_are_deletable_if_there_is_not_a_province_that_exists_as_a_zone_member(
+        RepositoryInterface $zoneMemberRepository,
+        RepositoryInterface $provinceRepository,
+        CountryInterface $country,
+        ProvinceInterface $firstProvince,
+        ProvinceInterface $secondProvince,
+        ProvinceInterface $thirdProvince
+    ): void {
+        $firstProvince->getCode()->willReturn('US-AK');
+        $secondProvince->getCode()->willReturn('US-TX');
+        $thirdProvince->getCode()->willReturn('US-KY');
+
+        $country->getProvinces()->willReturn(new ArrayCollection([$secondProvince->getWrappedObject()]));
+        $provinceRepository->findBy(['country' => $country])->willReturn([
+            $firstProvince->getWrappedObject(),
+            $secondProvince->getWrappedObject(),
+            $thirdProvince->getWrappedObject(),
+        ]);
+
+        $zoneMemberRepository
+            ->findOneBy(['code' => [0 => 'US-AK', 2 => 'US-KY']])
+            ->willReturn(null)
+        ;
+
+        $this->isDeletable($country)->shouldReturn(true);
+    }
+}

--- a/src/Sylius/Component/Addressing/spec/Checker/ZoneDeletionCheckerSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Checker/ZoneDeletionCheckerSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Addressing\Checker;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AddressingBundle\EventListener\ZoneMemberIntegrityListener;
+use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Sylius\Component\Addressing\Model\ProvinceInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ZoneDeletionCheckerSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $zoneMemberRepository): void
+    {
+        $this->beConstructedWith($zoneMemberRepository);
+    }
+
+    function it_implements_zone_deletion_checker_interface(): void
+    {
+        $this->shouldImplement(ZoneDeletionCheckerInterface::class);
+    }
+
+    function it_says_zone_is_not_deletable_if_the_zone_exists_as_a_zone_member(
+        RepositoryInterface $zoneMemberRepository,
+        ZoneInterface $zone,
+        ZoneMemberInterface $zoneMember,
+    ): void {
+        $zone->getCode()->willReturn('US');
+
+        $zoneMemberRepository->findOneBy(['code' => 'US'])->willReturn($zoneMember);
+
+        $this->isDeletable($zone)->shouldReturn(false);
+    }
+
+    function it_says_zone_is_not_deletable_if_the_zone_does_not_exist_as_a_zone_member(
+        RepositoryInterface $zoneMemberRepository,
+        ZoneInterface $zone,
+    ): void {
+        $zone->getCode()->willReturn('US');
+
+        $zoneMemberRepository->findOneBy(['code' => 'US'])->willReturn(null);
+
+        $this->isDeletable($zone)->shouldReturn(true);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no
| Related tickets |                      |
| License         | MIT                                                          |

It is possible to delete the resource (zone or province) that is already in use as a zone member. When we delete such a resource, we cannot access the zone edit screen (and probably even more) because we try to load an unexisting resource 💥

Sample error:
```
Unable to transform data for property path "code": Object "Sylius\Component\Addressing\Model\Zone" with identifier "code"="LETS_DELETE_ME" does not exist.
```