### PR TITLE
Allow ramsey/uuid ^4.0 to avoid PHP 8.1 warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "php-http/message-factory": "^1.0",
         "psr/cache": "^2.0",
         "psr/log": "^2.0",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.9 || ^4.0",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",
         "swiftmailer/swiftmailer": "^6.2",

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "php-http/message-factory": "^1.0",
         "psr/cache": "^2.0",
         "psr/log": "^2.0",
-        "ramsey/uuid": "^3.9 || ^4.0",
+        "ramsey/uuid": "^4.0",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",
         "swiftmailer/swiftmailer": "^6.2",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

There's a type error in 8.1 due to return type. 
`Error: During inheritance of JsonSerializable: Uncaught Behat\\Testwork\\Call\\Exception\\CallErrorException: 8192: Return type of Ramsey\\Uuid\\Uuid::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in \/var\/www\/html\/vendor\/ramsey\/uuid\/src\/Uuid.php line 216 `