### PR TITLE
Update on docker usage

### DIFF
--- a/docs/book/installation/installation_with_docker.rst
+++ b/docs/book/installation/installation_with_docker.rst
@@ -20,12 +20,12 @@ Development
 -----------
 
 Sylius Standard comes with the `multi-stage build <https://docs.docker.com/develop/develop-images/multistage-build/>`_.
-You can execute it via the ``docker compose up -d`` command in your favorite terminal. Please note that the speed of building images
+You can execute it via the ``docker-compose up -d`` command in your favorite terminal. Please note that the speed of building images
 and initializing containers depends on your local machine and internet connection - it may take some time. Then enter ``localhost`` in your browser or execute ``open localhost`` in your terminal.
 
 .. code-block:: bash
 
-    docker compose up -d
+    docker-compose up -d
     open localhost
 
 .. tip::


### PR DESCRIPTION
"docker compose up -d" throw an error, docker have no compose command.
changed for "docker-compose up -d" and worked like a charm

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10          |
| Bug fix?        | yes             |
| New feature?    | no          |
| BC breaks?      | no          |
| Deprecations?   | no         |
| Related tickets |                |
| License         | MIT            |

<!--
 - Bug fixes must be submitted against the 1.10 or 1.11 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
