### PR TITLE
docker dev curl install

### DIFF
--- a/.docker/dev/Dockerfile
+++ b/.docker/dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM sylius/standard:1.11-traditional
 
-RUN apt-get update && apt-get install php8.0-xdebug && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apt-get update && apt-get install curl php8.0-xdebug -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && architecture=$(uname -m) \


### PR DESCRIPTION
fix ```/bin/sh: 1: curl: not found``` on docker-compose up

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?        | 1.13                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
