### PR TITLE
POC of a command for removing expired carts in batches

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsBatchCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsBatchCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\OrderBundle\SyliusExpiredCartsEvents;
+use Sylius\Component\Order\Model\OrderInterface;
+use SyliusLabs\Polyfill\Symfony\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+final class RemoveExpiredCartsBatchCommand extends ContainerAwareCommand
+{
+    protected static $defaultName = 'sylius:remove-expired-carts-batch';
+
+    protected static $defaultDescription = 'Removes carts that have been idle for a period set in `sylius_order.expiration.cart` configuration key.';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private EventDispatcherInterface $eventDispatcher,
+        private string $orderClass,
+        private string $expirationTime
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                'batch-size',
+                InputArgument::OPTIONAL,
+                'How many carts will be removed at once',
+                '100'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $batchSize = (int)$input->getArgument('batch-size');
+        $io = new SymfonyStyle($input, $output);
+        $io->title(
+            sprintf('Command will remove carts that have been idle for <info>%s</info>.', $this->expirationTime)
+        );
+
+        $query = $this->entityManager->createQueryBuilder()
+            ->from($this->orderClass, 'o')
+            ->select('o')
+            ->andWhere('o.state = :state')
+            ->andWhere('o.updatedAt < :terminalDate')
+            ->setParameter('state', OrderInterface::STATE_CART)
+            ->setParameter('terminalDate', new \DateTime('-'.$this->expirationTime))
+            ->getQuery();
+
+        $io->info(sprintf('Removing carts in batches of %d...', $batchSize));
+        $i = 0;
+        $expiredCarts = [];
+        foreach ($io->progressIterate($query->toIterable()) as $cart) {
+            $this->entityManager->remove($cart);
+            $expiredCarts[] = $cart;
+            ++$i;
+            if (($i % $batchSize) === 0) {
+                $this->executeDeletions($expiredCarts);
+                $expiredCarts = [];
+            }
+        }
+
+        $this->executeDeletions($expiredCarts);
+
+        $io->success(sprintf('Successfully removed %d expired cards!', $i));
+
+        return self::SUCCESS;
+    }
+
+    private function executeDeletions(array $expiredCarts): void
+    {
+        $this->eventDispatcher->dispatch(new GenericEvent($expiredCarts), SyliusExpiredCartsEvents::PRE_REMOVE);
+        $this->entityManager->flush(); // Executes all deletions.
+        $this->eventDispatcher->dispatch(new GenericEvent($expiredCarts), SyliusExpiredCartsEvents::POST_REMOVE);
+        $this->entityManager->clear(); // Detaches all objects from Doctrine!
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -25,6 +25,14 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Sylius\Bundle\OrderBundle\Command\RemoveExpiredCartsBatchCommand">
+            <argument type="service" id="sylius.manager.order"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument>%sylius.model.order.class%</argument>
+            <argument>%sylius_order.cart_expiration_period%</argument>
+            <tag name="console.command" />
+        </service>
+
         <service id="sylius.context.cart.new" class="Sylius\Component\Order\Context\CartContext">
             <argument type="service" id="sylius.factory.order" />
             <tag name="sylius.context.cart" priority="-999" />


### PR DESCRIPTION
| Q               | A                                                         |
|-----------------|-----------------------------------------------------------|
| Branch?         | 1.13                                                      |
| Bug fix?        | no                                                        |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                        |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | alternative for #14532                                    |
| License         | MIT                                                       |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Command output for 2000 carts with memory usage: 
`symfony console sylius:remove-expired-carts-batch -vvv --no-debug --no-ansi >> var/log/carts-batch.log 2>&1;`
[carts-batch.log](https://github.com/Sylius/Sylius/files/10071721/carts-batch.log)

Alternatives that could replace this command or exist as separate commands:
1. Only selecting order ids and use them in a bulk delete query and dispatch new events with only order ids.
2. Execute a single query and let the database do the whole job without dispatching any events.