### PR TITLE
feat: set prices columns as bigint

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
@@ -25,9 +25,9 @@
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
-        <field name="price" column="price" type="integer" nullable="true" />
-        <field name="originalPrice" column="original_price" type="integer" nullable="true" />
-        <field name="minimumPrice" column="minimum_price" type="integer" nullable="true">
+        <field name="price" column="price" type="bigint" nullable="true" />
+        <field name="originalPrice" column="original_price" type="bigint" nullable="true" />
+        <field name="minimumPrice" column="minimum_price" type="bigint" nullable="true">
             <options>
                 <option name="default">0</option>
             </options>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -41,9 +41,9 @@
             </cascade>
         </one-to-many>
 
-        <field name="itemsTotal" column="items_total" type="integer" />
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
-        <field name="total" column="total" type="integer" />
+        <field name="itemsTotal" column="items_total" type="bigint" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
+        <field name="total" column="total" type="bigint" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -22,11 +22,11 @@
         </id>
 
         <field name="quantity" column="quantity" type="integer" />
-        <field name="unitPrice" column="unit_price" type="integer" />
-        <field name="originalUnitPrice" column="original_unit_price" type="integer" nullable="true"/>
-        <field name="unitsTotal" column="units_total" type="integer" />
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
-        <field name="total" column="total" type="integer" />
+        <field name="unitPrice" column="unit_price" type="bigint" />
+        <field name="originalUnitPrice" column="original_unit_price" type="bigint" nullable="true"/>
+        <field name="unitsTotal" column="units_total" type="bigint" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
+        <field name="total" column="total" type="bigint" />
         <field name="immutable" column="is_immutable" type="boolean" />
 
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="items">

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
@@ -21,7 +21,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
 
         <many-to-one field="orderItem" target-entity="Sylius\Component\Order\Model\OrderItemInterface" inversed-by="units">
             <join-column name="order_item_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />


### PR DESCRIPTION
- Allow usage of weak currencies such as Ariary
- 0,0011 Złoty = 1 Ariary, so when converted to int, the maximum value is overflowed if the value is to high

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | yes                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14557                      |
| License         | MIT                                                          |
