### PR TITLE
[Maintenance] `extra.symfony.require` configuration introduced

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -248,7 +248,8 @@
             "dev-master": "1.12-dev"
         },
         "symfony": {
-            "allow-contrib": false
+            "allow-contrib": false,
+            "require": "^5.4 || ^6.0"
         }
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

I didn't find this option documented in the Symfony docs, just a little info here:
https://symfony.com/doc/current/setup/upgrade_major.html#2-update-to-the-new-major-version-via-composer
and some info quoted from Symfony Cast - upgrade Symfony tutorial:
"This is a performance optimization from Flex: it basically makes sure that Flex only considers Symfony packages that match this version".
It looks like it may save some time working with the `composer update` command