### PR TITLE
[OrderProcessing] Parametrize hardcoded states in order processors

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -21,8 +21,10 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
 {
     private array $adjustmentsToRemove;
 
-    public function __construct(array $adjustmentsToRemove = [])
-    {
+    public function __construct(
+        array $adjustmentsToRemove = [],
+        private string $validState = OrderInterface::STATE_CART
+    ) {
         if (0 === func_num_args()) {
             @trigger_error(
                 'Not passing adjustments types explicitly is deprecated since 1.2 and will be prohibited in 2.0',
@@ -43,7 +45,7 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
 
     public function process(OrderInterface $order): void
     {
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -27,6 +27,7 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
     public function __construct(
         private OrderPaymentProviderInterface $orderPaymentProvider,
         private string $targetState = PaymentInterface::STATE_CART,
+        private string $invalidOrderState = OrderInterface::STATE_CANCELLED,
     ) {
     }
 
@@ -35,7 +36,7 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CANCELLED === $order->getState()) {
+        if ($this->invalidOrderState === $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -22,8 +22,10 @@ use Webmozart\Assert\Assert;
 
 final class OrderPricesRecalculator implements OrderProcessorInterface
 {
-    public function __construct(private ProductVariantPriceCalculatorInterface|ProductVariantPricesCalculatorInterface $productVariantPriceCalculator)
-    {
+    public function __construct(
+        private ProductVariantPriceCalculatorInterface|ProductVariantPricesCalculatorInterface $productVariantPriceCalculator,
+        private string $validState = OrderInterface::STATE_CART
+    ) {
         if ($this->productVariantPriceCalculator instanceof ProductVariantPriceCalculatorInterface) {
             @trigger_error(
                 sprintf('Passing a "Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" to "%s" constructor is deprecated since Sylius 1.11 and will be prohibited in 2.0. Use "Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface" instead.', self::class),
@@ -37,7 +39,7 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
@@ -21,8 +21,10 @@ use Webmozart\Assert\Assert;
 
 final class OrderPromotionProcessor implements OrderProcessorInterface
 {
-    public function __construct(private PromotionProcessorInterface $promotionProcessor)
-    {
+    public function __construct(
+        private PromotionProcessorInterface $promotionProcessor,
+        private string $validState = OrderInterface::STATE_CART
+    ) {
     }
 
     public function process(BaseOrderInterface $order): void
@@ -30,7 +32,7 @@ final class OrderPromotionProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -29,6 +29,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         private DefaultShippingMethodResolverInterface $defaultShippingMethodResolver,
         private FactoryInterface $shipmentFactory,
         private ?ShippingMethodsResolverInterface $shippingMethodsResolver = null,
+        private string $validState = OrderInterface::STATE_CART,
     ) {
         if (2 === func_num_args() || null === $shippingMethodsResolver) {
             @trigger_error(
@@ -43,7 +44,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -35,6 +35,7 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
         private ZoneMatcherInterface $zoneMatcher,
         private PrioritizedServiceRegistryInterface $strategyRegistry,
         private ?TaxationAddressResolverInterface $taxationAddressResolver = null,
+        private string $validState = OrderInterface::STATE_CART,
     ) {
         if ($this->taxationAddressResolver === null) {
             @trigger_error(sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated since Sylius 1.11 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
@@ -46,7 +47,7 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -24,8 +24,11 @@ use Webmozart\Assert\Assert;
 
 final class ShippingChargesProcessor implements OrderProcessorInterface
 {
-    public function __construct(private FactoryInterface $adjustmentFactory, private DelegatingCalculatorInterface $shippingChargesCalculator)
-    {
+    public function __construct(
+        private FactoryInterface $adjustmentFactory,
+        private DelegatingCalculatorInterface $shippingChargesCalculator,
+        private string $validState = OrderInterface::STATE_CART
+    ) {
     }
 
     public function process(BaseOrderInterface $order): void
@@ -33,7 +36,7 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if ($this->validState !== $order->getState()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
@@ -65,4 +65,22 @@ final class OrderAdjustmentsClearerSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_given_valid_state(OrderInterface $order): void
+    {
+        $this->beConstructedWith(
+            [
+                AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
+                AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
+            ],
+            OrderInterface::STATE_NEW
+        );
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
+        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
@@ -73,6 +73,18 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
         $this->process($order);
     }
 
+    function it_does_nothing_if_the_order_is_in_invalid_state(
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, OrderInterface::STATE_FULFILLED);
+
+        $order->getState()->willReturn(OrderInterface::STATE_FULFILLED);
+        $order->getLastPayment(Argument::any())->shouldNotBeCalled();
+
+        $this->process($order);
+    }
+
     function it_sets_last_order_currency_with_target_state_currency_code_and_amount(
         OrderInterface $order,
         PaymentInterface $payment,

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
@@ -92,4 +92,18 @@ final class OrderPricesRecalculatorSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_given_valid_state(
+        ProductVariantPricesCalculatorInterface $productVariantPriceCalculator,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($productVariantPriceCalculator, OrderInterface::STATE_CANCELLED);
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $order->getChannel()->shouldNotBeCalled();
+        $order->getItems()->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPromotionProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPromotionProcessorSpec.php
@@ -49,4 +49,17 @@ final class OrderPromotionProcessorSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_given_valid_state(
+        PromotionProcessorInterface $promotionProcessor,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($promotionProcessor, OrderInterface::STATE_NEW);
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $promotionProcessor->process($order)->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -310,4 +310,23 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_given_valid_state(
+        DefaultShippingMethodResolverInterface $defaultShippingMethodResolver,
+        FactoryInterface $shipmentFactory,
+        ShippingMethodsResolverInterface $shippingMethodsResolver,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($defaultShippingMethodResolver, $shipmentFactory, $shippingMethodsResolver, OrderInterface::STATE_NEW);
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $order->isEmpty()->shouldNotBeCalled();
+        $order->getItems()->shouldNotBeCalled();
+        $order->isShippingRequired()->shouldNotBeCalled();
+        $order->hasShipments()->shouldNotBeCalled();
+        $order->getShipments()->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
@@ -162,4 +162,25 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_provided_valid_state(
+        ZoneProviderInterface $defaultTaxZoneProvider,
+        ZoneMatcherInterface $zoneMatcher,
+        PrioritizedServiceRegistryInterface $strategyRegistry,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($defaultTaxZoneProvider, $zoneMatcher, $strategyRegistry, null, OrderInterface::STATE_CANCELLED);
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $order->getItems()->shouldNotBeCalled();
+        $order->getShipments()->shouldNotBeCalled();
+        $order->isEmpty()->shouldNotBeCalled();
+        $order->removeAdjustments(AdjustmentInterface::TAX_ADJUSTMENT)->shouldNotBeCalled();
+
+        $defaultTaxZoneProvider->getZone($order)->shouldNotBeCalled();
+        $strategyRegistry->all()->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -100,4 +100,19 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
 
         $this->process($order);
     }
+
+    function it_does_nothing_if_the_order_is_in_a_state_different_than_given_valid_state(
+        FactoryInterface $adjustmentFactory,
+        DelegatingCalculatorInterface $calculator,
+        OrderInterface $order
+    ): void {
+        $this->beConstructedWith($adjustmentFactory, $calculator, OrderInterface::STATE_NEW);
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+
+        $order->getShipments()->shouldNotBeCalled();
+        $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldNotBeCalled();
+
+        $this->process($order);
+    }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11   |
| Bug fix?        | yes (DX bug 💃)                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

With the current implementation, it's impossible to use order processors outside the checkout process, even if it would be a valid scenario (e.g. edit a placed order from the Admin panel). I believe we should avoid any hardcode in if statements (both with _magic_ strings and constants) by parametrizing the checked value or checking the result of service 🖖 