### PR TITLE
Adding a filter for state in product review grid

### DIFF
--- a/features/product/managing_product_reviews/filtering_product_reviews.feature
+++ b/features/product/managing_product_reviews/filtering_product_reviews.feature
@@ -14,8 +14,7 @@ Feature: Browsing product reviews
     @ui
     Scenario: Browsing accepted reviews
         When I want to browse product reviews
-        And I choose "accepted" as a status filter
+        And I choose "Accepted" as a status filter
         And I filter
         Then I should see a single product review in the list
         And I should see the product review "Awesome" in the list
-

--- a/features/product/managing_product_reviews/filtering_product_reviews.feature
+++ b/features/product/managing_product_reviews/filtering_product_reviews.feature
@@ -1,0 +1,21 @@
+@managing_product_reviews
+Feature: Browsing product reviews
+    In order to work with multiple reviews
+    As an Administrator
+    I want to filter product reviews
+
+    Background:
+        Given the store has customer "Mike Ross" with email "ross@teammike.com"
+        And the store has a product "Lamborghini Gallardo Model"
+        And this product has a review titled "Awesome" and rated 5 with a comment "Nice product" added by customer "ross@teammike.com"
+        And this product has a new review titled "Bad" and rated 1 added by customer "ross@teammike.com"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Browsing accepted reviews
+        When I want to browse product reviews
+        And I choose "accepted" as a status filter
+        And I filter
+        Then I should see a single product review in the list
+        And I should see the product review "Awesome" in the list
+

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
@@ -48,6 +48,22 @@ final class ManagingProductReviewsContext implements Context
     }
 
     /**
+     * @When I choose :state as a status filter
+     */
+    public function iChooseStateAsStatusFilter(string $state): void
+    {
+        $this->indexPage->chooseState($state);
+    }
+
+    /**
+     * @When I filter
+     */
+    public function iFilter(): void
+    {
+        $this->indexPage->filter();
+    }
+
+    /**
      * @When I delete them
      */
     public function iDeleteThem(): void

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
@@ -49,5 +49,4 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
             'filter_state' => '#criteria_status',
         ];
     }
-
 }

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
@@ -28,6 +28,11 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         $this->getActionButtonsField($parameters)->pressButton('Reject');
     }
 
+    public function chooseState(string $state): void
+    {
+        $this->getElement('filter_state')->selectOption($state);
+    }
+
     private function getActionButtonsField(array $parameters): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
@@ -37,4 +42,12 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
 
         return $tableAccessor->getFieldFromRow($table, $row, 'actions');
     }
+
+    protected function getDefinedElements(): array
+    {
+        return parent::getDefinedElements() + [
+            'filter_state' => '#criteria_status',
+        ];
+    }
+
 }

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPageInterface.php
@@ -20,4 +20,6 @@ interface IndexPageInterface extends BaseIndexPageInterface
     public function accept(array $parameters): void;
 
     public function reject(array $parameters): void;
+
+    public function chooseState(string $state): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_review.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_review.yml
@@ -41,6 +41,14 @@ sylius_grid:
                 title:
                     type: string
                     label: sylius.ui.title
+                status:
+                    type: select
+                    label: sylius.ui.status
+                    form_options:
+                        choices:
+                            sylius.ui.new: new
+                            sylius.ui.accepted: accepted
+                            sylius.ui.rejected: rejected
             actions:
                 item:
                     update:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

## Use case
When the admin wants to see which product reviews are still pending and needs to be reviewed, he needs to filter for the product reviews. 