### PR TITLE
[Cart] Set the created_by_guest flag as false if the cart was created by a customer authenticated via access token

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/PickupCartHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/PickupCartHandler.php
@@ -72,6 +72,7 @@ final class PickupCartHandler implements MessageHandlerInterface
         $cart->setTokenValue($pickupCart->tokenValue ?? $this->generator->generateUriSafeString(10));
         if ($customer !== null) {
             $cart->setCustomer($customer);
+            $cart->setCreatedByGuest(false);
         }
 
         $this->orderManager->persist($cart);

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Cart/PickupCartHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Cart/PickupCartHandlerSpec.php
@@ -88,6 +88,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer($customer)->shouldBeCalled();
+        $cart->setCreatedByGuest(false)->shouldBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
@@ -120,6 +121,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer($customer)->shouldNotBeCalled();
+        $cart->setCreatedByGuest(false)->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldNotBeCalled();
 
         $orderManager->persist($cart)->shouldNotBeCalled();
@@ -155,6 +157,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer(Argument::any())->shouldNotBeCalled();
+        $cart->setCreatedByGuest(false)->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
@@ -194,6 +197,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer(Argument::any())->shouldNotBeCalled();
+        $cart->setCreatedByGuest(false)->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
@@ -232,6 +236,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 
         $cartFactory->createNew()->willReturn($cart);
         $cart->setCustomer(Argument::any())->shouldNotBeCalled();
+        $cart->setCreatedByGuest(false)->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
 
         $this


### PR DESCRIPTION
[Cart] Set the created_by_guest flag as false if the cart was created by a customer authenticated via access token

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #14456                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
