### PR TITLE
[Fixtures] Fix removing images before suite

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Listener/ImagesPurgerListener.php
@@ -26,7 +26,8 @@ final class ImagesPurgerListener extends AbstractListener implements BeforeSuite
 
     public function beforeSuite(SuiteEvent $suiteEvent, array $options): void
     {
-        $this->filesystem->remove($this->imagesDirectoryPath . '/*');
+        $this->filesystem->remove($this->imagesDirectoryPath);
+        $this->filesystem->mkdir($this->imagesDirectoryPath);
         $this->filesystem->touch($this->imagesDirectoryPath . '/.gitkeep');
     }
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Listener/ImagesPurgerListenerSpec.php
@@ -27,7 +27,8 @@ final class ImagesPurgerListenerSpec extends ObjectBehavior
 
     public function it_removes_images_before_fixture_suite(Filesystem $filesystem, SuiteInterface $suite): void
     {
-        $filesystem->remove('/media/*')->shouldBeCalled();
+        $filesystem->remove('/media')->shouldBeCalled();
+        $filesystem->mkdir('/media')->shouldBeCalled();
         $filesystem->touch('/media/.gitkeep')->shouldBeCalled();
 
         $this->beforeSuite(new SuiteEvent($suite->getWrappedObject()), []);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11|
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | fixes #14095                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
