### PR TITLE
fix MoneyIntToLocalizedStringTransformer ignores comma separated numbers in Catalog Promotions Fixed Discount type field #138844

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
@@ -19,11 +19,9 @@ final class MoneyIntToLocalizedStringTransformer extends MoneyToLocalizedStringT
 {
     public function reverseTransform($value)
     {
-        if (!is_numeric($value)) {
-            return;
-        }
+        $result = parent::reverseTransform($value);
 
-        return (int) parent::reverseTransform($value);
+        return null !== $result ? (int) $result : null;
     }
 
     public function transform($value)


### PR DESCRIPTION


| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #13884                     |
| License         | MIT                                                          |
