### PR TITLE
[Hot-fix] Conflict with the SymfonyMockerContainer 1.0.6 due to incompatible version with Symfony 4.x

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -98,3 +98,13 @@ In this section we keep track of the reasons, why some restrictions were added t
 - `api-platform/core:2.7.2`:
 
   Due to the changes in the skolem IRI generation (see [this PR](https://github.com/api-platform/core/pull/5046))
+
+- `polishsymfonycommunity/symfony-mocker-container:1.0.6`:
+
+  ```
+  PHP Fatal error:  Declaration of PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer::has(string $id): bool 
+  must be compatible with Symfony\Component\DependencyInjection\Container::has($id) 
+  in /home/runner/work/Sylius/Sylius/vendor/polishsymfonycommunity/symfony-mocker-container/src/DependencyInjection/MockerContainer.php on line 64
+  ```
+
+  References: https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer/issues/20

--- a/composer.json
+++ b/composer.json
@@ -162,6 +162,7 @@
         "api-platform/core": "2.7.0 || 2.7.2",
         "doctrine/doctrine-bundle": "2.3.0",
         "jms/serializer-bundle": "3.9.0",
+        "polishsymfonycommunity/symfony-mocker-container": "1.0.6",
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/framework-bundle": "^4.4.38 || ^5.4.5",
         "symfony/password-hasher": "^6.0",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11|
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | https://github.com/PolishSymfonyCommunity/SymfonyMockerContainer/issues/20 |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
