### PR TITLE
[Github Actions] Make timeout for non-JS build longer

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -555,7 +555,7 @@ jobs:
 
         name: "Test non-JS application (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}), Twig ${{ matrix.twig }}, DBAL ${{ matrix.dbal }}.x), API Platform ${{ matrix.api-platform }})"
 
-        timeout-minutes: 25
+        timeout-minutes: 35
 
         strategy:
             fail-fast: false


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | symfony-6  |
| Bug fix?        | yes                                                       |
| New feature?    | no |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

On the recent builds, we've experienced a lot of cancelled jobs due to the longer build time. I raise the timeout to 35 minutes, although we should think about fixing the problem rather than overpassing it 🖖 