### PR TITLE
[Maintenance] Composer allow plugins finally sorted out + removal of symfony thanks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,6 @@
         "symfony/string": "^5.3",
         "symfony/swiftmailer-bundle": "^3.4",
         "symfony/templating": "^4.4 || ^5.4",
-        "symfony/thanks": "^1.2",
         "symfony/translation": "^4.4 || ^5.4",
         "symfony/twig-bundle": "^4.4 || ^5.4",
         "symfony/validator": "^4.4 || ^5.4",
@@ -226,7 +225,11 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "dealerdirect/phpcodesniffer-composer-installer": false
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

I'm proposing adding flex to our allowed plugins, as we are using it and it is in our req/dev. In addition, I've also disallowed `dealerdirect/phpcodesniffer-composer-installer`, as we are not using it directly. 

What is more, I'm proposing the removal of `symfony/thanks` lib, as it does not provide valuable features and is not present in any Symfony package anymore. We are the main package that still installs it https://packagist.org/packages/symfony/thanks/dependents?order_by=downloads&requires=all. Let's give it rest.

These plugins are executed by default right now, but this behaviour will change since the beginning of July. If we don't do anything we can expect the following error: 
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6213903/175053538-38ec7eba-00c9-403d-8f4c-e2bf328e748a.png">

Once merged, we should iterate over our other packages.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
