### PR TITLE
[UI] removed important flag from the button class

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
@@ -1165,7 +1165,7 @@ select.ui.dropdown {
 .ui.labeled.button,
 .ui.labeled.icon.button,
 .buttons .ui.labeled.icon.button {
-    display: inline-block !important;
+    display: inline-block;
     background: transparent !important;
     font-size: 15px !important;
     border-radius: 4px !important;


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | https://github.com/Sylius/Sylius/pull/13806
| License         | MIT                                                          |

This PR fixes a bug on the offer view
The previous Sylius layout:
<img width="1381" alt="image" src="https://user-images.githubusercontent.com/40125720/191003290-00b9d11c-5730-40ae-a0dc-ae7c11adf335.png">
Fixes:
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/40125720/191003706-335a3f6a-05b3-4474-8ced-3098f919259b.png">

