### PR TITLE
[Migrations] Minimum price migration fixed

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220614124639.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220614124639.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220614124639 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'null values in minimum price field changed to default';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('UPDATE sylius_channel_pricing SET minimum_price = 0 WHERE minimum_price IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Now we encounter bug that when we already have some data in the db and we use the prepared migrations they fail with 500 wherever we call the minimum price. It is caused by migration that sets default value to null, we managed to add another migration that changes default value to 0, but still does not update existing values and only new ones are correct

changes:

- new migration added that changes existing `minimum_price` null values to 0