### PR TITLE
Require SyliusMailerBundle 1.8 for Swiftmailer + Sf 5.4 packages builds

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -115,6 +115,7 @@ jobs:
                 name: Configure Swiftmailer (if needed)
                 working-directory: "src/Sylius/${{ matrix.package }}"
                 run: |
+                    composer require --no-progress --no-update --no-scripts --no-plugins "sylius/mailer-bundle:^1.8"
                     composer require --no-progress --no-update --no-scripts --no-plugins "symfony/swiftmailer-bundle:^3.4"
                     echo "APP_ENV=test_with_swiftmailer" >> $GITHUB_ENV
                 if: matrix.swiftmailer == true


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

It seems not to be perfectly checked before :dancer: Currently, if we want consciously to use Swiftmailer and Symfony 5.4 with Sylius application/package, we need to require only SyliusMailerBundle 1.8 - as 2.0 already has Swiftmailer dropped. I thought about adding a conflict to Swiftmailer on SyliusMailerBundle 2.0, but it's technically still possible to use it with Symfony 5.4 and implement the Swiftmailer adapter by your own, so I do not want to block that possibility 🖖 