### PR TITLE
Add missing `variant_selection_option` in Product fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -137,6 +137,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
             ->setNormalizer('channels', LazyOption::findBy($this->channelRepository, 'code'))
 
             ->setDefault('variant_selection_method', ProductInterface::VARIANT_SELECTION_MATCH)
+            ->setAllowedTypes('variant_selection_method', 'string')
             ->setAllowedValues('variant_selection_method', [ProductInterface::VARIANT_SELECTION_MATCH, ProductInterface::VARIANT_SELECTION_CHOICE])
 
             ->setDefault('product_attributes', [])

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
@@ -36,6 +36,7 @@ class ProductFixture extends AbstractResourceFixture
                 ->scalarNode('main_taxon')->cannotBeEmpty()->end()
                 ->arrayNode('taxons')->scalarPrototype()->end()->end()
                 ->arrayNode('channels')->scalarPrototype()->end()->end()
+                ->scalarNode('variant_selection_method')->end()
                 ->arrayNode('product_attributes')->variablePrototype()->end()->end()
                 ->arrayNode('product_options')->scalarPrototype()->end()->end()
                 ->arrayNode('images')->variablePrototype()->end()->end()

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
@@ -108,6 +108,15 @@ final class ProductFixtureTest extends TestCase
     /**
      * @test
      */
+    public function product_variant_selection_method_is_optional(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [['variant_selection_method' => 'custom']]]], 'custom.*.variant_selection_method');
+        $this->assertConfigurationIsValid([['custom' => [['variant_selection_method' => 'match']]]], 'custom.*.variant_selection_method');
+    }
+
+    /**
+     * @test
+     */
     public function product_product_options_are_optional(): void
     {
         $this->assertConfigurationIsValid([['custom' => [['product_options' => ['OPT-1', 'OPT-2']]]]], 'custom.*.product_options');


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11          |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | none                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
