### PR TITLE
[Symfony 6] JS Behat

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -802,7 +802,7 @@ jobs:
                 name: Run JS Behat
                 run: |
                     bin/console cache:pool:clear cache.global_clearer
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun
 
             -
                 name: Upload Behat logs

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,6 +1,8 @@
 framework:
     secret: '%env(APP_SECRET)%'
-    form: true
+    form: 
+        enabled: true
+        legacy_error_messages: false
     csrf_protection: true
     session:
         handler_id: ~

--- a/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
@@ -35,7 +35,7 @@ Feature: Creating a catalog promotion
         And it should have "winter_sale" code and "Winter sale" name
         And "Winter sale" catalog promotion should apply to "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
         And it should have "50%" discount
-        And this catalog promotion should be usable
+        And it should be active
         And "PHP T-Shirt" variant and "Kotlin T-Shirt" variant should be discounted
 
     @api @ui @javascript

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -30,8 +30,6 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\Component\Promotion\Event\CatalogPromotionCreated;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingCatalogPromotionsContext implements Context
@@ -39,7 +37,6 @@ final class ManagingCatalogPromotionsContext implements Context
     public function __construct(
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
-        private MessageBusInterface $messageBus,
         private IriConverterInterface $iriConverter,
         private SharedStorageInterface $sharedStorage,
     ) {
@@ -1173,14 +1170,6 @@ final class ManagingCatalogPromotionsContext implements Context
             ['products' => [$product->getCode()]],
             $this->responseChecker->getCollection($this->client->getLastResponse())[0]['scopes'][0]['configuration'],
         );
-    }
-
-    /**
-     * @Then this catalog promotion should be usable
-     */
-    public function thisCatalogPromotionShouldBeUsable(): void
-    {
-        Assert::isInstanceOf($this->messageBus->getDispatchedMessages()[0]['message'], CatalogPromotionCreated::class);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
@@ -61,7 +61,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iChooseAsTheBaseCurrency(CurrencyInterface $currency): void
     {
-        $this->client->addRequestData('baseCurrency', $this->iriConverter->getIriFromItem($currency));
+        $this->client->addRequestData('baseCurrency', $this->iriConverter->getIriFromItemInSection($currency, 'admin'));
     }
 
     /**
@@ -69,7 +69,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iChooseAsADefaultLocale(LocaleInterface $locale): void
     {
-        $this->client->addRequestData('defaultLocale', $this->iriConverter->getIriFromItem($locale));
+        $this->client->addRequestData('defaultLocale', $this->iriConverter->getIriFromItemInSection($locale, 'admin'));
     }
 
     /**
@@ -102,8 +102,8 @@ final class ManagingChannelsContext implements Context
     public function iChooseAndAsOperatingCountries(CountryInterface $country, CountryInterface $otherCountry): void
     {
         $this->client->addRequestData('countries', [
-            $this->iriConverter->getIriFromItem($country),
-            $this->iriConverter->getIriFromItem($otherCountry),
+            $this->iriConverter->getIriFromItemInSection($country, 'admin'),
+            $this->iriConverter->getIriFromItemInSection($otherCountry, 'admin'),
         ]);
     }
 
@@ -128,7 +128,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iSpecifyMenuTaxonAs(TaxonInterface $taxon): void
     {
-        $this->client->addRequestData('menuTaxon', $this->iriConverter->getIriFromItem($taxon));
+        $this->client->addRequestData('menuTaxon', $this->iriConverter->getIriFromItemInSection($taxon, 'admin'));
     }
 
     /**
@@ -242,7 +242,7 @@ final class ManagingChannelsContext implements Context
     {
         Assert::same(
             $this->responseChecker->getValue($this->client->show(Resources::CHANNELS, $channel->getCode()), 'menuTaxon'),
-            $this->iriConverter->getIriFromItem($taxon),
+            $this->iriConverter->getIriFromItemInSection($taxon, 'admin'),
             sprintf('Channel %s does not have %s menu taxon', $channel->getName(), $taxon->getName()),
         );
     }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
@@ -381,7 +381,7 @@ final class ManagingShippingMethodsContext implements Context
             $this->responseChecker->hasValueInCollection(
                 $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode()),
                 'channels',
-                $this->iriConverter->getIriFromItem($channel),
+                $this->iriConverter->getIriFromItemInSection($channel, 'admin'),
             ),
             sprintf('Shipping method is not assigned to %s channel', $channel->getName()),
         );

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -702,14 +702,6 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @Then I should be notified that a discount amount is not valid
-     */
-    public function iShouldBeNotifiedThatADiscountAmountIsNotValid(): void
-    {
-        Assert::same($this->formElement->getValidationMessage(), 'This value is not valid.');
-    }
-
-    /**
      * @Then I should be notified that a discount amount should be configured for at least one channel
      */
     public function iShouldBeNotifiedThatADiscountAmountShouldBeConfiguredForAtLeasOneChannel(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -914,14 +914,6 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @Then this catalog promotion should be usable
-     */
-    public function thisCatalogPromotionShouldBeUsable(): void
-    {
-        // Intentionally left blank
-    }
-
-    /**
      * @Then the catalog promotion :catalogPromotionName should be available in channel :channelName
      */
     public function theCatalogPromotionShouldBeAvailableInChannel(string $catalogPromotionName, string $channelName): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -277,7 +277,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iShouldBeNotifiedThatAMinimalValueShouldBeNumeric($element)
     {
-        $this->assertFieldValidationMessage($element, 'This value is not valid.');
+        $this->assertFieldValidationMessage($element, 'Please enter a valid money amount.');
     }
 
     /**
@@ -738,11 +738,7 @@ final class ManagingPromotionsContext implements Context
         Assert::same($this->updatePage->getActionValidationErrorsCount($channel->getCode()), $count);
     }
 
-    /**
-     * @param string $element
-     * @param string $expectedMessage
-     */
-    private function assertFieldValidationMessage($element, $expectedMessage)
+    private function assertFieldValidationMessage(string $element, string $expectedMessage)
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
@@ -165,7 +165,6 @@
         <service id="sylius.behat.context.api.admin.managing_catalog_promotions" class="Sylius\Behat\Context\Api\Admin\ManagingCatalogPromotionsContext">
             <argument type="service" id="sylius.behat.api_platform_client.admin" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
-            <argument type="service" id="sylius.event_bus" />
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ProductBundle\Controller;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAttributeChoiceType;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Product\Model\ProductAttribute;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,13 +50,12 @@ class ProductAttributeController extends ResourceController
     {
         $template = $request->attributes->get('template', '@SyliusAttribute/attributeValueForms.html.twig');
 
-        $form = $this->get('form.factory')->create(ProductAttributeChoiceType::class, null, [
-            'multiple' => true,
+        /** @var ProductAttribute[] $attributes */
+        $attributes = $this->repository->findBy([
+            'code' => $request->query->all('sylius_product_attribute_choice')
         ]);
-        $form->handleRequest($request);
 
-        $attributes = $form->getData();
-        if (null === $attributes) {
+        if (empty($attributes)) {
             throw new BadRequestHttpException();
         }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

[This](https://github.com/Sylius/Sylius/pull/14405/commits/41ac9949da0df5f81de33c731ce5290ad766f0f3) commit was created due to the changes to Symfony 5.4 and Symfony 6 `InputBag` class difference:
[Symfony 5.4](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpFoundation/InputBag.php#L39)
[Symfony 6](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/HttpFoundation/InputBag.php#L37)
The array of `sylius_product_attribute_choice` query parameters has previously been processed internally in the `$form->handleRequest($request);` method call and since we cannot influence the way of processing the logic of fetching the attributes, it has been moved to the controller.

Reason for changing the `framework` configuration:
`framework.form` configuration reference:
https://symfony.com/doc/current/forms.html#form-validation-messages