### PR TITLE
Adding batching to the expired carts remover

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
+++ b/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
@@ -40,10 +40,11 @@ final class ExpiredCartsRemover implements ExpiredCartsRemoverInterface
         $interval = 0;
         foreach ($expiredCarts as $expiredCart) {
             $this->orderManager->remove($expiredCart);
-            if ($interval !== 0 && $interval % $this->batchSize === 0) {
+            $interval++;
+            
+            if ($interval % $this->batchSize === 0) {
                 $this->orderManager->flush();
             }
-            $interval++;
         }
 
         $this->orderManager->flush();

--- a/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
@@ -51,9 +51,9 @@ final class ExpiredCartsRemoverSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $orderManager->remove($firstCart);
-        $orderManager->remove($secondCart);
-        $orderManager->flush();
+        $orderManager->remove($firstCart)->shouldBeCalledOnce();
+        $orderManager->remove($secondCart)->shouldBeCalledOnce();
+        $orderManager->flush()->shouldBeCalledOnce();
 
         $eventDispatcher
             ->dispatch(Argument::any(), SyliusExpiredCartsEvents::POST_REMOVE)
@@ -62,4 +62,29 @@ final class ExpiredCartsRemoverSpec extends ObjectBehavior
 
         $this->remove();
     }
+
+    function it_removes_carts_in_batches(
+        OrderRepositoryInterface $orderRepository,
+        ObjectManager $orderManager,
+        EventDispatcher $eventDispatcher,
+        OrderInterface $cart,
+    ): void {
+        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'))->willReturn(array_fill(0, 200, $cart));
+
+        $eventDispatcher
+            ->dispatch(Argument::any(), SyliusExpiredCartsEvents::PRE_REMOVE)
+            ->shouldBeCalled()
+        ;
+
+        $orderManager->remove(Argument::type(OrderInterface::class))->shouldBeCalledTimes(200);
+        $orderManager->flush()->shouldBeCalledTimes(2);
+
+        $eventDispatcher
+            ->dispatch(Argument::any(), SyliusExpiredCartsEvents::POST_REMOVE)
+            ->shouldBeCalled()
+        ;
+
+        $this->remove();
+    }
+
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                   |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

When running the clear cart remover it breaks the database or the memory usage, whatever dies first. So in this we flush regularly to also deal with big datasets and lots of carts to remove.