### PR TITLE
Fix package alias on API Bundle

### DIFF
--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -38,6 +38,10 @@ jobs:
             -
                 name: Run ECS
                 run: vendor/bin/ecs check --fix src/Sylius
+                
+            -
+                name: Run Package alias
+                run: vendor/bin/monorepo-builder package-alias
 
             -
                 name: Create Pull Request

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -2,10 +2,7 @@
     "name": "sylius/api-bundle",
     "type": "symfony-bundle",
     "description": "APIs management for Symfony projects.",
-    "keywords": [
-        "api",
-        "rest"
-    ],
+    "keywords": ["api", "rest"],
     "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
@@ -58,7 +55,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7-dev"
+            "dev-master": "1.9-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

I've fixed that running the following command
```bash
$ vendor/bin/monorepo-builder package-alias
```
