### PR TITLE
Validate non exist coupon code

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -58,6 +58,15 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
         /** @var PromotionCouponInterface $promotionCoupon */
         $promotionCoupon = $this->promotionCouponRepository->findOneBy(['code' => $value->couponCode]);
 
+        if (null === $promotionCoupon) {
+            $this->context->buildViolation('sylius.promotion_coupon.is_invalid')
+                ->atPath('couponCode')
+                ->addViolation()
+            ;
+
+            return;
+        }
+
         /** @var OrderInterface $cart */
         $cart = $this->orderRepository->findCartByTokenValue($value->getOrderTokenValue());
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| License         | MIT                                                          |

If user provide an non exist coupon code validation should fail