### PR TITLE
[bug]Check if last_error variable in twig exists and is not null

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Security/_error.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Security/_error.html.twig
@@ -1,6 +1,6 @@
 {% import '@SyliusUi/Macro/messages.html.twig' as messages %}
 
-{% if last_error %}
+{% if (last_error is defined) and (last_error is not null) %}
     <div class="ui left aligned basic segment">
         {{ messages.error(last_error.messageKey) }}
     </div>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12         |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | none                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Without checking if is defined
<img width="1512" alt="Screenshot 2022-07-21 at 17 51 30" src="https://user-images.githubusercontent.com/17534504/180258282-ca3433f1-acd9-4c76-adb8-897e39a69dc0.png">

Without checking if the variable is null
<img width="1509" alt="Screenshot 2022-07-21 at 17 52 37" src="https://user-images.githubusercontent.com/17534504/180258493-ecad8f48-4e25-4e8a-91c3-090f5b1d7ad2.png">


