### PR TITLE
Remove SymfonyMockerContainer fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,7 @@
         "phpstan/phpstan": "1.5.4",
         "phpstan/phpstan-doctrine": "1.3.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "psalm/plugin-mockery": "0.7.0",
         "psr/event-dispatcher": "^1.0",
         "rector/rector": "^0.12.20",
@@ -321,8 +321,5 @@
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         }
-    },
-    "repositories": [
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
-    ]
+    }
 }

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -40,7 +40,7 @@
         "doctrine/orm": "^2.13",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -73,8 +73,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -35,7 +35,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -68,8 +68,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -39,7 +39,7 @@
         "doctrine/orm": "^2.13",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -72,8 +72,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -49,7 +49,7 @@
     "require-dev": {
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0"
@@ -81,8 +81,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -40,7 +40,7 @@
         "doctrine/orm": "^2.13",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "twig/twig": "^2.12 || ^3.3"
@@ -72,8 +72,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -40,7 +40,7 @@
         "friendsofphp/proxy-manager-lts": "^1.0.7",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "twig/twig": "^2.12 || ^3.3"
@@ -72,8 +72,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -39,7 +39,7 @@
         "doctrine/orm": "^2.13",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sylius/currency-bundle": "^1.6",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
@@ -73,8 +73,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -39,7 +39,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sylius/locale-bundle": "^1.6",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0"
@@ -71,8 +71,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -44,7 +44,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -78,8 +78,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -52,7 +52,7 @@
     "require-dev": {
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -86,8 +86,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -44,7 +44,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0",
@@ -74,8 +74,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -43,7 +43,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
-        "polishsymfonycommunity/symfony-mocker-container": "dev-support-symfony-6",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/form": "^5.4 || ^6.0"
@@ -75,8 +75,7 @@
         {
             "type": "path",
             "url": "../../*/*"
-        },
-        { "type": "vcs", "url": "git@github.com:Zales0123/SymfonyMockerContainer.git" }
+        }
     ],
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

[1.0.6 version](https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer/releases/tag/v1.0.6) supports Symfony 6 🎉 