### PR TITLE
Fix dev dockerfile: add curl

### DIFF
--- a/.docker/dev/Dockerfile
+++ b/.docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM sylius/standard:1.11-traditional
 
-RUN apt-get update && apt-get install php8.0-xdebug && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apt-get update && apt-get install curl php8.0-xdebug -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(uname -m) \


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13  |
| Bug fix?        | somehow                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no  |
| Related tickets | https://github.com/Sylius/Sylius/issues/14559                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

`curl` is required to install blackfire and is not included in sylius/standard:1.11-traditional Curl installation ask a question, this is why I also add the non-interactive mode.
