### PR TITLE
[Fix][Maintenance] Cart item data mapper adjusted to be Sf6 compatible

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/form.xml
@@ -33,7 +33,7 @@
         <service id="sylius.form.data_mapper.order_item_quantity" class="Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper">
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service">
-                <service class="Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper">
+                <service class="Symfony\Component\Form\Extension\Core\DataMapper\DataMapper">
                     <argument type="service" id="property_accessor" />
                 </service>
             </argument>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/form.xml
@@ -33,9 +33,7 @@
         <service id="sylius.form.data_mapper.order_item_quantity" class="Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper">
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service">
-                <service class="Symfony\Component\Form\Extension\Core\DataMapper\DataMapper">
-                    <argument type="service" id="property_accessor" />
-                </service>
+                <service class="\Symfony\Component\Form\Extension\Core\DataMapper\DataMapper" />
             </argument>
         </service>
 

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -29,10 +29,10 @@
     "require": {
         "php": "^8.0",
         "stof/doctrine-extensions-bundle": "^1.4",
-        "sylius-labs/polyfill-symfony-framework-bundle": "^1.0",
+        "sylius-labs/polyfill-symfony-framework-bundle": "^1.0 || dev-master",
         "sylius/money-bundle": "^1.6",
         "sylius/order": "^1.6",
-        "sylius/resource-bundle": "^1.7",
+        "sylius/resource-bundle": "^1.9 || ^1.10@alpha",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/templating": "^5.4 || ^6.0"
     },

--- a/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
@@ -12,7 +12,7 @@ framework:
     default_locale: "%locale%"
     session:
         handler_id: ~
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     http_method_override: true
     test: ~
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | partially fixes #13274, based on #14066  |
| License         | MIT                                                          |

Changes required due to deprecation in Sf 6.0

After fix: https://github.com/Sylius/Sylius/runs/7076277139?check_suite_focus=true

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
