### PR TITLE
[Documentation] Add naming conventions to contributing section

### DIFF
--- a/docs/book/contributing/code/conventions.rst
+++ b/docs/book/contributing/code/conventions.rst
@@ -1,0 +1,50 @@
+Conventions
+===========
+
+This document describes conventions used in the Sylius to make it more consistent and predictable. Any new code
+delivered to Sylius should comply with the following conventions, we also encourage you to use them in your own projects
+based on Sylius.
+
+Naming
+------
+
+* Use ``camelCase`` for:
+
+    * PHP variables,
+    * method names (except PHPSpec and PHPUnit),
+    * arguments,
+    * Twig templates;
+
+* Use ``snake_case`` for:
+
+    * configuration parameters,
+    * Twig template variables,
+    * fixture fields,
+    * YAML files,
+    * XML files,
+    * Behat feature files,
+    * PHPSpec method names,
+    * PHPUnit method names;
+
+* Use ``SCREAMING_SNAKE_CASE`` for:
+
+    * constants,
+    * environment variables;
+
+* Use ``UpperCamelCase`` for:
+
+    * classes names,
+    * interfaces names,
+    * traits names,
+    * other PHP files names;
+
+* Prefix abstract classes with `Abstract`,
+* Suffix interfaces with  `Interface`,
+* Suffix traits with `Trait`,
+* Use a command name  with the `Handler` suffix to create a name of command handler,
+* Suffix exceptions with `Exception`,
+* Suffix PHPSpec classes with `Spec`,
+* Suffix PHPUnit tests with `Test`,
+* Prefix Twig templates that are just partial blocks with `_`,
+* Use fully qualified class name (FQCN) of an interface  as a service name of newly created service or FQCN of class
+  if there are multiple implementations of a given interface  unless it is inconsistent with the current scope of Sylius.

--- a/docs/book/contributing/code/index.rst
+++ b/docs/book/contributing/code/index.rst
@@ -7,6 +7,7 @@ Contributing Code
     patches
     security
     standards
+    conventions
     license
 
 .. include:: /book/contributing/code/map.rst.inc

--- a/docs/book/contributing/code/map.rst.inc
+++ b/docs/book/contributing/code/map.rst.inc
@@ -1,4 +1,5 @@
 * :doc:`/book/contributing/code/patches`
 * :doc:`/book/contributing/code/security`
 * :doc:`/book/contributing/code/standards`
+* :doc:`/book/contributing/code/conventions`
 * :doc:`/book/contributing/code/license`


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11|
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

I would like to initiate a new chapter in our docs, in the `Contributing` section. Definitely, there is a need for some iterations over it, especially that there is probably many more conventions to write down but I believe that it is a good start 😃 

![screencapture-localhost-63342-Sylius-docs-build-book-contributing-code-conventions-html-2022-07-26-14_10_58](https://user-images.githubusercontent.com/6140884/181002787-bbc444f6-c2f0-4c2e-b192-407b8e4fd7ba.png)

