### PR TITLE
[WIP] Translatable cart promotion labels on checkout

### DIFF
--- a/features/checkout/displaying_label_of_promotion_in_order_language.feature
+++ b/features/checkout/displaying_label_of_promotion_in_order_language.feature
@@ -7,7 +7,6 @@ Feature: Displaying label of promotion in order language
     Background:
         Given the store operates on a single channel in "United States"
         And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
-        And it uses the "Polish (Poland)" locale by default
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And there is a promotion "Holiday promotion"
         And the promotion has label translation "Promocja wakacyjna" in the "Polish (Poland)" locale
@@ -19,14 +18,14 @@ Feature: Displaying label of promotion in order language
 
     @ui
     Scenario: Displaying label in order language when the promotion is applied
-        Given I have product "PHP T-Shirt" in the cart using "English (United States)" locale
+        Given I have product "PHP T-Shirt" in the cart
         When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Offline" payment method
         Then I should see the promotion label named "Holiday promotion"
 
     @ui
     Scenario: Switching locale after adding product to cart
-        Given I have product "PHP T-Shirt" in the cart using "English (United States)" locale
+        Given I have product "PHP T-Shirt" in the cart
         And I change my locale to "Polish (Poland)"
         When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Offline" payment method

--- a/features/checkout/displaying_label_of_promotion_in_order_language.feature
+++ b/features/checkout/displaying_label_of_promotion_in_order_language.feature
@@ -1,0 +1,33 @@
+@checkout
+Feature: Displaying label of promotion in order language
+    In order to the proper information about promotion
+    As a Customer
+    I want to have the promotion label displayed in the order language
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
+        And it uses the "Polish (Poland)" locale by default
+        And the store has a product "PHP T-Shirt" priced at "$19.99"
+        And there is a promotion "Holiday promotion"
+        And the promotion has label translation "Promocja wakacyjna" in the "Polish (Poland)" locale
+        And the promotion has label translation "Holiday promotion" in the "English (United States)" locale
+        And the promotion gives "50%" off on every product when the item total is at least "$10.00"
+        And the store ships everywhere for Free
+        And the store allows paying Offline
+        And I am a logged in customer
+
+    @ui
+    Scenario: Displaying label in order language when the promotion is applied
+        Given I have product "PHP T-Shirt" in the cart using "English (United States)" locale
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I proceed selecting "Offline" payment method
+        Then I should see the promotion label named "Holiday promotion"
+
+    @ui
+    Scenario: Switching locale after adding product to cart
+        Given I have product "PHP T-Shirt" in the cart using "English (United States)" locale
+        And I change my locale to "Polish (Poland)"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I proceed selecting "Offline" payment method
+        Then I should see the promotion label named "Holiday promotion"

--- a/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
+++ b/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
@@ -17,7 +17,7 @@ Feature: Seeing a summary of the order with free product
         And it gives "$5.00" discount to every order
         And I am a logged in customer
 
-    @ui
+    @ui @api
     Scenario: Seeing Free order
         When I add "Greyjoy Coat" product to the cart
         And I define the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
+++ b/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
@@ -17,7 +17,7 @@ Feature: Seeing a summary of the order with free product
         And it gives "$5.00" discount to every order
         And I am a logged in customer
 
-    @ui @api
+    @ui
     Scenario: Seeing Free order
         When I add "Greyjoy Coat" product to the cart
         And I define the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/order/managing_orders/order_details/seeing_order_information_about_cart_promotion_in_admin_panel_locale.feature
+++ b/features/order/managing_orders/order_details/seeing_order_information_about_cart_promotion_in_admin_panel_locale.feature
@@ -1,0 +1,32 @@
+@managing_orders
+Feature: Seeing order information about cart promotion in the admin panel locale
+    In order to proper information about the promotion
+    As an Administrator
+    I want to be able to see the cart promotion label in the admin panel locale
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Angel T-Shirt" priced at "$39.00"
+        And there is a promotion "Holiday promotion"
+        And the promotion has label translation "Promocja wakacyjna" in the "Polish (Poland)" locale
+        And the promotion has label translation "Holiday promotion" in the "English (United States)" locale
+        And the promotion gives "50%" off on every product when the item total is at least "$10.00"
+        And the store ships everywhere for Free
+        And the store allows paying with "Cash on Delivery"
+        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
+        And the customer bought a single "Angel T-Shirt"
+        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States"
+        And for the billing address of "Mazikeen Lilim" in the "Pacific Coast Hwy", "90806" "Los Angeles", "United States"
+        And the customer chose "Free" shipping method with "Cash on Delivery" payment
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Seeing a cart promotion label in admin panel locale
+        When I view the summary of the order "#00000666"
+        Then I should see the cart promotion label "Holiday promotion"
+
+#    @ui
+#    Scenario: Switching the locale of admin panel and seeing a cart promotion label in admin panel locale
+#        When I change my locale to "Polish (Poland)"
+#        And I view the summary of the order "#00000666"
+#        Then I should see the cart promotion label "Promocja wakacyjna"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,6 +121,11 @@ parameters:
 			path: src/Sylius/Bundle/AdminBundle/Controller/DashboardController.php
 
 		-
+			message: "#^Call to static method create\\(\\) on an unknown class Nyholm\\\\Psr7\\\\Stream\\.$#"
+			count: 1
+			path: src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
+
+		-
 			message: "#^Method Sylius\\\\Bundle\\\\AdminBundle\\\\Controller\\\\RedirectHandler\\:\\:redirectToRoute\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
@@ -2251,6 +2256,11 @@ parameters:
 			path: src/Sylius/Bundle/CoreBundle/CatalogPromotion/Checker/CatalogPromotionEligibilityChecker.php
 
 		-
+			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\CatalogPromotion\\\\Checker\\\\InForTaxonsScopeVariantChecker\\:\\:__construct\\(\\) has parameter \\$taxonRepository with generic interface Sylius\\\\Component\\\\Taxonomy\\\\Repository\\\\TaxonRepositoryInterface but does not specify its types\\: T$#"
+			count: 1
+			path: src/Sylius/Bundle/CoreBundle/CatalogPromotion/Checker/InForTaxonsScopeVariantChecker.php
+
+		-
 			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\CatalogPromotion\\\\Checker\\\\ProductVariantForCatalogPromotionEligibility\\:\\:__construct\\(\\) has parameter \\$locator with generic class Symfony\\\\Component\\\\DependencyInjection\\\\ServiceLocator but does not specify its types\\: T$#"
 			count: 1
 			path: src/Sylius/Bundle/CoreBundle/CatalogPromotion/Checker/ProductVariantForCatalogPromotionEligibility.php
@@ -4254,6 +4264,16 @@ parameters:
 			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\Twig\\\\FilterExtension\\:\\:filter\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sylius/Bundle/CoreBundle/Twig/FilterExtension.php
+
+		-
+			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\Twig\\\\GenerateUrlFromAdjustmentExtension\\:\\:__construct\\(\\) has parameter \\$adjustmentRepository with generic interface Sylius\\\\Component\\\\Resource\\\\Repository\\\\RepositoryInterface but does not specify its types\\: T$#"
+			count: 1
+			path: src/Sylius/Bundle/CoreBundle/Twig/GenerateUrlFromAdjustmentExtension.php
+
+		-
+			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\Twig\\\\GenerateUrlFromAdjustmentExtension\\:\\:__construct\\(\\) has parameter \\$promotionRepository with generic interface Sylius\\\\Component\\\\Resource\\\\Repository\\\\RepositoryInterface but does not specify its types\\: T$#"
+			count: 1
+			path: src/Sylius/Bundle/CoreBundle/Twig/GenerateUrlFromAdjustmentExtension.php
 
 		-
 			message: "#^Method Sylius\\\\Bundle\\\\CoreBundle\\\\Validator\\\\Constraints\\\\CartItemAvailabilityValidator\\:\\:validate\\(\\) has parameter \\$value with no type specified\\.$#"

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -31,7 +31,9 @@ use Sylius\Component\Promotion\Generator\PromotionCouponGeneratorInstruction;
 use Sylius\Component\Promotion\Generator\PromotionCouponGeneratorInterface;
 use Sylius\Component\Promotion\Model\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionRuleInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Sylius\Component\Promotion\Repository\PromotionRepositoryInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 
 final class PromotionContext implements Context
 {
@@ -43,6 +45,7 @@ final class PromotionContext implements Context
         private TestPromotionFactoryInterface $testPromotionFactory,
         private PromotionRepositoryInterface $promotionRepository,
         private PromotionCouponGeneratorInterface $couponGenerator,
+        private FactoryInterface $promotionTranslationFactory,
         private ObjectManager $objectManager,
     ) {
     }
@@ -967,6 +970,21 @@ final class PromotionContext implements Context
     ): void {
         $promotion->addRule($this->ruleFactory->createItemTotal($firstChannel->getCode(), $firstAmount));
         $promotion->addRule($this->ruleFactory->createItemTotal($secondChannel->getCode(), $secondAmount));
+
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @Given /^(the promotion) has label translation "([^"]+)" (in the "([^"]+)" locale)$/
+     */
+    public function thePromotionHasTranslation(PromotionInterface $promotion, string $label, string $localeCode): void
+    {
+        /** @var PromotionTranslationInterface $translation */
+        $translation = $this->promotionTranslationFactory->createNew();
+        $translation->setLabel($label);
+        $translation->setLocale($localeCode);
+
+        $promotion->addTranslation($translation);
 
         $this->objectManager->flush();
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -980,6 +980,14 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then I should see the cart promotion label :label
+     */
+    public function iShouldSeeTheCartPromotionLabel(string $label): void
+    {
+        Assert::true($this->showPage->hasPromotionLabel($label));
+    }
+
+    /**
      * @param string $type
      * @param string $element
      * @param string $expectedMessage

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -304,15 +304,14 @@ final class CartContext implements Context
      * @Given I added product :product to the cart
      * @Given he added product :product to the cart
      * @Given /^I (?:have|had) (product "[^"]+") in the cart$/
-     * @Given /^I have (product "[^"]+") in the cart using ("([^"]+)" locale)$/
      * @Given /^the customer (?:added|adds) ("[^"]+" product) to the cart$/
      * @Given /^I (?:add|added) ("[^"]+" product) to the (cart)$/
      * @When I add product :product to the cart
      * @When they add product :product to the cart
      */
-    public function iAddProductToTheCart(ProductInterface $product, string $localeCode = 'en_US'): void
+    public function iAddProductToTheCart(ProductInterface $product): void
     {
-        $this->productShowPage->open(['slug' => $product->getSlug(), '_locale' => $localeCode]);
+        $this->productShowPage->open(['slug' => $product->getSlug()]);
         $this->productShowPage->addToCart();
 
         $this->sharedStorage->set('product', $product);

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -124,6 +124,14 @@ final class CartContext implements Context
     }
 
     /**
+     * @Given /^I use the ("([^"]+)" locale)$/
+     */
+    public function iUseTheLocale(string $localeCode): void
+    {
+        $this->sharedStorage->set('current_locale_code', $localeCode);
+    }
+
+    /**
      * @Then the grand total value should be :total
      * @Then my cart total should be :total
      * @Then the cart total should be :total
@@ -296,14 +304,15 @@ final class CartContext implements Context
      * @Given I added product :product to the cart
      * @Given he added product :product to the cart
      * @Given /^I (?:have|had) (product "[^"]+") in the cart$/
+     * @Given /^I have (product "[^"]+") in the cart using ("([^"]+)" locale)$/
      * @Given /^the customer (?:added|adds) ("[^"]+" product) to the cart$/
      * @Given /^I (?:add|added) ("[^"]+" product) to the (cart)$/
      * @When I add product :product to the cart
      * @When they add product :product to the cart
      */
-    public function iAddProductToTheCart(ProductInterface $product): void
+    public function iAddProductToTheCart(ProductInterface $product, string $localeCode = 'en_US'): void
     {
-        $this->productShowPage->open(['slug' => $product->getSlug()]);
+        $this->productShowPage->open(['slug' => $product->getSlug(), '_locale' => $localeCode]);
         $this->productShowPage->addToCart();
 
         $this->sharedStorage->set('product', $product);

--- a/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
@@ -217,4 +217,12 @@ final class CheckoutContext implements Context
         $this->registerElement->specifyLastName('Ironfoundersson');
         $this->registerElement->register();
     }
+
+    /**
+     * @Then I should see the promotion label named :label
+     */
+    public function iShouldSeeThePromotionLabelNamed(string $label): void
+    {
+        Assert::true($this->completePage->hasPromotionLabel($label));
+    }
 }

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -392,6 +392,13 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return  $this->getElement('shipment_shipped_at_date')->getText();
     }
 
+    public function hasPromotionLabel(string $promotionLabel): bool
+    {
+        $promotionDiscountsText = $this->getElement('promotion_discounts')->getText();
+
+        return str_contains($promotionDiscountsText, $promotionLabel);
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -60,6 +60,8 @@ interface ShowPageInterface extends SymfonyPageInterface
 
     public function getOrderPromotionTotal(): string;
 
+    public function hasPromotionLabel(string $promotionLabel): bool;
+
     public function hasPromotionDiscount(string $promotionName, string $promotionAmount): bool;
 
     public function hasTax(string $tax): bool;

--- a/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
@@ -231,6 +231,14 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
         return str_contains($shippingPromotions->getAttribute('data-html'), $promotionName);
     }
 
+    public function hasPromotionLabel(string $promotionLabel): bool
+    {
+        /** @var NodeElement $shippingPromotions */
+        $label = $this->getElement('promotion_label');
+
+        return str_contains($label->getAttribute('data-html'), $promotionLabel);
+    }
+
     public function tryToOpen(array $urlParameters = []): void
     {
         if (DriverHelper::isJavascript($this->getDriver())) {
@@ -275,6 +283,7 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
             'shipping_total' => '[data-test-shipping-total]',
             'tax_total' => '[data-test-tax-total]',
             'validation_errors' => '[data-test-validation-error]',
+            'promotion_label' => '[data-test-promotion-label]',
         ]);
     }
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/CompletePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/CompletePageInterface.php
@@ -79,4 +79,6 @@ interface CompletePageInterface extends SymfonyPageInterface
     public function hasShippingPromotionWithDiscount(string $promotionName, string $discount): bool;
 
     public function hasOrderPromotion(string $promotionName): bool;
+
+    public function hasPromotionLabel(string $promotionLabel): bool;
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -209,6 +209,7 @@
             <argument type="service" id="sylius.test.factory.promotion" />
             <argument type="service" id="sylius.repository.promotion" />
             <argument type="service" id="sylius.promotion_coupon_generator" />
+            <argument type="service" id="sylius.factory.promotion_translation" />
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -50,6 +50,7 @@ default:
 
                 - sylius.behat.context.transform.shared_storage
 
+                - sylius.behat.context.ui.admin.managing_administrator_locale
                 - sylius.behat.context.ui.admin.managing_orders
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.channel

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totalsPromotions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totalsPromotions.html.twig
@@ -14,7 +14,7 @@
                 {% for label, amount in promotionAdjustments %}
                     <div class="item">
                         <div class="right floated">{{ money.format(amount, order.currencyCode) }}</div>
-                        <div class="content"><strong>{{ label }}</strong>:</div>
+                        <div class="content"><a href="{{ sylius_generate_url_from_adjustment(label) }}"><strong>{{ label }}</strong></a>:</div>
                     </div>
                 {% endfor %}
             </div>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -178,6 +178,13 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="sylius.twig.extension.generate_url_from_adjustment" class="Sylius\Bundle\CoreBundle\Twig\GenerateUrlFromAdjustmentExtension" public="false">
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius.repository.adjustment" />
+            <argument type="service" id="sylius.repository.promotion" />
+            <tag name="twig.extension" />
+        </service>
+
         <service id="sylius.unique_id_based_order_token_assigner" class="Sylius\Component\Core\TokenAssigner\UniqueIdBasedOrderTokenAssigner">
             <argument type="service" id="sylius.random_generator" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Twig/GenerateUrlFromAdjustmentExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/GenerateUrlFromAdjustmentExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Sylius\Component\Order\Model\AdjustmentInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class GenerateUrlFromAdjustmentExtension extends AbstractExtension
+{
+    public function __construct(
+        private RouterInterface $router,
+        private RepositoryInterface $adjustmentRepository,
+        private RepositoryInterface $promotionRepository,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sylius_generate_url_from_adjustment', [$this, 'generateUrlFromAdjustment']),
+        ];
+    }
+
+    public function generateUrlFromAdjustment(string $label): string
+    {
+        /** @var AdjustmentInterface $adjustment */
+        $adjustment = $this->adjustmentRepository->findOneBy(['label' => $label]);
+        /** @var PromotionInterface $promotion */
+        $promotion = $this->promotionRepository->findOneBy(['code' => $adjustment->getOriginCode()]);
+
+        return $this->router->generate('sylius_admin_promotion_update', ['id' => $promotion->getId()]);
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_item.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_item.html.twig
@@ -13,6 +13,7 @@
         <span class="sylius-unit-price" {{ sylius_test_html_attribute('product-unit-price', item.productName) }}>{{ money.convertAndFormat(item.discountedUnitPrice) }}
             {% if item.unitPrice != item.discountedUnitPrice %}
             <i id="item-promotion-details" class="question circle icon unit-promotions popup-js"
+               {{ sylius_test_html_attribute('promotion-label') }}
                data-html="{% for promotion in unitPromotions %}<div>{{ promotion.label }}: {{ money.convertAndFormat(promotion.amount) }}</div>{% endfor %}">
             </i>
             {% endif %}

--- a/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
@@ -103,7 +103,7 @@ abstract class UnitDiscountPromotionActionCommand implements PromotionActionComm
         /** @var OrderAdjustmentInterface $adjustment */
         $adjustment = $this->adjustmentFactory->createNew();
         $adjustment->setType($type);
-        $adjustment->setLabel($translation->getLabel());
+        $adjustment->setLabel($translation->getLabel() ?? $promotion->getName());
         $adjustment->setOriginCode($promotion->getCode());
 
         return $adjustment;

--- a/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
@@ -68,7 +68,7 @@ abstract class UnitDiscountPromotionActionCommand implements PromotionActionComm
             return;
         }
 
-        $adjustment = $this->createAdjustment($promotion, AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $adjustment = $this->createAdjustment($promotion, $unit, AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
 
         /** @var OrderItemInterface $orderItem */
         $orderItem = $unit->getOrderItem();
@@ -90,12 +90,13 @@ abstract class UnitDiscountPromotionActionCommand implements PromotionActionComm
 
     protected function createAdjustment(
         PromotionInterface $promotion,
+        OrderItemUnitInterface $unit,
         string $type = AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
     ): OrderAdjustmentInterface {
         /** @var OrderAdjustmentInterface $adjustment */
         $adjustment = $this->adjustmentFactory->createNew();
         $adjustment->setType($type);
-        $adjustment->setLabel($promotion->getName());
+        $adjustment->setLabel($promotion->getTranslation($unit->getOrderItem()->getOrder()->getLocaleCode())->getLabel());
         $adjustment->setOriginCode($promotion->getCode());
 
         return $adjustment;

--- a/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitDiscountPromotionActionCommand.php
@@ -22,6 +22,7 @@ use Sylius\Component\Order\Model\AdjustmentInterface as OrderAdjustmentInterface
 use Sylius\Component\Promotion\Action\PromotionActionCommandInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
@@ -93,10 +94,16 @@ abstract class UnitDiscountPromotionActionCommand implements PromotionActionComm
         OrderItemUnitInterface $unit,
         string $type = AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
     ): OrderAdjustmentInterface {
+        /** @var OrderInterface $order */
+        $order = $unit->getOrderItem()->getOrder();
+
+        /** @var PromotionTranslationInterface $translation */
+        $translation = $promotion->getTranslation($order->getLocaleCode());
+
         /** @var OrderAdjustmentInterface $adjustment */
         $adjustment = $this->adjustmentFactory->createNew();
         $adjustment->setType($type);
-        $adjustment->setLabel($promotion->getTranslation($unit->getOrderItem()->getOrder()->getLocaleCode())->getLabel());
+        $adjustment->setLabel($translation->getLabel());
         $adjustment->setOriginCode($promotion->getCode());
 
         return $adjustment;

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -22,6 +22,7 @@ use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Order\Model\OrderItemUnitInterface;
 use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
 use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Webmozart\Assert\Assert;
 
 final class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustmentsApplicatorInterface
@@ -75,10 +76,16 @@ final class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustm
 
     private function addAdjustment(PromotionInterface $promotion, OrderItemUnitInterface $unit, int $amount): void
     {
+        /** @var OrderInterface $order */
+        $order = $unit->getOrderItem()->getOrder();
+
+        /** @var PromotionTranslationInterface $translation */
+        $translation = $promotion->getTranslation($order->getLocaleCode());
+
         $adjustment = $this->adjustmentFactory
             ->createWithData(
                 AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
-                $promotion->getTranslation($unit->getOrderItem()->getOrder()->getLocaleCode())->getLabel(),
+                $translation->getLabel() ?? $promotion->getName(),
                 $amount,
             )
         ;

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -76,7 +76,11 @@ final class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustm
     private function addAdjustment(PromotionInterface $promotion, OrderItemUnitInterface $unit, int $amount): void
     {
         $adjustment = $this->adjustmentFactory
-            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, $promotion->getName(), $amount)
+            ->createWithData(
+                AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
+                $promotion->getTranslation($unit->getOrderItem()->getOrder()->getLocaleCode())->getLabel(),
+                $amount,
+            )
         ;
         $adjustment->setOriginCode($promotion->getCode());
 

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountPromotionActionCommandSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountPromotionActionCommandSpec.php
@@ -28,6 +28,7 @@ use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Core\Promotion\Action\UnitDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Filter\FilterInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
@@ -71,6 +72,7 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         PromotionInterface $promotion,
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -101,6 +103,18 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
         $promotion->getAppliesToDiscounted()->willReturn(true);
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem2);
+        $orderItem2->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
@@ -142,6 +156,7 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
         CatalogPromotionInterface $catalogPromotion,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -177,6 +192,18 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
         $promotion->getAppliesToDiscounted()->willReturn(false);
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem2);
+        $orderItem2->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment);
         $promotionAdjustment->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
@@ -249,6 +276,7 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         PromotionInterface $promotion,
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -279,6 +307,18 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
         $promotion->getAppliesToDiscounted()->willReturn(true);
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem2);
+        $orderItem2->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
@@ -321,6 +361,7 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         PromotionInterface $promotion,
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -353,6 +394,18 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
 
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountPromotionActionCommandSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountPromotionActionCommandSpec.php
@@ -29,6 +29,7 @@ use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Core\Promotion\Action\UnitDiscountPromotionActionCommand;
 use Sylius\Component\Core\Promotion\Filter\FilterInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
@@ -73,6 +74,7 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         ProductVariantInterface $productVariant2,
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -110,6 +112,18 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
         $promotion->getAppliesToDiscounted()->willReturn(true);
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
@@ -149,6 +163,7 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         ChannelPricingInterface $channelPricing1,
         ChannelPricingInterface $channelPricing2,
         CatalogPromotionInterface $catalogPromotion,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->getChannel()->willReturn($channel);
         $channel->getCode()->willReturn('WEB_US');
@@ -186,6 +201,18 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         $promotion->getName()->willReturn('Test promotion');
         $promotion->getCode()->willReturn('TEST_PROMOTION');
         $promotion->getAppliesToDiscounted()->willReturn(false);
+
+        $unit1->getOrderItem()->willReturn($orderItem1);
+        $orderItem1->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $unit2->getOrderItem()->willReturn($orderItem2);
+        $orderItem2->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Test promotion');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment);
 

--- a/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
@@ -27,6 +27,7 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\PromotionTranslationInterface;
 
 final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 {
@@ -60,6 +61,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ProductVariantInterface $magnumItemVariant,
         ChannelPricingInterface $coltItemChannelPricing,
         ChannelPricingInterface $magnumItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(2);
         $order->getChannel()->willReturn($channel);
@@ -94,8 +96,20 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
             ->willReturn(new ArrayCollection([$magnumUnit->getWrappedObject()]))
         ;
 
-        $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
+
+        $firstColtUnit->getOrderItem()->willReturn($coltItem);
+        $secondColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $magnumUnit->getOrderItem()->willReturn($magnumItem);
+        $magnumItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 500)
@@ -132,6 +146,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ProductVariantInterface $magnumItemVariant,
         ChannelPricingInterface $coltItemChannelPricing,
         ChannelPricingInterface $magnumItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(2);
         $order->getChannel()->willReturn($channel);
@@ -167,6 +182,18 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
 
+        $coltUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $magnumUnit->getOrderItem()->willReturn($magnumItem);
+        $magnumItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
             ->willReturn($adjustment)
@@ -200,6 +227,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ChannelPricingInterface $coltItemChannelPricing,
         ChannelPricingInterface $magnumItemChannelPricing,
         ChannelPricingInterface $winchesterItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(3);
         $order->getChannel()->willReturn($channel);
@@ -248,6 +276,24 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
 
+        $coltUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $magnumUnit->getOrderItem()->willReturn($magnumItem);
+        $magnumItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $winchesterUnit->getOrderItem()->willReturn($winchesterItem);
+        $winchesterItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
             ->willReturn($firstAdjustment, $secondAdjustment)
@@ -277,6 +323,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ChannelInterface $channel,
         ProductVariantInterface $coltItemVariant,
         ChannelPricingInterface $coltItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(1);
         $order->getChannel()->willReturn($channel);
@@ -309,6 +356,24 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
 
+        $firstColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $secondColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $thirdColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
             ->willReturn($firstAdjustment, $secondAdjustment)
@@ -336,6 +401,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ChannelInterface $channel,
         ProductVariantInterface $coltItemVariant,
         ChannelPricingInterface $coltItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(1);
         $order->getChannel()->willReturn($channel);
@@ -362,6 +428,18 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 
         $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
+
+        $firstColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $secondColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
@@ -394,6 +472,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         ProductVariantInterface $magnumItemVariant,
         ChannelPricingInterface $coltItemChannelPricing,
         ChannelPricingInterface $magnumItemChannelPricing,
+        PromotionTranslationInterface $translation,
     ): void {
         $order->countItems()->willReturn(2);
         $order->getChannel()->willReturn($channel);
@@ -430,6 +509,24 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 
         $promotion->getName()->willReturn('Winter guns promotion!');
         $promotion->getCode()->willReturn('WINTER_GUNS_PROMOTION');
+
+        $firstColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $secondColtUnit->getOrderItem()->willReturn($coltItem);
+        $coltItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
+
+        $magnumUnit->getOrderItem()->willReturn($magnumItem);
+        $magnumItem->getOrder()->willReturn($order);
+        $order->getLocaleCode()->willReturn('en_US');
+        $translation->getLabel()->willReturn('Winter guns promotion!');
+        $promotion->getTranslation('en_US')->willReturn($translation);
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', -500)

--- a/src/Sylius/Component/Order/Aggregator/AdjustmentsByLabelAggregator.php
+++ b/src/Sylius/Component/Order/Aggregator/AdjustmentsByLabelAggregator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Order\Aggregator;
 
 use Sylius\Component\Order\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Webmozart\Assert\Assert;
 
 final class AdjustmentsByLabelAggregator implements AdjustmentsAggregatorInterface
@@ -27,6 +28,10 @@ final class AdjustmentsByLabelAggregator implements AdjustmentsAggregatorInterfa
             if (!isset($aggregatedAdjustments[$adjustment->getLabel()])) {
                 $aggregatedAdjustments[$adjustment->getLabel()] = 0;
             }
+
+//            if ($adjustment->getType() === BaseAdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) {
+//
+//            }
 
             $aggregatedAdjustments[$adjustment->getLabel()] += $adjustment->getAmount();
         }

--- a/src/Sylius/Component/Order/Aggregator/AdjustmentsByLabelAggregator.php
+++ b/src/Sylius/Component/Order/Aggregator/AdjustmentsByLabelAggregator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Component\Order\Aggregator;
 
 use Sylius\Component\Order\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Webmozart\Assert\Assert;
 
 final class AdjustmentsByLabelAggregator implements AdjustmentsAggregatorInterface
@@ -28,10 +27,6 @@ final class AdjustmentsByLabelAggregator implements AdjustmentsAggregatorInterfa
             if (!isset($aggregatedAdjustments[$adjustment->getLabel()])) {
                 $aggregatedAdjustments[$adjustment->getLabel()] = 0;
             }
-
-//            if ($adjustment->getType() === BaseAdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) {
-//
-//            }
 
             $aggregatedAdjustments[$adjustment->getLabel()] += $adjustment->getAmount();
         }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Related tickets | based on #14379                      |
| License         | MIT                                                          |

This is the second part of cart promotion translatable labels.

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
