### PR TITLE
[Maintenance] Fix setting sylius_ui.use_webpack parameter

### DIFF
--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -78,7 +78,7 @@ final class SyliusUiExtension extends Extension implements PrependExtensionInter
 
     public function prepend(ContainerBuilder $container): void
     {
-        $useWebpack = $this->getCurrentConfiguration($container)['use_webpack'] ?? true;
+        $useWebpack = $this->isWebpackEnabled($container);
 
         $container->setParameter('sylius_ui.use_webpack', $useWebpack);
 
@@ -98,13 +98,17 @@ final class SyliusUiExtension extends Extension implements PrependExtensionInter
         }
     }
 
-    private function getCurrentConfiguration(ContainerBuilder $container): array
+    private function isWebpackEnabled(ContainerBuilder $container): bool
     {
         /** @var ConfigurationInterface $configuration */
-        $configuration = $this->getConfiguration([], $container);
-
         $configs = $container->getExtensionConfig($this->getAlias());
 
-        return $this->processConfiguration($configuration, $configs);
+        foreach (array_reverse($configs) as $config) {
+            if (isset($config['use_webpack'])) {
+                return (bool) $config['use_webpack'];
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
@@ -77,6 +77,27 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /** @test */
+    public function it_uses_webpack_when_parameter_is_not_defined(): void
+    {
+        $this->container->setParameter('kernel.debug', true);
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_ui.use_webpack', true);
+    }
+
+    /** @test */
+    public function it_doesnt_use_webpack_when_parameter_is_set_to_false(): void
+    {
+        $this->container->setParameter('kernel.debug', true);
+        $this->container->prependExtensionConfig('sylius_ui', ['use_webpack' => false]);
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_ui.use_webpack', false);
+    }
+
     protected function getContainerExtensions(): array
     {
         return [new SyliusUiExtension()];


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes, but only affects 1.12                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

Previous way how we've been handling configuring `sylius_ui.use_webpack` was causing bugs e.g. on our demo.

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
