### PR TITLE
Lower hashing alogirthm memory cost in test

### DIFF
--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,3 +1,6 @@
 security:
     password_hashers:
-        Sylius\Component\User\Model\UserInterface: argon2i
+        Sylius\Component\User\Model\UserInterface:
+            algorithm: argon2i
+            time_cost: 3
+            memory_cost: 10


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

`plaintext` does not work for some reason 🤨 but lowering this configuration already results in a huge boost (35min vs 23-25min 😱), which seems like we come back to the time we had before 🖖 