### PR TITLE
[Documentation] Fix incorrect translation domain in implementation

### DIFF
--- a/docs/book/plugins/guide/implementation.rst
+++ b/docs/book/plugins/guide/implementation.rst
@@ -107,11 +107,11 @@ To make our new field available in Admin panel, a form extension is required:
         }
     }
 
-Translation keys placed in ``src/Resources/translations/message.{locale}.yml`` will be resolved automatically.
+Translation keys placed in ``src/Resources/translations/messages.{locale}.yml`` will be resolved automatically.
 
 .. code-block:: yaml
 
-    # src/Resources/translations/message.en.yml
+    # src/Resources/translations/messages.en.yml
 
     iron_man_sylius_product_on_demand_plugin:
         ui:


### PR DESCRIPTION
The domain used for translations is `messages` instead of `message`.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11          |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no --> |
| Related tickets | None                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
