### PR TITLE
[Symfony 6][Shop bundle] Fix shop user logout handler

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
@@ -44,11 +44,4 @@ final class ShopUserLogoutHandler
         $response = $this->httpUtils->createRedirectResponse($logoutEvent->getRequest(), $this->targetUrl);
         $logoutEvent->setResponse($response);
     }
-
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            LogoutEvent::class => [['onLogout', 64]],
-        ];
-    }
 }

--- a/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
@@ -15,12 +15,11 @@ namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\HttpUtils;
 
-final class ShopUserLogoutHandler implements EventSubscriberInterface
+final class ShopUserLogoutHandler
 {
     public function __construct(
         private HttpUtils $httpUtils,
@@ -41,7 +40,6 @@ final class ShopUserLogoutHandler implements EventSubscriberInterface
         $this->cartStorage->removeForChannel($channel);
 
         $this->tokenStorage->setToken(null);
-        $logoutEvent->getRequest()->getSession()->invalidate();
 
         $response = $this->httpUtils->createRedirectResponse($logoutEvent->getRequest(), $this->targetUrl);
         $logoutEvent->setResponse($response);

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
             <argument type="service" id="sylius.context.channel.composite" />
             <argument type="service" id="sylius.storage.cart_session" />
             <argument type="service" id="security.token_storage" />
-            <tag name="kernel.event_subscriber" />
+            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LogoutEvent" dispatcher="security.event_dispatcher.shop" method="onLogout" />
         </service>
 
         <service id="sylius.section_resolver.shop_uri_based_section_resolver" class="Sylius\Bundle\ShopBundle\SectionResolver\ShopUriBasedSectionResolver">

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -27,6 +27,8 @@
             <argument>sylius_shop_homepage</argument>
             <argument type="service" id="sylius.context.channel.composite" />
             <argument type="service" id="sylius.storage.cart_session" />
+            <argument type="service" id="security.token_storage" />
+            <tag name="kernel.event_subscriber" />
         </service>
 
         <service id="sylius.section_resolver.shop_uri_based_section_resolver" class="Sylius\Bundle\ShopBundle\SectionResolver\ShopUriBasedSectionResolver">

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
@@ -55,7 +55,6 @@ final class ShopUserLogoutHandlerSpec extends ObjectBehavior
         $httpUtils->createRedirectResponse($request, '/')->willReturn($response);
 
         $tokenStorage->setToken(null)->shouldBeCalled();
-        $session->invalidate()->shouldBeCalled();
         $cartStorage->removeForChannel($channel)->shouldBeCalled();
         $logoutEvent->setResponse($response)->shouldBeCalled();
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
@@ -19,9 +19,10 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\HttpUtils;
-use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
-use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
 final class ShopUserLogoutHandlerSpec extends ObjectBehavior
 {
@@ -29,18 +30,9 @@ final class ShopUserLogoutHandlerSpec extends ObjectBehavior
         HttpUtils $httpUtils,
         ChannelContextInterface $channelContext,
         CartStorageInterface $cartStorage,
+        TokenStorageInterface $tokenStorage,
     ): void {
-        $this->beConstructedWith($httpUtils, '/', $channelContext, $cartStorage);
-    }
-
-    function it_is_default_logout_success_handler(): void
-    {
-        $this->shouldHaveType(DefaultLogoutSuccessHandler::class);
-    }
-
-    function it_implements_logout_success_handler_interface(): void
-    {
-        $this->shouldImplement(LogoutSuccessHandlerInterface::class);
+        $this->beConstructedWith($httpUtils, '/', $channelContext, $cartStorage, $tokenStorage);
     }
 
     function it_clears_cart_session_after_logging_out_and_return_default_handler_response(
@@ -50,13 +42,23 @@ final class ShopUserLogoutHandlerSpec extends ObjectBehavior
         Request $request,
         Response $response,
         CartStorageInterface $cartStorage,
+        LogoutEvent $logoutEvent,
+        SessionInterface $session,
+        TokenStorageInterface $tokenStorage,
     ): void {
         $channelContext->getChannel()->willReturn($channel);
 
-        $cartStorage->removeForChannel($channel)->shouldBeCalled();
+        $logoutEvent->getRequest()->willReturn($request);
+        $logoutEvent->getResponse()->willReturn(null);
+        $request->getSession()->willReturn($session);
 
         $httpUtils->createRedirectResponse($request, '/')->willReturn($response);
 
-        $this->onLogoutSuccess($request)->shouldReturn($response);
+        $tokenStorage->setToken(null)->shouldBeCalled();
+        $session->invalidate()->shouldBeCalled();
+        $cartStorage->removeForChannel($channel)->shouldBeCalled();
+        $logoutEvent->setResponse($response)->shouldBeCalled();
+
+        $this->onLogout($logoutEvent);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            
|-----------------|--------------------------------------------------------------
| Branch?         | 1.12         
| Bug fix?        | yes                                                       
| New feature?    | no                                                       
| BC breaks?      | not sure                                                       
| Deprecations?   | no/
| Related tickets | partially #13274 
| License         | MIT                                                          

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Not sure about BC break
I removed the dependency of the removed service https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
