### PR TITLE
[Upgrade] A note about changes to the `access_control` configuration of `security.yaml`

### DIFF
--- a/UPGRADE-API-1.12.md
+++ b/UPGRADE-API-1.12.md
@@ -102,3 +102,11 @@ Here is how the response looks like:
 1. The 2nd parameter `localeCode` has been removed from `src/Sylius/Bundle/ApiBundle/Command/Cart/PickupCart.php` and now is set automatically by `src/Sylius/Bundle/ApiBundle/DataTransformer/LocaleCodeAwareInputCommandDataTransformer.php`.
 
 1. The responses of endpoints `/api/v2/admin/products` and `/api/v2/admin/products/{code}` have been changed in such a way that the field `defaultVariant` has been removed.
+
+1. The configuration of `config/packages/security.yaml` has to be updated:
+
+    ```diff
+        security:
+            access_control:
+    +           - { path: "%sylius.security.new_api_admin_route%/reset-password-requests", role: IS_AUTHENTICATED_ANONYMOUSLY }
+    ```


### PR DESCRIPTION


| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

Due to the API endpoints changes the configuration of `config/packages/security.yaml` in the end application needs to be adjusted accordingly.  

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
