### PR TITLE
[Core] Remove the "experimental" tag from Message* namespaces

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Message/Admin/Account/RequestResetPasswordEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Message/Admin/Account/RequestResetPasswordEmail.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Message\Admin\Account;
 
-/** @experimental */
 class RequestResetPasswordEmail
 {
     public function __construct(public string $email)

--- a/src/Sylius/Bundle/CoreBundle/Message/Admin/Account/SendResetPasswordEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Message/Admin/Account/SendResetPasswordEmail.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Message\Admin\Account;
 
-/** @experimental */
 class SendResetPasswordEmail
 {
     public function __construct(public string $email, public string $localeCode)

--- a/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/RequestResetPasswordEmailHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/RequestResetPasswordEmailHandler.php
@@ -23,7 +23,6 @@ use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
 
-/** @experimental */
 final class RequestResetPasswordEmailHandler implements MessageHandlerInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/SendResetPasswordEmailHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/MessageHandler/Admin/Account/SendResetPasswordEmailHandler.php
@@ -20,7 +20,6 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Webmozart\Assert\Assert;
 
-/** @experimental */
 final class SendResetPasswordEmailHandler implements MessageHandlerInterface
 {
     public function __construct(


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12          |
| Bug fix?        | no?yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | -                       |
| License         | MIT                                                          |

As outlined in [this discussion](https://github.com/Sylius/Sylius/pull/14147#discussion_r923448502).