### PR TITLE
[Symfony 6] Replace encoders with password_hashers

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -10,7 +10,7 @@ security:
         sylius_api_shop_user_provider:
             id: sylius.shop_user_provider.email_or_name_based
 
-    encoders:
+    password_hashers:
         Sylius\Component\User\Model\UserInterface: argon2i
     firewalls:
         admin:

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,5 +1,5 @@
 security:
-    encoders:
+    password_hashers:
         sha512: sha512
         Sylius\Component\User\Model\UserInterface: sha512
 

--- a/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
@@ -47,7 +47,7 @@ security:
                     foo:
                         password:           foo
                         roles:              ROLE_USER
-    encoders:
+    password_hashers:
         Sylius\Component\User\Model\UserInterface: sha512
     firewalls:
         admin:

--- a/src/Sylius/Bundle/UserBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/app/config.yml
@@ -2,7 +2,7 @@
 # (c) Paweł Jędrzejewski
 
 security:
-    encoders:
+    password_hashers:
         argon2i: argon2i
 
 sylius_user:

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/app/config/config.yml
@@ -51,7 +51,7 @@ security:
                     foo:
                         password: foo
                         roles: ROLE_USER
-    encoders:
+    password_hashers:
         Sylius\Component\User\Model\UserInterface: sha512
     firewalls:
         admin:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master         |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | partially #13274                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
