### PR TITLE
[Admin][Zones] Choosing disabled country as a zone member made possible for admin user

### DIFF
--- a/features/addressing/managing_zones/adding_zone.feature
+++ b/features/addressing/managing_zones/adding_zone.feature
@@ -6,6 +6,7 @@ Feature: Adding a new zone with country type members
 
     Background:
         Given the store has country "France"
+        And the store has disabled country "Austria"
         And the store also has country "United States"
         And this country has the "Alabama" province with "AL" code
         And the store has a zone "North America" with code "NA"
@@ -52,3 +53,13 @@ Feature: Adding a new zone with country type members
         Then I should be notified that it has been successfully created
         And the zone named "European Union" with the "France" country member should appear in the registry
         And its scope should be "shipping"
+
+    @ui @javascript @api
+    Scenario: Adding zone with disabled country
+        When I want to create a new zone consisting of country
+        And I name it "European Union"
+        And I specify its code as "EU"
+        And I add a country "Austria"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the zone named "European Union" with the "Austria" country member should appear in the registry

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -41,13 +41,11 @@ final class CountryChoiceType extends AbstractType
             ->setDefaults([
                 'choice_filter' => null,
                 'choices' => function (Options $options): iterable {
-                    if (null === $options['enabled']) {
-                        $countries = $this->countryRepository->findAll();
-                    } else {
-                        $countries = $this->countryRepository->findBy(['enabled' => $options['enabled']]);
+                    if ($options['enabled'] === true) {
+                        return  $this->countryRepository->findBy(['enabled' => $options['enabled']]);
                     }
 
-                    return $countries;
+                    return $this->countryRepository->findAll();
                 },
                 'choice_value' => 'code',
                 'choice_label' => 'name',

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -101,7 +101,11 @@ final class ZoneType extends AbstractResourceType
     private function getZoneMemberEntryOptions(string $zoneMemberType): array
     {
         $zoneMemberEntryOptions = [
-            ZoneInterface::TYPE_COUNTRY => ['label' => 'sylius.form.zone.types.country'],
+            ZoneInterface::TYPE_COUNTRY => [
+                'label' => 'sylius.form.zone.types.country',
+                'enabled' => false,
+                'attr' => ['class' => 'country_search_dropdown ui fluid search selection dropdown'],
+            ],
             ZoneInterface::TYPE_PROVINCE => ['label' => 'sylius.form.zone.types.province'],
             ZoneInterface::TYPE_ZONE => ['label' => 'sylius.form.zone.types.zone'],
         ];

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/CountryChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/CountryChoiceTypeTest.php
@@ -33,6 +33,9 @@ final class CountryChoiceTypeTest extends TypeTestCase
     /** @var ProphecyInterface|CountryInterface */
     private $poland;
 
+    /** @var ProphecyInterface|CountryInterface */
+    private $austria;
+
     protected function setUp(): void
     {
         $this->countryRepository = $this->prophesize(RepositoryInterface::class);
@@ -49,6 +52,13 @@ final class CountryChoiceTypeTest extends TypeTestCase
         $poland->getName()->willReturn('Poland');
         $this->poland = $poland;
 
+        /** @var ProphecyInterface|CountryInterface $austria */
+        $austria = $this->prophesize(CountryInterface::class);
+        $austria->getCode()->willReturn('AT');
+        $austria->getName()->willReturn('Austria');
+        $austria->isEnabled()->willReturn(false);
+        $this->austria = $austria;
+
         parent::setUp();
     }
 
@@ -61,9 +71,7 @@ final class CountryChoiceTypeTest extends TypeTestCase
         ];
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_returns_only_enabled_countries_by_default(): void
     {
         $this->countryRepository->findBy(['enabled' => true])->willReturn([
@@ -74,23 +82,20 @@ final class CountryChoiceTypeTest extends TypeTestCase
         $this->assertChoicesLabels(['France', 'Poland']);
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_all_countries(): void
+    /** @test */
+    public function it_returns_all_countries_when_option_enabled_is_false(): void
     {
         $this->countryRepository->findAll()->willReturn([
             $this->france->reveal(),
             $this->poland->reveal(),
+            $this->austria->reveal(),
         ]);
 
-        $this->assertChoicesLabels(['France', 'Poland'], ['enabled' => null]);
+        $this->assertChoicesLabels(['Austria','France', 'Poland'], ['enabled' => false]);
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_countries_in_an_alphabetical_order(): void
+    /** @test */
+    public function it_returns_enabled_countries_in_an_alphabetical_order(): void
     {
         $this->countryRepository->findBy(['enabled' => true])->willReturn([
             $this->poland->reveal(),
@@ -100,10 +105,32 @@ final class CountryChoiceTypeTest extends TypeTestCase
         $this->assertChoicesLabels(['France', 'Poland']);
     }
 
-    /**
-     * @test
-     */
-    public function it_returns_filtered_out_countries(): void
+    /** @test */
+    public function it_returns_all_countries_in_an_alphabetical_order(): void
+    {
+        $this->countryRepository->findAll()->willReturn([
+            $this->poland->reveal(),
+            $this->france->reveal(),
+            $this->austria->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['Austria', 'France', 'Poland'], ['enabled' => false]);
+    }
+
+    /** @test */
+    public function it_returns_all_filtered_out_countries(): void
+    {
+        $this->countryRepository->findAll()->willReturn([
+            $this->france->reveal(),
+            $this->poland->reveal(),
+            $this->austria->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['Poland'], ['choice_filter' => static fn (?CountryInterface $country): bool => $country !== null && $country->getName() === 'Poland', 'enabled' => false]);
+    }
+
+    /** @test */
+    public function it_returns_enabled_filtered_out_countries(): void
     {
         $this->countryRepository->findBy(['enabled' => true])->willReturn([
             $this->france->reveal(),

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Zone/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Zone/_form.html.twig
@@ -13,3 +13,10 @@
     <h4 class="ui dividing header">{{ 'sylius.ui.members'|trans }}</h4>
     {{ form_row(form.members, {'label': false}) }}
 </div>
+
+<style>
+    .ui.form .field>.country_search_dropdown {
+        display: inline-block;
+        width: 150px!important;
+    }
+</style>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Right now we’re experiencing a bug-o-feature, where when you disable a country that is a zone member, the members list on the Zone shows empty dropdown and field is unable to be controlled.

Changes made:

- adding disabled countries as zone members made possible for admin users
- search dropdown added instead of select dropdown field

Before:
![502e0587-5f2a-46e6-bf0a-978a51e0462c](https://user-images.githubusercontent.com/53942444/172257473-40796456-eef2-4287-9462-7c116b233012.png)
After:
<img width="601" alt="Zrzut ekranu 2022-06-7 o 15 24 15" src="https://user-images.githubusercontent.com/53942444/172391514-ce9b377c-32bb-4e45-b9d1-446ce161beda.png">


