### PR TITLE
[CatalogPromotions][Swagger] HTTP Response statuses documented for CatalogPromotion removing

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
@@ -133,6 +133,19 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="method">DELETE</attribute>
                 <attribute name="path">/admin/catalog-promotions/{code}</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\RemoveCatalogPromotionAction</attribute>
+                <attribute name="openapi_context">
+                    <attribute name="responses">
+                        <attribute name="202">
+                            <attribute name="description">CatalogPromotion resource removal request accepted</attribute>
+                        </attribute>
+                        <attribute name="400">
+                            <attribute name="description">Invalid CatalogPromotion state</attribute>
+                        </attribute>
+                        <attribute name="404">
+                            <attribute name="description">Resource not found</attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
             </itemOperation>
         </itemOperations>
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | https://github.com/Sylius/Sylius/pull/14270
| License         | MIT                                                          |

Missing swagger responses block:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/40125720/190454287-24f1268f-51b3-4998-a01c-33825f3e68e5.png">

