### PR TITLE
[Products][Admin][UI] Display the channel name instead of the channel code in the variant list

### DIFF
--- a/features/product/viewing_product_in_admin_panel/viewing_details_of_product_with_variants.feature
+++ b/features/product/viewing_product_in_admin_panel/viewing_details_of_product_with_variants.feature
@@ -41,8 +41,8 @@ Feature: Viewing details of a product with variants
     Scenario: Viewing variants block
         When I access "Iron Shield" product page
         Then I should see 2 variants
-        And I should see "Iron shield - very big" variant with code "123456789-xl", priced "$25.00" and current stock 5
-        And I should see "Iron shield - very small" variant with code "123456789-xs", priced "$15.00" and current stock 12
+        And I should see "Iron shield - very big" variant with code "123456789-xl", priced "$25.00" and current stock 5 and in "United States" channel
+        And I should see "Iron shield - very small" variant with code "123456789-xs", priced "$15.00" and current stock 12 and in "United States" channel
 
     @ui @javascript
     Scenario: Viewing media block

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
@@ -329,11 +329,22 @@ final class ProductShowPageContext implements Context
     }
 
     /**
-     * @Then I should see :variantName variant with code :code, priced :price and current stock :currentStock
+     * @Then I should see :variantName variant with code :code, priced :price and current stock :currentStock and in :channel channel
      */
-    public function iShouldSeeVariantWithCodePriceAndCurrentStock(string $variantName, string $code, string $price, string $currentStock): void
-    {
-        Assert::true($this->variantsElement->hasProductVariantWithCodePriceAndCurrentStock($variantName, $code, $price, $currentStock));
+    public function iShouldSeeVariantWithCodePriceAndCurrentStock(
+        string $variantName,
+        string $code,
+        string $price,
+        string $currentStock,
+        string $channel,
+    ): void {
+        Assert::true($this->variantsElement->hasProductVariantWithCodePriceAndCurrentStock(
+            $variantName,
+            $code,
+            $price,
+            $currentStock,
+            $channel,
+        ));
     }
 
     /**

--- a/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
@@ -31,6 +31,7 @@ final class VariantsElement extends Element implements VariantsElementInterface
         string $code,
         string $price,
         string $currentStock,
+        string $channel,
     ): bool {
         /** @var NodeElement $variantRow */
         $variantRows = $this->getDocument()->findAll('css', '#variants .variants-accordion__title');
@@ -38,7 +39,14 @@ final class VariantsElement extends Element implements VariantsElementInterface
         /** @var NodeElement $variant */
         foreach ($variantRows as $variant) {
             if (
-                $this->hasProductWithGivenNameCodePriceAndCurrentStock($variant, $name, $code, $price, $currentStock)
+                $this->hasProductWithGivenNameCodePriceAndCurrentStock(
+                    $variant,
+                    $name,
+                    $code,
+                    $price,
+                    $currentStock,
+                    $channel,
+                )
             ) {
                 return true;
             }
@@ -53,6 +61,7 @@ final class VariantsElement extends Element implements VariantsElementInterface
         string $code,
         string $price,
         string $currentStock,
+        string $channel,
     ): bool {
         $variantContent = $variant->getParent()->find(
             'css',
@@ -65,7 +74,7 @@ final class VariantsElement extends Element implements VariantsElementInterface
         if (
             $variant->find('css', '.content .variant-name')->getText() === $name &&
             $variant->find('css', '.content .variant-code')->getText() === $code &&
-            $variantContent->find('css', 'tr.pricing:contains("WEB-US") td:nth-child(2)')->getText() === $price &&
+            $variantContent->find('css', sprintf('tr.pricing:contains("%s") td:nth-child(2)', $channel))->getText() === $price &&
             $variant->find('css', '.current-stock')->getText() === $currentStock
         ) {
             return true;

--- a/src/Sylius/Behat/Element/Product/ShowPage/VariantsElementInterface.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/VariantsElementInterface.php
@@ -17,5 +17,11 @@ interface VariantsElementInterface
 {
     public function countVariantsOnPage(): int;
 
-    public function hasProductVariantWithCodePriceAndCurrentStock(string $name, string $code, string $price, string $currentStock): bool;
+    public function hasProductVariantWithCodePriceAndCurrentStock(
+        string $name,
+        string $code,
+        string $price,
+        string $currentStock,
+        string $channel,
+    ): bool;
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantContentPricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantContentPricing.html.twig
@@ -16,7 +16,7 @@
             {% for channelPricing in variant.channelPricings %}
                 <tr class="pricing">
                     <td class="five wide gray text">
-                        <strong>{{ channelPricing.channelCode }}</strong>
+                        <strong>{{ channelPricing.channelCode|sylius_channel_name }}</strong>
                     </td>
                     {% set channelCode = channelPricing.channelCode %}
                     <td>{{ money.format(channelPricing.price, currencies[channelCode]) }}</td>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11  <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |
Before:
<img width="863" alt="image" src="https://user-images.githubusercontent.com/40125720/192798840-808adc62-b455-45e4-b8e7-48572d55f492.png">
After:
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/40125720/192798991-e9f040bf-dcfe-4b42-b7a2-7811923b6a1f.png">

In the simple product `show`, we also display the translated name