### PR TITLE
[docker]Run JS Behat tests in docker

### DIFF
--- a/.docker/dev/Dockerfile
+++ b/.docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM sylius/standard:1.11-traditional
 
-RUN apt-get update && apt-get install php8.0-xdebug && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apt-get update && apt-get install curl php8.0-xdebug && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(uname -m) \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,31 +16,44 @@ jobs:
     static-analyze:
         name: Execute Static Analyze on Docker Compose
         runs-on: ubuntu-latest
-        env:
-            COMPOSE_FILE: docker-compose.test.yml
-
         steps:
             -
                 name: Checkout Code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -
                 name: Run PHPUnit, PHPSpec and Psalm
-                # docker-compose -f docker-compose.test.yml --profile static-analyze run static
-                run: docker compose --profile static-analyze run static
+                run: docker-compose -f docker-compose.test.yml --profile static-analyze run static
 
     integration:
         name: Execute Behat Tests on Docker Compose
         runs-on: ubuntu-latest
-        env:
-            COMPOSE_FILE: docker-compose.test.yml
-        
         steps:
             -
                 name: Checkout Code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
+                
+            -
+                name: Behat Configuration
+                run: mv behat.yml.docker behat.yml
 
             -
                 name: Run Behat
-                # docker-compose -f docker-compose.test.yml --profile integration run behat
-                run: docker-compose --profile integration run behat
+                run: docker compose -f docker-compose.test.yml --profile integration run behat
+
+    javascript:
+        name: Execute JS Behat Tests on Docker Compose
+        runs-on: ubuntu-latest
+        if: false
+        steps:
+            -   name: Checkout Code
+                uses: actions/checkout@v3
+
+            -   name: Behat Configuration
+                run: cp behat.yml.docker behat.yml
+
+            -   name: Run Behat
+                run: |
+                    docker compose -f docker-compose.test.yml --profile js up -d
+                    docker compose -f docker-compose.test.yml --profile js exec app make init
+                    docker compose -f docker-compose.test.yml --profile js exec app make behat-js

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 	composer install --no-interaction --no-scripts
 
 backend:
-	bin/console doctrine:database:create --no-interaction
+	bin/console doctrine:database:create --no-interaction --if-not-exists
 	bin/console sylius:install --no-interaction
 	bin/console sylius:fixtures:load default --no-interaction
 

--- a/behat.yml.docker
+++ b/behat.yml.docker
@@ -1,0 +1,68 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+imports:
+    - src/Sylius/Behat/Resources/config/suites.yml
+
+default:
+    formatters:
+        pretty:
+            verbose: true
+            paths: false
+            snippets: false
+
+    extensions:
+        DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
+
+        FriendsOfBehat\MinkDebugExtension:
+            directory: etc/build
+            clean_start: false
+            screenshot: true
+
+        Behat\MinkExtension:
+            files_path: "%paths.base%/src/Sylius/Behat/Resources/fixtures/"
+            base_url: "%env(SYLIUS_BEHAT_BASE_URL)%"
+            default_session: symfony
+            javascript_session: chrome_headless
+            sessions:
+                symfony:
+                    symfony: ~
+                chrome_headless:
+                    chrome:
+                        api_url: "%env(SYLIUS_BEHAT_API_URL)%"
+                        validate_certificate: false
+                chrome_headless_second_session:
+                    chrome:
+                        api_url: "%env(SYLIUS_BEHAT_API_URL)%"
+                        validate_certificate: false
+                chrome:
+                    selenium2:
+                        browser: chrome
+                        capabilities:
+                            browserName: chrome
+                            browser: chrome
+                            version: ""
+                            marionette: null # https://github.com/Behat/MinkExtension/pull/311
+                            chrome:
+                                switches:
+                                    - "start-fullscreen"
+                                    - "start-maximized"
+                                    - "no-sandbox"
+                            extra_capabilities:
+                                acceptSslCerts: true
+                                acceptInsecureCerts: true
+                                unexpectedAlertBehaviour: accept
+                                goog:chromeOptions:
+                                    w3c: false # https://github.com/Sylius/Sylius/issues/10561
+                firefox:
+                    selenium2:
+                        browser: firefox
+            show_auto: false
+
+        FriendsOfBehat\SymfonyExtension: ~
+
+        FriendsOfBehat\VariadicExtension: ~
+
+    gherkin:
+        filters:
+            tags: "~@todo&&~@cli" # CLI is excluded as it registers an error handler that mutes fatal errors

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,6 +23,8 @@ services:
             DATABASE_URL: "mysql://root:mysql@mysql/sylius_%kernel.environment%"
             PHP_DATE_TIMEZONE: "Europe/Warsaw"
             MESSENGER_TRANSPORT_DSN: "sync://"
+            SYLIUS_BEHAT_BASE_URL: "http://192.168.16.2"
+            SYLIUS_BEHAT_API_URL: "http://192.168.16.8:9222"
         volumes:
             - ./:/app:delegated
             - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
@@ -31,16 +33,52 @@ services:
             - mysql
         networks:
             - sylius
+    
+    app:
+        image: sylius/standard:1.11-traditional
+        profiles: ["js"]
+        environment:
+            APP_ENV: "test_cached"
+            DATABASE_URL: "mysql://root:mysql@mysql/sylius_%kernel.environment%"
+            PHP_DATE_TIMEZONE: "Europe/Warsaw"
+            MESSENGER_TRANSPORT_DSN: "sync://"
+            SYLIUS_BEHAT_BASE_URL: "http://192.168.16.2"
+            SYLIUS_BEHAT_API_URL: "http://192.168.16.8:9222"
+        volumes:
+            - ./:/app:delegated
+            - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
+            - ./.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated
+        depends_on:
+            - mysql
+            - chrome
+        networks:
+            sylius:
+                ipv4_address: 192.168.16.2
 
     mysql:
-        image: mysql:5.7
-        profiles: ["integration"]
-        platform: linux/amd64
+        image: mysql:8.0
+        profiles: ["integration", "js"]
         environment:
             MYSQL_ROOT_PASSWORD: mysql
         networks:
-            - sylius
+            sylius:
+                ipv4_address: 192.168.16.4
+    
+    chrome:
+        image: zenika/alpine-chrome
+        profiles: ["js"]
+        shm_size: "4gb"
+        command: "--enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --window-size=1920,1080 --proxy-server='direct://' --proxy-bypass-list='*' --disable-dev-shm-usage --disable-software-rasterizer"
+        volumes:
+            - ./:/app:rw,delegated
+        networks:
+            sylius:
+                ipv4_address: 192.168.16.8
 
 networks:
     sylius:
         driver: bridge
+        ipam:
+            driver: default
+            config:
+                - subnet: 192.168.16.0/24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ services:
             - sylius
 
     mysql:
-        image: mysql:5.7
-        platform: linux/amd64
+        image: mysql:8.0
         environment:
             MYSQL_ROOT_PASSWORD: mysql
         ports:
@@ -39,6 +38,15 @@ services:
 #            - 5432:5432
 #        networks:
 #            - sylius
+
+    chrome:
+        image: zenika/alpine-chrome
+        shm_size: "4gb"
+        command: "--enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --remote-debugging-address=0.0.0.0 --window-size=1920,1080 --proxy-server='direct://' --proxy-bypass-list='*'"
+        volumes:
+            - ./:/app:cached
+        networks:
+            - sylius
 
     mailhog:
         image: mailhog/mailhog


### PR DESCRIPTION
I am trying the latest version of `zenika/alpine-chrome` dockerized chrome browser with Sylius Behat Scenarios.

The way to run JS tests on macOS is to execute:
```bash
cp behat.yml.docker behat.yml
docker compose -f docker-compose.test.yml --profile js up -d
docker compose -f docker-compose.test.yml --profile js exec app make init
docker compose -f docker-compose.test.yml --profile js exec app make behat-js
```

The know issues are:
1. MacOS cannot map hostnames to IP addresses. That's why each container in docker compose, has IP address. It's a temporary solution, that will get refactored.
2. The JS tests failing on ubuntu/linux based systems as the is a problem with permissions. That's why the pipeline is turned off. Probably the whole docker will need a refactor to optimize and rethink the current solution.

Definitely using the chrome container is not the fastest nor best solution. Can't wait for the time's Panther will be used or any other engine. In the meantime I will try to improve the solution.
