### PR TITLE
Remove auto commenting feature on 1.10 & 1.11 as well

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -110,21 +110,6 @@ jobs:
                 id: composer_diff
                 with:
                     base: old-composer.lock
-                    
-            -
-                name: Show diff in comment to PR
-                uses: marocchino/sticky-pull-request-comment@v2
-                if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
-                with:
-                    recreate: true
-                    header: composer-diff # Creates a collapsed comment with the report
-                    message: |
-                        <details>
-                        <summary>Composer package changes</summary>
-                        
-                        ${{ steps.composer_diff.outputs.composer_diff }}
-                        
-                        </details>
 
             -
                 name: Check for security vulnerabilities


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10  |
| Bug fix?        | yes                                                       |
| New feature?    | no |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  same as https://github.com/Sylius/Sylius/pull/13970 |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
