### PR TITLE
[Addressing] Enable orphan removal for zone members

### DIFF
--- a/features/addressing/managing_countries/managing_provinces_of_country.feature
+++ b/features/addressing/managing_countries/managing_provinces_of_country.feature
@@ -44,6 +44,23 @@ Feature: Managing provinces of a country
         And this country should still have the "England" province
 
     @ui @javascript @api
+    Scenario: Removing a province that is not a zone member anymore should be possible
+        Given this country has the "Northern Ireland" province with "GB-NIR" code
+        And this country also has the "Scotland" province with "GB-SCT" code
+        And this country also has the "England" province with "GB-ENG" code
+        And the store has a zone "Great Britain" with code "GB"
+        And it has the "Northern Ireland" province member
+        And it also has the "Scotland" province member
+        And it also has the "England" province member
+        And the "England" province member has been removed from this zone
+        When I am editing this country
+        And I delete the "England" province of this country
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this country should not have the "England" province
+        And this country should still have the "Northern Ireland" and "Scotland" provinces
+
+    @ui @javascript @api
     Scenario: Removing and adding a new province to an existing country
         Given this country has the "Northern Ireland" province with "GB-NIR" code
         When I want to edit this country

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -75,6 +75,7 @@ final class ManagingCountriesContext implements Context
 
     /**
      * @When /^I want to edit (this country)$/
+     * @When /^I am editing (this country)$/
      * @When /^I want to create a new province in (country "([^"]+)")$/
      */
     public function iWantToEditThisCountry(CountryInterface $country): void
@@ -218,6 +219,16 @@ final class ManagingCountriesContext implements Context
             'code',
             $province->getCode()
         ));
+    }
+
+    /**
+     * @Then /^(this country) should(?:| still) have the ("[^"]*" and "[^"]*" provinces)$/
+     */
+    public function theCountryShouldHaveTheProvinceAndProvince(CountryInterface $country, array $provinces): void
+    {
+        foreach ($provinces as $province) {
+            $this->theCountryShouldHaveTheProvince($country, $province);
+        }
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Setup/ZoneContext.php
@@ -123,6 +123,19 @@ final class ZoneContext implements Context
     }
 
     /**
+     * @Given /^(the "([^"]*)" (?:country|province|zone) member) has been removed from (this zone)$/
+     */
+    public function theZoneMemberHasBeenRemoved(
+        ZoneMemberInterface $zoneMember,
+        string $zoneMemberName,
+        ZoneInterface $zone
+    ): void {
+        $zone->removeMember($zoneMember);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^(it) has the ("[^"]+" province) member$/
      * @Given /^(it) also has the ("[^"]+" province) member$/
      */

--- a/src/Sylius/Behat/Context/Transform/ProvinceContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProvinceContext.php
@@ -44,4 +44,12 @@ final class ProvinceContext implements Context
 
         return $province;
     }
+
+    /**
+     * @Transform /^"([^"]*)" and "([^"]*)" provinces$/
+     */
+    public function getProvincesByName(string ...$provinceNames): array
+    {
+        return $this->provinceRepository->findBy(['name' => $provinceNames]);
+    }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -45,6 +45,7 @@ final class ManagingCountriesContext implements Context
 
     /**
      * @When /^I want to edit (this country)$/
+     * @When /^I am editing (this country)$/
      */
     public function iWantToEditThisCountry(CountryInterface $country)
     {
@@ -158,13 +159,16 @@ final class ManagingCountriesContext implements Context
 
     /**
      * @Then /^(this country) should(?:| still) have the "([^"]*)" province$/
+     * @Then /^(this country) should(?:| still) have the "([^"]*)" and "([^"]*)" provinces$/
      * @Then /^the (country "[^"]*") should(?:| still) have the "([^"]*)" province$/
      */
-    public function countryShouldHaveProvince(CountryInterface $country, $provinceName)
+    public function countryShouldHaveProvince(CountryInterface $country, string ...$provinceNames)
     {
         $this->iWantToEditThisCountry($country);
 
-        Assert::true($this->updatePage->isThereProvince($provinceName));
+        foreach ($provinceNames as $provinceName) {
+            Assert::true($this->updatePage->isThereProvince($provinceName));
+        }
     }
 
     /**

--- a/src/Sylius/Behat/Resources/config/suites/api/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/addressing/managing_countries.yml
@@ -12,6 +12,7 @@ default:
 
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.zone_member
 
                 - sylius.behat.context.setup.admin_api_security
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
@@ -10,6 +10,7 @@ default:
                 - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.province
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.zone_member
 
                 - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -23,7 +23,7 @@
         <field name="type" column="type" type="string" length="8" />
         <field name="scope" column="scope" type="string" nullable="true"/>
 
-        <one-to-many field="members" target-entity="Sylius\Component\Addressing\Model\ZoneMemberInterface" mapped-by="belongsTo">
+        <one-to-many field="members" target-entity="Sylius\Component\Addressing\Model\ZoneMemberInterface" mapped-by="belongsTo" orphan-removal="true">
             <cascade>
                 <cascade-all/>
             </cascade>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | https://github.com/Sylius/Sylius/pull/14041                      |
| License         | MIT                                                          |

Without orphan removal, even if we delete the zone member, the corresponding province/country cannot be removed because orphans still exist in the database.