### PR TITLE
[docs]Recommend cron jobs values

### DIFF
--- a/docs/cookbook/deployment/cron-jobs.rst
+++ b/docs/cookbook/deployment/cron-jobs.rst
@@ -15,6 +15,13 @@ Sylius has two vital, predefined commands designed to be run as cron jobs on you
 * ``sylius:remove-expired-carts`` - to remove carts that have expired after desired time
 * ``sylius:cancel-unpaid-orders`` - to cancel orders that are still unpaid after desired time
 
+The recommended configuration
+
+.. code-block:: bash
+
+    0 */6 * * * sh php bin/console sylius:remove-expired-carts
+    0 */6 * * * sh php bin/console sylius:sylius:cancel-unpaid-orders
+
 How to configure a CRON job ?
 -----------------------------
 

--- a/docs/cookbook/deployment/cron-jobs.rst
+++ b/docs/cookbook/deployment/cron-jobs.rst
@@ -20,7 +20,7 @@ The recommended configuration
 .. code-block:: bash
 
     0 */6 * * * sh php bin/console sylius:remove-expired-carts
-    0 */6 * * * sh php bin/console sylius:sylius:cancel-unpaid-orders
+    0 */6 * * * sh php bin/console sylius:cancel-unpaid-orders
 
 How to configure a CRON job ?
 -----------------------------


### PR DESCRIPTION
<img width="816" alt="Screenshot 2022-08-22 at 18 15 44" src="https://user-images.githubusercontent.com/17534504/185969349-e77621fd-4485-467a-9183-1d54a8e8e6e4.png">


The https://docs.sylius.com/en/1.12/cookbook/deployment/cron-jobs.html site lacks default config values. Similar we put there: https://docs.sylius.com/en/1.12/cookbook/deployment/platform-sh.html#add-default-sylius-cronjobs