### PR TITLE
[Admin] Cart promotions translations for labels

### DIFF
--- a/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
+++ b/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
@@ -1,11 +1,12 @@
 @managing_promotions
-Feature: Adding promotions in different languages
+Feature: Adding promotion in different languages
     In order to see the label of promotion in specific language
     As an Administrator
     I want to be able to add a promotion and specify labels in different languages
 
     Background:
         Given the store operates on a single channel in "United States"
+        And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
         And I am logged in as an administrator
 
     @ui @javascript @no-api
@@ -17,3 +18,4 @@ Feature: Adding promotions in different languages
         And I add it
         Then I should be notified that it has been successfully created
         And the "Full metal promotion" promotion should appear in the registry
+        And the "Full metal promotion" promotion should have a label "W pełni metalowa promocja" in "Polish (Poland)" locale

--- a/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
+++ b/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
@@ -1,0 +1,19 @@
+@managing_promotions
+Feature: Adding promotions in different languages
+    In order to see the label of promotion in specific language
+    As an Administrator
+    I want to be able to add a promotion and specify labels in different languages
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And I am logged in as an administrator
+
+    @ui @javascript @no-api
+    Scenario: Adding a promotion with a label in a different language
+        When I want to create a new promotion
+        And I specify its code as "FULL_METAL_PROMOTION"
+        And I name it "Full metal promotion"
+        And I specify its label as "W pełni metalowa promocja" in "Polish (Poland)" locale
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the "Full metal promotion" promotion should appear in the registry

--- a/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
+++ b/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
@@ -1,6 +1,6 @@
 @managing_promotions
 Feature: Adding promotion in different languages
-    In order to see the label of promotion in specific language
+    In order to see the label of promotion in a specific language
     As an Administrator
     I want to be able to add a promotion and specify labels in different languages
 

--- a/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
+++ b/features/promotion/managing_promotions/adding_promotion_in_different_languages.feature
@@ -9,7 +9,7 @@ Feature: Adding promotion in different languages
         And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
         And I am logged in as an administrator
 
-    @ui @javascript @no-api
+    @ui @javascript
     Scenario: Adding a promotion with a label in a different language
         When I want to create a new promotion
         And I specify its code as "FULL_METAL_PROMOTION"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -24,7 +24,6 @@ use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
-use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingPromotionsContext implements Context
@@ -37,7 +36,6 @@ final class ManagingPromotionsContext implements Context
         private UpdatePageInterface $updatePage,
         private CurrentPageResolverInterface $currentPageResolver,
         private NotificationCheckerInterface $notificationChecker,
-        private LocaleConverterInterface $localeConverter,
     ) {
     }
 
@@ -114,16 +112,16 @@ final class ManagingPromotionsContext implements Context
      */
     public function iSpecifyItsLabelInLocaleCode(string $label, string $localeCode): void
     {
-        $this->createPage->specifyLabel($label, $this->localeConverter->convertNameToCode($localeCode));
+        $this->createPage->specifyLabel($label, $localeCode);
     }
 
     /**
-     * @When the :promotion promotion should have a label :label in :locale locale
+     * @When the :promotion promotion should have a label :label in :localeCode locale
      */
-    public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $locale): void
+    public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $localeCode): void
     {
         $this->updatePage->open(['id' => $promotion->getId()]);
-        $this->createPage->hasLabel($label, $this->localeConverter->convertNameToCode($locale));
+        $this->createPage->hasLabel($label, $localeCode);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -24,6 +24,7 @@ use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
+use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingPromotionsContext implements Context
@@ -36,6 +37,7 @@ final class ManagingPromotionsContext implements Context
         private UpdatePageInterface $updatePage,
         private CurrentPageResolverInterface $currentPageResolver,
         private NotificationCheckerInterface $notificationChecker,
+        private LocaleConverterInterface $localeConverter,
     ) {
     }
 
@@ -105,6 +107,14 @@ final class ManagingPromotionsContext implements Context
     public function iAddIt()
     {
         $this->createPage->create();
+    }
+
+    /**
+     * @When I specify its label as :label in :localeCode locale
+     */
+    public function iSpecifyItsLabelInLocaleCode(string $label, string $localeCode): void
+    {
+        $this->createPage->specifyLabel($label, $this->localeConverter->convertNameToCode($localeCode));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -118,6 +118,15 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
+     * @When the :promotion promotion should have a label :label in :locale locale
+     */
+    public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $locale): void
+    {
+        $this->updatePage->open(['id' => $promotion->getId()]);
+        $this->createPage->hasLabel($label, $this->localeConverter->convertNameToCode($locale));
+    }
+
+    /**
      * @When I add the "Has at least one from taxons" rule configured with :firstTaxon
      * @When I add the "Has at least one from taxons" rule configured with :firstTaxon and :secondTaxon
      */

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -27,6 +27,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
+    public function specifyLabel(string $label, string $locale): void
+    {
+        $this->getDocument()->fillField(sprintf('sylius_promotion_translations_%s_label', $locale), $label);
+    }
+
     public function addRule(?string $ruleName): void
     {
         $count = count($this->getCollectionItems('rules'));

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -29,6 +29,8 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 
     public function specifyLabel(string $label, string $locale): void
     {
+        $this->getDocument()->find('css', 'div[data-locale="' . $locale . '"]')->click();
+
         $this->getDocument()->fillField(sprintf('sylius_promotion_translations_%s_label', $locale), $label);
     }
 
@@ -189,6 +191,18 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     public function checkIfActionConfigurationFormIsVisible(): bool
     {
         return $this->hasElement('amount');
+    }
+
+    public function hasLabel(string $label, string $locale): bool
+    {
+        $this->getDocument()->find('css', 'div[data-locale="' . $locale . '"]')->click();
+
+        $labelElement = $this->getDocument()->find('css', sprintf('label:contains("%s")', $label));
+        if (null === $labelElement) {
+            return false;
+        }
+
+        return $labelElement->hasClass(sprintf('sylius-locale-%s', $locale));
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -27,11 +27,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    public function specifyLabel(string $label, string $locale): void
+    public function specifyLabel(string $label, string $localeCode): void
     {
-        $this->getDocument()->find('css', 'div[data-locale="' . $locale . '"]')->click();
+        $this->getDocument()->find('css', 'div[data-locale="' . $localeCode . '"]')->click();
 
-        $this->getDocument()->fillField(sprintf('sylius_promotion_translations_%s_label', $locale), $label);
+        $this->getDocument()->fillField(sprintf('sylius_promotion_translations_%s_label', $localeCode), $label);
     }
 
     public function addRule(?string $ruleName): void
@@ -193,16 +193,16 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $this->hasElement('amount');
     }
 
-    public function hasLabel(string $label, string $locale): bool
+    public function hasLabel(string $label, string $localeCode): bool
     {
-        $this->getDocument()->find('css', 'div[data-locale="' . $locale . '"]')->click();
+        $this->getDocument()->find('css', 'div[data-locale="' . $localeCode . '"]')->click();
 
         $labelElement = $this->getDocument()->find('css', sprintf('label:contains("%s")', $label));
         if (null === $labelElement) {
             return false;
         }
 
-        return $labelElement->hasClass(sprintf('sylius-locale-%s', $locale));
+        return $labelElement->hasClass(sprintf('sylius-locale-%s', $localeCode));
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -20,7 +20,7 @@ interface CreatePageInterface extends BaseCreatePageInterface
 {
     public function specifyCode(string $code): void;
 
-    public function specifyLabel(string $label, string $locale): void;
+    public function specifyLabel(string $label, string $localeCode): void;
 
     public function nameIt(string $name): void;
 
@@ -73,5 +73,5 @@ interface CreatePageInterface extends BaseCreatePageInterface
 
     public function checkIfActionConfigurationFormIsVisible(): bool;
 
-    public function hasLabel(string $label, string $locale): bool;
+    public function hasLabel(string $label, string $localeCode): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -72,4 +72,6 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function checkIfRuleConfigurationFormIsVisible(): bool;
 
     public function checkIfActionConfigurationFormIsVisible(): bool;
+
+    public function hasLabel(string $label, string $locale): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -20,6 +20,8 @@ interface CreatePageInterface extends BaseCreatePageInterface
 {
     public function specifyCode(string $code): void;
 
+    public function specifyLabel(string $label, string $locale): void;
+
     public function nameIt(string $name): void;
 
     public function addRule(?string $ruleName): void;

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -248,7 +248,9 @@
             <argument type="service" id="sylius.behat.page.admin.promotion.update" />
             <argument type="service" id="sylius.behat.current_page_resolver" />
             <argument type="service" id="sylius.behat.notification_checker" />
+            <argument type="service" id="sylius.locale_converter" />
         </service>
+
         <service id="sylius.behat.context.ui.admin.managing_promotion_coupons" class="Sylius\Behat\Context\Ui\Admin\ManagingPromotionCouponsContext">
             <argument type="service" id="sylius.behat.page.admin.promotion_coupon.create" />
             <argument type="service" id="sylius.behat.page.admin.promotion_coupon.generate" />

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
@@ -12,6 +12,7 @@ default:
                 - sylius.behat.context.transform.customer
                 - sylius.behat.context.transform.date_time
                 - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.locale
                 - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.promotion

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
@@ -22,6 +22,7 @@ default:
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.customer_group
                 - sylius.behat.context.setup.currency
+                - sylius.behat.context.setup.locale
                 - sylius.behat.context.setup.order
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/Show/_translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/Show/_translations.html.twig
@@ -14,10 +14,6 @@
                     <td class="three wide"><strong class="gray text">{{ 'sylius.ui.label'|trans }}</strong></td>
                     <td>{{ translation.label }}</td>
                 </tr>
-                <tr>
-                    <td class="three wide"><strong class="gray text">{{ 'sylius.ui.description'|trans }}</strong></td>
-                    <td>{{ translation.description|nl2br }}</td>
-                </tr>
                 </tbody>
             </table>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/Show/_translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/Show/_translations.html.twig
@@ -1,0 +1,25 @@
+<div class="ui hidden divider"></div>
+
+<div class="ui styled fluid accordion">
+    {% for translation in promotion.translations %}
+        <div class="title">
+            <i class="dropdown icon"></i>
+            <i class="{{ translation.locale|slice(-2)|lower }} flag"></i>
+            {{ translation.locale|sylius_locale_name }}
+        </div>
+        <div class="ui content">
+            <table class="ui very basic celled table">
+                <tbody>
+                <tr>
+                    <td class="three wide"><strong class="gray text">{{ 'sylius.ui.label'|trans }}</strong></td>
+                    <td>{{ translation.label }}</td>
+                </tr>
+                <tr>
+                    <td class="three wide"><strong class="gray text">{{ 'sylius.ui.description'|trans }}</strong></td>
+                    <td>{{ translation.description|nl2br }}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    {% endfor %}
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/_form.html.twig
@@ -1,3 +1,5 @@
+{% from '@SyliusAdmin/Macro/translationForm.html.twig' import translationForm %}
+
 <div class="ui two column stackable grid">
     <div class="column">
         {{ form_errors(form) }}
@@ -33,6 +35,9 @@
             {{ form_row(form.endsAt) }}
         </div>
     </div>
+</div>
+<div class="column">
+    {{ translationForm(form.translations) }}
 </div>
 <div class="ui segment">
     <h4 class="ui dividing header">{{ 'sylius.ui.configuration'|trans }}</h4>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -69,7 +69,6 @@
                 <attribute name="example">
                     <attribute name="en_US">
                         <attribute name="label">string</attribute>
-                        <attribute name="description">string</attribute>
                         <attribute name="locale">string</attribute>
                     </attribute>
                 </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -63,5 +63,17 @@
         <property name="rules" readable="true" />
         <property name="actions" readable="true" />
         <property name="channels" readable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="label">string</attribute>
+                        <attribute name="description">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionTranslation.xml
@@ -29,7 +29,6 @@
 
         <property name="id" identifier="true" writable="false" />
         <property name="label" identifier="false" />
-        <property name="description" identifier="false" />
         <property name="locale" identifier="false" required="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionTranslation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="%sylius.model.promotion_translation.class%" shortName="PromotionTranslation">
+        <attribute name="validation_groups">sylius</attribute>
+
+        <collectionOperations />
+
+        <itemOperations>
+            <itemOperation name="admin_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/admin/promotion-translations/{id}</attribute>
+            </itemOperation>
+        </itemOperations>
+
+        <property name="id" identifier="true" writable="false" />
+        <property name="label" identifier="false" />
+        <property name="description" identifier="false" />
+        <property name="locale" identifier="false" required="true" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
@@ -74,5 +74,11 @@
         <attribute name="channels">
             <group>admin:promotion:read</group>
         </attribute>
+
+        <attribute name="translations">
+            <group>admin:promotion:read</group>
+            <group>admin:promotion:create</group>
+            <group>admin:promotion:update</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+>
+    <class name="Sylius\Component\Promotion\Model\PromotionTranslation">
+        <attribute name="id">
+            <group>admin:promotion:read</group>
+        </attribute>
+
+        <attribute name="label">
+            <group>admin:promotion:read</group>
+            <group>admin:promotion:create</group>
+            <group>admin:promotion:update</group>
+        </attribute>
+
+        <attribute name="description">
+            <group>admin:promotion:read</group>
+            <group>admin:promotion:create</group>
+            <group>admin:promotion:update</group>
+        </attribute>
+
+        <attribute name="locale">
+            <group>admin:promotion:create</group>
+            <group>admin:promotion:update</group>
+        </attribute>
+    </class>
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
@@ -26,12 +26,6 @@
             <group>admin:promotion:update</group>
         </attribute>
 
-        <attribute name="description">
-            <group>admin:promotion:read</group>
-            <group>admin:promotion:create</group>
-            <group>admin:promotion:update</group>
-        </attribute>
-
         <attribute name="locale">
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Migrations;

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
@@ -28,7 +28,7 @@ final class Version20220926113252 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE sylius_promotion_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT NOT NULL, label VARCHAR(255) DEFAULT NULL, description VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_3C7A76182C2AC5D3 (translatable_id), UNIQUE INDEX sylius_promotion_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sylius_promotion_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT NOT NULL, label VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_3C7A76182C2AC5D3 (translatable_id), UNIQUE INDEX sylius_promotion_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_promotion_translation ADD CONSTRAINT FK_3C7A76182C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES sylius_promotion (id) ON DELETE CASCADE');
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220926113252.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220926113252 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create promotion translation';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE sylius_promotion_translation (id INT AUTO_INCREMENT NOT NULL, translatable_id INT NOT NULL, label VARCHAR(255) DEFAULT NULL, description VARCHAR(255) DEFAULT NULL, locale VARCHAR(255) NOT NULL, INDEX IDX_3C7A76182C2AC5D3 (translatable_id), UNIQUE INDEX sylius_promotion_translation_uniq_trans (translatable_id, locale), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_promotion_translation ADD CONSTRAINT FK_3C7A76182C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES sylius_promotion (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_promotion_translation DROP FOREIGN KEY FK_3C7A76182C2AC5D3');
+        $this->addSql('DROP TABLE sylius_promotion_translation');
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionType;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponType;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionRuleType;
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionTranslationType;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionType;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\Form\Type\DefaultResourceType;
@@ -39,6 +40,8 @@ use Sylius\Component\Promotion\Model\PromotionCouponInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionRule;
 use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslation;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Sylius\Component\Resource\Factory\Factory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -97,6 +100,23 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                         ->scalarNode('form')->defaultValue(PromotionType::class)->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                                ->arrayNode('translation')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->variableNode('options')->end()
+                                        ->arrayNode('classes')
+                                            ->addDefaultsIfNotSet()
+                                            ->children()
+                                                ->scalarNode('model')->defaultValue(PromotionTranslation::class)->cannotBeEmpty()->end()
+                                                ->scalarNode('interface')->defaultValue(PromotionTranslationInterface::class)->cannotBeEmpty()->end()
+                                                ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                                ->scalarNode('repository')->cannotBeEmpty()->end()
+                                                ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                                ->scalarNode('form')->defaultValue(PromotionTranslationType::class)->cannotBeEmpty()->end()
+                                            ->end()
+                                        ->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class PromotionTranslationType extends AbstractResourceType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('label', TextType::class, [
+                'label' => 'sylius.form.promotion.label',
+                'required' => false,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'sylius.form.promotion.description',
+                'required' => false,
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_promotion_translation';
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
@@ -27,10 +27,6 @@ final class PromotionTranslationType extends AbstractResourceType
                 'label' => 'sylius.form.promotion.label',
                 'required' => false,
             ])
-            ->add('description', TextareaType::class, [
-                'label' => 'sylius.form.promotion.description',
-                'required' => false,
-            ])
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Form\Type;
 
 use Sylius\Bundle\ResourceBundle\Form\EventSubscriber\AddCodeFormSubscriber;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -24,11 +25,23 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PromotionType extends AbstractResourceType
 {
+    public function __construct(
+        string $dataClass,
+        array $validationGroups,
+        private string $promotionTranslationType,
+    ) {
+        parent::__construct($dataClass, $validationGroups);
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name', TextType::class, [
                 'label' => 'sylius.form.promotion.name',
+            ])
+            ->add('translations', ResourceTranslationsType::class, [
+                'entry_type' => $this->promotionTranslationType,
+                'label' => 'sylius.form.promotion.translations',
             ])
             ->add('description', TextareaType::class, [
                 'label' => 'sylius.form.promotion.description',

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/PromotionTranslation.orm.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/PromotionTranslation.orm.xml
@@ -18,6 +18,5 @@
         </id>
 
         <field name="label" nullable="true" />
-        <field name="description" nullable="true" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/PromotionTranslation.orm.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/PromotionTranslation.orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+    <mapped-superclass name="Sylius\Component\Promotion\Model\PromotionTranslation" table="sylius_promotion_translation">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="label" nullable="true" />
+        <field name="description" nullable="true" />
+    </mapped-superclass>
+</doctrine-mapping>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
@@ -22,6 +22,9 @@
         <parameter key="sylius.form.type.promotion.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
+        <parameter key="sylius.form.type.promotion_translation.validation_groups" type="collection">
+            <parameter>sylius</parameter>
+        </parameter>
         <parameter key="sylius.form.type.promotion_action.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
@@ -71,6 +74,13 @@
         <service id="sylius.form.type.promotion" class="Sylius\Bundle\PromotionBundle\Form\Type\PromotionType">
             <argument>%sylius.model.promotion.class%</argument>
             <argument>%sylius.form.type.promotion.validation_groups%</argument>
+            <argument>Sylius\Bundle\PromotionBundle\Form\Type\PromotionTranslationType</argument>
+            <tag name="form.type" />
+        </service>
+
+        <service id="Sylius\Bundle\PromotionBundle\Form\Type\PromotionTranslationType">
+            <argument>%sylius.model.promotion_translation.class%</argument>
+            <argument>%sylius.form.type.promotion_translation.validation_groups%</argument>
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -24,6 +24,7 @@ sylius:
             description: Description
             ends_at: Ends at
             exclusive: Exclusive
+            label: Label
             name: Name
             priority: Priority
             rules: Rules

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -16,10 +16,15 @@ namespace Sylius\Component\Promotion\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\TimestampableTrait;
+use Sylius\Component\Resource\Model\TranslatableTrait;
+use Sylius\Component\Resource\Model\TranslationInterface;
 
 class Promotion implements PromotionInterface
 {
-    use TimestampableTrait;
+    use TimestampableTrait, TranslatableTrait {
+        __construct as private initializeTranslationsCollection;
+        getTranslation as private doGetTranslation;
+    }
 
     /** @var mixed */
     protected $id;
@@ -87,6 +92,8 @@ class Promotion implements PromotionInterface
 
     public function __construct()
     {
+        $this->initializeTranslationsCollection();
+
         $this->createdAt = new \DateTime();
 
         /** @var ArrayCollection<array-key, PromotionCouponInterface> $this->coupons */
@@ -309,5 +316,19 @@ class Promotion implements PromotionInterface
     public function setAppliesToDiscounted(bool $applyOnDiscounted): void
     {
         $this->appliesToDiscounted = $applyOnDiscounted;
+    }
+
+    /** @return PromotionTranslationInterface */
+    public function getTranslation(?string $locale = null): TranslationInterface
+    {
+        /** @var PromotionTranslationInterface $translation */
+        $translation = $this->doGetTranslation($locale);
+
+        return $translation;
+    }
+
+    protected function createTranslation(): PromotionTranslationInterface
+    {
+        return new PromotionTranslation();
     }
 }

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -17,8 +17,9 @@ use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
+use Sylius\Component\Resource\Model\TranslatableInterface;
 
-interface PromotionInterface extends CodeAwareInterface, TimestampableInterface, ResourceInterface
+interface PromotionInterface extends CodeAwareInterface, TimestampableInterface, TranslatableInterface, ResourceInterface
 {
     public function getName(): ?string;
 

--- a/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Promotion\Model;
+
+use Sylius\Component\Resource\Model\AbstractTranslation;
+
+class PromotionTranslation extends AbstractTranslation implements PromotionTranslationInterface
+{
+    protected mixed $id;
+
+    protected ?string $label = null;
+
+    protected ?string $description = null;
+
+    public function getId(): mixed
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): void
+    {
+        $this->description = $description;
+    }
+}

--- a/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
@@ -17,13 +17,14 @@ use Sylius\Component\Resource\Model\AbstractTranslation;
 
 class PromotionTranslation extends AbstractTranslation implements PromotionTranslationInterface
 {
-    protected mixed $id;
+    /** @var mixed */
+    protected $id;
 
     protected ?string $label = null;
 
     protected ?string $description = null;
 
-    public function getId(): mixed
+    public function getId()
     {
         return $this->id;
     }

--- a/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTranslation.php
@@ -22,8 +22,6 @@ class PromotionTranslation extends AbstractTranslation implements PromotionTrans
 
     protected ?string $label = null;
 
-    protected ?string $description = null;
-
     public function getId()
     {
         return $this->id;
@@ -37,15 +35,5 @@ class PromotionTranslation extends AbstractTranslation implements PromotionTrans
     public function setLabel(?string $label): void
     {
         $this->label = $label;
-    }
-
-    public function getDescription(): ?string
-    {
-        return $this->description;
-    }
-
-    public function setDescription(?string $description): void
-    {
-        $this->description = $description;
     }
 }

--- a/src/Sylius/Component/Promotion/Model/PromotionTranslationInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTranslationInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Promotion\Model;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Sylius\Component\Resource\Model\TranslationInterface;
+
+interface PromotionTranslationInterface extends ResourceInterface, TranslationInterface
+{
+    public function getLabel(): ?string;
+
+    public function setLabel(?string $label): void;
+
+    public function getDescription(): ?string;
+
+    public function setDescription(?string $description): void;
+}

--- a/src/Sylius/Component/Promotion/Model/PromotionTranslationInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTranslationInterface.php
@@ -21,8 +21,4 @@ interface PromotionTranslationInterface extends ResourceInterface, TranslationIn
     public function getLabel(): ?string;
 
     public function setLabel(?string $label): void;
-
-    public function getDescription(): ?string;
-
-    public function setDescription(?string $description): void;
 }

--- a/src/Sylius/Component/Promotion/spec/Model/PromotionSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Model/PromotionSpec.php
@@ -22,6 +22,12 @@ use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 
 final class PromotionSpec extends ObjectBehavior
 {
+    function let()
+    {
+        $this->setCurrentLocale('en_US');
+        $this->setFallbackLocale('en_US');
+    }
+
     function it_is_a_promotion(): void
     {
         $this->shouldImplement(PromotionInterface::class);

--- a/src/Sylius/Component/Promotion/spec/Model/PromotionTranslationSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Model/PromotionTranslationSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Promotion\Model;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Promotion\Model\PromotionTranslation;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
+
+final class PromotionTranslationSpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(PromotionTranslation::class);
+    }
+
+    function it_implements_catalog_promotion_translation_interface(): void
+    {
+        $this->shouldImplement(PromotionTranslationInterface::class);
+    }
+
+    function it_has_no_id_by_default(): void
+    {
+        $this->getId()->shouldReturn(null);
+    }
+
+    function its_label_is_mutable(): void
+    {
+        $this->setLabel('Mugs discount');
+        $this->getLabel()->shouldReturn('Mugs discount');
+    }
+
+    function its_description_is_mutable(): void
+    {
+        $this->setDescription('Discount on every mug.');
+        $this->getDescription()->shouldReturn('Discount on every mug.');
+    }
+}

--- a/src/Sylius/Component/Promotion/spec/Model/PromotionTranslationSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Model/PromotionTranslationSpec.php
@@ -39,10 +39,4 @@ final class PromotionTranslationSpec extends ObjectBehavior
         $this->setLabel('Mugs discount');
         $this->getLabel()->shouldReturn('Mugs discount');
     }
-
-    function its_description_is_mutable(): void
-    {
-        $this->setDescription('Discount on every mug.');
-        $this->getDescription()->shouldReturn('Discount on every mug.');
-    }
 }

--- a/tests/Api/Admin/PromotionTest.php
+++ b/tests/Api/Admin/PromotionTest.php
@@ -40,7 +40,6 @@ final class PromotionTest extends JsonApiTestCase
                 'translations' => ['en_US' => [
                     'locale' => 'en_US',
                     'label' => 'T-Shirts discount',
-                    'description' => '50% discount on every T-Shirt',
                 ]],
 
             ], JSON_THROW_ON_ERROR)

--- a/tests/Api/Admin/PromotionTest.php
+++ b/tests/Api/Admin/PromotionTest.php
@@ -37,6 +37,11 @@ final class PromotionTest extends JsonApiTestCase
                 'name' => 'T-Shirts discount',
                 'code' => 'tshirts_discount',
                 'appliesToDiscounted' => false,
+                'translations' => ['en_US' => [
+                    'locale' => 'en_US',
+                    'label' => 'T-Shirts discount',
+                    'description' => '50% discount on every T-Shirt',
+                ]],
 
             ], JSON_THROW_ON_ERROR)
         );

--- a/tests/Api/Responses/Expected/admin/post_promotion_response.json
+++ b/tests/Api/Responses/Expected/admin/post_promotion_response.json
@@ -28,7 +28,6 @@
         "@type": "PromotionTranslation",
         "id": @integer@,
         "label": "T-Shirts discount",
-        "description": "50% discount on every T-Shirt",
         "locale": "en_US",
         "translatable": "\/api\/v2\/admin\/promotions\/@string@"
     }

--- a/tests/Api/Responses/Expected/admin/post_promotion_response.json
+++ b/tests/Api/Responses/Expected/admin/post_promotion_response.json
@@ -19,5 +19,17 @@
     "actions": [],
     "appliesToDiscounted": false,
     "createdAt": @string@,
-    "updatedAt": @string@
+    "updatedAt": @string@,
+    "translations": {
+        "en_US": "\/api\/v2\/admin\/promotion-translations\/@integer@"
+    },
+    "translation": {
+        "@id": "\/api\/v2\/admin\/promotion-translations\/@integer@",
+        "@type": "PromotionTranslation",
+        "id": @integer@,
+        "label": "T-Shirts discount",
+        "description": "50% discount on every T-Shirt",
+        "locale": "en_US",
+        "translatable": "\/api\/v2\/admin\/promotions\/@string@"
+    }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| License         | MIT                                                          |

This PR provides the ability to translate the labels of cart promotions and the second part of showing them in shop ui and admin panel in orders will be added in other pr.

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/28228691/192985913-b9a3741e-5941-439b-95bd-e4741c7b9619.png">


<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
