### PR TITLE
[Maintenance][Security] Update shop logout handling

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -65,6 +65,13 @@ with test or remove these services with complier pass.
    -       authenticators:
    -           # ...
    +   jwt: true
+   shop:
+       logout:
+       path: sylius_shop_logout
+   -   target: sylius_shop_login
+   +   target: sylius_shop_homepage
+       invalidate_session: false
+   -   success_handler: sylius.handler.shop_user_logout
    ```
    
     and also you need to adjust all of your access_control like that:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -90,9 +90,8 @@ security:
                 remember_me_parameter: _remember_me
             logout:
                 path: sylius_shop_logout
-                target: sylius_shop_login
+                target: sylius_shop_homepage
                 invalidate_session: false
-                success_handler: sylius.handler.shop_user_logout
 
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/

--- a/features/account/signing_out.feature
+++ b/features/account/signing_out.feature
@@ -1,0 +1,16 @@
+@customer_account
+Feature: Signing out
+    In order to not leave my account open to passersby
+    As a Customer
+    I want to be able to log out of the store
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And I am a logged in customer
+        And I am browsing my orders
+
+    @ui @no-api
+    Scenario: Signing out
+        When I log out
+        Then I should be redirected to the homepage
+        And I should not be logged in

--- a/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/ShopUserLogoutHandler.php
@@ -14,34 +14,21 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Http\Event\LogoutEvent;
-use Symfony\Component\Security\Http\HttpUtils;
 
 final class ShopUserLogoutHandler
 {
     public function __construct(
-        private HttpUtils $httpUtils,
-        private string $targetUrl,
         private ChannelContextInterface $channelContext,
         private CartStorageInterface $cartStorage,
-        private TokenStorageInterface $tokenStorage,
     ) {
     }
 
-    public function onLogout(LogoutEvent $logoutEvent): void
+    public function onLogout(): void
     {
-        if ($logoutEvent->getResponse() !== null) {
-            return;
-        }
-
+        /** @var ChannelInterface $channel */
         $channel = $this->channelContext->getChannel();
         $this->cartStorage->removeForChannel($channel);
-
-        $this->tokenStorage->setToken(null);
-
-        $response = $this->httpUtils->createRedirectResponse($logoutEvent->getRequest(), $this->targetUrl);
-        $logoutEvent->setResponse($response);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -23,11 +23,8 @@
         <defaults public="true" />
 
         <service id="sylius.handler.shop_user_logout" class="Sylius\Bundle\ShopBundle\EventListener\ShopUserLogoutHandler">
-            <argument type="service" id="security.http_utils" />
-            <argument>sylius_shop_homepage</argument>
             <argument type="service" id="sylius.context.channel.composite" />
             <argument type="service" id="sylius.storage.cart_session" />
-            <argument type="service" id="security.token_storage" />
             <tag name="kernel.event_listener" event="Symfony\Component\Security\Http\Event\LogoutEvent" dispatcher="security.event_dispatcher.shop" method="onLogout" />
         </service>
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
@@ -17,46 +17,26 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
-use Symfony\Component\Security\Http\HttpUtils;
 
 final class ShopUserLogoutHandlerSpec extends ObjectBehavior
 {
     function let(
-        HttpUtils $httpUtils,
         ChannelContextInterface $channelContext,
         CartStorageInterface $cartStorage,
-        TokenStorageInterface $tokenStorage,
     ): void {
-        $this->beConstructedWith($httpUtils, '/', $channelContext, $cartStorage, $tokenStorage);
+        $this->beConstructedWith($channelContext, $cartStorage);
     }
 
-    function it_clears_cart_session_after_logging_out_and_return_default_handler_response(
+    function it_clears_cart_session_after_logging_out(
         ChannelContextInterface $channelContext,
         ChannelInterface $channel,
-        HttpUtils $httpUtils,
-        Request $request,
-        Response $response,
         CartStorageInterface $cartStorage,
         LogoutEvent $logoutEvent,
-        SessionInterface $session,
-        TokenStorageInterface $tokenStorage,
     ): void {
         $channelContext->getChannel()->willReturn($channel);
 
-        $logoutEvent->getRequest()->willReturn($request);
-        $logoutEvent->getResponse()->willReturn(null);
-        $request->getSession()->willReturn($session);
-
-        $httpUtils->createRedirectResponse($request, '/')->willReturn($response);
-
-        $tokenStorage->setToken(null)->shouldBeCalled();
         $cartStorage->removeForChannel($channel)->shouldBeCalled();
-        $logoutEvent->setResponse($response)->shouldBeCalled();
 
         $this->onLogout($logoutEvent);
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12               |
| Bug fix?        | yes                |
| New feature?    | no                 |
| BC breaks?      | ?                  |
| Deprecations?   | no                 |
| Related tickets | fixes #14218, related #14187 |
| License         | MIT                |

The missing interface stated in the issue is deprecated since Symfony 5.1, and all logout handler services have been deprecated in 5.4.
The handling should now be taken care of by listeners catching the `Symfony\Component\Security\Http\Event\LogoutEvent`.