### PR TITLE
[Maintenance] Update shop firewall logout node

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -32,6 +32,15 @@ and should be used only this way.
 are now included in every env starting with `test` keyword. If you wish to not have them, either you need to rename your env to not start 
 with test or remove these services with complier pass.
 
+6. Remove the `success_handler` node from shop's firewall
+    ```diff
+    logout:
+        path: sylius_shop_logout
+        target: sylius_shop_login
+        invalidate_session: false
+    -    success_handler: sylius.handler.shop_user_logout
+    ```
+
 ### Asset management changes
 
 We updated gulp-sass plugin as well as the sass implementation we use to be compatible with most installation

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -97,7 +97,6 @@ security:
                 path: sylius_shop_logout
                 target: sylius_shop_login
                 invalidate_session: false
-                success_handler: sylius.handler.shop_user_logout
             anonymous: true
 
         dev:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
             <argument type="service" id="sylius.context.channel.composite" />
             <argument type="service" id="sylius.storage.cart_session" />
             <argument type="service" id="security.token_storage" />
-            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LogoutEvent" dispatcher="security.event_dispatcher.shop" method="onLogout" />
+            <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LogoutEvent" dispatcher="security.event_dispatcher.shop" method="onLogout" priority="128" />
         </service>
 
         <service id="sylius.section_resolver.shop_uri_based_section_resolver" class="Sylius\Bundle\ShopBundle\SectionResolver\ShopUriBasedSectionResolver">


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #14218, related #14187                      |
| License         | MIT                                                          |

The missing interface stated in the issue is deprecated since Symfony 5.1, and all logout handler services have been deprecated in 5.4.
The handling should now be taken care of by listeners catching the `Symfony\Component\Security\Http\Event\LogoutEvent` event.

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
