### PR TITLE
Updating the RemoveExpiredCartCommand

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\OrderBundle\Command;
 use SyliusLabs\Polyfill\Symfony\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Sylius\Component\Order\Remover\ExpiredCartsRemoverInterface;
 
 /**
  * @final
@@ -23,6 +24,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class RemoveExpiredCartsCommand extends ContainerAwareCommand
 {
     protected static $defaultName = 'sylius:remove-expired-carts';
+
+    public function __construct(
+        private ?ExpiredCartsRemoverInterface $expiredCartsRemover = null,
+        private $expirationTime = null,
+    ) {
+        parent::__construct(null);
+    }
 
     protected function configure(): void
     {
@@ -33,15 +41,34 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $expirationTime = $this->getContainer()->getParameter('sylius_order.cart_expiration_period');
+        if ($this->expirationTime === null) {
+            trigger_deprecation(
+                'sylius/order-bundle',
+                '1.12',
+                sprintf('Not injecting the expiration time into %s', self::class),
+            );
+            $expirationTime = $this->getContainer()->getParameter('sylius_order.cart_expiration_period');
+        } else {
+            $expirationTime = $this->expirationTime;
+        }
+
         $output->writeln(sprintf(
             'Command will remove carts that have been idle for <info>%s</info>.',
             (string) $expirationTime,
         ));
 
-        $expiredCartsRemover = $this->getContainer()->get('sylius.expired_carts_remover');
-        $expiredCartsRemover->remove();
+        if ($this->expiredCartsRemover === null) {
+            trigger_deprecation(
+                'sylius/order-bundle',
+                '1.12',
+                sprintf('Not injecting the %s into the %s. Is deprecated', ExpiredCartsRemoverInterface::class, self::class)
+            );
+            $this->getContainer()->get('sylius.expired_carts_remover')->remove();
+        } else {
+            $this->expiredCartsRemover->remove();
+        }
 
         return 0;
     }
 }
+

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -22,6 +22,9 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\OrderBundle\Command\RemoveExpiredCartsCommand">
+            <argument type="service" id="sylius.expired_carts_remover" />
+            <argument>%sylius_order.cart_expiration_period%</argument>
+
             <tag name="console.command" />
         </service>
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                 |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | -                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
The command has been written in 2016 and now we know better to use dependency injection. For backwards compatibility we left the container and fall back to the old behavior.