### PR TITLE
Bring back security.authentication_manager alias if needed

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/Symfony5AuthenticationManagerPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/Symfony5AuthenticationManagerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/** @internal */
+final class Symfony5AuthenticationManagerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->has('security.authentication.manager')){
+            $container->setAlias('security.authentication_manager', 'security.authentication.manager');
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -21,6 +21,7 @@ use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Transformations;
 use Doctrine\Inflector\Rules\Word;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\ResolveShopUserTargetEntityPass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\Symfony5AuthenticationManagerPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\Symfony6PrivateServicesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBreakingErrorListenerPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\IgnoreAnnotationsPass;
@@ -75,14 +76,15 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         parent::build($container);
 
         $container->addCompilerPass(new CircularDependencyBreakingErrorListenerPass());
-        $container->addCompilerPass(new LazyCacheWarmupPass());
-        $container->addCompilerPass(new RegisterTaxCalculationStrategiesPass());
-        $container->addCompilerPass(new TranslatableEntityLocalePass());
         $container->addCompilerPass(new IgnoreAnnotationsPass());
-        $container->addCompilerPass(new ResolveShopUserTargetEntityPass());
-        $container->addCompilerPass(new RegisterUriBasedSectionResolverPass());
+        $container->addCompilerPass(new LazyCacheWarmupPass());
         $container->addCompilerPass(new LiipImageFiltersPass());
+        $container->addCompilerPass(new RegisterTaxCalculationStrategiesPass());
+        $container->addCompilerPass(new RegisterUriBasedSectionResolverPass());
+        $container->addCompilerPass(new ResolveShopUserTargetEntityPass());
+        $container->addCompilerPass(new Symfony5AuthenticationManagerPass());
         $container->addCompilerPass(new Symfony6PrivateServicesPass());
+        $container->addCompilerPass(new TranslatableEntityLocalePass());
     }
 
     /**


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | |
| License         | MIT                                                          |

We removed this alias [here](https://github.com/Sylius/Sylius/pull/13969/files#diff-676a77498218f1c920ba118a53a9ee921be3cf82f1f35faa5e96a2f2e9aa1b9eL272). I believe it's a BC break and this alias should still be there (of course, when the base service is registered - which is only in Symfony 5) 🖖 