### PR TITLE
Add a cli-based ChannelContext

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
@@ -40,6 +40,12 @@
         <service id="sylius.context.channel.composite" class="Sylius\Component\Channel\Context\CompositeChannelContext" public="false" />
         <service id="Sylius\Component\Channel\Context\ChannelContextInterface" alias="sylius.context.channel" />
 
+        <service id="sylius.context.channel.env_based" class="Sylius\Component\Channel\Context\EnvBased\ChannelContext" public="false">
+            <argument type="service" id="sylius.repository.channel" />
+            <argument>%env(default::SYLIUS_CHANNEL)%</argument>
+            <tag name="sylius.context.channel" priority="-256" />
+        </service>
+
         <service id="sylius.context.channel.request_based" class="Sylius\Component\Channel\Context\RequestBased\ChannelContext" public="false">
             <argument type="service" id="sylius.context.channel.request_based.resolver" />
             <argument type="service" id="request_stack" />

--- a/src/Sylius/Component/Channel/Context/EnvBased/ChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/EnvBased/ChannelContext.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Channel\Context\EnvBased;
+
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+
+final class ChannelContext implements ChannelContextInterface
+{
+    public function __construct(
+        private ChannelRepositoryInterface $channelRepository,
+        private ?string $channelCodeFromEnv,
+    ) {
+    }
+
+    public function getChannel(): ChannelInterface
+    {
+        if ('cli' !== PHP_SAPI || null === $this->channelCodeFromEnv) {
+            throw new ChannelNotFoundException();
+        }
+
+        $channel = $this->channelRepository->findOneByCode($this->channelCodeFromEnv);
+
+        if (null === $channel) {
+            throw new ChannelNotFoundException();
+        }
+
+        return $channel;
+    }
+}

--- a/src/Sylius/Component/Channel/spec/Context/EnvBased/ChannelContextSpec.php
+++ b/src/Sylius/Component/Channel/spec/Context/EnvBased/ChannelContextSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Channel\Context\EnvBased;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+
+final class ChannelContextSpec extends ObjectBehavior
+{
+    private const SYLIUS_CHANNEL = 'FASHION_WEB';
+
+    function let(ChannelRepositoryInterface $channelRepository): void
+    {
+        $this->beConstructedWith($channelRepository, self::SYLIUS_CHANNEL);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ChannelContextInterface::class);
+    }
+
+    function it_returns_channel(ChannelRepositoryInterface $channelRepository, ChannelInterface $channel): void
+    {
+        $channelRepository->findOneByCode(self::SYLIUS_CHANNEL)->willReturn($channel);
+
+        $this->getChannel()->shouldReturn($channel);
+    }
+
+    function it_throws_exception_when_channel_not_found(ChannelRepositoryInterface $channelRepository): void
+    {
+        $channelRepository->findOneByCode(self::SYLIUS_CHANNEL)->willReturn(null);
+
+        $this->shouldThrow(ChannelNotFoundException::class)->during('getChannel');
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | #9987                      |
| License         | MIT                                                          |

Hello,
This PR is simple, but I spend some time on trying different approaches and this is a result. This PR only provides a way to allow defining a channel via console command. Once approved, I will add a cookbook how to create a channel aware command.

I tried some approach, then I read comments from #9987. 

- Interfaces/traits → I didn't use them intentionally, the input value can be achieved only through `execute()` method so it might be hard to push the value to be available in another method
- Subscribers/Event Listener → We can listen on the command event, then get a value and push it into some field (e.g., using the above approach with interfaces/traits), but first things is we do a little magic to the solution, another thing we hard code 'channel' option or any other name we pick

I decided to create a some kind of bag we can push channel code we want to use inside a command, then it is available everywhere where we use channel context. I'm open to any suggestions 🤷🏼‍♂️.
