### PR TITLE
[Api] fixed normalization/denormalization resources groups

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
@@ -17,13 +17,6 @@
 >
     <resource class="%sylius.model.customer_group.class%" shortName="CustomerGroup">
         <attribute name="route_prefix">admin</attribute>
-
-        <attribute name="denormalization_context">
-            <attribute name="groups">
-                <attribute>admin:customer_group:create</attribute>
-            </attribute>
-        </attribute>
-
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>
@@ -36,6 +29,9 @@
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">admin:customer_group:create</attribute>
+                </attribute>
             </collectionOperation>
         </collectionOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
@@ -17,13 +17,6 @@
 >
     <resource class="%sylius.model.product_association_type.class%" shortName="ProductAssociationType">
         <attribute name="route_prefix">admin</attribute>
-
-        <attribute name="normalization_context">
-            <attribute name="groups">
-                <attribute>admin:product_association_type:read</attribute>
-            </attribute>
-        </attribute>
-
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>
@@ -32,10 +25,16 @@
                 <attribute name="filters">
                     <attribute>sylius.api.product_association_type_filter</attribute>
                 </attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_association_type:read</attribute>
+                </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_association_type:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:product_association_type:create</attribute>
                 </attribute>
@@ -45,10 +44,16 @@
         <itemOperations>
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_association_type:read</attribute>
+                </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_association_type:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:product_association_type:update</attribute>
                 </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -16,12 +16,6 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_option.class%" shortName="ProductOption">
-        <attribute name="normalization_context">
-            <attribute name="groups">
-                <attribute>admin:product_option:read</attribute>
-            </attribute>
-        </attribute>
-
         <attribute name="validation_groups">sylius</attribute>
 
         <attribute name="order">
@@ -32,11 +26,17 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option:read</attribute>
+                </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-options</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:product_option:create</attribute>
                 </attribute>
@@ -47,6 +47,9 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option:read</attribute>
+                </attribute>
             </itemOperation>
 
             <itemOperation name="shop_get">
@@ -60,6 +63,9 @@
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-options/{code}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:product_option:update</attribute>
                 </attribute>
@@ -70,6 +76,9 @@
             <subresourceOperation name="values_get_subresource">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}/values</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option:read</attribute>
+                </attribute>
             </subresourceOperation>
         </subresourceOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -16,18 +16,6 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_option_value.class%" shortName="ProductOptionValue">
-        <attribute name="normalization_context">
-            <attribute name="groups">
-                <attribute>admin:product_option_value:read</attribute>
-            </attribute>
-        </attribute>
-
-        <attribute name="denormalization_context">
-            <attribute name="groups">
-                <attribute>admin:product_option_value:write</attribute>
-            </attribute>
-        </attribute>
-
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations />
@@ -36,6 +24,9 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-option-values/{code}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:product_option_value:read</attribute>
+                </attribute>
             </itemOperation>
 
             <itemOperation name="shop_get">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -22,10 +22,6 @@
             <attribute name="position">ASC</attribute>
         </attribute>
 
-        <attribute name="normalization_context">
-            <attribute name="groups">admin:shipping_method:read</attribute>
-        </attribute>
-
         <itemOperations>
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
@@ -46,6 +42,9 @@
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/shipping-methods/{code}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:shipping_method:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:shipping_method:update</attribute>
                 </attribute>
@@ -64,6 +63,9 @@
                 <attribute name="openapi_context">
                     <attribute name="summary">Archives Shipping Method</attribute>
                 </attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:shipping_method:read</attribute>
+                </attribute>
             </itemOperation>
 
             <itemOperation name="admin_restore">
@@ -73,6 +75,9 @@
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Applicator\ArchivingShippingMethodApplicatorInterface:restore</attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Restores archived Shipping Method</attribute>
+                </attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:shipping_method:read</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -94,6 +99,9 @@
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/shipping-methods</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:shipping_method:read</attribute>
+                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:shipping_method:create</attribute>
                 </attribute>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

This PR is a follow-up of https://github.com/Sylius/Sylius/pull/14402, and attends to remove the "default" normalization context groups and specify for each operation the proper normalization/denormalization context groups.