### PR TITLE
[bug]Send request to GUS with https

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sylius.admin.notification.uri">http://gus.sylius.com/version</parameter>
+        <parameter key="sylius.admin.notification.uri">https://gus.sylius.com/version</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.9, 1.10, 1.11, 1.12         |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

Due to the change of the GUS deployment to Digital Ocean Apps - there is no longer a need to keep the URL as HTTP. We cannot keep it SSL free, as Digital Ocean enforces HTTPS. The real problem occurred because locally it saves website statistics, but with ex. a Postman - The redirect is present, and even with the "allow_redirect" parameter by Guzzle the Website does not hold, yet returns proper Sylius Version.

## Without SSL
<img width="854" alt="Screenshot 2022-08-01 at 16 47 01" src="https://user-images.githubusercontent.com/17534504/182178374-40cc8c8d-6302-4d4a-aaa0-95c88fd6008b.png">
## With SSL
<img width="882" alt="Screenshot 2022-08-01 at 16 59 31" src="https://user-images.githubusercontent.com/17534504/182178989-aa72f489-50bb-46dd-aae2-f7d253eb9774.png">

