### PR TITLE
:construction_worker: add symfony thanks to (not) allowed plugins (1.12+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -242,7 +242,8 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": false,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "symfony/thanks": false
         }
     },
     "extra": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | no ticket                      |
| License         | MIT                                                          |

I tried to build the project using:

```
docker-compose up -d
docker-compose exec app bash
make install
```

And it failed because symfony/thanks is not in the plugins allowed section. Since we love Symfony, it is nice to add it :) .