### PR TITLE
[API] Use tokenValue instead of id

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/Payment/GetPaymentConfiguration.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payment/GetPaymentConfiguration.php
@@ -34,7 +34,7 @@ final class GetPaymentConfiguration
         /** @var PaymentInterface|null $payment */
         $payment = $this->paymentRepository->findOneByOrderToken(
             $request->attributes->get('paymentId'),
-            $request->attributes->get('id'),
+            $request->attributes->get('tokenValue'),
         );
 
         Assert::notNull($payment);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #13272, #13681                      |
| License         | MIT                                                          |

`GET /api/v2/shop/orders/{tokenValue}/payments/{paymentId}/configuration` will now works as expected.
