### PR TITLE
[Api] fix order normalization groups

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -16,18 +16,15 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.order.class%" shortName="Order">
-        <attribute name="normalization_context">
-            <attribute name="groups">
-                <attribute>admin:order:read</attribute>
-            </attribute>
-        </attribute>
-
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">admin/orders</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:order:read</attribute>
+                </attribute>
             </collectionOperation>
 
             <collectionOperation name="shop_post">
@@ -35,6 +32,9 @@
                 <attribute name="path">/shop/orders</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\PickupCart</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">shop:order:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:order:create</attribute>
                 </attribute>
@@ -58,6 +58,9 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/orders/{tokenValue}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:order:read</attribute>
+                </attribute>
             </itemOperation>
 
             <itemOperation name="shop_get">
@@ -84,6 +87,11 @@
                 <attribute name="path">/admin/orders/{tokenValue}/cancel</attribute>
                 <attribute name="input">false</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Applicator\OrderStateMachineTransitionApplicatorInterface:cancel</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">
+                        <attribute>admin:order:read</attribute>
+                    </attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:order:update</attribute>
                 </attribute>
@@ -296,6 +304,9 @@
                 <attribute name="path">/shop/orders/{tokenValue}/items/{orderItemId}</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">shop:cart:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:change_quantity</attribute>
                 </attribute>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | yes (but the API is exprimental)                                                       |
| Deprecations?   | no |
| Related tickets |                      |
| License         | MIT                                                          |

When requesting `POST /api/v2/shop/orders`, the applied normalization group is `admin:order:read` whereas it should be `shop:order:read`. This could lead to exposing unexpected data.

I think that we can remove the "default" normalization context groups and specify for each operation the proper normalization/denormalization context groups (which fixes the bug and prevent future forgets).