### PR TITLE
[CatalogPromotions][API] Removal of catalog promotions

### DIFF
--- a/features/promotion/removing_catalog_promotions/removing_catalog_promotions.feature
+++ b/features/promotion/removing_catalog_promotions/removing_catalog_promotions.feature
@@ -13,37 +13,36 @@ Feature: Removing a catalog promotions
         And there is a catalog promotion "Winter Sale" that reduces price by "30%" and applies on "Clothes" taxon
         And I am logged in as an administrator
 
-    @api @ui @todo
+    @api
     Scenario: Removing an expired catalog promotion
         Given it is "2022-08-22" now
         And the catalog promotion "Winter sale" operates between "2021-12-20" and "2021-12-30"
-        When I remove a "Winter Sale" catalog promotion
-        Then I should be notified that it has been successfully deleted
+        When I request the removal of "Winter Sale" catalog promotion
+        Then I should be notified that the removal operation has started successfully
         And there should be an empty list of catalog promotions
         And "PHP T-Shirt" variant should not be discounted
 
-    @api @ui @todo
+    @api
     Scenario: Removing an active catalog promotion without any time limits
-        When I remove a "Winter Sale" catalog promotion
-        Then I should be notified that it has been successfully deleted
+        When I request the removal of "Winter Sale" catalog promotion
+        Then I should be notified that the removal operation has started successfully
         And there should be an empty list of catalog promotions
         And "PHP T-Shirt" variant should not be discounted
 
-    @api @ui @todo
+    @api
     Scenario: Removing an active catalog promotion in the time range
         Given it is "2022-12-15" now
         And the catalog promotion "Winter sale" operates between "2022-12-01" and "2022-12-30"
-        When I remove a "Winter Sale" catalog promotion
-        Then I should be notified that it has been successfully deleted
+        When I request the removal of "Winter Sale" catalog promotion
+        Then I should be notified that the removal operation has started successfully
         And there should be an empty list of catalog promotions
         And "PHP T-Shirt" variant should not be discounted
 
-    @api @ui @todo
+    @api
     Scenario: Removing a scheduled catalog promotion
         Given it is "2022-08-22" now
         And the catalog promotion "Winter sale" operates between "2022-12-01" and "2023-02-28"
-        When I remove a "Winter Sale" catalog promotion
-        Then I should be notified that it has been successfully deleted
+        When I request the removal of "Winter Sale" catalog promotion
+        Then I should be notified that the removal operation has started successfully
         And there should be an empty list of catalog promotions
         And "PHP T-Shirt" variant should not be discounted
-

--- a/src/Sylius/Behat/Client/ResponseChecker.php
+++ b/src/Sylius/Behat/Client/ResponseChecker.php
@@ -62,6 +62,11 @@ final class ResponseChecker implements ResponseCheckerInterface
         return $this->getResponseContentValue($response, 'hydra:description');
     }
 
+    public function isAccepted(Response $response): bool
+    {
+        return $response->getStatusCode() === Response::HTTP_ACCEPTED;
+    }
+
     public function isCreationSuccessful(Response $response): bool
     {
         return $response->getStatusCode() === Response::HTTP_CREATED;

--- a/src/Sylius/Behat/Client/ResponseCheckerInterface.php
+++ b/src/Sylius/Behat/Client/ResponseCheckerInterface.php
@@ -31,6 +31,8 @@ interface ResponseCheckerInterface
 
     public function getError(Response $response): string;
 
+    public function isAccepted(Response $response): bool;
+
     public function isCreationSuccessful(Response $response): bool;
 
     public function isUpdateSuccessful(Response $response): bool;

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -899,6 +899,25 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I request the removal of :catalogPromotion catalog promotion
+     */
+    public function iRequestTheRemovalOfCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
+    {
+        $this->client->delete(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
+    }
+
+    /**
+     * @Then I should be notified that the removal operation has started successfully
+     */
+    public function iShouldBeNotifiedThatTheRemovalOperationHasStartedSuccessfully(): void
+    {
+        Assert::true(
+            $this->responseChecker->isAccepted($this->client->getLastResponse()),
+            'Removal operation has not started successfully',
+        );
+    }
+
+    /**
      * @Then there should be :amount new catalog promotion on the list
      * @Then there should be :amount catalog promotions on the list
      * @Then there should be an empty list of catalog promotions

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -43,6 +43,7 @@ imports:
     - suites/api/promotion/managing_catalog_promotions.yml
     - suites/api/promotion/managing_promotions.yml
     - suites/api/promotion/receiving_discount.yml
+    - suites/api/promotion/removing_catalog_promotions.yml
     - suites/api/shipping/applying_shipping_method_rules.yml
     - suites/api/shipping/viewing_shipping_methods.yml
     - suites/api/shipping/managing_shipments.yml

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/removing_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/removing_catalog_promotions.yml
@@ -1,0 +1,32 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        api_removing_catalog_promotions:
+            contexts:
+                - sylius.behat.context.hook.doctrine_orm
+                - Sylius\Calendar\Tests\Behat\Context\Hook\CalendarContext
+
+                - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.locale
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.product_variant
+                - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.taxon
+                - Sylius\Behat\Context\Transform\CatalogPromotionContext
+
+                - sylius.behat.context.setup.admin_api_security
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.product_taxon
+                - sylius.behat.context.setup.taxonomy
+                - Sylius\Behat\Context\Setup\CatalogPromotionContext
+                - Sylius\Calendar\Tests\Behat\Context\Setup\CalendarContext
+
+                - sylius.behat.context.api.admin.managing_catalog_promotions
+                - sylius.behat.context.api.shop.product_variant
+
+            filters:
+                tags: "@removing_catalog_promotions&&@api"

--- a/src/Sylius/Bundle/ApiBundle/Controller/RemoveCatalogPromotionAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/RemoveCatalogPromotionAction.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Controller;
+
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessorInterface;
+use Sylius\Component\Promotion\Exception\CatalogPromotionNotFoundException;
+use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/** @experimental */
+final class RemoveCatalogPromotionAction
+{
+    public function __construct(
+        private CatalogPromotionRemovalProcessorInterface $catalogPromotionRemovalProcessor
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        try {
+            $this->catalogPromotionRemovalProcessor->removeCatalogPromotion($request->attributes->get('code'));
+
+            return new Response(status: Response::HTTP_ACCEPTED);
+        } catch (CatalogPromotionNotFoundException) {
+            return new JsonResponse(status: Response::HTTP_NOT_FOUND);
+        } catch (InvalidCatalogPromotionStateException $exception) {
+            return new JsonResponse(
+                ['code' => Response::HTTP_BAD_REQUEST, 'message' => $exception->getMessage()],
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
@@ -82,6 +82,7 @@ Example configuration for `percentage_discount` action type:
                     <attribute name="groups">admin:catalog_promotion:read</attribute>
                 </attribute>
             </itemOperation>
+
             <itemOperation name="shop_get">
                 <attribute name="path">/shop/catalog-promotions/{code}</attribute>
                 <attribute name="method">GET</attribute>
@@ -126,6 +127,12 @@ Example configuration for `percentage_discount` action type:
 ```
                     </attribute>
                 </attribute>
+            </itemOperation>
+
+            <itemOperation name="admin_delete">
+                <attribute name="method">DELETE</attribute>
+                <attribute name="path">/admin/catalog-promotions/{code}</attribute>
+                <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\RemoveCatalogPromotionAction</attribute>
             </itemOperation>
         </itemOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -93,6 +93,10 @@
             <argument type="service" id="sylius.command_bus" />
         </service>
 
+        <service id="Sylius\Bundle\ApiBundle\Controller\RemoveCatalogPromotionAction" public="true">
+            <argument type="service" id="Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessorInterface" />
+        </service>
+
         <service id="Sylius\Bundle\ApiBundle\DataProvider\ChannelAwareItemDataProvider" decorates="api_platform.item_data_provider">
             <argument type="service" id="Sylius\Bundle\ApiBundle\DataProvider\ChannelAwareItemDataProvider.inner" />
             <argument type="service" id="sylius.context.channel" />

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CatalogPromotion\Command;
+
+final class RemoveInactiveCatalogPromotion
+{
+    public function __construct(public string $code)
+    {
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CatalogPromotion\CommandHandler;
+
+use Doctrine\ORM\EntityManager;
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Command\RemoveInactiveCatalogPromotion;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
+use Sylius\Component\Promotion\Model\CatalogPromotionStates;
+use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
+
+final class RemoveInactiveCatalogPromotionHandler
+{
+    public function __construct(
+        private CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        private EntityManager $entityManager,
+    ) {
+    }
+
+    public function __invoke(RemoveInactiveCatalogPromotion $command): void
+    {
+        /** @var CatalogPromotionInterface|null $catalogPromotion */
+        $catalogPromotion = $this->catalogPromotionRepository->findOneBy(['code' => $command->code]);
+
+        if (null === $catalogPromotion) {
+            return;
+        }
+
+        if ($catalogPromotion->getState() !== CatalogPromotionStates::STATE_INACTIVE) {
+            throw new InvalidCatalogPromotionStateException(
+                sprintf(
+                    'Catalog promotion with code "%s" cannot be removed as it is not in an inactive state.',
+                    $catalogPromotion->getCode()
+                )
+            );
+        }
+
+        $this->entityManager->remove($catalogPromotion);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
+
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Command\RemoveInactiveCatalogPromotion;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
+use Sylius\Component\Promotion\Exception\CatalogPromotionNotFoundException;
+use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
+use Sylius\Component\Promotion\Model\CatalogPromotionStates;
+use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CatalogPromotionRemovalProcessor implements CatalogPromotionRemovalProcessorInterface
+{
+    public function __construct(
+        private CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        private MessageBusInterface $commandBus,
+        private MessageBusInterface $eventBus,
+    ) {
+    }
+
+    public function removeCatalogPromotion(string $catalogPromotionCode): void
+    {
+        /** @var CatalogPromotionInterface|null $catalogPromotion */
+        $catalogPromotion = $this->getCatalogPromotion($catalogPromotionCode);
+
+        if ($catalogPromotion->getState() === CatalogPromotionStates::STATE_INACTIVE) {
+            $this->announceInactiveCatalogPromotionRemoval($catalogPromotionCode);
+
+            return;
+        }
+
+        if ($catalogPromotion->getState() === CatalogPromotionStates::STATE_ACTIVE) {
+            $this->disableCatalogPromotion($catalogPromotion);
+            $this->announceCatalogPromotionEnd($catalogPromotionCode);
+            $this->announceInactiveCatalogPromotionRemoval($catalogPromotionCode);
+
+            return;
+        }
+
+        if ($catalogPromotion->getState() === CatalogPromotionStates::STATE_PROCESSING) {
+            throw new InvalidCatalogPromotionStateException(
+                sprintf(
+                    'Catalog promotion with code "%s" cannot be removed as it is now being processed.',
+                    $catalogPromotionCode
+                )
+            );
+        }
+
+        throw new \DomainException('Invalid catalog promotion state.');
+    }
+
+    private function announceCatalogPromotionEnd(string $catalogPromotionCode): void
+    {
+        $this->eventBus->dispatch(new CatalogPromotionEnded($catalogPromotionCode));
+    }
+
+    private function announceInactiveCatalogPromotionRemoval(string $catalogPromotionCode): void
+    {
+        $this->commandBus->dispatch(new RemoveInactiveCatalogPromotion($catalogPromotionCode));
+    }
+
+    private function disableCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
+    {
+        $catalogPromotion->setEnabled(false);
+    }
+
+    private function getCatalogPromotion(string $catalogPromotionCode): CatalogPromotionInterface
+    {
+        /** @var CatalogPromotionInterface|null $catalogPromotion */
+        $catalogPromotion = $this->catalogPromotionRepository->findOneBy(['code' => $catalogPromotionCode]);
+
+        if (null === $catalogPromotion) {
+            throw new CatalogPromotionNotFoundException('Catalog promotion with given code does not exist.');
+        }
+
+        return $catalogPromotion;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
+
+interface CatalogPromotionRemovalProcessorInterface
+{
+    public function removeCatalogPromotion(string $catalogPromotionCode): void;
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/messenger.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/messenger.yaml
@@ -1,18 +1,30 @@
 framework:
     messenger:
-        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
-
         transports:
-        # https://symfony.com/doc/current/messenger.html#transport-configuration
-            main: '%env(MESSENGER_TRANSPORT_DSN)%'
-
+            main: 
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                failure_transport: 'main_failed'
+            main_failed: 
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    queue_name: 'main_failed'
+            catalog_promotion_removal: 
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                failure_transport: 'catalog_promotion_removal_failed'
+                options:
+                    queue_name: 'catalog_promotion_removal'
+            catalog_promotion_removal_failed:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    queue_name: 'catalog_promotion_removal_failed'
+        reset_on_message: true
         routing:
             'Sylius\Bundle\CoreBundle\CatalogPromotion\Command\UpdateCatalogPromotionState': main
             'Sylius\Bundle\CoreBundle\CatalogPromotion\Command\ApplyCatalogPromotionsOnVariants': main
+            'Sylius\Bundle\CoreBundle\CatalogPromotion\Command\RemoveInactiveCatalogPromotion': catalog_promotion_removal
             'Sylius\Component\Promotion\Event\CatalogPromotionCreated': main
             'Sylius\Component\Promotion\Event\CatalogPromotionEnded': main
             'Sylius\Component\Promotion\Event\CatalogPromotionUpdated': main
-
         default_bus: sylius.command_bus
         buses:
             sylius.command_bus: &command_bus

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/command_handlers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/command_handlers.xml
@@ -23,6 +23,12 @@
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
+        <service id="Sylius\Bundle\CoreBundle\CatalogPromotion\CommandHandler\RemoveInactiveCatalogPromotionHandler">
+            <argument type="service" id="sylius.repository.catalog_promotion" />
+            <argument type="service" id="sylius.manager.catalog_promotion"/>
+            <tag name="messenger.message_handler" bus="sylius.command_bus" />
+        </service>
+
         <service id="Sylius\Bundle\CoreBundle\CatalogPromotion\CommandHandler\UpdateCatalogPromotionStateHandler">
             <argument type="service" id="Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionStateProcessorInterface" />
             <argument type="service" id="sylius.repository.catalog_promotion" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/processors.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/catalog_promotion/processors.xml
@@ -49,5 +49,14 @@
         >
             <argument type="service" id="Sylius\Bundle\CoreBundle\CatalogPromotion\CommandDispatcher\ApplyCatalogPromotionsOnVariantsCommandDispatcherInterface" />
         </service>
+
+        <service
+            id="Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessorInterface"
+            class="Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessor"
+        >
+            <argument type="service" id="sylius.repository.catalog_promotion" />
+            <argument type="service" id="sylius.command_bus" />
+            <argument type="service" id="sylius.event_bus" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandlerSpec.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\CatalogPromotion\CommandHandler;
+
+use Doctrine\ORM\EntityManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Command\RemoveInactiveCatalogPromotion;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
+use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
+
+final class RemoveInactiveCatalogPromotionHandlerSpec extends ObjectBehavior
+{
+    public function let(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        EntityManager $entityManager,
+    ): void {
+        $this->beConstructedWith($catalogPromotionRepository, $entityManager);
+    }
+
+    public function it_removes_an_inactive_catalog_promotion(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        EntityManager $entityManager,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('inactive');
+
+        $this(new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE'));
+
+        $entityManager->remove($catalogPromotion)->shouldBeCalled();
+    }
+
+    public function it_throws_an_exception_if_catalog_promotion_is_not_in_an_inactive_state(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        EntityManager $entityManager,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('active');
+        $catalogPromotion->getCode()->willReturn('CATALOG_PROMOTION_CODE');
+
+        $entityManager->remove(Argument::any())->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(InvalidCatalogPromotionStateException::class)
+            ->during('__invoke', [new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE')])
+        ;
+    }
+
+    public function it_returns_if_there_is_no_catalog_promotion_with_given_code(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        EntityManager $entityManager,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn(null);
+
+        $entityManager->remove(Argument::any())->shouldNotBeCalled();
+
+        $this(new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE'));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorSpec.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\CatalogPromotion\Command\RemoveInactiveCatalogPromotion;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Event\CatalogPromotionEnded;
+use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
+use Sylius\Component\Promotion\Exception\CatalogPromotionNotFoundException;
+use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
+use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class CatalogPromotionRemovalProcessorSpec extends ObjectBehavior
+{
+    public function let(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+    ): void {
+        $this->beConstructedWith($catalogPromotionRepository, $commandBus, $eventBus);
+    }
+
+    public function it_removes_an_active_catalog_promotion_by_disabling_it_and_dispatching_catalog_promotion_ended_event_and_remove_inactive_catalog_promotion_command(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('active');
+
+        $catalogPromotion->setEnabled(false)->shouldBeCalled();
+
+        $event = new CatalogPromotionEnded('CATALOG_PROMOTION_CODE');
+        $command = new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE');
+
+        $eventBus->dispatch($event)->willReturn(new Envelope($event));
+        $commandBus->dispatch($command)->willReturn(new Envelope($command));
+
+        $this->removeCatalogPromotion('CATALOG_PROMOTION_CODE');
+    }
+
+    public function it_removes_an_inactive_catalog_promotion_by_dispatching_remove_inactive_catalog_promotion_command_without_recalculating_the_catalog(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('inactive');
+
+        $catalogPromotion->setEnabled(Argument::any())->shouldNotBeCalled();
+
+        $event = new CatalogPromotionEnded('CATALOG_PROMOTION_CODE');
+        $command = new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE');
+
+        $eventBus->dispatch($event)->shouldNotBeCalled();
+        $commandBus->dispatch($command)->willReturn(new Envelope($command));
+
+        $this->removeCatalogPromotion('CATALOG_PROMOTION_CODE');
+    }
+
+    public function it_does_not_dispatch_any_events_and_commands_if_catalog_promotion_from_command_does_not_exist(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn(null);
+
+        $catalogPromotion->getState()->shouldNotBeCalled();
+
+        $catalogPromotion->setEnabled(Argument::any())->shouldNotBeCalled();
+
+        $event = new CatalogPromotionUpdated('CATALOG_PROMOTION_CODE');
+        $command = new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE');
+
+        $eventBus->dispatch($event)->shouldNotBeCalled();
+        $commandBus->dispatch($command)->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(CatalogPromotionNotFoundException::class)
+            ->during('removeCatalogPromotion', ['CATALOG_PROMOTION_CODE'])
+        ;
+    }
+
+    public function it_throws_an_exception_if_catalog_promotion_is_being_processed(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('processing');
+
+        $catalogPromotion->setEnabled(Argument::any())->shouldNotBeCalled();
+
+        $event = new CatalogPromotionEnded('CATALOG_PROMOTION_CODE');
+        $command = new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE');
+
+        $eventBus->dispatch($event)->shouldNotBeCalled();
+        $commandBus->dispatch($command)->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(InvalidCatalogPromotionStateException::class)
+            ->during('removeCatalogPromotion', ['CATALOG_PROMOTION_CODE'])
+        ;
+    }
+
+    public function it_throws_an_exception_if_catalog_promotion_state_is_out_of_invalid_one(
+        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
+        MessageBusInterface $commandBus,
+        MessageBusInterface $eventBus,
+        CatalogPromotionInterface $catalogPromotion,
+    ): void {
+        $catalogPromotionRepository->findOneBy(['code' => 'CATALOG_PROMOTION_CODE'])->willReturn($catalogPromotion);
+
+        $catalogPromotion->getState()->willReturn('invalid_state');
+
+        $catalogPromotion->setEnabled(Argument::any())->shouldNotBeCalled();
+
+        $event = new CatalogPromotionEnded('CATALOG_PROMOTION_CODE');
+        $command = new RemoveInactiveCatalogPromotion('CATALOG_PROMOTION_CODE');
+
+        $eventBus->dispatch($event)->shouldNotBeCalled();
+        $commandBus->dispatch($command)->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(\DomainException::class)
+            ->during('removeCatalogPromotion', ['CATALOG_PROMOTION_CODE'])
+        ;
+    }
+}

--- a/src/Sylius/Component/Promotion/Exception/CatalogPromotionNotFoundException.php
+++ b/src/Sylius/Component/Promotion/Exception/CatalogPromotionNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Promotion\Exception;
+
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+final class CatalogPromotionNotFoundException extends ResourceNotFoundException
+{
+}

--- a/src/Sylius/Component/Promotion/Exception/InvalidCatalogPromotionStateException.php
+++ b/src/Sylius/Component/Promotion/Exception/InvalidCatalogPromotionStateException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Promotion\Exception;
+
+final class InvalidCatalogPromotionStateException extends \RuntimeException
+{
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | no                                                 |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

This PR introduced a way to remove catalog promotions. As this operation may have an impact on the prices of the products, it is divided into two parts. First, ( if catalog promotion is eligible ) disabling considered promotion, and second, actually remove it. We can take advantage of Symfony messenger and the prepared configuration of three transports ( failed included ) or perform it without the messenger - synchronously.

<img width="860" alt="image" src="https://user-images.githubusercontent.com/40125720/187917517-9d6de750-f94c-470b-89fc-5acdfd3ed98b.png">

Configuration of transports:
<img width="566" alt="image" src="https://user-images.githubusercontent.com/40125720/190244016-0f251cc6-8a0f-4255-8fbb-90308e1acb64.png">

