### PR TITLE
[Hot?-fix] Fix redirect on parametrized create pages

### DIFF
--- a/features/payment/managing_payment_methods/being_redirected_to_previous_filtered_page.feature
+++ b/features/payment/managing_payment_methods/being_redirected_to_previous_filtered_page.feature
@@ -1,0 +1,21 @@
+@managing_payment_methods
+Feature: Being redirected to previous filtered page
+    In order to smoothen navigating through the Admin panel
+    As an Administrator
+    I want to be redirected to a previously filtered page after taking any action
+
+    Background:
+        Given the store operates on a channel named "Poland"
+        And the store allows paying with "Cash on Delivery"
+        And the store allows paying with "Offline"
+        And this payment method has been disabled
+        And I am logged in as an administrator
+
+    @ui @no-api
+    Scenario: Being redirected to previous filtered page after cancelling creating a new payment method
+        When I browse payment methods
+        And I choose enabled filter
+        And I filter
+        And I want to create a new offline payment method
+        And I cancel my changes
+        Then I should be redirected to the previous page of only enabled payment methods

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -167,6 +167,14 @@ final class ManagingPaymentMethodsContext implements Context
     }
 
     /**
+     * @When I cancel my changes
+     */
+    public function iCancelMyChanges(): void
+    {
+        $this->createPage->cancelChanges();
+    }
+
+    /**
      * @When I check (also) the :paymentMethodName payment method
      */
     public function iCheckThePaymentMethod(string $paymentMethodName): void
@@ -209,6 +217,22 @@ final class ManagingPaymentMethodsContext implements Context
     public function iBrowsePaymentMethods()
     {
         $this->indexPage->open();
+    }
+
+    /**
+     * @When I choose enabled filter
+     */
+    public function iChooseEnabledFilter(): void
+    {
+        $this->indexPage->chooseEnabledFilter();
+    }
+
+    /**
+     * @When I filter
+     */
+    public function iFilter(): void
+    {
+        $this->indexPage->filter();
     }
 
     /**
@@ -439,5 +463,13 @@ final class ManagingPaymentMethodsContext implements Context
     {
         $this->createPage->setStripeSecretKey('TEST');
         $this->createPage->setStripePublishableKey('TEST');
+    }
+
+    /**
+     * @Then I should be redirected to the previous page of only enabled payment methods
+     */
+    public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter(): void
+    {
+        Assert::true($this->indexPage->isEnabledFilterApplied());
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -135,6 +135,16 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $this->getDocument()->clickLink($order);
     }
 
+    public function chooseEnabledFilter(): void
+    {
+        $this->getElement('enabled_filter')->selectOption('Yes');
+    }
+
+    public function isEnabledFilterApplied(): bool
+    {
+        return $this->getElement('enabled_filter')->getValue() === 'true';
+    }
+
     public function getRouteName(): string
     {
         return $this->routeName;
@@ -150,6 +160,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         return array_merge(parent::getDefinedElements(), [
             'bulk_actions' => '.sylius-grid-nav__bulk',
             'confirmation_button' => '#confirmation-button',
+            'enabled_filter' => '#criteria_enabled',
             'filter' => 'button:contains("Filter")',
             'table' => '.table',
         ]);

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
@@ -34,9 +34,13 @@ interface IndexPageInterface extends SymfonyPageInterface
 
     public function countItems(): int;
 
+    public function chooseEnabledFilter(): void;
+
     public function filter(): void;
 
     public function bulkDelete(): void;
 
     public function sort(string $order): void;
+
+    public function isEnabledFilterApplied(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePage.php
@@ -33,6 +33,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         );
     }
 
+    public function cancelChanges(): void
+    {
+        $this->getElement('cancel_button')->click();
+    }
+
     public function checkChannel(string $channelName): void
     {
         $this->getDocument()->checkField($channelName);
@@ -97,6 +102,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
+            'cancel_button' => '[data-test-cancel-changes-button]',
             'code' => '#sylius_payment_method_code',
             'enabled' => '#sylius_payment_method_enabled',
             'gateway_name' => '#sylius_payment_method_gatewayConfig_gatewayName',

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePageInterface.php
@@ -21,6 +21,8 @@ interface CreatePageInterface extends BaseCreatePageInterface
 
     public function disable(): void;
 
+    public function cancelChanges(): void;
+
     public function nameIt(string $name, string $languageCode): void;
 
     public function specifyCode(string $code): void;

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -48,11 +48,6 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         $this->getElement('channel_filter')->selectOption($channelName);
     }
 
-    public function chooseEnabledFilter(): void
-    {
-        $this->getElement('enabled_filter')->selectOption('Yes');
-    }
-
     public function hasProductAccessibleImage(string $productCode): bool
     {
         $productRow = $this->getTableAccessor()->getRowWithFields($this->getElement('table'), ['code' => $productCode]);
@@ -83,11 +78,6 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
     public function checkLastProductHasDataAttribute(string $attributeName): bool
     {
         return $this->getElement('last_product')->find('css', sprintf('[%s]', $attributeName)) !== null;
-    }
-
-    public function isEnabledFilterApplied(): bool
-    {
-        return $this->getElement('enabled_filter')->getValue() === 'true';
     }
 
     public function getPageNumber(): int

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -25,8 +25,6 @@ interface IndexPageInterface extends CrudIndexPageInterface
 
     public function chooseChannelFilter(string $channelName): void;
 
-    public function chooseEnabledFilter(): void;
-
     public function filter(): void;
 
     public function goToPage(int $page): void;
@@ -36,6 +34,4 @@ interface IndexPageInterface extends CrudIndexPageInterface
     public function checkLastProductHasDataAttribute(string $attributeName): bool;
 
     public function getPageNumber(): int;
-
-    public function isEnabledFilterApplied(): bool;
 }

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
@@ -12,16 +12,16 @@ default:
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.taxon
 
+                - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.product
-                - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.taxonomy
 
                 - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_products
                 - sylius.behat.context.ui.shop.browsing_product
                 - Sylius\Behat\Context\Ui\Admin\ProductCreationContext
-                    
+
             filters:
                 tags: "@admin_panel&&@ui"

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
@@ -1,5 +1,11 @@
+{% if paths.cancel is not null %}
+    {% set cancelPath = paths.cancel|split('?')[0] %}
+{% else %}
+    {% set cancelPath = null %}
+{% endif %}
+
 <div class="ui hidden divider"></div>
 <div class="ui buttons">
     <button class="ui labeled icon primary button" type="submit"><i class="plus icon"></i>{{- 'sylius.ui.create'|trans -}}</button>
-    {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': sylius_generate_redirect_path(paths.cancel|default(null))} %}
+    {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': sylius_generate_redirect_path(cancelPath)} %}
 </div>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | continuation of https://github.com/Sylius/Sylius/pull/14159 |
| License         | MIT                                                          |

A feature introduced in the mentioned PR works well, despite the places when the create path is somehow parametrized (e.g. product attributes or payment methods). The problem is, that [RedirectPathExtension](https://github.com/Sylius/Sylius/blob/1.12/src/Sylius/Bundle/AdminBundle/Twig/RedirectPathExtension.php#L53) does not generate the path if it already contains some query parameters. When we access the parametrised creation page, the parameter is included in the index URL used for "cancel button" (see video below):


https://user-images.githubusercontent.com/6212718/180255165-534ce9e7-80a7-44d6-8753-ce5f3676f447.mov

It's not expected behaviour for sure (if not a bug) but did not result in any problems until now. **However** we need to leave usage of the parameters in the cancel URL, for the nested routes e.g. product variants index which contains product id as well.

Therefore, for now, I decided it would be fair to assume that every parameter that is not used as a path attribute during the cancel URL creation could be skipped. I've also added a redirect-related scenario for payment methods to show the fix works indeed 🖖 