### PR TITLE
[Api] Sorting products by price should be per channel

### DIFF
--- a/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
+++ b/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
@@ -33,7 +33,7 @@ Feature: Sorting listed products on multiple channels
     Scenario: Sorting products by their prices with descending order on channel Poland
         When I change my current channel to "Poland"
         And I browse products from taxon "Sylius merch"
-        And I sort products by the lowest price first
+        And I sort products by the highest price first
         Then I should see 2 products in the list
         And the first product on the list should have name "Sylius Con stickers"
 
@@ -49,6 +49,6 @@ Feature: Sorting listed products on multiple channels
     Scenario: Sorting products by their prices with descending order on channel Germany
         When I change my current channel to "Germany"
         And I browse products from taxon "Sylius merch"
-        And I sort products by the lowest price first
+        And I sort products by the highest price first
         Then I should see 2 products in the list
         And the first product on the list should have name "Sylius Con shirt"

--- a/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
+++ b/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
@@ -29,6 +29,7 @@ Feature: Sorting listed products on multiple channels
         Then I should see 2 products in the list
         And the first product on the list should have name "Sylius Con shirt"
 
+    @api @ui
     Scenario: Sorting products by their prices with descending order on channel Poland
         When I change my current channel to "Poland"
         And I browse products from taxon "Sylius merch"
@@ -36,6 +37,7 @@ Feature: Sorting listed products on multiple channels
         Then I should see 2 products in the list
         And the first product on the list should have name "Sylius Con stickers"
 
+    @api @ui
     Scenario: Sorting products by their prices with ascending order on channel Germany
         When I change my current channel to "Germany"
         And I browse products from taxon "Sylius merch"
@@ -43,6 +45,7 @@ Feature: Sorting listed products on multiple channels
         Then I should see 2 products in the list
         And the first product on the list should have name "Sylius Con stickers"
 
+    @api @ui
     Scenario: Sorting products by their prices with descending order on channel Germany
         When I change my current channel to "Germany"
         And I browse products from taxon "Sylius merch"

--- a/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
+++ b/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
@@ -1,0 +1,30 @@
+@viewing_products
+Feature: Sorting listed products on multiple channels
+    In order to change the order in which products are displayed
+    As a Customer
+    I want to be able to sort products per channel
+
+    Background:
+        Given the store operates on a channel named "Poland" with hostname "shop.pl"
+        And the store operates on another channel named "Germany" with hostname "shop.de"
+        And the store classifies its products as "Sylius merch"
+        And the store has a product "Sylius Con shirt" with code "sylius-con-shirt", created at "27-10-2022"
+        And this product is available in the "Poland" channel
+        And this product is available in the "Germany" channel
+        And this product belongs to "Sylius merch"
+        And this product's price in "Poland" channel is "$25.00"
+        And this product's price in "Germany" channel is "$25.00"
+        And the store also has a product "Sylius Con stickers" with code "sylius-con-stickers", created at "27-10-2022"
+        And this product belongs to "Sylius merch"
+        And this product is available in the "Poland" channel
+        And this product is available in the "Germany" channel
+        And this product's price in "Poland" channel is "$30.00"
+        And this product's price in "Germany" channel is "$20.00"
+
+    @api @ui
+    Scenario: Sorting products by their prices with ascending order
+        When I change my current channel to "Poland"
+        And I browse products from taxon "Sylius merch"
+        And I sort products by the lowest price first
+        Then I should see 2 products in the list
+        And the first product on the list should have name "Sylius Con shirt"

--- a/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
+++ b/features/product/viewing_products/viewing_sorted_products_multiple_channels.feature
@@ -22,8 +22,29 @@ Feature: Sorting listed products on multiple channels
         And this product's price in "Germany" channel is "$20.00"
 
     @api @ui
-    Scenario: Sorting products by their prices with ascending order
+    Scenario: Sorting products by their prices with ascending order on channel Poland
         When I change my current channel to "Poland"
+        And I browse products from taxon "Sylius merch"
+        And I sort products by the lowest price first
+        Then I should see 2 products in the list
+        And the first product on the list should have name "Sylius Con shirt"
+
+    Scenario: Sorting products by their prices with descending order on channel Poland
+        When I change my current channel to "Poland"
+        And I browse products from taxon "Sylius merch"
+        And I sort products by the lowest price first
+        Then I should see 2 products in the list
+        And the first product on the list should have name "Sylius Con stickers"
+
+    Scenario: Sorting products by their prices with ascending order on channel Germany
+        When I change my current channel to "Germany"
+        And I browse products from taxon "Sylius merch"
+        And I sort products by the lowest price first
+        Then I should see 2 products in the list
+        And the first product on the list should have name "Sylius Con stickers"
+
+    Scenario: Sorting products by their prices with descending order on channel Germany
+        When I change my current channel to "Germany"
         And I browse products from taxon "Sylius merch"
         And I sort products by the lowest price first
         Then I should see 2 products in the list

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -721,6 +721,19 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^(this product)'s price in ("[^"]+" channel) is ("[^"]+")$/
+     */
+    public function theProductPriceInChannelIs(ProductInterface $product, ChannelInterface $channel, int $price)
+    {
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $this->defaultVariantResolver->getVariant($product);
+        $channelPricing = $productVariant->getChannelPricingForChannel($channel);
+        $channelPricing->setPrice($price);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^(this product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
      * @Given /^the ("[^"]+" product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
      * @Given /^(it)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11  |
| Bug fix?        | yes                                                       |
| New feature?    | no|
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | https://github.com/Sylius/Sylius/issues/14487                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 branch
 - Features and deprecations must be submitted against the 1.12 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

[Api] Sorting products by price should be channel specific. Having a different price for the same product on another channel, should not affect the sorting on the current channel. 
