### PR TITLE
[idea]Ignore export of docker, docs, adr and github files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/docs                   export-ignore
+/.docker                export-ignore
+/.github                export-ignore
+/adr                    export-ignore
+docker-compose.*.yml    export-ignore


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master          |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | none                      |
| License         | MIT                                                          |

git export is used by packageist when updating the package, but do we in our vendor need everything that is currently in the repository? In my opinion, we don't. It is a proposal for optimization. For example, the docs are 13MB.
