### PR TITLE
[docker]Define BLACKFIRE_DISABLE_LEGACY_PORT env as 1 instead of true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
             BLACKFIRE_SERVER_TOKEN: ~
             BLACKFIRE_CLIENT_ID: ~
             BLACKFIRE_CLIENT_TOKEN: ~
-            BLACKFIRE_DISABLE_LEGACY_PORT: true
+            BLACKFIRE_DISABLE_LEGACY_PORT: 1
         ports:
             - 8307:8307
         networks:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master <!-- see the comment below -->          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | none                      |
| License         | MIT                                                          |

Got issue that `BLACKFIRE_DISABLE_LEGACY_PORT` should not be boolean, as the environment variables do not handle this type.
