### PR TITLE
[WIP] [API] Use Payum 🎉

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Command/Payum/PayumRequest.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Payum/PayumRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Command\Payum;
+
+use Sylius\Bundle\ApiBundle\Command\CommandAwareDataTransformerInterface;
+
+/** experimental */
+class PayumRequest implements CommandAwareDataTransformerInterface
+{
+    public function __construct(private string $payum_token)
+    {
+    }
+
+    public function getPayumToken(): string
+    {
+        return $this->payum_token;
+    }
+
+    public function setPayumToken(string $payum_token): void
+    {
+        $this->payum_token = $payum_token;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/AfterPayPayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/AfterPayPayment.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Controller\Payum;
+
+use Payum\Core\Payum;
+use Sylius\Bundle\PayumBundle\Factory\GetStatusFactoryInterface;
+use Sylius\Bundle\PayumBundle\Model\PaymentSecurityTokenInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @experimental */
+final class AfterPayPayment
+{
+    public function __construct(
+        private Payum $payum,
+        private GetStatusFactoryInterface $getStatusFactory,
+    ) {
+    }
+
+    public function __invoke(Request $request): PaymentSecurityTokenInterface
+    {
+        /** @var PaymentSecurityTokenInterface $token */
+        $token = $this->payum->getHttpRequestVerifier()->verify($request);
+
+        $gateway = $this->payum->getGateway($token->getGatewayName());
+
+        $statusRequest = $this->getStatusFactory->createNewWithModel($token);
+
+        $gateway->execute($statusRequest);
+
+        $this->payum->getHttpRequestVerifier()->invalidate($token);
+
+        return $token;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/AfterPayPayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/AfterPayPayment.php
@@ -14,9 +14,14 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Controller\Payum;
 
 use Payum\Core\Payum;
+use Payum\Core\Reply\HttpRedirect;
+use Sylius\Bundle\ApiBundle\Converter\PayumReplyConverterInterface;
 use Sylius\Bundle\PayumBundle\Factory\GetStatusFactoryInterface;
+use Sylius\Bundle\PayumBundle\Factory\ResolveNextRouteFactoryInterface;
 use Sylius\Bundle\PayumBundle\Model\PaymentSecurityTokenInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 /** @experimental */
 final class AfterPayPayment
@@ -24,10 +29,24 @@ final class AfterPayPayment
     public function __construct(
         private Payum $payum,
         private GetStatusFactoryInterface $getStatusFactory,
+        private ResolveNextRouteFactoryInterface $resolveNextRouteFactory,
+        private RouterInterface $router,
+        private PayumReplyConverterInterface $payumReplyConverter,
     ) {
     }
 
-    public function __invoke(Request $request): PaymentSecurityTokenInterface
+    /**
+     * This controller is design to reproduce what SyliusPayumBundle `PayumController` is doing.
+     * The only difference is that here we `catchReply=true`, meaning if a ReplyInterface is thrown
+     * then it is caught to convert the $reply to a JSON object.
+     *
+     * If the "GetStatus" Payum request is not triggering a `Reply` (but return `null`) then
+     * invalidate the token and return a redirect reply to the "Token's after url"
+     * else return the "Reply" itself.
+     *
+     * @see \Sylius\Bundle\PayumBundle\Controller\PayumController::afterCaptureAction
+     */
+    public function __invoke(Request $request): JsonResponse
     {
         /** @var PaymentSecurityTokenInterface $token */
         $token = $this->payum->getHttpRequestVerifier()->verify($request);
@@ -36,10 +55,24 @@ final class AfterPayPayment
 
         $statusRequest = $this->getStatusFactory->createNewWithModel($token);
 
-        $gateway->execute($statusRequest);
+        $reply = $gateway->execute($statusRequest, true);
 
-        $this->payum->getHttpRequestVerifier()->invalidate($token);
+        if (null === $reply) {
+            $this->payum->getHttpRequestVerifier()->invalidate($token);
+        } else {
+            return $this->payumReplyConverter->convert($reply);
+        }
 
-        return $token;
+        $resolveNextRouteRequest = $this->resolveNextRouteFactory->createNewWithModel($statusRequest->getFirstModel());
+        $reply = $gateway->execute($resolveNextRouteRequest, true);
+
+        if (null === $reply) {
+            $reply = new HttpRedirect($this->router->generate(
+                $resolveNextRouteRequest->getRouteName(),
+                $resolveNextRouteRequest->getRouteParameters()
+            ));
+        }
+
+        return $this->payumReplyConverter->convert($reply);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
@@ -30,8 +30,11 @@ final class CapturePayment
     }
 
     /**
-     * This controller is design to reproduce what Payum `CaptureController` is doing
-     * If the "Capture" request is not triggering a `Reply` (but return `null`) then
+     * This controller is design to reproduce what Payum `CaptureController` is doing.
+     * The only difference is that here we `catchReply=true`, meaning if a ReplyInterface is thrown
+     * then it is caught to convert the $reply to a JSON object.
+     *
+     * If the "Capture" Payum request is not triggering a `Reply` (but return `null`) then
      * invalidate the token and return a redirect reply to the "Token's after url"
      * else return the "Reply" itself.
      *

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Controller\Payum;
+
+use Payum\Core\Payum;
+use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Request\Capture;
+use Sylius\Bundle\ApiBundle\Converter\PayumReplyConverterInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @experimental */
+final class CapturePayment
+{
+    public function __construct(
+        private Payum $payum,
+        private PayumReplyConverterInterface $payumReplyConverter,
+    ) {
+    }
+
+    /**
+     * This controller is design to reproduce what Payum `CaptureController` is doing
+     * If the Capture is not triggering a `Reply` then invalidate the token and return
+     * the Token's after url else return the reply and token info.
+     *
+     * @see \Payum\Bundle\PayumBundle\Controller\CaptureController::doAction
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $token = $this->payum->getHttpRequestVerifier()->verify($request);
+
+        $gateway = $this->payum->getGateway($token->getGatewayName());
+
+        $captureRequest = new Capture($token);
+
+        $reply = $gateway->execute($captureRequest, true);
+
+        if (null === $reply) {
+            $this->payum->getHttpRequestVerifier()->invalidate($token);
+
+            $reply = new HttpRedirect($token->getTargetUrl());
+        }
+
+        return $this->payumReplyConverter->convert($reply);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
@@ -31,8 +31,9 @@ final class CapturePayment
 
     /**
      * This controller is design to reproduce what Payum `CaptureController` is doing
-     * If the Capture is not triggering a `Reply` then invalidate the token and return
-     * the Token's after url else return the reply and token info.
+     * If the "Capture" request is not triggering a `Reply` (but return `null`) then
+     * invalidate the token and return build a redirect reply to the "Token's after url"
+     * else return the "Reply" itself.
      *
      * @see \Payum\Bundle\PayumBundle\Controller\CaptureController::doAction
      */

--- a/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/Payum/CapturePayment.php
@@ -32,7 +32,7 @@ final class CapturePayment
     /**
      * This controller is design to reproduce what Payum `CaptureController` is doing
      * If the "Capture" request is not triggering a `Reply` (but return `null`) then
-     * invalidate the token and return build a redirect reply to the "Token's after url"
+     * invalidate the token and return a redirect reply to the "Token's after url"
      * else return the "Reply" itself.
      *
      * @see \Payum\Bundle\PayumBundle\Controller\CaptureController::doAction
@@ -50,7 +50,7 @@ final class CapturePayment
         if (null === $reply) {
             $this->payum->getHttpRequestVerifier()->invalidate($token);
 
-            $reply = new HttpRedirect($token->getTargetUrl());
+            $reply = new HttpRedirect($token->getAfterUrl());
         }
 
         return $this->payumReplyConverter->convert($reply);

--- a/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
@@ -57,7 +57,7 @@ final class PayumReplyConverter implements PayumReplyConverterInterface
         }
 
         throw new LogicException(sprintf(
-            'This "%s" is not an instanceof "%s", please make your gateway reply a Payum HttpResponse.',
+            'This "%s" is not an instance of "%s", please make your gateway reply a Payum HttpResponse.',
             get_class($reply),
             HttpResponse::class
         ));

--- a/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
@@ -36,10 +36,15 @@ final class PayumReplyConverter implements PayumReplyConverterInterface
     {
         if ($reply instanceof SymfonyHttpResponse) {
             $response = $reply->getResponse();
+
+            $content = $response->getContent();
+            /** @var string[] $headers */
+            $headers = $response->headers->all();
+
             $reply = new HttpResponse(
-                $response->getContent(),
+                $content === false ? '' : $content,
                 $response->getStatusCode(),
-                $response->headers->all(),
+                $headers,
             );
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Converter;
+
+use Payum\Core\Bridge\Symfony\Reply\HttpResponse as SymfonyHttpResponse;
+use Payum\Core\Reply\HttpResponse;
+use Payum\Core\Reply\ReplyInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * In the Payum world, The ReplyInterface is used by :
+ * - Payum\Core\Reply\HttpResponse
+ * - Payum\Core\Bridge\Symfony\Reply\HttpResponse
+ *
+ * If for some reason a Payum gateway is using another kind of class then this service
+ * must be decorated by this gateway to ensure that the ReplyInterface object will
+ * be converted to the right JSON array
+ *
+ * @experimental
+ */
+final class PayumReplyConverter implements PayumReplyConverterInterface
+{
+    public function convert(ReplyInterface $reply): JsonResponse
+    {
+        if ($reply instanceof SymfonyHttpResponse) {
+            $reply = new HttpResponse(
+                $reply->getResponse()->getContent(),
+                $reply->getResponse()->getStatusCode(),
+                $reply->getResponse()->headers->all(),
+            );
+        }
+
+        return new JsonResponse([
+            'content' => $reply->getContent(),
+            'statusCode' => $reply->getStatusCode(),
+            'headers' => $reply->getHeaders(),
+        ]);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverterInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Converter/PayumReplyConverterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Converter;
+
+use Payum\Core\Reply\ReplyInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+interface PayumReplyConverterInterface
+{
+    public function convert(ReplyInterface $reply): JsonResponse;
+}

--- a/src/Sylius/Bundle/ApiBundle/Provider/CaptureUrlPaymentConfigurationProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/CaptureUrlPaymentConfigurationProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Provider;
+
+use Payum\Core\Payum;
+use Payum\Core\Security\TokenInterface;
+use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Webmozart\Assert\Assert;
+
+final class CaptureUrlPaymentConfigurationProvider implements CompositePaymentConfigurationProviderInterface
+{
+    public function __construct(
+        private CompositePaymentConfigurationProviderInterface $decoratedCompositePaymentConfigurationProvider,
+        private Payum $payum
+    ) {
+    }
+
+    public function provide(PaymentInterface $payment): array
+    {
+        $configuration = $this->decoratedCompositePaymentConfigurationProvider->provide($payment);
+        if (isset($configuration['capture_url'])) {
+            return $configuration;
+        }
+
+        $token = $this->provideTokenBasedOnPayment($payment);
+        $configuration['capture_url'] = $token->getTargetUrl();
+
+        return $configuration;
+    }
+
+    private function provideTokenBasedOnPayment(PaymentInterface $payment): TokenInterface
+    {
+        $gatewayConfig = $this->getGatewayConfig($payment);
+        $config = $gatewayConfig->getConfig();
+        $gatewayName = $gatewayConfig->getGatewayName();
+        $tokenFactory = $this->payum->getTokenFactory();
+
+        $afterToken = $tokenFactory->createToken(
+            $gatewayName,
+            $payment,
+            $config['sylius_api_after_path'] ?? 'api_payums_shop_after_pay_item',
+            $config['sylius_api_after_path_parameters'] ?? [],
+        );
+
+        return $tokenFactory->createToken(
+            $gatewayName,
+            $payment,
+            'api_payums_shop_capture_item',
+            [],
+            $afterToken->getTargetUrl()
+        );
+    }
+
+    private function getGatewayConfig(PaymentInterface $payment): GatewayConfigInterface
+    {
+        /** @var PaymentMethodInterface|null $paymentMethod */
+        $paymentMethod = $payment->getMethod();
+        Assert::notNull($paymentMethod);
+
+        /** @var GatewayConfigInterface|null $gatewayConfig */
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+        Assert::notNull($gatewayConfig);
+
+        return $gatewayConfig;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payum.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payum.xml
@@ -16,7 +16,7 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="Sylius\Bundle\ApiBundle\Command\Payum\PayumRequest" shortName="Payum">
-        <attribute name="messenger">input</attribute>
+        <attribute name="messenger">true</attribute>
         <attribute name="validation_groups">sylius</attribute>
         <attribute name="read">false</attribute>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payum.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payum.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="Sylius\Bundle\ApiBundle\Command\Payum\PayumRequest" shortName="Payum">
+        <attribute name="messenger">input</attribute>
+        <attribute name="validation_groups">sylius</attribute>
+        <attribute name="read">false</attribute>
+
+        <collectionOperations />
+
+        <itemOperations>
+
+            <itemOperation name="shop_capture">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/payum/{payum_token}/capture</attribute>
+                <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\Payum\CapturePayment</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">shop:payum:read</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Capture a payment via a Payum Capture request</attribute>
+                </attribute>
+            </itemOperation>
+
+            <itemOperation name="shop_after_pay">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/payum/{payum_token}/after-pay</attribute>
+                <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\Payum\AfterPayPayment</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">shop:payum:read</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">After Payment processing via a Payum GetStatus request</attribute>
+                </attribute>
+            </itemOperation>
+        </itemOperations>
+
+        <property name="payum_token" identifier="true" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -142,5 +142,15 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\PayumCaptureDocumentationNormalizer.inner" />
             <argument>%sylius.security.new_api_route%</argument>
         </service>
+
+        <service
+            id="Sylius\Bundle\ApiBundle\Swagger\PayumAfterPayDocumentationNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\PayumAfterPayDocumentationNormalizer.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/integrations/swagger.xml
@@ -132,5 +132,15 @@
             <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\AcceptLanguageHeaderDocumentationNormalizer.inner" />
             <argument type="service" id="sylius.repository.locale" />
         </service>
+
+        <service
+            id="Sylius\Bundle\ApiBundle\Swagger\PayumCaptureDocumentationNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Swagger\PayumCaptureDocumentationNormalizer.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_payment_methods.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_payment_methods.xml
@@ -21,5 +21,10 @@
         <service id="Sylius\Bundle\ApiBundle\Provider\CompositePaymentConfigurationProvider">
             <argument type="tagged_iterator" tag="sylius.api.payment_method_handler" />
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Provider\CaptureUrlPaymentConfigurationProvider" decorates="Sylius\Bundle\ApiBundle\Provider\CompositePaymentConfigurationProvider">
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CaptureUrlPaymentConfigurationProvider.inner" />
+            <argument type="service" id="payum" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
@@ -20,12 +20,15 @@
 
         <service id="Sylius\Bundle\ApiBundle\Controller\Payum\CapturePayment" public="true">
             <argument type="service" id="payum" />
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />
+            <argument type="service" id="sylius.api.converter.payum_reply" />
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\Controller\Payum\AfterPayPayment" public="true">
             <argument type="service" id="payum" />
             <argument type="service" id="sylius.factory.payum_get_status_action" />
+            <argument type="service" id="sylius.factory.payum_resolve_next_route" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius.api.converter.payum_reply" />
         </service>
 
         <service id="sylius.api.converter.payum_reply" class="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
@@ -28,6 +28,8 @@
             <argument type="service" id="sylius.factory.payum_get_status_action" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />
+        <service id="sylius.api.converter.payum_reply" class="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />
+        <service id="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverterInterface" alias="sylius.api.converter.payum_reply" />
+
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/payum.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <defaults public="true" />
+
+        <service id="Sylius\Bundle\ApiBundle\Controller\Payum\CapturePayment" public="true">
+            <argument type="service" id="payum" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />
+        </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Controller\Payum\AfterPayPayment" public="true">
+            <argument type="service" id="payum" />
+            <argument type="service" id="sylius.factory.payum_get_status_action" />
+        </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Converter\PayumReplyConverter" />
+    </services>
+</container>

--- a/src/Sylius/Bundle/ApiBundle/Swagger/PayumAfterPayDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/PayumAfterPayDocumentationNormalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+final class PayumAfterPayDocumentationNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private NormalizerInterface $decoratedNormalizer,
+        private string $apiRoute,
+    ) {
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        $docs['components']['schemas']['PayumAfterPay'] = [
+            'type' => 'object',
+            'properties' => [
+                'content' => [
+                    'type' => 'string',
+                    'readOnly' => true,
+                    'example' => '
+<p>
+    Payment successful
+</p>',
+                ],
+                'statusCode' => [
+                    'type' => 'integer',
+                    'readOnly' => true,
+                    'example' => 200,
+                ],
+                'headers' => [
+                    'type' => 'object',
+                    'additionalProperties' => [
+                        'type' => 'string',
+                    ],
+                    'readOnly' => true,
+                    'example' => [
+                        'Content-Type' => 'text/html',
+                        'X-Custom-Header' => 'foo',
+                    ],
+                ],
+            ],
+        ];
+
+        $docs['paths'][$this->apiRoute . '/shop/payum/{payum_token}/after-pay']['get']['responses'][Response::HTTP_OK] = [
+            'description' => 'Get Payum get status reply',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        '$ref' => '#/components/schemas/PayumAfterPay',
+                    ],
+                ],
+            ]
+        ];
+
+        return $docs;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Swagger/PayumAfterPayDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/PayumAfterPayDocumentationNormalizer.php
@@ -48,7 +48,7 @@ final class PayumAfterPayDocumentationNormalizer implements NormalizerInterface
                 'statusCode' => [
                     'type' => 'integer',
                     'readOnly' => true,
-                    'example' => 200,
+                    'example' => 302,
                 ],
                 'headers' => [
                     'type' => 'object',
@@ -57,7 +57,7 @@ final class PayumAfterPayDocumentationNormalizer implements NormalizerInterface
                     ],
                     'readOnly' => true,
                     'example' => [
-                        'Content-Type' => 'text/html',
+                        'Location' => '/api/v2/order/my_token_123/pay',
                         'X-Custom-Header' => 'foo',
                     ],
                 ],

--- a/src/Sylius/Bundle/ApiBundle/Swagger/PayumCaptureDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/PayumCaptureDocumentationNormalizer.php
@@ -45,7 +45,7 @@ final class PayumCaptureDocumentationNormalizer implements NormalizerInterface
     <form action="...">
         <p>
             <label>
-            Crédit card details:
+            Credit card details:
             <input type="text" name="cc-details">
             </label>
         </p>

--- a/src/Sylius/Bundle/ApiBundle/Swagger/PayumCaptureDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/PayumCaptureDocumentationNormalizer.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+final class PayumCaptureDocumentationNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private NormalizerInterface $decoratedNormalizer,
+        private string $apiRoute,
+    ) {
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        $docs['components']['schemas']['PayumCapture'] = [
+            'type' => 'object',
+            'properties' => [
+                'content' => [
+                    'type' => 'string',
+                    'readOnly' => true,
+                    'example' => '
+<p>
+    <form action="...">
+        <p>
+            <label>
+            Crédit card details:
+            <input type="text" name="cc-details">
+            </label>
+        </p>
+        <p>
+            <button type="submit">Pay !</button>
+        </p>
+    </form>
+</p>',
+                ],
+                'statusCode' => [
+                    'type' => 'integer',
+                    'readOnly' => true,
+                    'example' => 200,
+                ],
+                'headers' => [
+                    'type' => 'object',
+                    'additionalProperties' => [
+                        'type' => 'string',
+                    ],
+                    'readOnly' => true,
+                    'example' => [
+                        'Content-Type' => 'text/html',
+                        'X-Custom-Header' => 'foo',
+                    ],
+                ],
+            ],
+        ];
+
+        $docs['paths'][$this->apiRoute . '/shop/payum/{payum_token}/capture']['get']['responses'][Response::HTTP_OK] = [
+            'description' => 'Get Payum capture reply',
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        '$ref' => '#/components/schemas/PayumCapture',
+                    ],
+                ],
+            ]
+        ];
+
+        return $docs;
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

This PR is a POC of how Payum can be used with the API.

## Current Sylius behaviour

### API

When an `Order` is `completed` the users of the current API are able to found only one endpoint to make the visitor pay:

```
GET /api/v2/shop/orders/{tokenValue}/payments/{paymentId}/configuration
```

From my point of view this API endpoint is design to retrieve information about the payment method.
Some Payum gateways are even giving the ability to prepare a payment (SyliusPaypalPlugin for example).

### Shop UI

When an `Order` is `completed` the visitor is redirected to the `sylius_shop_order_pay` route (`/{_locale}/order/{tokenValue}/pay`. It basically creates a Payum Tokens and redirect the visitor to the "Payum capture" url.
When the payment is done the "After-pay" url (`sylius_shop_order_after_pay`) is normally used to display success/error page.

## PR proposal

### GET configuration

```
GET /api/v2/shop/orders/{tokenValue}/payments/{paymentId}/configuration
```

This endpoint will always add to the configuration array a field named "capture_url" using a new API Payum capture endpoint route:
![image](https://user-images.githubusercontent.com/861820/203617527-39d17584-c7df-4e23-aedb-5499e6281f75.png)

> 🧠 I also though about generating this "capture" URL into another new endpoint like `GET /api/v2/shop/payum/pay` to reproduce the Shop UI behaviour. Creating this new endpoint will avoid adding not required info into this configuration endpoint.

# New Payum endpoints

Two new API endpoints have been created:

```
GET /api/v2/shop/payum/{payum_token}/capture
GET /api/v2/shop/payum/{payum_token}/after-pay
```

The first API endpoint route has been used to generate the API Payum "capture" URL (see screenshot above).
Requesting this endpoint will trigger a Payum `Capture` request and info about what to display or where to redirect the visitor are 
responded:

![image](https://user-images.githubusercontent.com/861820/203623158-2d781bf5-1cad-4271-b220-01a422d9db9e.png)

Here all Payum gateways will act differently but it's always an HTTP response with: a content, a status code and headers.
API consumers will have to make some work to be able to handle all kind of  behaviour, but I imagine it can be something like that :

```javascript
if (response.status === 200) {
  // display the HTML content or what so ever
  response.content;
}
if (response.status === 302) {
  // Redirect the visitor to the target URL
  window.location = response.headers["Location"];
  // Or even display the HTML content which include meta markup <meta http-equiv="refresh" content="1;url=%1$s" />
}
```

When the visitor finish paying then the "after pay" URL is used to trigger a Payum `Status` request refreshing the status of the `Payment`, allowing API users to display the right ending message.

## WIP @todo

- [ ] Add Payum Authorize endpoint
- [ ] Add Unit tests
- [ ] Add spec tests
- [ ] Add Behat tests
- [ ] Add documentation

