### PR TITLE
[DX] Add EditorConfig for test API responses

### DIFF
--- a/tests/Api/Responses/.editorconfig
+++ b/tests/Api/Responses/.editorconfig
@@ -1,0 +1,2 @@
+[*.json]
+indent_size = 4


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11|
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

EditorConfig from the root directory forces us to use 2 indents but in tests, we use 4 instead.