### PR TITLE
Make the add-to-cart module more resilient to errors

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
@@ -36,9 +36,16 @@ $.fn.extend({
         validationElement.removeClass('hidden');
         let validationMessage = '';
 
-        Object.entries(response.errors.errors).forEach(([, message]) => {
-          validationMessage += message;
-        });
+        if (response.hasOwnProperty('errors')) {
+          Object.entries(response.errors.errors).forEach(([, message]) => {
+            validationMessage += message;
+          });
+        } else if (response.hasOwnProperty('message')) {
+          validationMessage = response.message;
+        } else {
+          validationMessage = 'Could not add your item to the cart.';
+        }
+
         validationElement.html(validationMessage);
         $(element).removeClass('loading');
       },


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | N/A                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

If the AJAX call to add an item to the cart results in a 500 error, the user gets an empty validation error block.  This is because the JSON response body for a 500 error doesn't have an "errors" property, and the current code also triggers a JavaScript error trying to access a property on undefined.  This change makes the code a little more resilient by checking for the presence of the "errors" property (which would come from the controller handling this request) or a "message" property (which would come from the error handler building the response) and falls back to a generic message if neither of those is present to avoid a blank validation error block (yes I realize the fallback is hardcoded English but I didn't want to get into a huge refactoring to inject a translatable message here).