### PR TITLE
[Maintenance] Exclude copied IRI converter in ECS config

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -26,6 +26,7 @@ return static function (ECSConfig $config): void {
         InlineDocCommentDeclarationSniff::class . '.NoAssignment',
         VisibilityRequiredFixer::class => ['*Spec.php'],
         '**/var/*',
+        'src/Sylius/Behat/Service/Converter/IriConverter.php',
     ]);
     $config->ruleWithConfiguration(
         HeaderCommentFixer::class,


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | mentioned in https://github.com/Sylius/Sylius/pull/14424#discussion_r990984599                      |
| License         | MIT                                                          |