### PR TITLE
[Product] Fixed product attribute translations #11570

### DIFF
--- a/features/product/managing_products/adding_select_attribute_in_different_locales.feature
+++ b/features/product/managing_products/adding_select_attribute_in_different_locales.feature
@@ -1,0 +1,30 @@
+@managing_products
+Feature: Adding select attributes in different locales to a product
+    In order to extend my merchandise with more complex products
+    As an Administrator
+    I want to add select attribute choices in different locales to a product
+
+    Background:
+        Given the store operates on a channel named "Web"
+        And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
+        And it uses the "English (United States)" locale by default
+        And the store has a product "Symfony Mug"
+        And the store has a select product attribute "Mug material" with value "Ceramic"
+        And this product attribute's "Ceramic" value is labeled "Ceramic" in the "English (United States)" locale
+        And this product attribute's "Ceramic" value is labeled "Ceramika" in the "Polish (Poland)" locale
+        And I am logged in as an administrator
+
+    @ui @javascript @no-api
+    Scenario: Adding a product with a select attribute with choices in different locales
+        When I want to create a new simple product
+        And I specify its code as "mug"
+        And I name it "PHP Mug" in "English (United States)"
+        And I set its price to "$100.00" for "Web" channel
+        And I add the "Mug material" attribute
+        And I select "Ceramic" value in "English (United States)" for the "Mug material" attribute
+        And I select "Ceramika" value in "Polish (Poland)" for the "Mug material" attribute
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the product "PHP Mug" should appear in the store
+        And select attribute "Mug material" of product "PHP Mug" should be "Ceramic" in "English (United States)"
+        And select attribute "Mug material" of product "PHP Mug" should be "Ceramika" in "Polish (Poland)"

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -158,6 +158,45 @@ final class ProductAttributeContext implements Context
     }
 
     /**
+     * @Given /^(this product attribute)'s "([^"]+)" value is labeled "([^"]+)" in the ("[^"]+" locale)$/
+     */
+    public function thisProductAttributeValueIsLabeledInTheLocale(
+        ProductAttributeInterface $attribute,
+        string $value,
+        string $label,
+        string $localeCode,
+    ): void {
+        $uuid = $this->getSelectAttributeValueUuidByChoiceValue($attribute, $value);
+
+        $configuration = $attribute->getConfiguration();
+        $choices[$uuid] = $configuration['choices'][$uuid] + [$localeCode => $label];
+        $configuration['choices'] = $choices;
+
+        $attribute->setConfiguration($configuration);
+    }
+
+    private function getSelectAttributeValueUuidByChoiceValue(
+        ProductAttributeInterface $attribute,
+        string $value,
+    ): string {
+        $choices = $attribute->getConfiguration()['choices'] ?? [];
+
+        foreach ($choices as $uuid => $choice) {
+            foreach ($choice as $choiceValue) {
+                if ($value === $choiceValue) {
+                    return $uuid;
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Value "%s" not found in attribute %s',
+            $value,
+            $attribute->getName(),
+        ));
+    }
+
+    /**
      * @Given /^(this product attribute) has set min value as (\d+) and max value as (\d+)$/
      */
     public function thisAttributeHasSetMinValueAsAndMaxValueAs(ProductAttributeInterface $attribute, $min, $max)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -463,10 +463,19 @@ final class ManagingProductsContext implements Context
      * @When I set its :attribute attribute to :value
      * @When I set its :attribute attribute to :value in :language
      * @When I do not set its :attribute attribute in :language
+     * @When I add the :attribute attribute
      */
     public function iSetItsAttributeTo($attribute, $value = null, $language = 'en_US')
     {
         $this->createSimpleProductPage->addAttribute($attribute, $value ?? '', $language);
+    }
+
+    /**
+     * @When I select :value value in :language for the :attribute attribute
+     */
+    public function iSelectValueInLanguageForTheAttribute(string $value, string $language, string $attribute): void
+    {
+        $this->createSimpleProductPage->selectAttributeValue($attribute, $value, $language);
     }
 
     /**
@@ -511,6 +520,16 @@ final class ManagingProductsContext implements Context
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
         Assert::same($this->updateSimpleProductPage->getAttributeValue($attributeName, $language), $value);
+    }
+
+    /**
+     * @Then select attribute :attributeName of product :product should be :value in :language
+     */
+    public function itsSelectAttributeShouldBe($attributeName, ProductInterface $product, $value, $language = 'en_US')
+    {
+        $this->updateSimpleProductPage->open(['id' => $product->getId()]);
+
+        Assert::same($this->updateSimpleProductPage->getAttributeSelectText($attributeName, $language), $value);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -74,7 +74,16 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->getDocument()->pressButton('Add attributes');
         $this->waitForFormElement();
 
+        if ('' === $value) {
+            return;
+        }
+
         $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->setValue($value);
+    }
+
+    public function selectAttributeValue(string $attributeName, string $value, string $localeCode): void
+    {
+        $this->getElement('attribute_value_select', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->selectOption($value);
     }
 
     public function addNonTranslatableAttribute(string $attributeName, string $value): void
@@ -253,6 +262,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
             'attribute' => '.attribute',
             'attribute_delete_button' => '#attributesContainer .attributes-group .attributes-header:contains("%attributeName%") button',
             'attribute_value' => '#attributesContainer [data-test-product-attribute-value-in-locale="%attributeName% %localeCode%"] input',
+            'attribute_value_select' => '#attributesContainer [data-test-product-attribute-value-in-locale="%attributeName% %localeCode%"] select',
             'attributes_choice' => '#sylius_product_attribute_choice',
             'channel_checkbox' => '.checkbox:contains("%channelName%") input',
             'code' => '#sylius_product_code',

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
@@ -36,6 +36,8 @@ interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
 
     public function addAttribute(string $attributeName, string $value, string $localeCode): void;
 
+    public function selectAttributeValue(string $attributeName, string $value, string $localeCode): void;
+
     public function addNonTranslatableAttribute(string $attributeName, string $value): void;
 
     public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -78,6 +78,13 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return $this->getElement('attribute', ['%attributeName%' => $attribute, '%localeCode%' => $localeCode])->getValue();
     }
 
+    public function getAttributeSelectText(string $attribute, string $localeCode): string
+    {
+        $this->clickTabIfItsNotActive('attributes');
+
+        return $this->getElement('attribute_select', ['%attributeName%' => $attribute, '%localeCode%' => $localeCode])->getText();
+    }
+
     public function getNonTranslatableAttributeValue(string $attribute): string
     {
         $this->clickTabIfItsNotActive('attributes');
@@ -446,6 +453,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
             'association_dropdown_item' => '.field > label:contains("%association%") ~ .product-select > div.menu > div.item:contains("%item%")',
             'association_dropdown_item_selected' => '.field > label:contains("%association%") ~ .product-select > a.label:contains("%item%")',
             'attribute' => '#attributesContainer [data-test-product-attribute-value-in-locale="%attributeName% %localeCode%"] input',
+            'attribute_select' => '#attributesContainer [data-test-product-attribute-value-in-locale="%attributeName% %localeCode%"] select',
             'attribute_element' => '.attribute',
             'attribute_delete_button' => '#attributesContainer .attributes-group .attributes-header:contains("%attributeName%") button',
             'code' => '#sylius_product_code',

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
@@ -37,6 +37,8 @@ interface UpdateSimpleProductPageInterface extends BaseUpdatePageInterface
 
     public function getAttributeValue(string $attributeName, string $localeCode): string;
 
+    public function getAttributeSelectText(string $attributeName, string $localeCode): string;
+
     public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;
 
     public function getNumberOfAttributes(): int;

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
@@ -110,7 +110,7 @@ class ProductAttributeController extends ResourceController
                 $attributeForm,
                 null,
                 [
-                    'label' => $attribute->getName(),
+                    'label' => $attribute->getTranslation($localeCode)->getName(),
                     'configuration' => $attribute->getConfiguration(),
                     'locale_code' => $localeCode,
                 ],

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ProductBundle\Controller;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAttributeChoiceType;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -85,13 +86,13 @@ class ProductAttributeController extends ResourceController
         $forms = [];
 
         if (!$attribute->isTranslatable()) {
-            array_push($localeCodes, null);
+            $adminLocaleCode = $this->get(LocaleContextInterface::class)->getLocaleCode();
 
-            return [null => $this->createFormAndView($attributeForm, $attribute)];
+            return [null => $this->createFormAndView($attributeForm, $attribute, $adminLocaleCode)];
         }
 
         foreach ($localeCodes as $localeCode) {
-            $forms[$localeCode] = $this->createFormAndView($attributeForm, $attribute);
+            $forms[$localeCode] = $this->createFormAndView($attributeForm, $attribute, $localeCode);
         }
 
         return $forms;
@@ -100,6 +101,7 @@ class ProductAttributeController extends ResourceController
     private function createFormAndView(
         $attributeForm,
         AttributeInterface $attribute,
+        string $localeCode,
     ): FormView {
         return $this
             ->get('form.factory')
@@ -107,7 +109,11 @@ class ProductAttributeController extends ResourceController
                 'value',
                 $attributeForm,
                 null,
-                ['label' => $attribute->getName(), 'configuration' => $attribute->getConfiguration()],
+                [
+                    'label' => $attribute->getName(),
+                    'configuration' => $attribute->getConfiguration(),
+                    'locale_code' => $localeCode,
+                ],
             )
             ->createView()
         ;


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #11570                     |
| License         | MIT                                                          |

Bug :
Select attributes on product edit page in BO are not translated.

Fix : 
Get locale from context and translate with this locale.

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
