### PR TITLE
Allow to set zero tax rate

### DIFF
--- a/features/taxation/managing_tax_rates/adding_tax_rate.feature
+++ b/features/taxation/managing_tax_rates/adding_tax_rate.feature
@@ -22,6 +22,19 @@ Feature: Adding a new tax rate
         Then I should be notified that it has been successfully created
         And the tax rate "United States Sales Tax" should appear in the registry
 
+    @ui
+    Scenario: Adding a zero tax rate
+        When I want to create a new tax rate
+        And I specify its code as "US_SALES_TAX"
+        And I name it "United States Sales Tax"
+        And I define it for the "United States" zone
+        And I make it applicable for the "Food and Beverage" tax category
+        And I specify its amount as 0%
+        And I choose the default tax calculator
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the tax rate "United States Sales Tax" should appear in the registry
+
     @ui @javascript
     Scenario: Adding a new tax rate which will be included in product price
         When I want to create a new tax rate

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/validation/TaxRate.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/validation/TaxRate.xml
@@ -53,7 +53,7 @@
                 <option name="message">sylius.tax_rate.amount.not_blank</option>
                 <option name="groups">sylius</option>
             </constraint>
-            <constraint name="Positive">
+            <constraint name="PositiveOrZero">
                 <option name="message">sylius.tax_rate.amount.invalid</option>
                 <option name="groups">sylius</option>
             </constraint>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10<!-- see the comment below -->          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This PR allows adding a 0% tax rate (available i.e. in Poland).
