### PR TITLE
[Maintenance] Bump doctrine/orm minimal version to 2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.0.1",
         "doctrine/inflector": "^1.4 || ^2.0",
         "doctrine/migrations": "^3.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.13",
         "egulias/email-validator": "^3.1",
         "enshrined/svg-sanitize": "^0.15.4",
         "fakerphp/faker": "^1.9",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | -                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We agreed we already have a code making it impossible to use a lower version than `2.13`, so this PR comes with a minimal version bump 💃🏻.
