### PR TITLE
Catch ChannelNotFoundException in profiler

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Collector;
 
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
@@ -113,7 +114,7 @@ final class CartCollector extends DataCollector
                     'payment' => $cart->getPaymentState(),
                 ],
             ];
-        } catch (CartNotFoundException) {
+        } catch (CartNotFoundException | ChannelNotFoundException) {
             $this->data = [];
         }
     }

--- a/src/Sylius/Bundle/ShopBundle/EventListener/SessionCartSubscriber.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/SessionCartSubscriber.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\EventListener;
 
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
 use Sylius\Component\Order\Context\CartContextInterface;
@@ -57,7 +58,7 @@ final class SessionCartSubscriber implements EventSubscriberInterface
 
             /** @var OrderInterface $cart */
             Assert::isInstanceOf($cart, OrderInterface::class);
-        } catch (CartNotFoundException) {
+        } catch (CartNotFoundException | ChannelNotFoundException) {
             return;
         }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | master |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| License         | MIT                                                          |

Project with Sylius installed should work even when Channel is not found.

Sylius attached some event listener to `onKernelResponse` and the web profiler, and these listener shouldn't break the application when channel is not found (which is likely match by hostname).

Use case is I have a Sylius application with multiple hostname, and one of the hostname is not registered as Sylius channel because it is not a ecommerce site.