### PR TITLE
[Hot-fix] Do not fail scenario after 422 response page

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Crud;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -75,6 +77,24 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     public function getMessageInvalidForm(): string
     {
         return $this->getDocument()->find('css', '.ui.icon.negative.message')->getText();
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
+use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Core\Model\AddressInterface;
 
@@ -70,5 +72,23 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
             'street' => '[data-test-street]',
             'province_validation_message' => '[data-test-validation-error]:contains("province")',
         ]);
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
+use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Service\JQueryHelper;
 
 class UpdatePage extends SymfonyPage implements UpdatePageInterface
@@ -90,6 +92,24 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
             'selected_province' => '[data-test-province-code] option[selected="selected"]',
             'street' => '[data-test-street]',
         ]);
+    }
+
+    protected function verifyStatusCode(): void
+    {
+        try {
+            $statusCode = $this->getSession()->getStatusCode();
+        } catch (DriverException) {
+            return; // Ignore drivers which cannot check the response status code
+        }
+
+        if (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 422) {
+            return;
+        }
+
+        $currentUrl = $this->getSession()->getCurrentUrl();
+        $message = sprintf('Could not open the page: "%s". Received an error status code: %s', $currentUrl, $statusCode);
+
+        throw new UnexpectedPageException($message);
     }
 
     private function waitForElement(int $timeout, string $elementName): void


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

[This change](https://github.com/Sylius/SyliusResourceBundle/pull/488) resulted in a different response code which we checks in our Behats. It's a hot-fix, as we should change it in the SyliusResourceBundle itself :dancer: But I would like to unblock builds