### PR TITLE
[Maintenance] Use getObject instead of getEntity on doctrine events

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/CanonicalizerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CanonicalizerListener.php
@@ -26,7 +26,7 @@ final class CanonicalizerListener
 
     public function canonicalize(LifecycleEventArgs $event): void
     {
-        $item = $event->getEntity();
+        $item = $event->getObject();
 
         if ($item instanceof CustomerInterface) {
             $item->setEmailCanonical($this->canonicalizer->canonicalize($item->getEmail()));

--- a/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
@@ -27,7 +27,7 @@ final class DefaultUsernameORMListener
 {
     public function onFlush(OnFlushEventArgs $onFlushEventArgs)
     {
-        $entityManager = $onFlushEventArgs->getEntityManager();
+        $entityManager = $onFlushEventArgs->getObjectManager();
         $unitOfWork = $entityManager->getUnitOfWork();
 
         $this->processEntities($unitOfWork->getScheduledEntityInsertions(), $entityManager, $unitOfWork);

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
@@ -37,7 +37,7 @@ final class ImagesRemoveListener
 
     public function onFlush(OnFlushEventArgs $event): void
     {
-        foreach ($event->getEntityManager()->getUnitOfWork()->getScheduledEntityDeletions() as $entityDeletion) {
+        foreach ($event->getObjectManager()->getUnitOfWork()->getScheduledEntityDeletions() as $entityDeletion) {
             if (!$entityDeletion instanceof ImageInterface) {
                 continue;
             }

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CanonicalizerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CanonicalizerListenerSpec.php
@@ -29,7 +29,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
 
     function it_canonicalize_user_username_on_pre_persist_doctrine_event($canonicalizer, LifecycleEventArgs $event, ShopUserInterface $user): void
     {
-        $event->getEntity()->willReturn($user);
+        $event->getObject()->willReturn($user);
         $user->getUsername()->willReturn('testUser');
         $user->getEmail()->willReturn('test@email.com');
 
@@ -43,7 +43,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
 
     function it_canonicalize_customer_email_on_pre_persist_doctrine_event($canonicalizer, LifecycleEventArgs $event, CustomerInterface $customer): void
     {
-        $event->getEntity()->willReturn($customer);
+        $event->getObject()->willReturn($customer);
         $customer->getEmail()->willReturn('testUser@Email.com');
 
         $customer->setEmailCanonical('testuser@email.com')->shouldBeCalled();
@@ -54,7 +54,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
 
     function it_canonicalize_user_username_on_pre_update_doctrine_event($canonicalizer, LifecycleEventArgs $event, ShopUserInterface $user): void
     {
-        $event->getEntity()->willReturn($user);
+        $event->getObject()->willReturn($user);
         $user->getUsername()->willReturn('testUser');
         $user->getEmail()->willReturn('test@email.com');
 
@@ -68,7 +68,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
 
     function it_canonicalize_customer_email_on_pre_update_doctrine_event($canonicalizer, LifecycleEventArgs $event, CustomerInterface $customer): void
     {
-        $event->getEntity()->willReturn($customer);
+        $event->getObject()->willReturn($customer);
         $customer->getEmail()->willReturn('testUser@Email.com');
 
         $customer->setEmailCanonical('testuser@email.com')->shouldBeCalled();
@@ -80,7 +80,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
     function it_canonicalize_only_user_or_customer_interface_implementation_on_pre_presist($canonicalizer, LifecycleEventArgs $event): void
     {
         $item = new \stdClass();
-        $event->getEntity()->willReturn($item);
+        $event->getObject()->willReturn($item);
 
         $canonicalizer->canonicalize(Argument::any())->shouldNotBeCalled();
 
@@ -90,7 +90,7 @@ final class CanonicalizerListenerSpec extends ObjectBehavior
     function it_canonicalize_only_user_or_customer_interface_implementation_on_pre_update($canonicalizer, LifecycleEventArgs $event): void
     {
         $item = new \stdClass();
-        $event->getEntity()->willReturn($item);
+        $event->getObject()->willReturn($item);
 
         $canonicalizer->canonicalize(Argument::any())->shouldNotBeCalled();
 

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/DefaultUsernameORMListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/DefaultUsernameORMListenerSpec.php
@@ -32,7 +32,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         ShopUserInterface $user,
         ClassMetadata $userMetadata,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([$customer]);
@@ -61,7 +61,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         ShopUserInterface $user,
         ClassMetadata $userMetadata,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([$user]);
@@ -90,7 +90,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         ShopUserInterface $user,
         ClassMetadata $userMetadata,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
@@ -119,7 +119,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         ShopUserInterface $user,
         ClassMetadata $userMetadata,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
@@ -148,7 +148,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         ShopUserInterface $user,
         ClassMetadata $userMetadata,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
@@ -174,7 +174,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         UnitOfWork $unitOfWork,
         CustomerInterface $customer,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([$customer]);
@@ -193,7 +193,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         UnitOfWork $unitOfWork,
         CustomerInterface $customer,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
@@ -212,7 +212,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         EntityManager $entityManager,
         UnitOfWork $unitOfWork,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([]);
@@ -230,7 +230,7 @@ final class DefaultUsernameORMListenerSpec extends ObjectBehavior
         \stdClass $stdObject,
         \stdClass $stdObject2,
     ): void {
-        $onFlushEventArgs->getEntityManager()->willReturn($entityManager);
+        $onFlushEventArgs->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
 
         $unitOfWork->getScheduledEntityInsertions()->willReturn([$stdObject]);

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
@@ -45,7 +45,7 @@ final class ImagesRemoveListenerSpec extends ObjectBehavior
         ImageInterface $image,
         ProductInterface $product,
     ): void {
-        $event->getEntityManager()->willReturn($entityManager);
+        $event->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
         $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 
@@ -66,7 +66,7 @@ final class ImagesRemoveListenerSpec extends ObjectBehavior
         ProductInterface $product,
         FilterConfiguration $filterConfiguration,
     ): void {
-        $onFlushEvent->getEntityManager()->willReturn($entityManager);
+        $onFlushEvent->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
         $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 
@@ -96,7 +96,7 @@ final class ImagesRemoveListenerSpec extends ObjectBehavior
         ProductInterface $product,
         FilterConfiguration $filterConfiguration,
     ): void {
-        $onFlushEvent->getEntityManager()->willReturn($entityManager);
+        $onFlushEvent->getObjectManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
         $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 

--- a/src/Sylius/Bundle/ProductBundle/EventListener/SelectProductAttributeChoiceRemoveListener.php
+++ b/src/Sylius/Bundle/ProductBundle/EventListener/SelectProductAttributeChoiceRemoveListener.php
@@ -28,7 +28,7 @@ final class SelectProductAttributeChoiceRemoveListener
 
     public function postUpdate(LifecycleEventArgs $event): void
     {
-        $productAttribute = $event->getEntity();
+        $productAttribute = $event->getObject();
 
         if (!$productAttribute instanceof ProductAttributeInterface) {
             return;
@@ -38,7 +38,7 @@ final class SelectProductAttributeChoiceRemoveListener
             return;
         }
 
-        $entityManager = $event->getEntityManager();
+        $entityManager = $event->getObjectManager();
 
         $unitOfWork = $entityManager->getUnitOfWork();
         $changeSet = $unitOfWork->getEntityChangeSet($productAttribute);

--- a/src/Sylius/Bundle/ProductBundle/spec/EventListener/SelectProductAttributeChoiceRemoveListenerSpec.php
+++ b/src/Sylius/Bundle/ProductBundle/spec/EventListener/SelectProductAttributeChoiceRemoveListenerSpec.php
@@ -39,8 +39,8 @@ final class SelectProductAttributeChoiceRemoveListenerSpec extends ObjectBehavio
         ProductAttributeInterface $productAttribute,
         ProductAttributeValueInterface $productAttributeValue,
     ): void {
-        $event->getEntity()->willReturn($productAttribute);
-        $event->getEntityManager()->willReturn($entityManager);
+        $event->getObject()->willReturn($productAttribute);
+        $event->getObjectManager()->willReturn($entityManager);
 
         $productAttribute->getType()->willReturn(SelectAttributeType::TYPE);
 
@@ -85,8 +85,8 @@ final class SelectProductAttributeChoiceRemoveListenerSpec extends ObjectBehavio
         EntityManagerInterface $entityManager,
         ProductAttributeInterface $productAttribute,
     ): void {
-        $event->getEntity()->willReturn($productAttribute);
-        $event->getEntityManager()->willReturn($entityManager);
+        $event->getObject()->willReturn($productAttribute);
+        $event->getObjectManager()->willReturn($entityManager);
 
         $productAttribute->getType()->willReturn(SelectAttributeType::TYPE);
 
@@ -116,8 +116,8 @@ final class SelectProductAttributeChoiceRemoveListenerSpec extends ObjectBehavio
         EntityManagerInterface $entityManager,
         ProductAttributeInterface $productAttribute,
     ): void {
-        $event->getEntity()->willReturn($productAttribute);
-        $event->getEntityManager()->willReturn($entityManager);
+        $event->getObject()->willReturn($productAttribute);
+        $event->getObjectManager()->willReturn($entityManager);
 
         $productAttribute->getType()->willReturn(SelectAttributeType::TYPE);
 
@@ -147,7 +147,7 @@ final class SelectProductAttributeChoiceRemoveListenerSpec extends ObjectBehavio
         EntityManagerInterface $entityManager,
         LifecycleEventArgs $event,
     ): void {
-        $event->getEntity()->willReturn('wrongObject');
+        $event->getObject()->willReturn('wrongObject');
 
         $entityManager
             ->getRepository('Sylius\Component\Product\Model\ProductAttributeValue')
@@ -161,7 +161,7 @@ final class SelectProductAttributeChoiceRemoveListenerSpec extends ObjectBehavio
         EntityManagerInterface $entityManager,
         ProductAttributeInterface $productAttribute,
     ): void {
-        $event->getEntity()->willReturn($productAttribute);
+        $event->getObject()->willReturn($productAttribute);
         $productAttribute->getType()->willReturn('wrongType');
 
         $entityManager

--- a/src/Sylius/Bundle/UserBundle/EventListener/PasswordUpdaterListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/PasswordUpdaterListener.php
@@ -31,7 +31,7 @@ class PasswordUpdaterListener
 
     public function prePersist(LifecycleEventArgs $event): void
     {
-        $user = $event->getEntity();
+        $user = $event->getObject();
 
         if (!$user instanceof UserInterface) {
             return;
@@ -42,7 +42,7 @@ class PasswordUpdaterListener
 
     public function preUpdate(LifecycleEventArgs $event): void
     {
-        $user = $event->getEntity();
+        $user = $event->getObject();
 
         if (!$user instanceof UserInterface) {
             return;

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/PasswordUpdaterListenerSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/PasswordUpdaterListenerSpec.php
@@ -56,7 +56,7 @@ final class PasswordUpdaterListenerSpec extends ObjectBehavior
         LifecycleEventArgs $event,
         UserInterface $user,
     ): void {
-        $event->getEntity()->willReturn($user);
+        $event->getObject()->willReturn($user);
 
         $user->getPlainPassword()->willReturn('testPassword');
 
@@ -70,7 +70,7 @@ final class PasswordUpdaterListenerSpec extends ObjectBehavior
         LifecycleEventArgs $event,
         UserInterface $user,
     ): void {
-        $event->getEntity()->willReturn($user);
+        $event->getObject()->willReturn($user);
 
         $user->getPlainPassword()->willReturn('testPassword');
 
@@ -83,7 +83,7 @@ final class PasswordUpdaterListenerSpec extends ObjectBehavior
         PasswordUpdaterInterface $passwordUpdater,
         LifecycleEventArgs $event,
     ): void {
-        $event->getEntity()->willReturn('user');
+        $event->getObject()->willReturn('user');
         $passwordUpdater->updatePassword(Argument::any())->shouldNotBeCalled();
 
         $this->prePersist($event);
@@ -93,7 +93,7 @@ final class PasswordUpdaterListenerSpec extends ObjectBehavior
         PasswordUpdaterInterface $passwordUpdater,
         LifecycleEventArgs $event,
     ): void {
-        $event->getEntity()->willReturn('user');
+        $event->getObject()->willReturn('user');
         $passwordUpdater->updatePassword(Argument::any())->shouldNotBeCalled();
 
         $this->preUpdate($event);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                   |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no  |
| Related tickets | |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
