### PR TITLE
[UIBundle] Register undefined callable handler for twig filters and functions

### DIFF
--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/RegisterUndefinedCallablePass.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/RegisterUndefinedCallablePass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\UiBundle\Twig\UndefinedCallableHandler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RegisterUndefinedCallablePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('twig')) {
+            return;
+        }
+
+        $container->getDefinition('twig')
+            ->addMethodCall('registerUndefinedFunctionCallback', [[new Reference(UndefinedCallableHandler::class), 'onUndefinedFunction']])
+            ->addMethodCall('registerUndefinedFilterCallback', [[new Reference(UndefinedCallableHandler::class), 'onUndefinedFilter']])
+        ;
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -56,5 +56,7 @@
         <service id="Sylius\Bundle\UiBundle\Storage\FilterStorage" public="false">
             <argument type="service" id="request_stack" />
         </service>
+
+        <service id="Sylius\Bundle\UiBundle\Twig\UndefinedCallableHandler" public="false" />
     </services>
 </container>

--- a/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
+++ b/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\UiBundle;
 
 use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\LegacySonataBlockPass;
+use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\RegisterUndefinedCallablePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -25,5 +26,6 @@ final class SyliusUiBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new LegacySonataBlockPass());
+        $container->addCompilerPass(new RegisterUndefinedCallablePass());
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Twig/UndefinedCallableHandler.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/UndefinedCallableHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\Twig;
+
+use Twig\Error\SyntaxError;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+final class UndefinedCallableHandler
+{
+    /**
+     * @var string[]
+     */
+    private const FUNCTION_COMPONENTS = [
+        'sm_can' => 'winzou/state-machine-bundle',
+        'sylius_grid_render_bulk_action' => 'sylius/grid-bundle',
+        'sylius_grid_render_field' => 'sylius/grid-bundle',
+        'sylius_grid_render_filter' => 'sylius/grid-bundle',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const FILTER_COMPONENTS = [
+        'sylius_currency_symbol' => 'sylius/currency-bundle',
+        'sylius_locale_name' => 'sylius/locale-bundle',
+        'imagine_filter' => 'liip/imagine-bundle',
+    ];
+
+    public static function onUndefinedFunction(string $name): TwigFunction|false
+    {
+        if (!isset(self::FUNCTION_COMPONENTS[$name])) {
+            return false;
+        }
+
+        throw new SyntaxError(sprintf('Unknown function "%s". Did you forget to run "composer require %s"?', $name, self::FUNCTION_COMPONENTS[$name]));
+    }
+
+    public static function onUndefinedFilter(string $name): TwigFilter|false
+    {
+        if (!isset(self::FILTER_COMPONENTS[$name])) {
+            return false;
+        }
+
+        throw new SyntaxError(sprintf('Unknown filter "%s". Did you forget to run "composer require %s"?', $name, self::FILTER_COMPONENTS[$name]));
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/spec/Twig/UndefinedCallableHandlerSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Twig/UndefinedCallableHandlerSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\UiBundle\Twig;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\UiBundle\Twig\UndefinedCallableHandler;
+use Twig\Error\SyntaxError;
+
+final class UndefinedCallableHandlerSpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(UndefinedCallableHandler::class);
+    }
+
+    function it_returns_false_on_non_handled_undefined_function(): void
+    {
+        $this::onUndefinedFunction('undefined_function')->shouldReturn(false);
+    }
+
+    function it_throws_a_syntax_error_on_handled_undefined_function(): void
+    {
+        $this->shouldThrow(SyntaxError::class)->during('onUndefinedFunction', ['sylius_grid_render_field']);
+    }
+
+    function it_returns_false_on_non_handled_undefined_filter(): void
+    {
+        $this::onUndefinedFilter('undefined_filter')->shouldReturn(false);
+    }
+
+    function it_throws_a_syntax_error_on_handled_undefined_filter(): void
+    {
+        $this->shouldThrow(SyntaxError::class)->during('onUndefinedFilter', ['sylius_currency_symbol']);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.1                  |
| Bug fix?        | kind of, due to some package dependencies on twig templates                                                    |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | Z                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Linked to #14437 

Some Twig templates are using filters and functions from other package dependencies. They are not on requirements of this package. So we need to inform about the missing package.
