### PR TITLE
[UI] Fix autocomplete empty value

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -41,10 +41,10 @@ $.fn.extend({
               value: item[choiceValue],
             }));
 
-            if (!element.hasClass('multiple')){
+            if (!element.hasClass('multiple')) {
               results.unshift({
                 name: '&nbsp;',
-                value: '&nbsp;',
+                value: '',
               });
             }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 |
| Bug fix?        | yes  |
| New feature?    | no   |
| BC breaks?      | no   |
| Deprecations?   | no   |
| Related tickets | -    |
| License         | MIT  |

Using the `&nbsp;` as value breaks non-multiple autocomplete when choosing the empty option.