### PR TITLE
Fixes in Order serialization after changes on 1.11

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -33,7 +33,10 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\PickupCart</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:read</attribute>
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:order:create</attribute>
@@ -106,7 +109,9 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:add_item</attribute>
@@ -128,7 +133,10 @@
                     <attribute name="groups">shop:cart:select_shipping_method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:read</attribute>
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Selects shipping methods for particular shipment</attribute>
@@ -162,7 +170,10 @@
                     <attribute name="groups">shop:cart:select_payment_method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:read</attribute>
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Selects payment methods for particular payment</attribute>
@@ -261,7 +272,10 @@
                     <attribute name="groups">shop:cart:complete</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:read</attribute>
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Completes checkout</attribute>
@@ -342,7 +356,10 @@
                     <attribute name="groups">shop:cart:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:read</attribute>
+                        <attribute>shop:cart:read</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Addresses cart to given location, logged in Customer does not have to provide an email. Applies coupon to cart.</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
@@ -37,6 +37,7 @@
 
         <attribute name="channel">
             <group>admin:order:read</group>
+            <group>shop:order:read</group>
         </attribute>
 
         <attribute name="customer">
@@ -63,6 +64,7 @@
 
         <attribute name="state">
             <group>admin:order:read</group>
+            <group>shop:order:read</group>
         </attribute>
 
         <attribute name="paymentState">


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

After the https://github.com/Sylius/Sylius/pull/14402 merge and the [removal of default normalization group](https://github.com/Sylius/Sylius/pull/14402/files#diff-5c42df62aeb90479125f3100616bad0954aef6c1137444db381398a7fc2acaf1L19-L24), some problems raised up in our contract tests. I fixed them by adding proper serialization groups, but I believe the main issue is the inconsistency between `shop:order:read` and `shop:cart:read` groups and their usage. We should take a look at it and think, how to improve it (maybe they even should be combined together 🤷‍♂️).