### PR TITLE
[API] Rename OrderPromotionCodeAssigner

### DIFF
--- a/UPGRADE-API-1.12.md
+++ b/UPGRADE-API-1.12.md
@@ -113,3 +113,5 @@ Here is how the response looks like:
 
 1. The second argument `$billingAddress` of `Sylius\Bundle\ApiBundle\Modifier\OrderAddressModifierInterface::modify` 
    has become nullable.
+
+1. The `Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface` has been renamed to `Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface`.

--- a/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssigner.php
+++ b/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssigner.php
@@ -19,6 +19,7 @@ use Sylius\Component\Promotion\Model\PromotionCouponInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 use Webmozart\Assert\Assert;
 
+/** @experimental */
 final class OrderPromotionCodeAssigner implements OrderPromotionCodeAssignerInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssigner.php
+++ b/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssigner.php
@@ -19,7 +19,7 @@ use Sylius\Component\Promotion\Model\PromotionCouponInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 use Webmozart\Assert\Assert;
 
-final class OrderPromoCodeAssigner implements OrderPromoCodeAssignerInterface
+final class OrderPromotionCodeAssigner implements OrderPromotionCodeAssignerInterface
 {
     public function __construct(
         private PromotionCouponRepositoryInterface $promotionCouponRepository,

--- a/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssignerInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssignerInterface.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Assigner;
 
 use Sylius\Component\Core\Model\OrderInterface;
 
+/** @experimental */
 interface OrderPromotionCodeAssignerInterface
 {
     public function assign(OrderInterface $cart, ?string $couponCode = null): OrderInterface;

--- a/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssignerInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Assigner/OrderPromotionCodeAssignerInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Assigner;
 
 use Sylius\Component\Core\Model\OrderInterface;
 
-interface OrderPromoCodeAssignerInterface
+interface OrderPromotionCodeAssignerInterface
 {
     public function assign(OrderInterface $cart, ?string $couponCode = null): OrderInterface;
 }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/UpdateCartHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/UpdateCartHandler.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
 
-use Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface;
+use Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Bundle\ApiBundle\Modifier\OrderAddressModifierInterface;
 use Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface;
@@ -28,7 +28,7 @@ final class UpdateCartHandler implements MessageHandlerInterface
     public function __construct(
         private OrderRepositoryInterface $orderRepository,
         private OrderAddressModifierInterface $orderAddressModifier,
-        private OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        private OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         private CustomerProviderInterface $customerProvider,
     ) {
     }
@@ -51,7 +51,7 @@ final class UpdateCartHandler implements MessageHandlerInterface
             $order = $this->orderAddressModifier->modify($order, $billingAddress, $shippingAddress);
         }
 
-        $order = $this->orderPromoCodeAssigner->assign($order, $updateCart->getCouponCode());
+        $order = $this->orderPromotionCodeAssigner->assign($order, $updateCart->getCouponCode());
 
         return $order;
     }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -156,7 +156,7 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface" class="Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssigner" public="true">
+        <service id="Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface" class="Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssigner" public="true">
             <argument type="service" id="sylius.repository.promotion_coupon" />
             <argument type="service" id="sylius.order_processing.order_processor" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -65,7 +65,7 @@
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\UpdateCartHandler">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Modifier\OrderAddressModifierInterface"/>
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Context\UserContextInterface" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />

--- a/src/Sylius/Bundle/ApiBundle/Tests/CommandHandler/ChangeAddressOrderHandlerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/CommandHandler/ChangeAddressOrderHandlerTest.php
@@ -17,7 +17,7 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Persistence\ObjectManager;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
-use Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface;
+use Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Bundle\ApiBundle\CommandHandler\Checkout\UpdateCartHandler;
 use Sylius\Bundle\ApiBundle\Modifier\OrderAddressModifierInterface;
@@ -47,7 +47,7 @@ final class ChangeAddressOrderHandlerTest extends KernelTestCase
 
         $orderAddressModifier = $container->get(OrderAddressModifierInterface::class);
 
-        $orderPromoCodeAssigner = $container->get(OrderPromoCodeAssignerInterface::class);
+        $orderPromotionCodeAssigner = $container->get(OrderPromotionCodeAssignerInterface::class);
 
         $customerProvider = $container->get(CustomerProviderInterface::class);
 
@@ -73,7 +73,7 @@ final class ChangeAddressOrderHandlerTest extends KernelTestCase
         $updateCartHandler = new UpdateCartHandler(
             $orderRepository,
             $orderAddressModifier,
-            $orderPromoCodeAssigner,
+            $orderPromotionCodeAssigner,
             $customerProvider,
         );
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Assigner/OrderPromotionCodeAssignerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Assigner/OrderPromotionCodeAssignerSpec.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Model\PromotionCouponInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 
-final class OrderPromoCodeAssignerSpec extends ObjectBehavior
+final class OrderPromotionCodeAssignerSpec extends ObjectBehavior
 {
     function let(
         PromotionCouponRepositoryInterface $promotionCouponRepository,

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Checkout/UpdateCartHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Checkout/UpdateCartHandlerSpec.php
@@ -15,7 +15,7 @@ namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\ApiBundle\Assigner\OrderPromoCodeAssignerInterface;
+use Sylius\Bundle\ApiBundle\Assigner\OrderPromotionCodeAssignerInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Bundle\ApiBundle\Modifier\OrderAddressModifierInterface;
 use Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface;
@@ -30,10 +30,10 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function let(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         CustomerProviderInterface $customerProvider,
     ) {
-        $this->beConstructedWith($orderRepository, $orderAddressModifier, $orderPromoCodeAssigner, $customerProvider);
+        $this->beConstructedWith($orderRepository, $orderAddressModifier, $orderPromotionCodeAssigner, $customerProvider);
     }
 
     function it_is_a_message_handler(): void
@@ -44,7 +44,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_throws_exception_if_cart_is_not_found(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
         AddressInterface $shippingAddress,
         AddressInterface $billingAddress,
@@ -55,7 +55,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
 
         $orderAddressModifier->modify($order, $billingAddress, $shippingAddress, 'john.doe@email.com')->shouldNotBeCalled();
 
-        $orderPromoCodeAssigner->assign($order, 'coupon')->shouldNotBeCalled();
+        $orderPromotionCodeAssigner->assign($order, 'coupon')->shouldNotBeCalled();
 
         $updateCart = new UpdateCart('john.doe@email.com', $billingAddress->getWrappedObject(), $shippingAddress->getWrappedObject(), 'coupon');
         $updateCart->setOrderTokenValue('cart');
@@ -68,7 +68,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_modifies_billing_address(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
         AddressInterface $billingAddress,
     ): void {
@@ -84,7 +84,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
             ->willReturn($order)
         ;
 
-        $orderPromoCodeAssigner
+        $orderPromotionCodeAssigner
             ->assign($order->getWrappedObject(), null)
             ->shouldBeCalled()
             ->willReturn($order->getWrappedObject())
@@ -96,7 +96,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_modifies_shipping_address(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
         AddressInterface $shippingAddress,
     ): void {
@@ -117,7 +117,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
             ->willReturn($order)
         ;
 
-        $orderPromoCodeAssigner
+        $orderPromotionCodeAssigner
             ->assign($order, null)
             ->shouldBeCalled()
             ->willReturn($order)
@@ -129,7 +129,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_applies_coupon(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
     ): void {
         $updateCart = new UpdateCart(null, null, null, 'couponCode');
@@ -141,7 +141,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
 
         $orderAddressModifier->modify($order->getWrappedObject(), Argument::any())->shouldNotBeCalled();
 
-        $orderPromoCodeAssigner
+        $orderPromotionCodeAssigner
             ->assign($order->getWrappedObject(), 'couponCode')
             ->shouldBeCalled()
             ->willReturn($order->getWrappedObject())
@@ -153,7 +153,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_modifies_address_and_email_and_applies_coupon(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
         AddressInterface $billingAddress,
         AddressInterface $shippingAddress,
@@ -183,7 +183,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
             ->willReturn($order)
         ;
 
-        $orderPromoCodeAssigner
+        $orderPromotionCodeAssigner
             ->assign($order->getWrappedObject(), 'couponCode')
             ->shouldBeCalled()
             ->willReturn($order->getWrappedObject())
@@ -195,7 +195,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
     function it_sets_the_customer_by_email(
         OrderRepositoryInterface $orderRepository,
         OrderAddressModifierInterface $orderAddressModifier,
-        OrderPromoCodeAssignerInterface $orderPromoCodeAssigner,
+        OrderPromotionCodeAssignerInterface $orderPromotionCodeAssigner,
         OrderInterface $order,
         AddressInterface $billingAddress,
         AddressInterface $shippingAddress,
@@ -225,7 +225,7 @@ final class UpdateCartHandlerSpec extends ObjectBehavior
             ->willReturn($order->getWrappedObject())
         ;
 
-        $orderPromoCodeAssigner
+        $orderPromotionCodeAssigner
             ->assign($order->getWrappedObject(), 'couponCode')
             ->shouldBeCalled()
             ->willReturn($order->getWrappedObject())


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
