### PR TITLE
[Maintenance] Fixed name of the client when using it in HomepageContext

### DIFF
--- a/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
@@ -46,7 +46,7 @@ final class HomepageContext implements Context
     {
         Assert::true(
             $this->responseChecker->hasItemWithValue(
-                $this->productsClient->getLastResponse(),
+                $this->client->getLastResponse(),
                 'name',
                 $productName
             )
@@ -60,7 +60,7 @@ final class HomepageContext implements Context
     {
         Assert::false(
             $this->responseChecker->hasItemWithValue(
-                $this->productsClient->getLastResponse(),
+                $this->client->getLastResponse(),
                 'name',
                 $productName
             )


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->          |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

Fix for client name in two lines. Probably after rebase or upmerge.

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
