### PR TITLE
[Catalog Promotions] Add `_sylius.alias` to the routings

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/catalog_promotion.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/catalog_promotion.yaml
@@ -25,6 +25,7 @@ sylius_admin_catalog_promotion_show:
             section: admin
             template: "@SyliusAdmin/CatalogPromotion/show.html.twig"
             permission: true
+            alias: catalog_promotion
 
 sylius_admin_catalog_promotion_delete:
     path: /catalog-promotions/{code}
@@ -34,3 +35,4 @@ sylius_admin_catalog_promotion_delete:
         _sylius:
             section: admin
             permission: true
+            alias: catalog_promotion


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

It might be useful while filtering Sylius actions for being aware of which one belongs to the Catalog Promotion.