### PR TITLE
Adding skipIf for migrations to allow future runs when they should apply

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220203115813.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220203115813.php
@@ -30,7 +30,9 @@ final class Version20220203115813 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        if ($this->isUsingDoctrineTransport() && !$schema->hasTable('messenger_messages')) {
+        $this->skipIf(!$this->isUsingDoctrineTransport(), 'MESSENGER_TRANSPORT_DSN was not found or is not using Doctrine');
+
+        if (!$schema->hasTable('messenger_messages')) {
             $this->addSql('CREATE TABLE messenger_messages (id BIGINT AUTO_INCREMENT NOT NULL, body LONGTEXT NOT NULL, headers LONGTEXT NOT NULL, queue_name VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, available_at DATETIME NOT NULL, delivered_at DATETIME DEFAULT NULL, INDEX IDX_75EA56E016BA31DB (delivered_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
@@ -27,9 +27,7 @@ final class Version20220407131547 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        if (!$schema->hasTable('messenger_messages')) {
-            return;
-        }
+        $this->skipIf(!$schema->hasTable('messenger_messages'), 'messenger_messages table was not found');
 
         $existingIndexes = $this->getExistingIndexesNames('messenger_messages');
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
While upgrading to Sylius 1.11 I came across this issue where these migrations were executed but I hadn't set the `MESSENGER_TRANSPORT_DSN` environment variable yet.

This resulted in a diff on my database after I added the variable.

By using the `skipIf()` for these migrations will not be executed, it will just give a notice:

```
[notice] Migration Sylius\Bundle\CoreBundle\Migrations\Version20220203115813 skipped during Execution. Reason: "MESSENGER_TRANSPORT_DSN was not found or is not using Doctrine"
[notice] Migration Sylius\Bundle\CoreBundle\Migrations\Version20220407131547 skipped during Execution. Reason: "messenger_messages table was not found"
```
They keep getting skipped on future runs, however when you add the environment variable they will be executed and only then.