### PR TITLE
Fixed the way an unknown email is treated when requesting a password reset 

### DIFF
--- a/features/account/resetting_password.feature
+++ b/features/account/resetting_password.feature
@@ -22,7 +22,15 @@ Feature: Resetting a password
         When I reset password for email "goodman@example.com" in "Polish (Poland)" locale
         Then an email with reset token should be sent to "goodman@example.com" in "Polish (Poland)" locale
 
-    @ui @email @api
+    @email @api @ui
+    Scenario: Notifying about sending reset instructions even when an account with email does not exist
+        When I want to reset password
+        And I specify customer email as "does-not-exist@example.com"
+        And I reset it
+        Then I should be notified that email with reset instruction has been sent
+        But "does-not-exist@example.com" should receive no emails
+
+    @ui @api
     Scenario: Changing my account password with token I received
         Given I have already received a resetting password email
         When I follow link on my email to reset my password
@@ -32,7 +40,7 @@ Feature: Resetting a password
         Then I should be notified that my password has been successfully reset
         And I should be able to log in as "goodman@example.com" with "newp@ssw0rd" password
 
-    @ui @email @api
+    @ui @api
     Scenario: Trying to change my account password twice with token I received
         Given I have already received a resetting password email
         When I follow link on my email to reset my password

--- a/features/admin/resetting_password.feature
+++ b/features/admin/resetting_password.feature
@@ -15,6 +15,14 @@ Feature: Resetting an administrator's password
         Then I should be notified that email with reset instruction has been sent
         And an email with instructions on how to reset the administrator's password should be sent to "sylius@example.com"
 
+    @email @api @ui
+    Scenario: Notifying about sending reset instructions even when an admin with email does not exist
+        When I want to reset password
+        And I specify email as "does-not-exist@example.com"
+        And I reset it
+        Then I should be notified that email with reset instruction has been sent
+        But "does-not-exist@example.com" should receive no emails
+
     @api
     Scenario: Changing my administrator's password
         Given I have already received a resetting password email

--- a/src/Sylius/Behat/Context/Api/EmailContext.php
+++ b/src/Sylius/Behat/Context/Api/EmailContext.php
@@ -161,6 +161,14 @@ final class EmailContext implements Context
         );
     }
 
+    /**
+     * @Then :recipient should receive no emails
+     */
+    public function recipientShouldReceiveNoEmails(string $recipient): void
+    {
+        Assert::false($this->emailChecker->hasRecipient($recipient));
+    }
+
     private function assertEmailContainsMessageTo(string $message, string $recipient): void
     {
         Assert::true($this->emailChecker->hasMessageTo($message, $recipient));

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -158,6 +158,14 @@ final class EmailContext implements Context
         );
     }
 
+    /**
+     * @Then :recipient should receive no emails
+     */
+    public function recipientShouldReceiveNoEmails(string $recipient): void
+    {
+        Assert::false($this->emailChecker->hasRecipient($recipient));
+    }
+
     private function assertEmailContainsMessageTo(string $message, string $recipient): void
     {
         Assert::true($this->emailChecker->hasMessageTo($message, $recipient));

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/RequestResetPasswordTokenHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/RequestResetPasswordTokenHandler.php
@@ -37,7 +37,9 @@ final class RequestResetPasswordTokenHandler implements MessageHandlerInterface
     public function __invoke(RequestResetPasswordToken $command): void
     {
         $user = $this->userRepository->findOneByEmail($command->getEmail());
-        Assert::notNull($user);
+        if (null === $user) {
+            return;
+        }
 
         $user->setPasswordResetToken($this->generator->generate());
         $user->setPasswordRequestedAt($this->calendar->now());

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Account/RequestResetPasswordTokenHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Account/RequestResetPasswordTokenHandlerSpec.php
@@ -70,17 +70,18 @@ final class RequestResetPasswordTokenHandlerSpec extends ObjectBehavior
         $this($requestResetPasswordToken);
     }
 
-    function it_throws_exception_if_shop_user_has_not_been_found(UserRepositoryInterface $userRepository): void
-    {
+    function it_does_nothing_when_shop_user_has_not_been_found(
+        UserRepositoryInterface $userRepository,
+        MessageBusInterface $messageBus,
+    ): void {
         $userRepository->findOneByEmail('test@email.com')->willReturn(null);
+
+        $messageBus->dispatch(Argument::any())->shouldNotBeCalled();
 
         $requestResetPasswordToken = new RequestResetPasswordToken('test@email.com');
         $requestResetPasswordToken->setChannelCode('WEB');
         $requestResetPasswordToken->setLocaleCode('en_US');
 
-        $this
-            ->shouldThrow(\InvalidArgumentException::class)
-            ->during('__invoke', [$requestResetPasswordToken])
-        ;
+        $this($requestResetPasswordToken);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/RequestResetPasswordEmailHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/RequestResetPasswordEmailHandler.php
@@ -22,7 +22,6 @@ use Sylius\Component\User\Security\Generator\GeneratorInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
-use Webmozart\Assert\Assert;
 
 /** @experimental */
 final class RequestResetPasswordEmailHandler implements MessageHandlerInterface
@@ -39,7 +38,9 @@ final class RequestResetPasswordEmailHandler implements MessageHandlerInterface
     {
         /** @var AdminUserInterface|null $adminUser */
         $adminUser = $this->userRepository->findOneByEmail($requestResetPasswordEmail->email);
-        Assert::notNull($adminUser);
+        if (null === $adminUser) {
+            return;
+        }
 
         $adminUser->setPasswordResetToken($this->generator->generate());
         $adminUser->setPasswordRequestedAt($this->calendar->now());

--- a/src/Sylius/Bundle/CoreBundle/spec/MessageHandler/Admin/Account/RequestResetPasswordEmailHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/MessageHandler/Admin/Account/RequestResetPasswordEmailHandlerSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Bundle\CoreBundle\MessageHandler\Admin\Account;
 
 use DateTime;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\RequestResetPasswordEmail;
 use Sylius\Bundle\CoreBundle\Message\Admin\Account\SendResetPasswordEmail;
 use Sylius\Calendar\Provider\DateTimeProviderInterface;
@@ -75,14 +76,14 @@ final class RequestResetPasswordEmailHandlerSpec extends ObjectBehavior
         $this(new RequestResetPasswordEmail('admin@example.com'));
     }
 
-    public function it_throws_exception_while_handling_if_user_doesnt_exist(
-        UserRepositoryInterface $userRepository
+    public function it_does_nothing_while_handling_if_user_doesnt_exist(
+        UserRepositoryInterface $userRepository,
+        MessageBusInterface $messageBus,
     ): void {
         $userRepository->findOneByEmail('admin@example.com')->willReturn(null);
 
-        $this
-            ->shouldThrow(\InvalidArgumentException::class)
-            ->during('__invoke', [new RequestResetPasswordEmail('admin@example.com')])
-        ;
+        $messageBus->dispatch(Argument::any())->shouldNotBeCalled();
+
+        $this(new RequestResetPasswordEmail('admin@example.com'));
     }
 }

--- a/src/Sylius/Component/Core/Test/Services/EmailChecker.php
+++ b/src/Sylius/Component/Core/Test/Services/EmailChecker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Test\Services;
 
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Webmozart\Assert\Assert;
@@ -27,11 +28,14 @@ final class EmailChecker implements EmailCheckerInterface
     {
         $this->assertRecipientIsValid($recipient);
 
-        $messages = $this->getMessages($this->spoolDirectory);
-        foreach ($messages as $message) {
-            if ($this->isMessageTo($message, $recipient)) {
-                return true;
+        try {
+            $messages = $this->getMessages($this->spoolDirectory);
+            foreach ($messages as $message) {
+                if ($this->isMessageTo($message, $recipient)) {
+                    return true;
+                }
             }
+        } catch (DirectoryNotFoundException) {
         }
 
         return false;


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12          |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

Based on the work done in #14138 

The way a request to reset the password is treated should seemingly be the same regardless if the user exists or not.