### PR TITLE
Fix - move RedirectPathExtension from Admin bundle to Ui bundle

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Controller;
 
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RedirectHandlerInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/AdminFilterSubscriber.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\EventListener;
 
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -61,16 +61,6 @@
             <tag name="twig.extension" />
         </service>
 
-        <service id="Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension">
-            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
-            <argument type="service" id="router" />
-            <tag name="twig.extension" />
-        </service>
-
-        <service id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" public="false">
-            <argument type="service" id="request_stack" />
-        </service>
-
         <service id="sylius.http_client" class="GuzzleHttp\Client" public="false" />
         <service id="sylius.http_message_factory" class="Http\Message\MessageFactory\GuzzleMessageFactory" public="false" />
     </services>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -105,7 +105,7 @@
             public="false"
         >
             <argument type="service" id="Sylius\Bundle\AdminBundle\Controller\RedirectHandler.inner" />
-            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <argument type="service" id="Sylius\Bundle\UiBundle\Storage\FilterStorage" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
@@ -32,7 +32,7 @@
         </service>
 
         <service id="sylius.event_subscriber.admin_filter_subscriber" class="Sylius\Bundle\AdminBundle\EventListener\AdminFilterSubscriber">
-            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <argument type="service" id="Sylius\Bundle\UiBundle\Storage\FilterStorage" />
             <tag name="kernel.event_subscriber" event="kernel.request" />
         </service>
     </services>

--- a/src/Sylius/Bundle/AdminBundle/spec/Controller/RedirectHandlerSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/Controller/RedirectHandlerSpec.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\AdminBundle\Controller;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RedirectHandlerInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/EventListener/AdminFilterSubscriberSpec.php
@@ -15,7 +15,7 @@ namespace spec\Sylius\Bundle\AdminBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -46,5 +46,15 @@
             <argument>%sylius_ui.sonata_block.whitelisted_variables%</argument>
             <tag name="twig.extension" />
         </service>
+
+        <service id="Sylius\Bundle\UiBundle\Twig\RedirectPathExtension">
+            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <argument type="service" id="router" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="Sylius\Bundle\UiBundle\Storage\FilterStorage" public="false">
+            <argument type="service" id="request_stack" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -48,7 +48,7 @@
         </service>
 
         <service id="Sylius\Bundle\UiBundle\Twig\RedirectPathExtension">
-            <argument type="service" id="Sylius\Bundle\AdminBundle\Storage\FilterStorage" />
+            <argument type="service" id="Sylius\Bundle\UiBundle\Storage\FilterStorage" />
             <argument type="service" id="router" />
             <tag name="twig.extension" />
         </service>

--- a/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
+++ b/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\AdminBundle\Storage;
+namespace Sylius\Bundle\UiBundle\Storage;
 
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;

--- a/src/Sylius/Bundle/UiBundle/Storage/FilterStorageInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Storage/FilterStorageInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\AdminBundle\Storage;
+namespace Sylius\Bundle\UiBundle\Storage;
 
 interface FilterStorageInterface
 {

--- a/src/Sylius/Bundle/UiBundle/Twig/RedirectPathExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/RedirectPathExtension.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Twig;
 
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Extension\AbstractExtension;

--- a/src/Sylius/Bundle/UiBundle/Twig/RedirectPathExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/RedirectPathExtension.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\AdminBundle\Twig;
+namespace Sylius\Bundle\UiBundle\Twig;
 
 use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Sylius/Bundle/UiBundle/spec/Storage/FilterStorageSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Storage/FilterStorageSpec.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\UiBundle\spec\Storage;
+namespace spec\Sylius\Bundle\UiBundle\Storage;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;

--- a/src/Sylius/Bundle/UiBundle/spec/Storage/FilterStorageSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Storage/FilterStorageSpec.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\AdminBundle\Storage;
+namespace Sylius\Bundle\UiBundle\spec\Storage;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\AdminBundle\Storage\FilterStorageInterface;
+use Sylius\Bundle\UiBundle\Storage\FilterStorageInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 

--- a/tests/Twig/RedirectPathExtensionTest.php
+++ b/tests/Twig/RedirectPathExtensionTest.php
@@ -22,7 +22,7 @@ final class RedirectPathExtensionTest extends KernelTestCase
         $container->get('request_stack')->push($request);
 
         $this->redirectPathExtension = $container->get('Sylius\Bundle\UiBundle\Twig\RedirectPathExtension');
-        $container->get('Sylius\Bundle\AdminBundle\Storage\FilterStorage')->set(['criteria' => ['enabled' => true]]);
+        $container->get('Sylius\Bundle\UiBundle\Storage\FilterStorage')->set(['criteria' => ['enabled' => true]]);
     }
 
     /** @test */

--- a/tests/Twig/RedirectPathExtensionTest.php
+++ b/tests/Twig/RedirectPathExtensionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Twig;
 
-use Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension;
+use Sylius\Bundle\UiBundle\Twig\RedirectPathExtension;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -21,7 +21,7 @@ final class RedirectPathExtensionTest extends KernelTestCase
         $request->setSession($session);
         $container->get('request_stack')->push($request);
 
-        $this->redirectPathExtension = $container->get('Sylius\Bundle\AdminBundle\Twig\RedirectPathExtension');
+        $this->redirectPathExtension = $container->get('Sylius\Bundle\UiBundle\Twig\RedirectPathExtension');
         $container->get('Sylius\Bundle\AdminBundle\Storage\FilterStorage')->set(['criteria' => ['enabled' => true]]);
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The create button on Ui bundle uses a twig extension from Admin bundle

![Capture d’écran du 2022-10-12 11-41-07](https://user-images.githubusercontent.com/8329789/195308817-5fef4502-e452-4f57-8e16-80a355db7ec8.png)
