### PR TITLE
Fix incorrect JSON format in database migration

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -70,7 +70,7 @@ final class Version20201208105207 extends AbstractMigration
             }
         }
 
-        return json_encode($parsedDetails);
+        return str_replace('\\', '\\\\', json_encode($parsedDetails));
     }
 
     private function setDefaultAdjustmentData(): void


### PR DESCRIPTION
Fix the following MySQL error:
```txt
  An exception occurred while executing 'UPDATE sylius_adjustment SET shipment_id = 50889, details = '{"shippingMethodCode":"5","shippingMethodName":"\"______\" _____\u0101__"}' WHERE id = 694687':

  SQLSTATE[22032]: <<Unknown error>>: 3140 Invalid JSON text: "Missing a comma or '}' after an object member." at position 49 in value for column 'sylius
  _adjustment.details'.
```

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.9                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | n/a                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
