### PR TITLE
Fix ProvinceAddressConstraintValidator

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -81,7 +81,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
         }
 
         /** @var ProvinceInterface|null $province */
-        $province = $this->provinceRepository->findOneBy(['code' => $address->getProvinceCode()]);
+        $province = $this->provinceRepository->findOneBy(['code' => $address->getProvinceCode(), 'country' => $country]);
 
         if (null === $province) {
             return false;


### PR DESCRIPTION
Currently, provinces validation can fail for provinces sharing the same code, like for example "WI", used by both USA Wisconsin and Austria's Wien.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT
