### PR TITLE
[Symfony 6] Fix command arguments denormalizer return typehint

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandArgumentsDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandArgumentsDenormalizer.php
@@ -29,7 +29,7 @@ final class CommandArgumentsDenormalizer implements ContextAwareDenormalizerInte
     ) {
     }
 
-    public function supportsDenormalization($data, $type, $format = null, array $context = [])
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         /** @psalm-var class-string $inputClassName|null */
         $inputClassName = $this->getInputClassName($context);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master        |
| Bug fix?        | yes (for Symfony 6)                                                      |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | partially #13274                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The return type has changed on Symfony 6, this is not a bc-break cause the service is final.
I based this PR to the master branch to prove it works correctly with a success build.