### PR TITLE
[DX] Removing duplicate attribute iteration

### DIFF
--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -225,23 +225,12 @@ class Product implements ProductInterface, \Stringable
 
     public function hasAttributeByCodeAndLocale(string $attributeCode, ?string $localeCode = null): bool
     {
-        $localeCode = $localeCode ?: $this->getTranslation()->getLocale();
-
-        foreach ($this->attributes as $attribute) {
-            if ($attribute->getAttribute()->getCode() === $attributeCode &&
-                ($attribute->getLocaleCode() === $localeCode || null === $attribute->getLocaleCode())) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->getAttributeByCodeAndLocale($attributeCode, $localeCode) !== null;
     }
 
     public function getAttributeByCodeAndLocale(string $attributeCode, ?string $localeCode = null): ?AttributeValueInterface
     {
-        if (null === $localeCode) {
-            $localeCode = $this->getTranslation()->getLocale();
-        }
+        $localeCode = $localeCode ?: $this->getTranslation()->getLocale();
 
         foreach ($this->attributes as $attribute) {
             if ($attribute->getAttribute()->getCode() === $attributeCode &&


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master           |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | - |
| License         | MIT                                                          |

## What
I have removed the duplicate implementation of the `hasAttributeByCodeAndLocale` function in the product. This can be done without any other changes because the only difference to the `getAttributeByCodeAndLocale` is the fact that it just returns if the attribute is null or not.

## Why
This will make it easier to change the logic of finding attributes since it is not centralized in only one place. But both functions return early when they've found the attribute.

## Known problems
This is still not really the best way of handling attributes in my opinion since storing the attributes in a hashmap (associative array) would provide constant look up time. But this is outside of the scope of this pull request.