### PR TITLE
Rename tag tagged to tagged_iterator

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
@@ -57,7 +57,7 @@
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\DataProvider\ProductAttributesSubresourceDataProvider">
-            <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.collection" />
+            <argument type="tagged_iterator" tag="api_platform.doctrine.orm.query_extension.collection" />
             <argument type="service" id="sylius.repository.product_attribute_value" />
             <argument type="service" id="sylius.context.locale" />
             <argument type="service" id="sylius.locale_provider.channel_based" />


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->          |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

As `tagged` has been deprecated in Symfony 4.4: https://github.com/symfony/symfony/pull/31321
<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
