### PR TITLE
Missing length validation for label in cart promotion translations

### DIFF
--- a/features/promotion/managing_promotions/promotion_validation.feature
+++ b/features/promotion/managing_promotions/promotion_validation.feature
@@ -6,6 +6,7 @@ Feature: Promotion validation
 
     Background:
         Given the store operates on a single channel in "United States"
+        And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
         And I am logged in as an administrator
 
     @ui
@@ -51,6 +52,14 @@ Feature: Promotion validation
         And I make it available from "24.12.2017" to "12.12.2017"
         And I try to save my changes
         Then I should be notified that promotion cannot end before it start
+
+    @ui @javascript
+    Scenario: Adding a promotion with label exceeding 255 characters
+        Given there is a promotion "Christmas sale"
+        When I want to modify this promotion
+        And I replace its label with a string exceeding the limit in "Polish (Poland)" locale
+        And I try to save my changes
+        Then I should be notified that promotion label in "Polish (Poland)" locale is too long
 
     @ui @javascript
     Scenario: Trying to add a new promotion without specifying a order percentage discount

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -116,6 +116,14 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
+     * @When I replace its label with a string exceeding the limit in :localeCode locale
+     */
+    public function iSpecifyItsLabelWithAStringExceedingTheLimitInLocale(string $localeCode): void
+    {
+        $this->createPage->specifyLabel(str_repeat('a', 256), $localeCode);
+    }
+
+    /**
      * @When the :promotion promotion should have a label :label in :localeCode locale
      */
     public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $localeCode): void
@@ -764,6 +772,20 @@ final class ManagingPromotionsContext implements Context
         $this->notificationChecker->checkNotification(
             sprintf('Some rules of the promotions with codes %s have been updated.', $promotion->getCode()),
             NotificationType::info(),
+        );
+    }
+
+    /**
+     * @Then I should be notified that promotion label in :localeCode locale is too long
+     */
+    public function iShouldBeNotifiedThatPromotionLabelIsTooLong(string $localeCode): void
+    {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
+        $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
+
+        Assert::same(
+            $currentPage->getValidationMessageForTranslation('label', $localeCode),
+            'This value is too long. It should have 255 characters or less.',
         );
     }
 

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Promotion;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\CountsChannelBasedErrors;
 use Sylius\Behat\Behaviour\NamesIt;
@@ -149,6 +150,22 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $this->countChannelErrors($this->getElement('rules'), $channelCode);
     }
 
+    /**
+     * @throws ElementNotFoundException
+     */
+    public function getValidationMessageForTranslation(string $element, string $localeCode): string
+    {
+        $foundElement = $this->getElement($element, ['%localeCode%' => $localeCode])->getParent();
+
+        $validationMessage = $foundElement->find('css', '.sylius-validation-error');
+        if (null === $validationMessage) {
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+        }
+
+        return $validationMessage->getText();
+    }
+
+
     protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
@@ -166,6 +183,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             'ends_at_date' => '#sylius_promotion_endsAt_date',
             'ends_at_time' => '#sylius_promotion_endsAt_time',
             'exclusive' => '#sylius_promotion_exclusive',
+            'label' => '#sylius_promotion_translations_%localeCode%_label',
             'name' => '#sylius_promotion_name',
             'priority' => '#sylius_promotion_priority',
             'rule_amount' => '[id^="sylius_promotion_rules_"][id$="_configuration_%channelCode%_amount"]',

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Promotion;
 
+use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
@@ -58,4 +59,9 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
     public function getActionValidationErrorsCount(string $channelCode): int;
 
     public function getRuleValidationErrorsCount(string $channelCode): int;
+
+    /**
+     * @throws ElementNotFoundException
+     */
+    public function getValidationMessageForTranslation(string $element, string $localeCode): string;
 }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\PromotionBundle\Form\Type;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
 
 final class PromotionTranslationType extends AbstractResourceType
 {
@@ -25,6 +26,12 @@ final class PromotionTranslationType extends AbstractResourceType
             ->add('label', TextType::class, [
                 'label' => 'sylius.form.promotion.label',
                 'required' => false,
+                'constraints' => [
+                    new Length([
+                        'max' => 255,
+                        'groups' => ['sylius'],
+                    ]),
+                ],
             ])
         ;
     }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionTranslationType.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\PromotionBundle\Form\Type;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Length;
 
 final class PromotionTranslationType extends AbstractResourceType
 {
@@ -26,12 +25,6 @@ final class PromotionTranslationType extends AbstractResourceType
             ->add('label', TextType::class, [
                 'label' => 'sylius.form.promotion.label',
                 'required' => false,
-                'constraints' => [
-                    new Length([
-                        'max' => 255,
-                        'groups' => ['sylius'],
-                    ]),
-                ],
             ])
         ;
     }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/Promotion.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/Promotion.xml
@@ -61,5 +61,8 @@
         <property name="rules">
             <constraint name="Valid" />
         </property>
+        <property name="translations">
+            <constraint name="Valid" />
+        </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/PromotionTranslation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
+    <class name="Sylius\Component\Promotion\Model\PromotionTranslation">
+        <property name="label">
+            <constraint name="Length">
+                <option name="max">255</option>
+                <option name="groups">sylius</option>
+            </constraint>
+        </property>
+    </class>
+</constraint-mapping>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                       |
| Related tickets | partially #14379                      |
| License         | MIT                                                          |

Before:
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/28228691/197703187-df499c37-5e17-47c4-bac3-b26a9ab74f64.png">

After:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/28228691/197703323-1004a8a9-6cb0-48f5-804b-0957dddd3a1d.png">


<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
