### PR TITLE
Fixing the expired cart command

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -115,13 +115,14 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
         ;
     }
 
-    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate): array
+    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate, int $limit): array
     {
         return $this->createQueryBuilder('o')
             ->andWhere('o.state = :state')
             ->andWhere('o.updatedAt < :terminalDate')
             ->setParameter('state', OrderInterface::STATE_CART)
             ->setParameter('terminalDate', $terminalDate)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
+++ b/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
@@ -33,21 +33,14 @@ final class ExpiredCartsRemover implements ExpiredCartsRemoverInterface
 
     public function remove(): void
     {
-        $expiredCarts = $this->orderRepository->findCartsNotModifiedSince(new \DateTime('-' . $this->expirationPeriod));
 
-        $this->eventDispatcher->dispatch(new GenericEvent($expiredCarts), SyliusExpiredCartsEvents::PRE_REMOVE);
-
-        $interval = 0;
-        foreach ($expiredCarts as $expiredCart) {
-            $this->orderManager->remove($expiredCart);
-            $interval++;
-            
-            if ($interval % $this->batchSize === 0) {
-                $this->orderManager->flush();
+        $expiredDate = new \DateTime('-' . $this->expirationPeriod);
+        while ([] !== ($expiredCarts = $this->orderRepository->findCartsNotModifiedSince($expiredDate, $this->batchSize))) {
+            $this->eventDispatcher->dispatch(new GenericEvent($expiredCarts), SyliusExpiredCartsEvents::PRE_REMOVE);
+            foreach ($expiredCarts as $expiredCart) {
+                $this->orderManager->remove($expiredCart);
             }
-        }
 
-        if ($interval % $this->batchSize !== 0) {
             $this->orderManager->flush();
         }
 

--- a/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
@@ -41,10 +41,11 @@ final class ExpiredCartsRemoverSpec extends ObjectBehavior
         OrderInterface $firstCart,
         OrderInterface $secondCart,
     ): void {
-        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'))->willReturn([
-            $firstCart,
-            $secondCart,
-        ]);
+        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'), 100)
+            ->shouldBeCalledTimes(2)
+            ->willReturn([ $firstCart, $secondCart ])
+            ->willReturn([])
+        ;
 
         $eventDispatcher
             ->dispatch(Argument::any(), SyliusExpiredCartsEvents::PRE_REMOVE)
@@ -69,7 +70,12 @@ final class ExpiredCartsRemoverSpec extends ObjectBehavior
         EventDispatcher $eventDispatcher,
         OrderInterface $cart,
     ): void {
-        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'))->willReturn(array_fill(0, 200, $cart));
+        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'), 100)
+            ->shouldBeCalledTimes(3)
+            ->willReturn(array_fill(0, 100, $cart))
+            ->willReturn(array_fill(0, 100, $cart))
+            ->willReturn([])
+        ;
 
         $eventDispatcher
             ->dispatch(Argument::any(), SyliusExpiredCartsEvents::PRE_REMOVE)

--- a/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
@@ -40,7 +40,7 @@ interface OrderRepositoryInterface extends RepositoryInterface
     /**
      * @return array|OrderInterface[]
      */
-    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate): array;
+    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate, int $pageSize = 100): array;
 
     public function createCartQueryBuilder(): QueryBuilder;
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | related to #14481, #14482                      |
| License         | MIT                                                          |

## The problem

Currently when trying to remove a huge amount of expired carts (like 1 million) the process will crash before it even begins. The issue is that in the current implementation `findCartsNotModifiedSince` returns a list of all carts which kills the memory when trying to execute it.

## The solution

Run the find command in a batch and then remove the batch. (The problem is I don't really understand phpspec so someone which more experience with that could maybe help out here.)

I am also using the fact that php has a leaky scope, it's not pretty. But this is the only way to not dispatch more than one `SyliusExpiredCartsEvents::POST_REMOVE`.

## Other considerations

It could even be replaced with a direct delete statement?