### PR TITLE
[GitHub Actions] Fix builds with a fixed symfony-cli version

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -60,6 +60,12 @@ jobs:
                     coverage: none
 
             -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
+
+            -
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
@@ -206,6 +212,12 @@ jobs:
                     tools: symfony
                     coverage: none
 
+            -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
+
             -   name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
@@ -270,6 +282,12 @@ jobs:
                     extensions: intl, gd, opcache, pgsql, pdo_pgsql
                     tools: symfony
                     coverage: none
+
+            -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
 
             -
                 name: Restrict Symfony version
@@ -355,6 +373,12 @@ jobs:
                     extensions: intl, gd, opcache, mysql, pdo_mysql
                     tools: symfony
                     coverage: none
+
+            -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
 
             -
                 name: Restrict Symfony version
@@ -500,6 +524,12 @@ jobs:
                     coverage: none
 
             -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
+
+            -
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
@@ -634,6 +664,12 @@ jobs:
                     extensions: intl, gd, opcache, mysql, pdo_mysql
                     tools: symfony
                     coverage: none
+
+            -
+                name: Install Symfony CLI
+                run: |
+                    wget https://github.com/symfony-cli/symfony-cli/releases/download/v5.4.14/symfony-cli_5.4.14_amd64.deb
+                    sudo dpkg -i symfony-cli_5.4.14_amd64.deb
 
             -
                 name: Restrict Symfony version

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -94,3 +94,7 @@ In this section we keep track of the reasons, why some restrictions were added t
    `Sylius\Bundle\ApiBundle\Swagger\AcceptLanguageHeaderDocumentationNormalizer` 
    references this class throws an exception
   `Class "ApiPlatform\Core\Metadata\Resource\ResourceNameCollection" not found`
+
+ - `api-platform/core:2.7.2`:
+
+   Due to the changes in the skolem IRI generation (see [this PR](https://github.com/api-platform/core/pull/5046)) 

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "api-platform/core": "2.7.0",
+        "api-platform/core": "2.7.0 || 2.7.2",
         "doctrine/doctrine-bundle": "2.3.0",
         "jms/serializer-bundle": "3.9.0",
         "symfony/doctrine-bridge": "4.4.16",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                              |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

The reason why we might have to use a fixed Symfony CLI version temporarily is described in https://github.com/symfony-cli/symfony-cli/issues/194.