### PR TITLE
[API] Fix TaxonFilter default order behavior

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TaxonFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TaxonFilter.php
@@ -63,7 +63,7 @@ final class TaxonFilter extends AbstractContextAwareFilter
             ->setParameter('taxonRoot', $taxonRoot)
         ;
 
-        if (empty($context['filters']['order'])) {
+        if (null !== $taxonRoot && empty($context['filters']['order'])) {
             $queryBuilder->addOrderBy('productTaxon.position');
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/spec/Filter/Doctrine/TaxonFilterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Filter/Doctrine/TaxonFilterSpec.php
@@ -95,7 +95,6 @@ final class TaxonFilterSpec extends ObjectBehavior
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
     ): void {
-        $context['filters']['order'] = ['differentOrderParameter' => 'asc'];
         $iriConverter->getItemFromIri('api/taxon')->willThrow(ItemNotFoundException::class);
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -115,7 +114,6 @@ final class TaxonFilterSpec extends ObjectBehavior
             $queryBuilder,
             $queryNameGenerator,
             'resourceClass',
-            context: $context,
         );
     }
 
@@ -125,7 +123,6 @@ final class TaxonFilterSpec extends ObjectBehavior
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
     ): void {
-        $context['filters']['order'] = ['differentOrderParameter' => 'asc'];
         $iriConverter->getItemFromIri('non-existing-taxon')->willThrow(InvalidArgumentException::class);
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -146,7 +143,6 @@ final class TaxonFilterSpec extends ObjectBehavior
             $queryBuilder,
             $queryNameGenerator,
             'resourceClass',
-            context: $context,
         );
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master         |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets |                     |
| License         | MIT                                                          |

To be consistent with what spec methods describe:
 - `it_does_not_add_the_default_order_by_taxon_position_if_taxon_does_not_exist`
 - `it_does_not_add_the_default_order_by_taxon_position_if_taxon_is_given_with_wrong_format`