### PR TITLE
:construction_worker: add symfony thanks to (not) allowed plugins (1.11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -228,7 +228,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "symfony/flex": true,
-            "dealerdirect/phpcodesniffer-composer-installer": false
+            "dealerdirect/phpcodesniffer-composer-installer": false,
+            "symfony/thanks": false
         }
     },
     "extra": {


### PR DESCRIPTION
Discussion
----------

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

This is https://github.com/Sylius/Sylius/pull/14582 but for 1.11 branch
