### PR TITLE
Allows to add one by one the attributes in product edit page by calculating the right length for the input name

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -128,7 +128,7 @@ const setAttributeChoiceListener = function setAttributeChoiceListener() {
 
         $('#sylius_product_attribute_choice').val('');
 
-        addAttributesNumber($.grep(attributeFormElements, a => $(a).hasClass('attribute')).length);
+        addAttributesNumber(attributeFormElements.find('.attribute').length);
         modifySelectorOnAttributesListElementDelete();
 
         $('form').removeClass('loading');


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.10, 1.11, 1.12              |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14521                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
