### PR TITLE
Fix calculate order item subtotal

### DIFF
--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -145,9 +145,7 @@ class OrderItem extends BaseOrderItem implements OrderItemInterface
     {
         return array_reduce(
             $this->getUnits()->toArray(),
-            function (int $subtotal, BaseOrderItemUnitInterface $unit) {
-                return $subtotal + $this->unitPrice + $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
-            },
+            fn (int $subtotal, BaseOrderItemUnitInterface $unit) => $subtotal + $this->unitPrice + $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT),
             0
         );
     }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Order\Model\OrderItem as BaseOrderItem;
 use Sylius\Component\Order\Model\OrderItemInterface as BaseOrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnitInterface as BaseOrderItemUnitInterface;
 use Webmozart\Assert\Assert;
 
 class OrderItem extends BaseOrderItem implements OrderItemInterface
@@ -142,6 +143,12 @@ class OrderItem extends BaseOrderItem implements OrderItemInterface
 
     public function getSubtotal(): int
     {
-        return $this->getDiscountedUnitPrice() * $this->quantity;
+        return array_reduce(
+            $this->getUnits()->toArray(),
+            function (int $subtotal, BaseOrderItemUnitInterface $unit) {
+                return $subtotal + $this->unitPrice + $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+            },
+            0
+        );
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\Adjustment;
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderItemUnit;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Resource\Model\VersionedInterface;
 
@@ -97,24 +99,29 @@ final class OrderItemSpec extends ObjectBehavior
         $this->getDiscountedUnitPrice()->shouldReturn(10000);
     }
 
-    function it_returns_subtotal_which_consist_of_discounted_unit_price_multiplied_by_quantity(
-        OrderItemUnitInterface $firstUnit,
-        OrderItemUnitInterface $secondUnit
-    ): void {
+    function its_subtotal_consist_of_sum_of_units_discounted_price(): void
+    {
         $this->setUnitPrice(10000);
 
-        $firstUnit->getOrderItem()->willReturn($this);
-        $firstUnit->getTotal()->willReturn(9000);
-        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-500);
+        $firstUnit = new OrderItemUnit($this->getWrappedObject());
+        $adjustment1 = new Adjustment();
+        $adjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $adjustment1->setAmount(-1667);
+        $firstUnit->addAdjustment($adjustment1);
 
-        $secondUnit->getOrderItem()->willReturn($this);
-        $secondUnit->getTotal()->willReturn(9000);
-        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-500);
+        $secondUnit = new OrderItemUnit($this->getWrappedObject());
+        $adjustment2 = new Adjustment();
+        $adjustment2->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $adjustment2->setAmount(-1667);
+        $secondUnit->addAdjustment($adjustment2);
 
-        $this->addUnit($firstUnit);
-        $this->addUnit($secondUnit);
+        $secondUnit = new OrderItemUnit($this->getWrappedObject());
+        $adjustment3 = new Adjustment();
+        $adjustment3->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $adjustment3->setAmount(-1666);
+        $secondUnit->addAdjustment($adjustment3);
 
-        $this->getSubtotal()->shouldReturn(19000);
+        $this->getSubtotal()->shouldReturn(25000);
     }
 
     function it_has_no_variant_by_default(): void

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -99,29 +99,25 @@ final class OrderItemSpec extends ObjectBehavior
         $this->getDiscountedUnitPrice()->shouldReturn(10000);
     }
 
-    function its_subtotal_consist_of_sum_of_units_discounted_price(): void
-    {
+    function its_subtotal_consists_of_sum_of_units_discounted_price(
+        OrderItemUnitInterface $firstUnit,
+        OrderItemUnitInterface $secondUnit,
+    ): void {
         $this->setUnitPrice(10000);
 
-        $firstUnit = new OrderItemUnit($this->getWrappedObject());
-        $adjustment1 = new Adjustment();
-        $adjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
-        $adjustment1->setAmount(-1667);
-        $firstUnit->addAdjustment($adjustment1);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-1667);
+        $firstUnit->getTotal()->willReturn(10000);
+        $firstUnit->getOrderItem()->willReturn($this->getWrappedObject());
 
-        $secondUnit = new OrderItemUnit($this->getWrappedObject());
-        $adjustment2 = new Adjustment();
-        $adjustment2->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
-        $adjustment2->setAmount(-1667);
-        $secondUnit->addAdjustment($adjustment2);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT)->willReturn(400);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-3333);
+        $secondUnit->getTotal()->willReturn(10000);
+        $secondUnit->getOrderItem()->willReturn($this->getWrappedObject());
 
-        $secondUnit = new OrderItemUnit($this->getWrappedObject());
-        $adjustment3 = new Adjustment();
-        $adjustment3->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
-        $adjustment3->setAmount(-1666);
-        $secondUnit->addAdjustment($adjustment3);
+        $this->addUnit($firstUnit->getWrappedObject());
+        $this->addUnit($secondUnit->getWrappedObject());
 
-        $this->getSubtotal()->shouldReturn(25000);
+        $this->getSubtotal()->shouldReturn(15000);
     }
 
     function it_has_no_variant_by_default(): void


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| Related tickets | replace https://github.com/Sylius/Sylius/pull/13986, fixes https://github.com/Sylius/Sylius/issues/13532 and https://github.com/Sylius/Sylius/issues/11585                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We also should add here behat scenario, but TBH, I don't know how to prepare proper background