### PR TITLE
Increase OAuth tokens size

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220524072159.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220524072159.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220524072159 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update OAuth access_token and refresh_token length';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_user_oauth CHANGE access_token access_token VARCHAR(2048) DEFAULT NULL, CHANGE refresh_token refresh_token VARCHAR(2048) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_user_oauth CHANGE access_token access_token VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`, CHANGE refresh_token refresh_token VARCHAR(255) CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/UserOAuth.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/UserOAuth.orm.xml
@@ -23,8 +23,8 @@
 
         <field name="provider" type="string" />
         <field name="identifier" type="string" />
-        <field name="accessToken" column="access_token" type="string" nullable="true" />
-        <field name="refreshToken" column="refresh_token" type="string" nullable="true" />
+        <field name="accessToken" column="access_token" type="string" nullable="true" length="2048"/>
+        <field name="refreshToken" column="refresh_token" type="string" nullable="true" length="2048"/>
 
         <many-to-one field="user" target-entity="Sylius\Component\User\Model\UserInterface" inversed-by="oauthAccounts">
             <join-column name="user_id" referenced-column-name="id" />


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master (can change to 1.7)           |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/13505, related to https://github.com/Sylius/Sylius/issues/11608                      |
| License         | MIT                                                          |

- [x] update length in `UserOAuth.orm.xml`
- [x] add migration

Token length reference
- Facebook https://developers.facebook.com/docs/facebook-login/guides/access-tokens#size
- Google https://developers.google.com/identity/protocols/oauth2#size
