### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,9 @@ name: Auto-merge
 on:
     pull_request: ~
 
+permissions:
+  contents: read
+
 jobs:
     auto-merge:
         runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Docker Based Pipeline
 on:
     push:
 
+permissions:
+  contents: read
+
 jobs:
     static-analyze:
         name: Execute Static Analyze on Docker Compose

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -6,8 +6,14 @@ on:
             cron: "0 2 * * MON" # Run at 2am every Monday
     workflow_dispatch: ~
     
+permissions:
+  contents: read
+
 jobs:
     coding-standard:
+        permissions:
+          contents: write  # for peter-evans/create-pull-request to create branch
+          pull-requests: write  # for peter-evans/create-pull-request to create a PR
         runs-on: ubuntu-latest
         
         name: "Coding standard refactor"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
