### PR TITLE
Fix Percent float to localized string transformer

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/PercentFloatToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/PercentFloatToLocalizedStringTransformer.php
@@ -28,7 +28,7 @@ final class PercentFloatToLocalizedStringTransformer extends PercentToLocalizedS
      * @throws TransformationFailedException if the given value is not a string or
      *                                       if the value could not be transformed
      */
-    public function reverseTransform($value)
+    public function reverseTransform(mixed $value)
     {
         if (!is_numeric($value)) {
             return;
@@ -40,7 +40,7 @@ final class PercentFloatToLocalizedStringTransformer extends PercentToLocalizedS
     /**
      * @param float|string $value
      */
-    public function transform($value)
+    public function transform(mixed $value)
     {
         if (!is_numeric($value)) {
             return;


### PR DESCRIPTION
| Q               | A                                                          
|-----------------|--------------------------------------------------------------
| Branch?         | symfony-6
| Bug fix?        | yes                                                       
| New feature?    | no                                                       
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #13274 
| License         | MIT                                                          

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

It throws an error there https://github.com/Sylius/Sylius/runs/7229517957?check_suite_focus=true#step:15:13 on Sylius/Sylius#14079

It's green here https://github.com/Sylius/Sylius/runs/7229800892?check_suite_focus=true
and there https://github.com/Sylius/Sylius/runs/7229796910?check_suite_focus=true
