### PR TITLE
[Symfony 6] Fix notification controller

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
@@ -56,7 +56,7 @@ final class NotificationController
         try {
             $hubResponse = $this->client->send($hubRequest, ['verify' => false]);
         } catch (GuzzleException) {
-            return JsonResponse::create('', JsonResponse::HTTP_NO_CONTENT);
+            return new JsonResponse('', JsonResponse::HTTP_NO_CONTENT);
         }
 
         $hubResponse = json_decode($hubResponse->getBody()->getContents(), true);


### PR DESCRIPTION
| Q               | A                                                            
|-----------------|--------------------------------------------------------------
| Branch?         | 1.12          |
| Bug fix?        | yes (for Symfony 6)                                                      
| New feature?    | no                                                       
| BC breaks?      | no                                                       
| Deprecations?   | no 
| Related tickets | partially #13274 
| License         | MIT                                                          

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The static create method was deprecated on Symfony 5 and has been removed on Symfony 6.