### PR TITLE
[ProductAttributes] Change translatable status to yes/no in ProductAttributes grid

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_attribute.yml
@@ -30,7 +30,7 @@ sylius_grid:
                     label: sylius.ui.translatable
                     sortable: ~
                     options:
-                        template: "@SyliusUi/Grid/Field/enabled.html.twig"
+                        template: "@SyliusUi/Grid/Field/yesNo.html.twig"
             filters:
                 code:
                     type: string


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
We decided to change `enabled/disabled` status of `translatable` to `yes/no` as it seems to be more accurate in this case
![image](https://user-images.githubusercontent.com/53942444/188644931-ee7bb992-f978-4dc5-bac4-d3e1fa237e09.png)
