### PR TITLE
[UI] Redirect to previous filtered page after perform any action from index resource page

### DIFF
--- a/features/admin/being_redirected_to_previous_filtered_page.feature
+++ b/features/admin/being_redirected_to_previous_filtered_page.feature
@@ -34,7 +34,7 @@ Feature: Being redirected to previous filtered page
         When I browse products
         And I choose enabled filter
         And I filter
-        And I go to 2nd page
+        And I go to the 2nd page
         And I want to modify the "Znicz Pruszków T-Shirt" product
         And I cancel my changes
         Then I should be redirected to the 2nd page of only enabled products
@@ -44,7 +44,7 @@ Feature: Being redirected to previous filtered page
         When I browse products
         And I choose enabled filter
         And I filter
-        And I go to 2nd page
+        And I go to the 2nd page
         And I want to create a new simple product
         And I cancel my changes
         Then I should be redirected to the 2nd page of only enabled products

--- a/features/admin/being_redirected_to_previous_filtered_page.feature
+++ b/features/admin/being_redirected_to_previous_filtered_page.feature
@@ -13,7 +13,7 @@ Feature: Being redirected to previous filtered page
         And I am logged in as an administrator
 
     @ui @no-api
-    Scenario: Redirecting to previous filtered page after deleting a product
+    Scenario: Being redirected to previous filtered page after deleting a product
         When I browse products
         And I choose enabled filter
         And I filter
@@ -21,7 +21,7 @@ Feature: Being redirected to previous filtered page
         Then I should be redirected to the previous page of only enabled products
 
     @ui @no-api
-    Scenario: Redirecting to previous filtered page after cancelling editing a product
+    Scenario: Being redirected to previous filtered page after cancelling editing a product
         When I browse products
         And I choose enabled filter
         And I filter
@@ -30,7 +30,7 @@ Feature: Being redirected to previous filtered page
         Then I should be redirected to the previous page of only enabled products
 
     @ui @no-api
-    Scenario: Redirecting to previous filtered page with pagination after cancelling editing a product
+    Scenario: Being redirected to previous filtered page with pagination after cancelling editing a product
         When I browse products
         And I choose enabled filter
         And I filter
@@ -40,7 +40,7 @@ Feature: Being redirected to previous filtered page
         Then I should be redirected to the 2nd page of only enabled products
 
     @ui @javascript @no-api
-    Scenario: Redirecting to previous filtered page after cancelling creating a new product
+    Scenario: Being redirected to previous filtered page after cancelling creating a new product
         When I browse products
         And I choose enabled filter
         And I filter

--- a/features/admin/being_redirected_to_previous_filtered_page.feature
+++ b/features/admin/being_redirected_to_previous_filtered_page.feature
@@ -1,8 +1,8 @@
 @admin_panel
 Feature: Being redirected to previous filtered page
-    In order to have proper filtered page
+    In order to return to a properly filtered page
     As an Administrator
-    I want to be able to redirect to previous filtered page after any action from index
+    I want to be redirected to a previously filtered page after taking any action on index
 
     Background:
         Given the store operates on a channel named "Poland"

--- a/features/admin/redirecting_to_previous_filtered_page.feature
+++ b/features/admin/redirecting_to_previous_filtered_page.feature
@@ -1,5 +1,5 @@
 @admin_panel
-Feature: Redirecting to previous filtered page
+Feature: Being redirected to previous filtered page
     In order to have proper filtered page
     As an Administrator
     I want to be able to redirect to previous filtered page after any action from index
@@ -7,32 +7,44 @@ Feature: Redirecting to previous filtered page
     Background:
         Given the store operates on a channel named "Poland"
         And the store classifies its products as "Clothes"
+        And the store has 15 products
         And the store has a product "FC Barcelona T-Shirt"
-        And the store has a product "FC Barcelona Home T-Shirt"
+        And the store has a product "Znicz Pruszków T-Shirt"
         And I am logged in as an administrator
 
-    @ui
-    Scenario: Redirecting to previous filtered page after delete product
+    @ui @no-api
+    Scenario: Redirecting to previous filtered page after deleting a product
         When I browse products
         And I choose enabled filter
         And I filter
         And I delete the "FC Barcelona T-Shirt" product on filtered page
-        Then I should be redirected to the previous filtered page with enabled filter
+        Then I should be redirected to the previous page of only enabled products
 
-    @ui
-    Scenario: Redirecting to previous filtered page after cancelling editing product
+    @ui @no-api
+    Scenario: Redirecting to previous filtered page after cancelling editing a product
         When I browse products
         And I choose enabled filter
         And I filter
         And I want to modify the "FC Barcelona T-Shirt" product
         And I cancel my changes
-        Then I should be redirected to the previous filtered page with enabled filter
+        Then I should be redirected to the previous page of only enabled products
 
-    @ui @javascript
-    Scenario: Redirecting to previous filtered page after cancelling editing product after creating new product
+    @ui @no-api
+    Scenario: Redirecting to previous filtered page with pagination after cancelling editing a product
         When I browse products
         And I choose enabled filter
         And I filter
-        And I create a new simple product "FC Barcelona Away T-Shirt" priced at "$20.00" with "Clothes" taxon in the "Poland" channel
+        And I go to 2nd page
+        And I want to modify the "Znicz Pruszków T-Shirt" product
         And I cancel my changes
-        Then I should be redirected to the previous filtered page with enabled filter
+        Then I should be redirected to the 2nd page of only enabled products
+
+    @ui @javascript @no-api
+    Scenario: Redirecting to previous filtered page after cancelling creating a new product
+        When I browse products
+        And I choose enabled filter
+        And I filter
+        And I go to 2nd page
+        And I want to create a new simple product
+        And I cancel my changes
+        Then I should be redirected to the 2nd page of only enabled products

--- a/features/admin/redirecting_to_previous_filtered_page.feature
+++ b/features/admin/redirecting_to_previous_filtered_page.feature
@@ -16,7 +16,7 @@ Feature: Redirecting to previous filtered page
         When I browse products
         And I choose enabled filter
         And I filter
-        And I delete the "FC Barcelona T-Shirt" product
+        And I delete the "FC Barcelona T-Shirt" product on filtered page
         Then I should be redirected to the previous filtered page with enabled filter
 
     @ui

--- a/features/admin/redirecting_to_previous_filtered_page.feature
+++ b/features/admin/redirecting_to_previous_filtered_page.feature
@@ -11,7 +11,7 @@ Feature: Redirecting to previous filtered page
         And the store has a product "FC Barcelona Home T-Shirt"
         And I am logged in as an administrator
 
-    @ui @todo
+    @ui
     Scenario: Redirecting to previous filtered page after delete product
         When I browse products
         And I choose enabled filter

--- a/features/admin/redirecting_to_previous_filtered_page.feature
+++ b/features/admin/redirecting_to_previous_filtered_page.feature
@@ -1,4 +1,4 @@
-@admin_dashboard
+@admin_panel
 Feature: Redirecting to previous filtered page
     In order to have proper filtered page
     As an Administrator
@@ -6,22 +6,33 @@ Feature: Redirecting to previous filtered page
 
     Background:
         Given the store operates on a channel named "Poland"
+        And the store classifies its products as "Clothes"
+        And the store has a product "FC Barcelona T-Shirt"
+        And the store has a product "FC Barcelona Home T-Shirt"
         And I am logged in as an administrator
-        And I am browsing products
 
-    @ui
+    @ui @todo
     Scenario: Redirecting to previous filtered page after delete product
-        Given I have only disabled products filtered out
-        And I am on page 3
-        When I delete one of the products
-        And I am returned to the products index
-        Then I should be on page number 3 of the disabled products index
+        When I browse products
+        And I choose enabled filter
+        And I filter
+        And I delete the "FC Barcelona T-Shirt" product
+        Then I should be redirected to the previous filtered page with enabled filter
 
     @ui
     Scenario: Redirecting to previous filtered page after cancelling editing product
-        Given I have only disabled products filtered out
-        And I am on page 3
-        When I edit one of the products
-        And I cancel the edit
-        And I am returned to the products index
-        Then I should be on page number 3 of the disabled products index
+        When I browse products
+        And I choose enabled filter
+        And I filter
+        And I want to modify the "FC Barcelona T-Shirt" product
+        And I cancel my changes
+        Then I should be redirected to the previous filtered page with enabled filter
+
+    @ui @javascript
+    Scenario: Redirecting to previous filtered page after cancelling editing product after creating new product
+        When I browse products
+        And I choose enabled filter
+        And I filter
+        And I create a new simple product "FC Barcelona Away T-Shirt" priced at "$20.00" with "Clothes" taxon in the "Poland" channel
+        And I cancel my changes
+        Then I should be redirected to the previous filtered page with enabled filter

--- a/features/admin/redirecting_to_previous_filtered_page.feature
+++ b/features/admin/redirecting_to_previous_filtered_page.feature
@@ -1,0 +1,27 @@
+@admin_dashboard
+Feature: Redirecting to previous filtered page
+    In order to have proper filtered page
+    As an Administrator
+    I want to be able to redirect to previous filtered page after any action from index
+
+    Background:
+        Given the store operates on a channel named "Poland"
+        And I am logged in as an administrator
+        And I am browsing products
+
+    @ui
+    Scenario: Redirecting to previous filtered page after delete product
+        Given I have only disabled products filtered out
+        And I am on page 3
+        When I delete one of the products
+        And I am returned to the products index
+        Then I should be on page number 3 of the disabled products index
+
+    @ui
+    Scenario: Redirecting to previous filtered page after cancelling editing product
+        Given I have only disabled products filtered out
+        And I am on page 3
+        When I edit one of the products
+        And I cancel the edit
+        And I am returned to the products index
+        Then I should be on page number 3 of the disabled products index

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -78,6 +78,18 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given the store has :numberOfProducts products
+     */
+    public function storeHasMoreProducts(int $numberOfProducts): void
+    {
+        for ($i = 0; $i < $numberOfProducts; $i++) {
+            $product = $this->createProduct('TEST' . $i);
+
+            $this->saveProduct($product);
+        }
+    }
+
+    /**
      * @Given /^(this product) is originally priced at ("[^"]+") in ("[^"]+" channel)$/
      */
     public function thisProductHasOriginallyPriceInChannel(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -353,7 +353,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When I delete the :product product on filtered page
      */
-    public function iDeleteProductOnFilteredPage(ProductInterface $product)
+    public function iDeleteProductOnFilteredPage(ProductInterface $product): void
     {
         $this->sharedStorage->set('product', $product);
 
@@ -408,6 +408,14 @@ final class ManagingProductsContext implements Context
     }
 
     /**
+     * @When /^I go to ([^"]+)(nd) page$/
+     */
+    public function iGoToPage(int $page): void
+    {
+        $this->indexPage->goToPage($page);
+    }
+
+    /**
      * @Then I should not be able to edit its code
      */
     public function iShouldNotBeAbleToEditItsCode(): void
@@ -456,7 +464,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When I cancel my changes
      */
-    public function iCancelChanges()
+    public function iCancelChanges(): void
     {
         $currentPage = $this->resolveCurrentPage();
 
@@ -1167,11 +1175,20 @@ final class ManagingProductsContext implements Context
     }
 
     /**
-     * @Then I should be redirected to the previous filtered page with enabled filter
+     * @Then I should be redirected to the previous page of only enabled products
      */
-    public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter()
+    public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter(): void
     {
         Assert::true($this->indexPage->isEnabledFilterApplied());
+    }
+
+    /**
+     * @Then /^I should be redirected to the ([^"]+)(nd) page of only enabled products$/
+     */
+    public function iShouldBeRedirectedToThePreviousFilteredPageWithFilterAndPage(int $page): void
+    {
+        Assert::true($this->indexPage->isEnabledFilterApplied());
+        Assert::eq($this->indexPage->checkPageNumber(), $page);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -346,7 +346,10 @@ final class ManagingProductsContext implements Context
     {
         $this->sharedStorage->set('product', $product);
 
-        $this->iWantToBrowseProducts();
+        if (!$this->indexPage->isOpen()) {
+            $this->iWantToBrowseProducts();
+        }
+
         $this->indexPage->deleteResourceOnPage(['name' => $product->getName()]);
     }
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -408,7 +408,7 @@ final class ManagingProductsContext implements Context
     }
 
     /**
-     * @When /^I go to ([^"]+)(nd) page$/
+     * @When /^I go to the (\d)(?:st|nd|rd|th) page$/
      */
     public function iGoToPage(int $page): void
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -212,6 +212,14 @@ final class ManagingProductsContext implements Context
     }
 
     /**
+     * @When I choose enabled filter
+     */
+    public function iChooseEnabledFilter(): void
+    {
+        $this->indexPage->chooseEnabledFilter();
+    }
+
+    /**
      * @When I filter
      */
     public function iFilter(): void
@@ -433,6 +441,16 @@ final class ManagingProductsContext implements Context
         $currentPage = $this->resolveCurrentPage();
 
         $currentPage->saveChanges();
+    }
+
+    /**
+     * @When I cancel my changes
+     */
+    public function iCancelChanges()
+    {
+        $currentPage = $this->resolveCurrentPage();
+
+        $currentPage->cancelChanges();
     }
 
     /**
@@ -1136,6 +1154,14 @@ final class ManagingProductsContext implements Context
     public function theLastProductOnTheListShouldNotHaveName(): void
     {
         Assert::true($this->indexPage->checkLastProductHasDataAttribute('data-test-missing-translation-paragraph'));
+    }
+
+    /**
+     * @Then I should be redirected to the previous filtered page with enabled filter
+     */
+    public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter()
+    {
+        Assert::true($this->indexPage->isEnabledFilterApplied());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -346,9 +346,16 @@ final class ManagingProductsContext implements Context
     {
         $this->sharedStorage->set('product', $product);
 
-        if (!$this->indexPage->isOpen()) {
-            $this->iWantToBrowseProducts();
-        }
+        $this->iWantToBrowseProducts();
+        $this->indexPage->deleteResourceOnPage(['name' => $product->getName()]);
+    }
+
+    /**
+     * @When I delete the :product product on filtered page
+     */
+    public function iDeleteProductOnFilteredPage(ProductInterface $product)
+    {
+        $this->sharedStorage->set('product', $product);
 
         $this->indexPage->deleteResourceOnPage(['name' => $product->getName()]);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -1188,7 +1188,7 @@ final class ManagingProductsContext implements Context
     public function iShouldBeRedirectedToThePreviousFilteredPageWithFilterAndPage(int $page): void
     {
         Assert::true($this->indexPage->isEnabledFilterApplied());
-        Assert::eq($this->indexPage->checkPageNumber(), $page);
+        Assert::eq($this->indexPage->getPageNumber(), $page);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -38,7 +38,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
 
     public function cancelChanges(): void
     {
-        $this->getDocument()->clickLink('sylius_cancel_changes_button');
+        $this->getDocument()->find('css', '[data-test-cancel-changes-button]')->click();
     }
 
     public function getValidationMessage(string $element): string

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -36,6 +36,11 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
         $this->getDocument()->pressButton('sylius_save_changes_button');
     }
 
+    public function cancelChanges(): void
+    {
+        $this->getDocument()->clickLink('sylius_cancel_changes_button');
+    }
+
     public function getValidationMessage(string $element): string
     {
         $foundElement = $this->getFieldElement($element);

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
@@ -30,5 +30,7 @@ interface UpdatePageInterface extends SymfonyPageInterface
 
     public function saveChanges(): void;
 
+    public function cancelChanges(): void;
+
     public function getMessageInvalidForm(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -236,6 +236,11 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         return $this->getElement('prices_validation_message')->getText();
     }
 
+    public function cancelChanges(): void
+    {
+        $this->getDocument()->clickLink('sylius_cancel_changes_button');
+    }
+
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         if (!isset($parameters['%locale%'])) {

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -238,7 +238,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
 
     public function cancelChanges(): void
     {
-        $this->getDocument()->clickLink('sylius_cancel_changes_button');
+        $this->getElement('cancel_button')->click();
     }
 
     protected function getElement(string $name, array $parameters = []): NodeElement
@@ -260,6 +260,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
             'attribute_delete_button' => '#attributesContainer .attributes-group .attributes-header:contains("%attributeName%") button',
             'attribute_value' => '#attributesContainer [data-test-product-attribute-value-in-locale="%attributeName% %localeCode%"] input',
             'attributes_choice' => '#sylius_product_attribute_choice',
+            'cancel_button' => '[data-test-cancel-changes-button]',
             'channel_checkbox' => '.checkbox:contains("%channelName%") input',
             'code' => '#sylius_product_code',
             'form' => 'form[name="sylius_product"]',

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
@@ -64,4 +64,6 @@ interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
     public function setShippingRequired(bool $isShippingRequired): void;
 
     public function getChannelPricingValidationMessage(): string;
+
+    public function cancelChanges(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Product;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Sylius\Behat\Page\Admin\Crud\IndexPage as CrudIndexPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
@@ -69,6 +70,11 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         $field->clickLink('Details');
     }
 
+    public function goToPage(int $page): void
+    {
+        $this->getElement('pagination_button', ['%page%' => $page])->click();
+    }
+
     public function checkFirstProductHasDataAttribute(string $attributeName): bool
     {
         return $this->getElement('first_product')->find('css', sprintf('[%s]', $attributeName)) !== null;
@@ -84,6 +90,11 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         return $this->getElement('enabled_filter')->getValue() === 'true';
     }
 
+    public function checkPageNumber(): int
+    {
+        return (int) $this->getElement('page_number')->getText();
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -91,6 +102,9 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
             'enabled_filter' => '#criteria_enabled',
             'first_product' => '.table > tbody > tr:first-child',
             'last_product' => '.table > tbody > tr:last-child',
+            'page_number' => '.sylius-grid-nav__pagination .active',
+            'pagination_button' => '.sylius-grid-nav__pagination a.item:contains("%page%")',
+            'pagination_buttons' => '.sylius-grid-nav__pagination',
             'taxon_filter' => '.sylius-tree__item a:contains("%taxon%")',
         ]);
     }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -90,7 +90,7 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         return $this->getElement('enabled_filter')->getValue() === 'true';
     }
 
-    public function checkPageNumber(): int
+    public function getPageNumber(): int
     {
         return (int) $this->getElement('page_number')->getText();
     }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -47,6 +47,11 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         $this->getElement('channel_filter')->selectOption($channelName);
     }
 
+    public function chooseEnabledFilter(): void
+    {
+        $this->getElement('enabled_filter')->selectOption('Yes');
+    }
+
     public function hasProductAccessibleImage(string $productCode): bool
     {
         $productRow = $this->getTableAccessor()->getRowWithFields($this->getElement('table'), ['code' => $productCode]);
@@ -74,13 +79,19 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         return $this->getElement('last_product')->find('css', sprintf('[%s]', $attributeName)) !== null;
     }
 
+    public function isEnabledFilterApplied(): bool
+    {
+        return $this->getElement('enabled_filter')->getValue() === 'true';
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
             'channel_filter' => '#criteria_channel',
-            'taxon_filter' => '.sylius-tree__item a:contains("%taxon%")',
+            'enabled_filter' => '#criteria_enabled',
             'first_product' => '.table > tbody > tr:first-child',
             'last_product' => '.table > tbody > tr:last-child',
+            'taxon_filter' => '.sylius-tree__item a:contains("%taxon%")',
         ]);
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -35,7 +35,7 @@ interface IndexPageInterface extends CrudIndexPageInterface
 
     public function checkLastProductHasDataAttribute(string $attributeName): bool;
 
-    public function checkPageNumber(): int;
+    public function getPageNumber(): int;
 
     public function isEnabledFilterApplied(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -29,9 +29,13 @@ interface IndexPageInterface extends CrudIndexPageInterface
 
     public function filter(): void;
 
+    public function goToPage(int $page): void;
+
     public function checkFirstProductHasDataAttribute(string $attributeName): bool;
 
     public function checkLastProductHasDataAttribute(string $attributeName): bool;
+
+    public function checkPageNumber(): int;
 
     public function isEnabledFilterApplied(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -25,9 +25,13 @@ interface IndexPageInterface extends CrudIndexPageInterface
 
     public function chooseChannelFilter(string $channelName): void;
 
+    public function chooseEnabledFilter(): void;
+
     public function filter(): void;
 
     public function checkFirstProductHasDataAttribute(string $attributeName): bool;
 
     public function checkLastProductHasDataAttribute(string $attributeName): bool;
+
+    public function isEnabledFilterApplied(): bool;
 }

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -77,6 +77,7 @@ imports:
     - suites/ui/admin/impersonating_customers.yml
     - suites/ui/admin/locale.yml
     - suites/ui/admin/login.yml
+    - suites/ui/admin/panel.yml
     - suites/ui/cart/shopping_cart.yml
     - suites/ui/channel/channels.yml
     - suites/ui/channel/managing_channels.yml

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
@@ -1,0 +1,53 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        ui_panel:
+            contexts:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.admin
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.currency
+                - sylius.behat.context.transform.customer
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.locale
+                - sylius.behat.context.transform.payment
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.product_association_type
+                - sylius.behat.context.transform.product_option
+                - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.shipping_method
+                - sylius.behat.context.transform.taxon
+                - sylius.behat.context.transform.zone
+
+                - sylius.behat.context.setup.admin_user
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.currency
+                - sylius.behat.context.setup.geographical
+                - sylius.behat.context.setup.locale
+                - sylius.behat.context.setup.order
+                - sylius.behat.context.setup.payment
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.product_association
+                - sylius.behat.context.setup.product_attribute
+                - sylius.behat.context.setup.product_option
+                - sylius.behat.context.setup.product_review
+                - sylius.behat.context.setup.product_taxon
+                - sylius.behat.context.setup.admin_security
+                - sylius.behat.context.setup.shipping
+                - sylius.behat.context.setup.shipping_category
+                - sylius.behat.context.setup.taxonomy
+                - sylius.behat.context.setup.zone
+
+                - sylius.behat.context.ui.admin.browsing_product_variants
+                - sylius.behat.context.ui.admin.managing_administrator_locale
+                - sylius.behat.context.ui.admin.managing_products
+                - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.shop.browsing_product
+                - Sylius\Behat\Context\Ui\Admin\ProductCreationContext
+                    
+            filters:
+                tags: "@admin_panel&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
@@ -7,45 +7,19 @@ default:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
 
-                - sylius.behat.context.transform.address
                 - sylius.behat.context.transform.admin
                 - sylius.behat.context.transform.channel
-                - sylius.behat.context.transform.currency
-                - sylius.behat.context.transform.customer
-                - sylius.behat.context.transform.lexical
-                - sylius.behat.context.transform.locale
-                - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
-                - sylius.behat.context.transform.product_association_type
-                - sylius.behat.context.transform.product_option
-                - sylius.behat.context.transform.shared_storage
-                - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.taxon
-                - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.channel
-                - sylius.behat.context.setup.currency
-                - sylius.behat.context.setup.geographical
-                - sylius.behat.context.setup.locale
-                - sylius.behat.context.setup.order
-                - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product
-                - sylius.behat.context.setup.product_association
-                - sylius.behat.context.setup.product_attribute
-                - sylius.behat.context.setup.product_option
-                - sylius.behat.context.setup.product_review
-                - sylius.behat.context.setup.product_taxon
                 - sylius.behat.context.setup.admin_security
-                - sylius.behat.context.setup.shipping
-                - sylius.behat.context.setup.shipping_category
                 - sylius.behat.context.setup.taxonomy
-                - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.ui.admin.browsing_product_variants
-                - sylius.behat.context.ui.admin.managing_administrator_locale
                 - sylius.behat.context.ui.admin.managing_products
-                - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.shop.browsing_product
                 - Sylius\Behat\Context\Ui\Admin\ProductCreationContext
                     

--- a/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
@@ -23,7 +23,6 @@ final class RedirectHandler implements RedirectHandlerInterface
 {
     public function __construct(
         private RedirectHandlerInterface $decoratedRedirectHandler,
-        private FilterStorageInterface $filterStorage
     ) {
     }
 
@@ -35,15 +34,17 @@ final class RedirectHandler implements RedirectHandlerInterface
     public function redirectToIndex(RequestConfiguration $configuration, ?ResourceInterface $resource = null): Response
     {
         $request = $configuration->getRequest();
-        $request->query->add($this->filterStorage->all());
+
+        $parameters = $configuration->getParameters();
+        $parameters->add(['redirect' => ['referer' => $request->headers->get('referer')]]);
 
         $requestConfiguration = new RequestConfiguration(
             $configuration->getMetadata(),
             $request,
-            $configuration->getParameters()
+            $parameters
         );
 
-        return $this->decoratedRedirectHandler->redirectToReferer($requestConfiguration);
+        return $this->decoratedRedirectHandler->redirectToIndex($requestConfiguration);
     }
 
     public function redirectToRoute(RequestConfiguration $configuration, string $route, array $parameters = []): Response

--- a/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Controller;
+
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RedirectHandlerInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RedirectHandler implements RedirectHandlerInterface
+{
+    public function __construct(
+        private RedirectHandlerInterface $decoratedRedirectHandler,
+        private FilterStorageInterface $filterStorage
+    ) {
+    }
+
+    public function redirectToResource(RequestConfiguration $configuration, ResourceInterface $resource): Response
+    {
+        return $this->decoratedRedirectHandler->redirectToResource($configuration, $resource);
+    }
+
+    public function redirectToIndex(RequestConfiguration $configuration, ?ResourceInterface $resource = null): Response
+    {
+        $request = $configuration->getRequest();
+        $request->query->add($this->filterStorage->all());
+
+        $requestConfiguration = new RequestConfiguration(
+            $configuration->getMetadata(),
+            $request,
+            $configuration->getParameters()
+        );
+
+        return $this->decoratedRedirectHandler->redirectToReferer($requestConfiguration);
+    }
+
+    public function redirectToRoute(RequestConfiguration $configuration, string $route, array $parameters = []): Response
+    {
+        return $this->decoratedRedirectHandler->redirectToRoute($configuration, $route, $parameters);
+    }
+
+    public function redirect(RequestConfiguration $configuration, string $url, int $status = 302): Response
+    {
+        return $this->decoratedRedirectHandler->redirect($configuration, $url, $status);
+    }
+
+    public function redirectToReferer(RequestConfiguration $configuration): Response
+    {
+        return $this->decoratedRedirectHandler->redirectToReferer($configuration);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
@@ -23,6 +23,7 @@ final class RedirectHandler implements RedirectHandlerInterface
 {
     public function __construct(
         private RedirectHandlerInterface $decoratedRedirectHandler,
+        private FilterStorageInterface $filterStorage,
     ) {
     }
 
@@ -33,18 +34,11 @@ final class RedirectHandler implements RedirectHandlerInterface
 
     public function redirectToIndex(RequestConfiguration $configuration, ?ResourceInterface $resource = null): Response
     {
-        $request = $configuration->getRequest();
-
-        $parameters = $configuration->getParameters();
-        $parameters->add(['redirect' => ['referer' => $request->headers->get('referer')]]);
-
-        $requestConfiguration = new RequestConfiguration(
-            $configuration->getMetadata(),
-            $request,
-            $parameters
+        return $this->decoratedRedirectHandler->redirectToRoute(
+            $configuration,
+            (string) $configuration->getRedirectRoute('index'),
+            array_merge($configuration->getRedirectParameters($resource), $this->filterStorage->all())
         );
-
-        return $this->decoratedRedirectHandler->redirectToIndex($requestConfiguration);
     }
 
     public function redirectToRoute(RequestConfiguration $configuration, string $route, array $parameters = []): Response

--- a/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
@@ -20,12 +20,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 final class AdminFilterSubscriber implements EventSubscriberInterface
 {
-    public function __construct(
-        private FilterStorageInterface $filterStorage,
-    ) {
+    public function __construct(private FilterStorageInterface $filterStorage)
+    {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',
@@ -38,15 +37,17 @@ final class AdminFilterSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ('html' !== $event->getRequest()->getRequestFormat()) {
+        $eventRequest = $event->getRequest();
+
+        if ('html' !== $eventRequest->getRequestFormat()) {
             return;
         }
 
-        $eventRequest = $event->getRequest();
         $requestAttributes = $eventRequest->attributes;
         $originalRoute = $requestAttributes->get('_route');
 
-        if (!$this->isSyliusRoute($originalRoute) ||
+        if (
+            !$this->isSyliusRoute($originalRoute) ||
             !$this->isAdminSection($requestAttributes->get('_sylius', []))
         ) {
             return;
@@ -76,7 +77,7 @@ final class AdminFilterSubscriber implements EventSubscriberInterface
 
     private function isIndexResourceRoute(string $route): bool
     {
-        return str_contains($route, 'index');
+        return str_ends_with($route, 'index');
     }
 
     private function isSyliusRoute(string $route): bool

--- a/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\EventListener;
+
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class AdminFilterSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private FilterStorageInterface $filterStorage,
+    ) {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$this->isMainRequest($event)) {
+            return;
+        }
+
+        if ('html' !== $event->getRequest()->getRequestFormat()) {
+            return;
+        }
+
+        $eventRequest = $event->getRequest();
+        $requestAttributes = $eventRequest->attributes;
+        $originalRoute = $requestAttributes->get('_route');
+
+        if (!$this->isSyliusRoute($originalRoute) ||
+            !$this->isAdminSection($requestAttributes->get('_sylius', []))
+        ) {
+            return;
+        }
+
+        if (null === $requestAttributes->get('_controller')) {
+            return;
+        }
+
+        if (!$this->isIndexResourceRoute($originalRoute)) {
+            return;
+        }
+
+        if ($this->filterStorage->all() !== $eventRequest->query->all()) {
+            $this->filterStorage->set($eventRequest->query->all());
+        }
+    }
+
+    private function isMainRequest(RequestEvent $event): bool
+    {
+        if (\method_exists($event, 'isMainRequest')) {
+            return $event->isMainRequest();
+        }
+
+        return $event->isMasterRequest();
+    }
+
+    private function isIndexResourceRoute(string $route): bool
+    {
+        return str_contains($route, 'index');
+    }
+
+    private function isSyliusRoute(string $route): bool
+    {
+        return str_starts_with($route, 'sylius');
+    }
+
+    private function isAdminSection(array $syliusParameters): bool
+    {
+        return array_key_exists('section', $syliusParameters) && 'admin' === $syliusParameters['section'];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
@@ -46,15 +46,15 @@ final class AdminFilterSubscriber implements EventSubscriberInterface
         $requestAttributes = $eventRequest->attributes;
         $originalRoute = $requestAttributes->get('_route');
 
+        if (!$this->isIndexResourceRoute($originalRoute)) {
+            return;
+        }
+
         if (!$this->isAdminSection($requestAttributes->get('_sylius', []))) {
             return;
         }
 
         if (null === $requestAttributes->get('_controller')) {
-            return;
-        }
-
-        if (!$this->isIndexResourceRoute($originalRoute)) {
             return;
         }
 

--- a/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
@@ -46,10 +46,7 @@ final class AdminFilterSubscriber implements EventSubscriberInterface
         $requestAttributes = $eventRequest->attributes;
         $originalRoute = $requestAttributes->get('_route');
 
-        if (
-            !$this->isSyliusRoute($originalRoute) ||
-            !$this->isAdminSection($requestAttributes->get('_sylius', []))
-        ) {
+        if (!$this->isAdminSection($requestAttributes->get('_sylius', []))) {
             return;
         }
 
@@ -78,11 +75,6 @@ final class AdminFilterSubscriber implements EventSubscriberInterface
     private function isIndexResourceRoute(string $route): bool
     {
         return str_ends_with($route, 'index');
-    }
-
-    private function isSyliusRoute(string $route): bool
-    {
-        return str_starts_with($route, 'sylius');
     }
 
     private function isAdminSection(array $syliusParameters): bool

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -60,6 +60,16 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="Sylius\Bundle\AdminBundle\Twig\FilterExtension">
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <argument type="service" id="router" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Storage\FilterStorage">
+            <argument type="service" id="session" />
+        </service>
+
         <service id="sylius.http_client" class="GuzzleHttp\Client" public="false" />
         <service id="sylius.http_message_factory" class="Http\Message\MessageFactory\GuzzleMessageFactory" public="false" />
     </services>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -60,7 +60,7 @@
             <tag name="twig.extension" />
         </service>
 
-        <service id="Sylius\Bundle\AdminBundle\Twig\FilterExtension">
+        <service id="Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension">
             <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
             <argument type="service" id="router" />
             <tag name="twig.extension" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -66,7 +66,7 @@
             <tag name="twig.extension" />
         </service>
 
-        <service id="Sylius\Bundle\AdminBundle\Storage\FilterStorage">
+        <service id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" public="false">
             <argument type="service" id="session" />
         </service>
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -82,6 +82,7 @@
                  public="false"
         >
             <argument type="service" id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler.inner" />
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -77,9 +77,10 @@
             <argument type="string">%kernel.environment%</argument>
         </service>
 
-        <service id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler"
-                 decorates="sylius.resource_controller.redirect_handler"
-                 public="false"
+        <service
+            id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler"
+            decorates="sylius.resource_controller.redirect_handler"
+            public="false"
         >
             <argument type="service" id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler.inner" />
             <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -76,5 +76,13 @@
             <argument type="string">%sylius.admin.notification.uri%</argument>
             <argument type="string">%kernel.environment%</argument>
         </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler"
+                 decorates="sylius.resource_controller.redirect_handler"
+                 public="false"
+        >
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler.inner" />
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -82,7 +82,6 @@
                  public="false"
         >
             <argument type="service" id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler.inner" />
-            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
@@ -33,7 +33,7 @@
 
         <service id="sylius.event_subscriber.admin_filter_subscriber" class="Sylius\Bundle\AdminBundle\EventListener\AdminFilterSubscriber">
             <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
-            <tag name="kernel.event_subscriber" event="kernel.controller" />
+            <tag name="kernel.event_subscriber" event="kernel.request" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
@@ -30,5 +30,10 @@
             <argument type="service" id="sylius.section_resolver.uri_based_section_resolver" />
             <tag name="kernel.event_subscriber" event="kernel.response" />
         </service>
+
+        <service id="sylius.event_subscriber.admin_filter_subscriber" class="Sylius\Bundle\AdminBundle\EventListener\AdminFilterSubscriber">
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <tag name="kernel.event_subscriber" event="kernel.controller" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -19,7 +19,7 @@
 
     {{ sylius_template_event([event_prefix ~ '.form', 'sylius.admin.update.form'], {'metadata': metadata, 'resource': resource, 'form': form}) }}
 
-    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': index_url}} %}
+    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_path(index_url)}} %}
 
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -19,7 +19,7 @@
 
     {{ sylius_template_event([event_prefix ~ '.form', 'sylius.admin.update.form'], {'metadata': metadata, 'resource': resource, 'form': form}) }}
 
-    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_path(index_url)}} %}
+    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_redirect_path(index_url)}} %}
 
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Update/_content.html.twig
@@ -17,6 +17,6 @@
     {{ sylius_template_event('sylius.admin.order.update.form', {'resource': resource}) }}
 
     {{ form_row(form._token) }}
-    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path('sylius_admin_order_index')}} %}
+    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_path(path('sylius_admin_order_index'))}} %}
 </div>
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Update/_content.html.twig
@@ -17,6 +17,6 @@
     {{ sylius_template_event('sylius.admin.order.update.form', {'resource': resource}) }}
 
     {{ form_row(form._token) }}
-    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_path(path('sylius_admin_order_index'))}} %}
+    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': sylius_generate_redirect_path(path('sylius_admin_order_index'))}} %}
 </div>
 {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/Storage/FilterStorage.php
+++ b/src/Sylius/Bundle/AdminBundle/Storage/FilterStorage.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Storage;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class FilterStorage implements FilterStorageInterface
+{
+    public function __construct(private SessionInterface $session)
+    {
+    }
+
+    public function set(array $filters): void
+    {
+        $this->session->set('filters', $filters);
+    }
+
+    public function all(): array
+    {
+        return $this->session->get('filters', []);
+    }
+
+    public function hasFilters(): bool
+    {
+        return [] !== $this->session->get('filters', []);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Storage/FilterStorageInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Storage/FilterStorageInterface.php
@@ -16,6 +16,8 @@ namespace Sylius\Bundle\AdminBundle\Storage;
 interface FilterStorageInterface
 {
     public function set(array $filters): void;
+
     public function all(): array;
+
     public function hasFilters(): bool;
 }

--- a/src/Sylius/Bundle/AdminBundle/Storage/FilterStorageInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Storage/FilterStorageInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Storage;
+
+interface FilterStorageInterface
+{
+    public function set(array $filters): void;
+    public function all(): array;
+    public function hasFilters(): bool;
+}

--- a/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
@@ -30,11 +30,11 @@ final class FilterExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sylius_generate_path', [$this, 'generatePath']),
+            new TwigFunction('sylius_generate_redirect_path', [$this, 'generateRedirectPath']),
         ];
     }
 
-    public function generatePath(string $path): string
+    public function generateRedirectPath(string $path): string
     {
         $request = Request::create($path);
 

--- a/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Twig;
+
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class FilterExtension extends AbstractExtension
+{
+    public function __construct(
+        private FilterStorageInterface $filterStorage,
+        private RouterInterface $router,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_generate_path', [$this, 'generatePath']),
+        ];
+    }
+
+    public function generatePath(string $path): string
+    {
+        $request = Request::create($path);
+
+        try {
+            $routeInfo = $this->router->match($request->getPathInfo());
+        } catch (\Throwable) {
+            return $path;
+        }
+
+        if ([] !== $request->query->all()) {
+            return $path;
+        }
+
+        $route = $routeInfo['_route'];
+
+        return $this->router->generate($route, $this->filterStorage->all());
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/FilterExtension.php
@@ -21,6 +21,8 @@ use Twig\TwigFunction;
 
 final class FilterExtension extends AbstractExtension
 {
+    private const NUMBER_OF_ROUTE_PROPERTIES = 3;
+
     public function __construct(
         private FilterStorageInterface $filterStorage,
         private RouterInterface $router,
@@ -34,8 +36,12 @@ final class FilterExtension extends AbstractExtension
         ];
     }
 
-    public function generateRedirectPath(string $path): string
+    public function generateRedirectPath(?string $path): ?string
     {
+        if (null === $path) {
+            return null;
+        }
+
         $request = Request::create($path);
 
         try {
@@ -44,12 +50,17 @@ final class FilterExtension extends AbstractExtension
             return $path;
         }
 
-        if ([] !== $request->query->all()) {
+        if ([] !== $request->query->all() || $this->hasAdditionalParameters($routeInfo)) {
             return $path;
         }
 
         $route = $routeInfo['_route'];
 
         return $this->router->generate($route, $this->filterStorage->all());
+    }
+
+    private function hasAdditionalParameters(array $routeInfo): bool
+    {
+        return count($routeInfo) > self::NUMBER_OF_ROUTE_PROPERTIES;
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Twig/RedirectPathExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/RedirectPathExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-final class FilterExtension extends AbstractExtension
+final class RedirectPathExtension extends AbstractExtension
 {
     private const NUMBER_OF_ROUTE_PROPERTIES = 3;
 

--- a/src/Sylius/Bundle/AdminBundle/spec/Controller/RedirectHandlerSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/Controller/RedirectHandlerSpec.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\AdminBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RedirectHandlerInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RedirectHandlerSpec extends ObjectBehavior
+{
+    function let(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $this->beConstructedWith($decoratedRedirectHandler, $filterStorage);
+    }
+
+    function it_implements_redirect_handler_interface(): void
+    {
+        $this->shouldImplement(RedirectHandlerInterface::class);
+    }
+
+    function it_redirects_to_resource(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        RequestConfiguration $configuration,
+        ResourceInterface $resource,
+    ): void {
+        $decoratedRedirectHandler->redirectToResource($configuration, $resource)->shouldBeCalled();
+
+        $this->redirectToResource($configuration, $resource)->shouldHaveType(Response::class);
+    }
+
+    function it_redirects_to_index(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        RequestConfiguration $configuration,
+        ResourceInterface $resource,
+        FilterStorageInterface $filterStorage,
+    ): void {
+        $configuration->getRedirectRoute('index')->willReturn('index');
+        $configuration->getRedirectParameters($resource)->willReturn([]);
+        $filterStorage->all()->willReturn(['foo' => 'bar']);
+
+        $decoratedRedirectHandler->redirectToRoute($configuration, 'index', ['foo' => 'bar'])->shouldBeCalled();
+
+        $this->redirectToRoute($configuration, 'index', ['foo' => 'bar'])->shouldHaveType(Response::class);
+    }
+
+    function it_redirects(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        RequestConfiguration $configuration,
+    ): void {
+        $decoratedRedirectHandler->redirect($configuration, 'http://test.com', 302)->shouldBeCalled();
+
+        $this->redirect($configuration, 'http://test.com', 302)->shouldHaveType(Response::class);
+    }
+
+    function it_redirects_to_route(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        RequestConfiguration $configuration,
+    ): void {
+        $decoratedRedirectHandler->redirectToRoute($configuration, 'my_route', [])->shouldBeCalled();
+
+        $this->redirectToRoute($configuration, 'my_route', [])->shouldHaveType(Response::class);
+    }
+
+    function it_redirects_to_referer(
+        RedirectHandlerInterface $decoratedRedirectHandler,
+        RequestConfiguration $configuration,
+    ): void {
+        $decoratedRedirectHandler->redirectToReferer($configuration)->shouldBeCalled();
+
+        $this->redirectToReferer($configuration)->shouldHaveType(Response::class);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\AdminBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class AdminFilterSubscriberSpec extends ObjectBehavior
+{
+    function let(FilterStorageInterface $filterStorage): void
+    {
+        $this->beConstructedWith($filterStorage);
+    }
+
+    function it_subscribes_to_kernel_request_event(): void
+    {
+        $this::getSubscribedEvents()->shouldReturn([KernelEvents::REQUEST => 'onKernelRequest']);
+    }
+
+    function it_adds_filter_to_filter_storage(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('html');
+
+        $attributes->get('_route')->willReturn('sylius_admin_product_index');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'admin']);
+        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_request_is_not_main(
+        RequestEvent $event,
+        Request $request,
+    ): void {
+        $event->isMainRequest()->willReturn(false);
+        $request->getRequestFormat()->willReturn('html');
+
+        $event->getRequest()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_request_format_is_not_html(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('json');
+
+        $attributes->get('_route')->willReturn('sylius_admin_product_index');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'admin']);
+        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_route_is_not_sylius_route(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('html');
+
+        $attributes->get('_route')->willReturn('product_index');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'admin']);
+        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_it_is_not_an_admin_section(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('json');
+
+        $attributes->get('_route')->willReturn('sylius_admin_product_index');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'shop']);
+        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_controller_is_null(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('json');
+
+        $attributes->get('_route')->willReturn('sylius_admin_product_index');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'shop']);
+        $attributes->get('_controller')->willReturn(null);
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_not_add_filter_to_filter_storage_if_it_is_not_a_index_resource_route(
+        RequestEvent $event,
+        Request $request,
+        ParameterBag $attributes,
+        ParameterBag $query,
+        FilterStorageInterface $filterStorage
+    ): void {
+        $event->isMainRequest()->willReturn(true);
+        $request->getRequestFormat()->willReturn('json');
+
+        $attributes->get('_route')->willReturn('sylius_admin_product_update');
+        $attributes->get('_sylius', [])->willReturn(['section' => 'shop']);
+        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
+        $request->attributes = $attributes;
+
+        $query->all()->willReturn(['filter' => 'foo']);
+        $request->query = $query;
+
+        $filterStorage->all()->willReturn([]);
+
+        $event->getRequest()->willReturn($request);;
+
+        $filterStorage->set(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
@@ -16,7 +16,6 @@ namespace spec\Sylius\Bundle\AdminBundle\EventListener;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -39,7 +38,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('html');
@@ -78,7 +77,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('json');
@@ -105,7 +104,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('html');
@@ -132,7 +131,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('json');
@@ -159,7 +158,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('json');
@@ -186,7 +185,7 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         Request $request,
         ParameterBag $attributes,
         ParameterBag $query,
-        FilterStorageInterface $filterStorage
+        FilterStorageInterface $filterStorage,
     ): void {
         $event->isMainRequest()->willReturn(true);
         $request->getRequestFormat()->willReturn('json');

--- a/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
@@ -99,33 +99,6 @@ final class AdminFilterSubscriberSpec extends ObjectBehavior
         $this->onKernelRequest($event);
     }
 
-    function it_does_not_add_filter_to_filter_storage_if_route_is_not_sylius_route(
-        RequestEvent $event,
-        Request $request,
-        ParameterBag $attributes,
-        ParameterBag $query,
-        FilterStorageInterface $filterStorage,
-    ): void {
-        $event->isMainRequest()->willReturn(true);
-        $request->getRequestFormat()->willReturn('html');
-
-        $attributes->get('_route')->willReturn('product_index');
-        $attributes->get('_sylius', [])->willReturn(['section' => 'admin']);
-        $attributes->get('_controller')->willReturn('Sylius\Bundle\AdminBundle\Controller\ProductController::indexAction');
-        $request->attributes = $attributes;
-
-        $query->all()->willReturn(['filter' => 'foo']);
-        $request->query = $query;
-
-        $filterStorage->all()->willReturn([]);
-
-        $event->getRequest()->willReturn($request);;
-
-        $filterStorage->set(Argument::any())->shouldNotBeCalled();
-
-        $this->onKernelRequest($event);
-    }
-
     function it_does_not_add_filter_to_filter_storage_if_it_is_not_an_admin_section(
         RequestEvent $event,
         Request $request,

--- a/src/Sylius/Bundle/AdminBundle/spec/Storage/FilterStorageSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/Storage/FilterStorageSpec.php
@@ -29,7 +29,7 @@ final class FilterStorageSpec extends ObjectBehavior
         $this->shouldImplement(FilterStorageInterface::class);
     }
 
-    function it_sets_a_filters_in_a_session(SessionInterface $session): void
+    function it_sets_filters_in_a_session(SessionInterface $session): void
     {
         $filters = [
             'filter' => 'value',

--- a/src/Sylius/Bundle/AdminBundle/spec/Storage/FilterStorageSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/Storage/FilterStorageSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\AdminBundle\Storage;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class FilterStorageSpec extends ObjectBehavior
+{
+    function let(SessionInterface $session): void
+    {
+        $this->beConstructedWith($session);
+    }
+
+    function it_implements_a_cart_storage_interface(): void
+    {
+        $this->shouldImplement(FilterStorageInterface::class);
+    }
+
+    function it_sets_a_filters_in_a_session(SessionInterface $session): void
+    {
+        $filters = [
+            'filter' => 'value',
+        ];
+
+        $session->set('filters', $filters)->shouldBeCalled();
+
+        $this->set($filters);
+    }
+
+    function it_returns_all_filters_from_a_session(SessionInterface $session): void
+    {
+        $filters = [
+            'filter' => 'value',
+        ];
+
+        $session->get('filters', [])->willReturn($filters);
+
+        $this->all()->shouldReturn($filters);
+    }
+
+    function it_returns_true_if_filters_are_set(SessionInterface $session): void
+    {
+        $filters = [
+            'filter' => 'value',
+        ];
+
+        $session->get('filters', [])->willReturn($filters);
+
+        $this->hasFilters()->shouldReturn(true);
+    }
+
+    function it_returns_false_if_filters_are_not_set(SessionInterface $session): void
+    {
+        $filters = [];
+
+        $session->get('filters', [])->willReturn($filters);
+
+        $this->hasFilters()->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
@@ -1,1 +1,3 @@
-<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button" id="sylius_cancel_changes_button">{{ 'sylius.ui.cancel'|trans }}</a>
+<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button" {{ sylius_test_html_attribute('cancel-changes-button')}}>
+    {{ 'sylius.ui.cancel'|trans }}
+</a>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
@@ -1,1 +1,1 @@
-<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button">{{ 'sylius.ui.cancel'|trans }}</a>
+<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button" id="sylius_cancel_changes_button">{{ 'sylius.ui.cancel'|trans }} </a>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_cancel.html.twig
@@ -1,1 +1,1 @@
-<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button" id="sylius_cancel_changes_button">{{ 'sylius.ui.cancel'|trans }} </a>
+<a href="{{ path|default(app.request.headers.get('referer')) }}" class="ui button" id="sylius_cancel_changes_button">{{ 'sylius.ui.cancel'|trans }}</a>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
@@ -1,5 +1,5 @@
 <div class="ui hidden divider"></div>
 <div class="ui buttons">
     <button class="ui labeled icon primary button" type="submit"><i class="plus icon"></i>{{- 'sylius.ui.create'|trans -}}</button>
-    {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': paths.cancel|default(null)} %}
+    {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': sylius_generate_redirect_path(paths.cancel|default(null))} %}
 </div>

--- a/tests/Twig/RedirectPathExtensionTest.php
+++ b/tests/Twig/RedirectPathExtensionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Twig;
+
+use Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class RedirectPathExtensionTest extends KernelTestCase
+{
+    private RedirectPathExtension $redirectPathExtension;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->redirectPathExtension = $this->getContainer()->get('Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension');
+        $this->getContainer()->get('Sylius\Bundle\AdminBundle\Storage\FilterStorage')->set(['criteria' => ['enabled' => true]]);
+    }
+
+    /** @test */
+    public function it_returns_redirect_path_with_filters_from_storage_applied(): void
+    {
+        $redirectPath = $this->redirectPathExtension->generateRedirectPath('/admin/shipping-categories/');
+
+        $this->assertSame('/admin/shipping-categories/?criteria%5Benabled%5D=1', $redirectPath);
+    }
+
+    /** @test */
+    public function it_returns_given_path_if_route_has_some_more_configuration(): void
+    {
+        $redirectPath = $this->redirectPathExtension->generateRedirectPath('/admin/ajax/products/search');
+
+        $this->assertSame('/admin/ajax/products/search', $redirectPath);
+    }
+
+    /** @test */
+    public function it_returns_given_path_if_route_already_has_query_parameters(): void
+    {
+        $redirectPath = $this->redirectPathExtension->generateRedirectPath('/admin/shipping-categories/?foo=bar');
+
+        $this->assertSame('/admin/shipping-categories/?foo=bar', $redirectPath);
+    }
+
+    /** @test */
+    public function it_returns_given_path_if_route_is_not_matched(): void
+    {
+        $redirectPath = $this->redirectPathExtension->generateRedirectPath('/admin/invalid-path');
+
+        $this->assertSame('/admin/invalid-path', $redirectPath);
+    }
+
+    /** @test */
+    public function it_returns_null_if_the_path_is_null_as_well(): void
+    {
+        $redirectPath = $this->redirectPathExtension->generateRedirectPath(null);
+
+        $this->assertNull($redirectPath);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->          |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

This pull request resolves the problem of redirecting to the not filtered page after eg. deleting the product or returning to page after editing some of resources by clicking cancel on update page.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
