### PR TITLE
Fix removing the root taxon, when the second one is Menu Taxon of the channel

### DIFF
--- a/features/taxonomy/managing_taxons/deleting_taxon.feature
+++ b/features/taxonomy/managing_taxons/deleting_taxon.feature
@@ -6,6 +6,7 @@ Feature: Deleting a taxon
 
     Background:
         Given I am logged in as an administrator
+        And the store operates on a channel named "Web Store"
 
     @ui @javascript
     Scenario: Deleted taxon should disappear from the registry
@@ -27,7 +28,16 @@ Feature: Deleting a taxon
     @ui @javascript
     Scenario: Being unable to delete a menu taxon of a channel
         Given the store classifies its products as "T-Shirts" and "Caps"
-        And the store operates on a channel named "Web Store"
         And channel "Web Store" has menu taxon "Caps"
         When I try to delete taxon named "Caps"
         Then I should be notified that I cannot delete a menu taxon of any channel
+
+    @ui @javascript
+    Scenario: Deleting root taxon above menu taxon
+        Given the store has "Main Category" taxonomy
+        And the store has "Clothes Category" taxonomy
+        And channel "Web Store" has menu taxon "Main Category"
+        When I want to see all taxons in store
+        And I move down "Main Category" taxon
+        And I delete taxon named "Clothes Category"
+        Then the taxon named "Clothes Category" should no longer exist in the registry

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -267,6 +267,10 @@ final class ManagingTaxonsContext implements Context
      */
     public function taxonNamedShouldNotBeAdded($name)
     {
+        if (!$this->createPage->isOpen()) {
+            $this->createPage->open();
+        }
+
         Assert::same($this->createPage->countTaxonsByName($name), 0);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
@@ -68,4 +68,15 @@ final class TaxonDeletionListener
             ]);
         }
     }
+
+    public function handleRemovingRootTaxonAtPositionZero(GenericEvent $event): void
+    {
+        /** @var TaxonInterface $taxon */
+        $taxon = $event->getSubject();
+        Assert::isInstanceOf($taxon, TaxonInterface::class);
+
+        if ($taxon->getPosition() === 0) {
+            $taxon->setPosition(-1);
+        }
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -93,6 +93,7 @@
             <argument type="service" id="sylius.promotion_rule_updater.has_taxon" />
             <tag name="kernel.event_listener" event="sylius.taxon.pre_delete" method="protectFromRemovingMenuTaxon" />
             <tag name="kernel.event_listener" event="sylius.taxon.post_delete" method="removeTaxonFromPromotionRules" />
+            <tag name="kernel.event_listener" event="sylius.taxon.pre_delete" method="handleRemovingRootTaxonAtPositionZero" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/TaxonDeletionListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/TaxonDeletionListenerSpec.php
@@ -123,4 +123,15 @@ final class TaxonDeletionListenerSpec extends ObjectBehavior
 
         $this->removeTaxonFromPromotionRules($event);
     }
+
+    function it_changes_taxon_position_to_minus_one_if_base_position_is_zero(
+        GenericEvent $event,
+        TaxonInterface $taxon,
+    ): void {
+        $event->getSubject()->willReturn($taxon);
+        $taxon->getPosition()->willReturn(0);
+        $taxon->setPosition(-1)->shouldBeCalled();
+
+        $this->handleRemovingRootTaxonAtPositionZero($event);
+    }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11  <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes [#X](https://github.com/Sylius/Sylius/issues/14460)                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

It seems like the problem exists when the taxon at the second position in the tree is `Menu taxon` of the channel.
Relation between channel and taxon causes to trigger the `SetField()` method inside of `postFlush()` method of `Gedmo\Sortable\SortableListener` only when position of the root taxon is 0 then `recomputeSingleEntityChangeSet()` of `Doctrine\ORM\UnitOfWork` throws an Exception, becouse it tries to work on unexisting object.

The solution below forces to move taxon before deleting at the last position of the tree by setting it to `-1` so we will not break the order of the taxons. 
This fix is probably not the best solution, but I couldn't find anything more suitable 🤷🏽‍♂️ 