### PR TITLE
[Fixtures] Add a fixture listener for removing images

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
@@ -26,7 +26,8 @@ final class ImagesPurgerListener extends AbstractListener implements BeforeSuite
 
     public function beforeSuite(SuiteEvent $suiteEvent, array $options): void
     {
-        $this->filesystem->remove($this->imagesDirectoryPath);
+        $this->filesystem->remove($this->imagesDirectoryPath . '/*');
+        $this->filesystem->touch($this->imagesDirectoryPath . '/.gitkeep');
     }
 
     public function getName(): string

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Fixture\Listener;
+
+use Sylius\Bundle\FixturesBundle\Listener\AbstractListener;
+use Sylius\Bundle\FixturesBundle\Listener\BeforeSuiteListenerInterface;
+use Sylius\Bundle\FixturesBundle\Listener\SuiteEvent;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class ImagesPurgerListener extends AbstractListener implements BeforeSuiteListenerInterface
+{
+    public function __construct(private Filesystem $filesystem, private string $imagesDirectoryPath)
+    {
+    }
+
+    public function beforeSuite(SuiteEvent $suiteEvent, array $options): void
+    {
+        $this->filesystem->remove($this->imagesDirectoryPath);
+    }
+
+    public function getName(): string
+    {
+        return 'images_purger';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -27,6 +27,7 @@ imports:
 
 parameters:
     sylius_core.public_dir: "%kernel.project_dir%/web"
+    sylius_core.images_dir: "%sylius_core.public_dir%/media/image"
 
 doctrine:
     orm:
@@ -47,7 +48,7 @@ knp_gaufrette:
     adapters:
         sylius_image:
             local:
-                directory: "%sylius_core.public_dir%/media/image"
+                directory: "%sylius_core.images_dir%"
                 create: true
     filesystems:
         sylius_image:
@@ -57,7 +58,7 @@ liip_imagine:
     loaders:
         default:
             filesystem:
-                data_root: "%sylius_core.public_dir%/media/image"
+                data_root: "%sylius_core.images_dir%"
     resolvers:
         default:
             web_path:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -6,6 +6,7 @@ sylius_fixtures:
         default:
             listeners:
                 orm_purger: ~
+                images_purger: ~
                 logger: ~
 
             fixtures:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_listeners.xml
@@ -22,5 +22,11 @@
             <argument type="tagged_iterator" tag="sylius.catalog_promotion.criteria" />
             <tag name="sylius_fixtures.listener" />
         </service>
+
+        <service id="Sylius\Bundle\CoreBundle\Fixture\Listener\ImagesPurgerListener" public="false">
+            <argument type="service" id="filesystem" />
+            <argument>%sylius_core.images_dir%</argument>
+            <tag name="sylius_fixtures.listener" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Fixture\Listener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\FixturesBundle\Listener\SuiteEvent;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class ImagesPurgerListenerSpec extends ObjectBehavior
+{
+    public function let(Filesystem $filesystem): void
+    {
+        $this->beConstructedWith($filesystem, '/media');
+    }
+
+    public function it_removes_images_before_fixture_suite(Filesystem $filesystem, SuiteInterface $suite): void
+    {
+        $filesystem->remove('/media')->shouldBeCalled();
+
+        $this->beforeSuite(new SuiteEvent($suite->getWrappedObject()), []);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
@@ -27,7 +27,8 @@ final class ImagesPurgerListenerSpec extends ObjectBehavior
 
     public function it_removes_images_before_fixture_suite(Filesystem $filesystem, SuiteInterface $suite): void
     {
-        $filesystem->remove('/media')->shouldBeCalled();
+        $filesystem->remove('/media/*')->shouldBeCalled();
+        $filesystem->touch('/media/.gitkeep')->shouldBeCalled();
 
         $this->beforeSuite(new SuiteEvent($suite->getWrappedObject()), []);
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11|
| Bug fix?        | yes?                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

Currently without removing pictures when loading fixtures, the images directory can grow unnecessarily very quickly.