### PR TITLE
[Order] Add cart summary event

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
@@ -38,6 +38,13 @@ class OrderController extends ResourceController
             $cart = $this->getOrderRepository()->findCartById($cart->getId());
         }
 
+        $this->getEventDispatcher()->dispatch(new GenericEvent($cart), SyliusCartEvents::CART_SUMMARY);
+        $event = $this->eventDispatcher->dispatch(ResourceActions::SHOW, $configuration, $cart);
+        $eventResponse = $event->getResponse();
+        if (null !== $eventResponse) {
+            return $eventResponse;
+        }
+
         if (!$configuration->isHtmlRequest()) {
             return $this->viewHandler->handle($configuration, View::create($cart));
         }

--- a/src/Sylius/Component/Order/SyliusCartEvents.php
+++ b/src/Sylius/Component/Order/SyliusCartEvents.php
@@ -16,4 +16,6 @@ namespace Sylius\Component\Order;
 interface SyliusCartEvents
 {
     public const CART_CHANGE = 'sylius.cart_change';
+
+    public const CART_SUMMARY = 'sylius.cart_summary';
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no  |
| Related tickets | fixes #14127                      |
| License         | MIT                                                          |

Added two events that are dispatched when accessing a cart:
- `sylius.order.show` same as all other resources on show
- `sylius.cart_summary` specifically for this route

Similar approach has been done within `saveAction` where we get the default resource-based update event as well as `sylius.cart_change`.