### PR TITLE
[Adjustment] Adjustment cloning resets ID and timestamps

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -1,3 +1,7 @@
+# UPGRADE FROM `v1.11.7` TO `v1.11.8`
+
+1. Cloning `Sylius\Component\Order\Model\Adjustment` resets values of fields `id`, `createdAt` and `updatedAt`.
+
 # UPGRADE FROM `v1.11.6` TO `v1.11.7`
 
 1. Method `Sylius\Component\Channel\Repository\ChannelRepository::findOneByHostname` has become deprecated, use

--- a/src/Sylius/Component/Order/Model/Adjustment.php
+++ b/src/Sylius/Component/Order/Model/Adjustment.php
@@ -57,6 +57,13 @@ class Adjustment implements AdjustmentInterface
         $this->createdAt = new \DateTime();
     }
 
+    public function __clone()
+    {
+        $this->id = null;
+        $this->createdAt = new \DateTime();
+        $this->updatedAt = null;
+    }
+
     public function getId()
     {
         return $this->id;

--- a/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
@@ -240,4 +240,13 @@ final class AdjustmentSpec extends ObjectBehavior
         $this->setDetails(['taxRateAmount' => 0.1]);
         $this->getDetails()->shouldReturn(['taxRateAmount' => 0.1]);
     }
+
+    function it_resets_internal_information_while_cloning(): void
+    {
+        $this->setUpdatedAt(new \DateTime());
+        $new = clone $this->getWrappedObject();
+
+        $this->getCreatedAt()->shouldNotBe($new->getCreatedAt());
+        $this->getUpdatedAt()->shouldNotBe($new->getUpdatedAt());
+    }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                 |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

Makes adjustments easier to spread between orders/shipments.