### PR TITLE
Widen ramsey/uuid version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "php-http/message-factory": "^1.0",
         "psr/cache": "^2.0",
         "psr/log": "^2.0",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.0|^4.0",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",
         "swiftmailer/swiftmailer": "^6.2",


### PR DESCRIPTION
This commit allows Sylius to use either version 3 or version 4 of the UUID package. Limiting Sylius to just 3.9.x causes deprecation notices because it doesn't implement a return type on JsonSerializable, whereas this is fixed in 4.x.

If downstream consumers rely on behavior specific to 3.x, they can continue using that. However, consumers who wish to upgrade to 4.x can do so without breaking Sylius.

-----

I've followed the documentation at: https://uuid.ramsey.dev/en/stable/upgrading/3-to-4.html as well as manually testing with both 3.0, 3.9, 4.0, and 4.5.

-----

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                                                         |
| Bug fix?        | no                                                           |
| New feature?    | no                                                           |
| BC breaks?      | no                                                           |
| Deprecations?   | no                                                           |
| Related tickets | N/A                                                          |
| License         | MIT                                                          |