### PR TITLE
Fix ORM call method in images listener on 1.12

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
@@ -37,7 +37,7 @@ final class ImagesRemoveListener
 
     public function onFlush(OnFlushEventArgs $event): void
     {
-        foreach ($event->getObjectManager()->getUnitOfWork()->getScheduledEntityDeletions() as $entityDeletion) {
+        foreach ($event->getEntityManager()->getUnitOfWork()->getScheduledEntityDeletions() as $entityDeletion) {
             if (!$entityDeletion instanceof ImageInterface) {
                 continue;
             }

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
@@ -45,7 +45,7 @@ final class ImagesRemoveListenerSpec extends ObjectBehavior
         ImageInterface $image,
         ProductInterface $product,
     ): void {
-        $event->getObjectManager()->willReturn($entityManager);
+        $event->getEntityManager()->willReturn($entityManager);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork);
         $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                |
| Bug fix?        | yes                                                       |
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #14347                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
