### PR TITLE
Allow ramsey/uuid v4 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "payum/payum": "^1.7",
         "payum/payum-bundle": "^2.4",
         "php-http/guzzle6-adapter": "^2.0",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.9|^4.0",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",
         "swiftmailer/swiftmailer": "^6.2",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.9 || ^4.0",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/attribute": "^1.6",
         "sylius/resource-bundle": "^1.7",


### PR DESCRIPTION
sylius uses only v1 uuid functionality so no breakage
it might maybe even be better to switch to symfony/uid?
anybody depending on ramsey (3) should have a root dependency on it anyways?

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11
| Bug fix?        | no
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no
| Related tickets | fixes none                      |
| License         | MIT                                                          |

