### PR TITLE
feat: create admin user from CLI

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Command;
 
 use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\Locale\Model\Locale;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
@@ -70,10 +71,7 @@ class CreateAdminUserCommand extends Command
         $adminUser->setFirstName($firstName);
         $adminUser->setLastName($lastName);
 
-        $locales = [];
-        foreach ($this->localeRepository->findAll() as $locale) {
-            $locales[] = $locale->getCode();
-        }
+        $locales = array_map(static fn (Locale $locale) => $locale->getCode(), $this->localeRepository->findAll());
 
         $localeCode = $this->io->choice('Select the locale code', $locales, 'en_US');
         $adminUser->setLocaleCode($localeCode);

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -52,6 +52,7 @@ class CreateAdminUserCommand extends Command
 
         if ($this->checkIfAdminUserExists($email)) {
             $this->io->error(sprintf('Admin user with email address %s already exists.', $email));
+
             return COMMAND::FAILURE;
         }
 

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Command;
 
 use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -12,7 +13,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\Container;
 
 #[AsCommand(
     name: 'sylius:admin-user:create',
@@ -25,7 +25,7 @@ class CreateAdminUserCommand extends Command
     public function __construct(
         private UserRepositoryInterface $adminUserRepository,
         private RepositoryInterface $localeRepository,
-        private Container $container,
+        private FactoryInterface $adminUserFactory,
     ) {
         parent::__construct();
     }
@@ -62,7 +62,7 @@ class CreateAdminUserCommand extends Command
         $password = $this->io->askHidden('Password');
 
         /** @var AdminUserInterface $adminUser */
-        $adminUser = $this->container->get('sylius.factory.admin_user')->createNew();
+        $adminUser = $this->adminUserFactory->createNew();
 
         $adminUser->setEmail($email);
         $adminUser->setPlainPassword($password);
@@ -81,7 +81,7 @@ class CreateAdminUserCommand extends Command
         $enabled = $this->io->confirm('Do you want to enabled this admin user?', true);
         $adminUser->setEnabled($enabled);
 
-        $this->container->get('sylius.repository.admin_user')->add($adminUser);
+        $this->adminUserRepository->add($adminUser);
 
         $this->io->success(sprintf('Admin user %s was successfully created', $adminUser->getEmail()));
 

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Component\Core\Model\AdminUser;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'sylius:admin-user:create',
+    description: 'Create a new admin user'
+)]
+class CreateAdminUserCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private UserRepositoryInterface $adminUserRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->title('Admin user creation');
+
+        $question = $this->io->confirm('Do you want to create an admin user ?', true);
+
+        if (!$question) {
+            return Command::INVALID;
+        }
+
+        do {
+            $email = $this->io->ask('Email', null);
+        }
+        while (!$this->validateEmail($email));
+
+        if (!$this->checkIfAdminUserExists($email)) {
+            $this->io->error(sprintf('Admin user with email address %s already exists.', $email));
+            return COMMAND::FAILURE;
+        }
+
+        $userName = $this->io->ask('Username', null);
+        $firstName = $this->io->ask('Firstname', null);
+        $lastName = $this->io->ask('Lastname', null);
+        $password = $this->io->askHidden('Password');
+
+        $adminUser = new AdminUser();
+        $adminUser->setEmail($email);
+        $adminUser->setEncoderName('argon2i');
+        $adminUser->setPlainPassword($password);
+        $adminUser->setUsername($userName);
+        $adminUser->setFirstName($firstName);
+        $adminUser->setLastName($lastName);
+        $adminUser->setLocaleCode('en_US');
+        $adminUser->setEnabled(true);
+
+        $this->entityManager->persist($adminUser);
+        $this->entityManager->flush();
+
+        $this->io->success(sprintf('Admin user %s was successfully created', $adminUser->getEmail()));
+
+        return Command::SUCCESS;
+    }
+
+    private function validateEmail(string $email): bool
+    {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->io->error('Email address is not valid. Please, enter a valid address');
+            return false;
+        }
+
+        return true;
+    }
+
+    private function checkIfAdminUserExists(string $email): bool
+    {
+        return null === $this->adminUserRepository->findOneByEmail($email);
+    }
+}
+
+

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -78,7 +78,7 @@ class CreateAdminUserCommand extends Command
         $localeCode = $this->io->choice('Select the locale code', $locales, 'en_US');
         $adminUser->setLocaleCode($localeCode);
 
-        $enabled = $this->io->confirm('Do you want to enabled this admin user ?', true);
+        $enabled = $this->io->confirm('Do you want to enabled this admin user?', true);
         $adminUser->setEnabled($enabled);
 
         $this->container->get('sylius.repository.admin_user')->add($adminUser);
@@ -92,6 +92,7 @@ class CreateAdminUserCommand extends Command
     {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
             $this->io->error('Email address is not valid. Please, enter a valid address');
+
             return false;
         }
 

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -37,9 +37,9 @@ class CreateAdminUserCommand extends Command
     {
         $this->io->title('Admin user creation');
 
-        $question = $this->io->confirm('Do you want to create an admin user ?', true);
+        $confirm = $this->io->confirm('Do you want to create an admin user ?', true);
 
-        if (!$question) {
+        if (!$confirm) {
             return Command::INVALID;
         }
 
@@ -48,7 +48,7 @@ class CreateAdminUserCommand extends Command
         }
         while (!$this->validateEmail($email));
 
-        if (!$this->checkIfAdminUserExists($email)) {
+        if ($this->checkIfAdminUserExists($email)) {
             $this->io->error(sprintf('Admin user with email address %s already exists.', $email));
             return COMMAND::FAILURE;
         }
@@ -88,8 +88,6 @@ class CreateAdminUserCommand extends Command
 
     private function checkIfAdminUserExists(string $email): bool
     {
-        return null === $this->adminUserRepository->findOneByEmail($email);
+        return null !== $this->adminUserRepository->findOneByEmail($email);
     }
 }
-
-

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -31,7 +31,7 @@
         <service id="Sylius\Bundle\AdminBundle\Command\CreateAdminUserCommand">
             <argument type="service" id="sylius.repository.admin_user" />
             <argument type="service" id="sylius.repository.locale" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="sylius.factory.admin_user" />
             <tag name="console.command" />
         </service>
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -29,9 +29,9 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\AdminBundle\Command\CreateAdminUserCommand">
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="sylius.repository.admin_user" />
             <argument type="service" id="sylius.repository.locale" />
+            <argument type="service" id="service_container" />
             <tag name="console.command" />
         </service>
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -28,6 +28,10 @@
     <services>
         <defaults public="true" />
 
+        <service id="Sylius\Bundle\AdminBundle\Command\CreateAdminUserCommand" autowire="true">
+            <tag name="console.command" />
+        </service>
+
         <service id="sylius.context.locale.admin_based" class="Sylius\Bundle\AdminBundle\Context\AdminBasedLocaleContext">
             <argument type="service" id="security.token_storage" />
             <tag name="sylius.context.locale" priority="128" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -28,7 +28,10 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Bundle\AdminBundle\Command\CreateAdminUserCommand" autowire="true">
+        <service id="Sylius\Bundle\AdminBundle\Command\CreateAdminUserCommand">
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="sylius.repository.admin_user" />
+            <argument type="service" id="sylius.repository.locale" />
             <tag name="console.command" />
         </service>
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                 |
| Bug fix?        | no                                                      |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14172                      |
| License         | MIT                                                          |

Added the command `sylius:admin-user:create` to create admin user from CLI

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
