### PR TITLE
Make compatible with knplabs/gaufrette up to 0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "friendsofsymfony/rest-bundle": "^3.0",
         "gedmo/doctrine-extensions": "^3.2",
         "jms/serializer-bundle": "^3.5",
-        "knplabs/gaufrette": "^0.8",
+        "knplabs/gaufrette": "^0.8|^0.9|^0.10",
         "knplabs/knp-gaufrette-bundle": "^0.7",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -31,7 +31,7 @@
         "egulias/email-validator": "^3.0",
         "fakerphp/faker": "^1.10",
         "jms/serializer-bundle": "^3.5",
-        "knplabs/gaufrette": "^0.8",
+        "knplabs/gaufrette": "^0.8|^0.9|^0.10",
         "knplabs/knp-gaufrette-bundle": "^0.7",
         "liip/imagine-bundle": "^2.3",
         "sonata-project/block-bundle": "^4.2",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.0",
         "enshrined/svg-sanitize": "^0.15.4",
-        "knplabs/gaufrette": "^0.8",
+        "knplabs/gaufrette": "^0.8|^0.9|^0.10",
         "payum/payum": "^1.6",
         "php-http/guzzle6-adapter": "^2.0",
         "sylius/addressing": "^1.6",


### PR DESCRIPTION
there are no breaking changes introduced in either version , but due
to how sub v1 version management works, only minors
are installed when you require with ^

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no
| Related tickets | none                      |
| License         | MIT                                                          |
