### PR TITLE
[Docs][CatalogPromotions][Messenger] Failure transports

### DIFF
--- a/docs/book/products/catalog_promotions.rst
+++ b/docs/book/products/catalog_promotions.rst
@@ -368,6 +368,11 @@ it is responsible for the priority of consumed messages:
 
     php bin/console messenger:consume main catalog_promotion_removal
 
+Each transport has its own failure transport, which is responsible for storing messages that haven't been processed for some reason.
+For the **main** transport it is the **main_failed** transport and for the **catalog_promotion_removal** transport it is the **catalog_promotion_removal_failed** transport.
+
+You can read more about failure handling in the `Symfony Messenger documentation <https://symfony.com/doc/current/messenger.html#retries-failures>`_.
+
 For synchronous processing, no additional configuration is required.
 
 How to manage catalog promotion priority?


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | no|
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | #14314 
| License         | MIT                                                          |
<img width="805" alt="image" src="https://user-images.githubusercontent.com/40125720/194866107-094b3790-e815-49cf-bca5-82e92276a2a9.png">

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
