### PR TITLE
Disassociate OrderItemUnit from all shipments before removal

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -291,6 +291,13 @@ class Order extends BaseOrder implements OrderInterface
 
     public function removeShipments(): void
     {
+        // Disassociate OrderItemUnit from all shipments before removal
+        foreach ($this->shipments as $shipment) {
+            foreach ($shipment->getUnits() as $unit) {
+                $shipment->removeUnit($unit);
+            }
+        }
+        
         $this->shipments->clear();
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | |
| License         | MIT                                                          |

The `$order->removeShipments()` would trigger the following Doctrine error because OrderItemUnit is still associated with shipment.

> A new entity was found through the relationship 'OrderItemUnit#shipment' that was not configured to cascade persist operations for entity: . To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example @ManyToOne(..,cascade={\"persist\"}).

One `removeShipments()` usage is in `OrderShipmentProcessor` when there is no shipping method available to the order.