### PR TITLE
:fr: Add missing validation error on tax rate fr translation

### DIFF
--- a/src/Sylius/Bundle/TaxationBundle/Resources/translations/validators.fr.yml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/translations/validators.fr.yml
@@ -15,6 +15,7 @@ sylius:
         name:
             not_blank: Veuillez entrer le nom de la taxe.
         amount:
+            invalid: Le taux de taxe doit être supérieur ou égal à 0.
             not_blank: Veuillez entrer le taux de la taxe.
         calculator:
             not_blank: Veuillez sélectionner le calculateur de la taxe.


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.110                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | none                      |
| License         | MIT                                                          |

Hello & sorry about this one I know it should be on crowdin but I can't find the file!

![image](https://user-images.githubusercontent.com/972456/196194870-e141798b-3d7d-4a18-8d5d-f3bf9cddadde.png)

But the translation is missing in every branch... https://github.com/Sylius/Sylius/blob/1.12/src/Sylius/Bundle/TaxationBundle/Resources/translations/validators.fr.yml#L18