### PR TITLE
[Behat][PostgreSQL] Fix removing items from cart

### DIFF
--- a/features/cart/shopping_cart/seeing_shipping_costs_only_when_required.feature
+++ b/features/cart/shopping_cart/seeing_shipping_costs_only_when_required.feature
@@ -29,6 +29,6 @@ Feature: Seeing shipping costs only when order requires shipping
     Scenario: Not seeing free cost if the order items that require shipping are removed
         Given I have "Guards! Guards! - book" variant of this product in the cart
         When I add "Guards! Guards! - ebook" variant of this product to the cart
-        And I remove product "Guards! Guards!" from the cart
+        And I remove "Guards! Guards! - book" variant from the cart
         Then I see the summary of my cart
         And I should not see shipping total for my cart

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -206,6 +206,15 @@ final class CartContext implements Context
     }
 
     /**
+     * @When /^I remove ("[^"]+" variant) from the (cart)$/
+     */
+    public function iRemoveVariantFromTheCart(ProductVariantInterface $variant, string $tokenValue): void
+    {
+        $itemResponse = $this->getOrderItemResponseFromProductVariantInCart($variant, $tokenValue);
+        $this->removeOrderItemFromCart((string) $itemResponse['id'], $tokenValue);
+    }
+
+    /**
      * @When I pick up (my )cart (again)
      * @When I pick up cart in the :localeCode locale
      * @When the visitor picks up the cart
@@ -847,6 +856,20 @@ final class CartContext implements Context
         foreach ($items as $item) {
             $response = $this->getProductForItem($item);
             if ($this->responseChecker->hasValue($response, 'code', $product->getCode())) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function getOrderItemResponseFromProductVariantInCart(ProductVariantInterface $variant, string $tokenValue): ?array
+    {
+        $items = $this->responseChecker->getValue($this->shopClient->show(Resources::ORDERS, $tokenValue), 'items');
+
+        foreach ($items as $item) {
+            $response = $this->getProductVariantForItem($item);
+            if ($this->responseChecker->hasValue($response, 'code', $variant->getCode())) {
                 return $item;
             }
         }

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -24,6 +24,7 @@ use Sylius\Behat\Page\Shop\Product\ShowPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\SessionManagerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductOptionInterface;
 use Webmozart\Assert\Assert;
@@ -88,6 +89,16 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
         $this->summaryPage->removeProduct($productName);
+    }
+
+    /**
+     * @When I remove :variant variant from the cart
+     */
+    public function iRemoveVariantFromTheCart(ProductVariantInterface $variant): void
+    {
+        $this->summaryPage->open();
+        $product = $variant->getProduct();
+        $this->summaryPage->removeProduct($product->getName());
     }
 
     /**


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | yes?                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | fixes #14336 |
| License         | MIT                                                          |

It is a little bit strange to me, because the build was green (yesterday) in PR with enabling Behat tests for Postgres, but it seems that this scenario is failing (randomly?) because of the different order of items compared to MySQL. As I've reproduced that locally, I was able to fix that 😃 

Failing build: https://github.com/Sylius/Sylius/actions/runs/3099676219/jobs/5026644424#step:26:517
<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
