### PR TITLE
Fix channel color in fixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -125,7 +125,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             })
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('hostname', fn (Options $options): string => $options['code'] . '.localhost')
-            ->setDefault('color', fn (Options $options): string => $this->faker->colorName)
+            ->setDefault('color', fn (Options $options): string => $this->faker->hexColor)
             ->setDefault('enabled', fn (Options $options): bool => $this->faker->boolean(90))
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('skipping_shipping_step_allowed', false)


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10        |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

If there is not color in HEX on the Channel, the color will be displayed incorrectly when editing the Channel.
The default (black) color is prefilled in the form and the old value is overwritten after saving.
