### PR TITLE
[Sf6] Add UserBundle mappings to Symfony6 support

### DIFF
--- a/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
+++ b/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
@@ -29,6 +29,8 @@ final class SyliusUserBundle extends AbstractResourceBundle
 
     public function build(ContainerBuilder $container): void
     {
+        parent::build($container);
+
         $container->addCompilerPass(new RemoveUserPasswordEncoderPass());
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets | partially #13969                     |
| License         | MIT                                                          |

Fix to bug introduced in: https://github.com/Sylius/Sylius/commit/5aeecf55f8b7ba701739aa9ca8459557feae64ef#diff-da93be4b0c24ff88c728406f195e5d8843618d70ebe35fa6a971d5c48fe3f511R30. As can be seen for example here: https://github.com/Sylius/Sylius/blob/1.12/src/Sylius/Bundle/LocaleBundle/SyliusLocaleBundle.php#L25 we need to call parent build, to register related classes in doctrine. This was missing, thus following error: https://github.com/Sylius/Sylius/runs/7519764615?check_suite_focus=true pop uped.

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
