### PR TITLE
[Api] Change int to integer in ProductVariant and ShippingMethod documentation normalizers

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductVariantDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductVariantDocumentationNormalizer.php
@@ -32,7 +32,7 @@ final class ProductVariantDocumentationNormalizer implements NormalizerInterface
         $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
 
         $docs['components']['schemas']['ProductVariant.jsonld-shop.product_variant.read']['properties']['price'] = [
-            'type' => 'int',
+            'type' => 'integer',
             'readOnly' => true,
             'default' => 0,
         ];
@@ -43,7 +43,7 @@ final class ProductVariantDocumentationNormalizer implements NormalizerInterface
         ];
 
         $docs['components']['schemas']['ProductVariant.jsonld-shop.product_variant.read']['properties']['originalPrice'] = [
-            'type' => 'int',
+            'type' => 'integer',
             'readOnly' => true,
             'default' => 0,
         ];

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ShippingMethodDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ShippingMethodDocumentationNormalizer.php
@@ -32,7 +32,7 @@ final class ShippingMethodDocumentationNormalizer implements NormalizerInterface
         $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
 
         $docs['components']['schemas']['ShippingMethod.jsonld-shop.shipping_method.read']['properties']['price'] = [
-            'type' => 'int',
+            'type' => 'integer',
             'readOnly' => true,
             'default' => 0,
         ];


### PR DESCRIPTION
In the `ProductVariantDocumentationNormalizer`, the `price` and `originalPrice` properties have a manual configuration pushed to the array. In this config, `type` is defined as `int`. The issue here is that `int` is not a valid OpenApi data type. 

The same issue occurs with the `price` property in `ShippingMethodDocumentationNormalizer`.  

This fix simply changes `int` to `integer` for the above three properties. 

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11             |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                     |
| Deprecations?   | no |
| Related tickets |                   |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
