### PR TITLE
Hide "View in your store" widget in case ShopBundle disabled

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_channelLinks.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_channelLinks.html.twig
@@ -1,3 +1,5 @@
+{% set homepagePath = sylius_bundle_loaded_checker('SyliusShopBundle') ? path('sylius_shop_homepage') : '/' %}
+
 {% if channels|length > 1 %}
     <div class="ui simple dropdown item">
         <span>
@@ -6,7 +8,7 @@
         <i class="dropdown icon"></i>
         <div class="menu">
             {% for channel in channels|filter(channel => channel.hostname is not empty) %}
-            <a href="{{ sylius_channel_url(path('sylius_shop_homepage'), channel) }}" target="_blank" class="item">
+            <a href="{{ sylius_channel_url(homepagePath, channel) }}" target="_blank" class="item">
                 {% include '@SyliusAdmin/Common/_channel.html.twig' %}
             </a>
             {% endfor %}
@@ -15,5 +17,5 @@
 {% elseif channels|length == 1 %}
     {% set channel = channels|first %}
 
-    <a href="{{ sylius_channel_url(path('sylius_shop_homepage'), channel) }}" target="_blank" class="item">{{ 'sylius.ui.view_your_store'|trans }}</a>
+    <a href="{{ sylius_channel_url(homepagePath, channel) }}" target="_blank" class="item">{{ 'sylius.ui.view_your_store'|trans }}</a>
 {% endif %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                   |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no   |
| Related tickets | fixes #14171                       |
| License         | MIT                                                          |

In case ShopBundle is disabled, admin home page crashes due template's attempt to render `sylius_shop_homepage` route.
<details><summary>Before</summary>

![image](https://user-images.githubusercontent.com/870747/202773401-e0f78364-4e5e-4b52-9fa7-79198867113d.png)
</details>

<details><summary>After</summary>

![image](https://user-images.githubusercontent.com/870747/202773507-35b0328a-7c47-45b3-a1db-1b104a149414.png)
</details>

"View in your store" feature/widget still active, but conditionally not rendered as UI event left in place.
https://github.com/Sylius/Sylius/blob/23dc8d6915b2540f88ffceb7b9ea9a3214543837/src/Sylius/Bundle/AdminBundle/Resources/config/app/events.yaml#L208
