### PR TITLE
Run behat using dual session as javascript scenario

### DIFF
--- a/features/checkout/preventing_from_claiming_cart_of_wrong_user.feature
+++ b/features/checkout/preventing_from_claiming_cart_of_wrong_user.feature
@@ -14,7 +14,7 @@ Feature: Preventing from claiming cart of a wrong user
         And the store allows paying offline
         And there is a user "robb@stark.com" identified by "KingInTheNorth"
 
-    @ui @no-api
+    @ui @javascript @no-api
     Scenario: Preventing anonymous user from claiming cart of logged in user
         Given I am logged in as "robb@stark.com"
         And I have product "PHP T-Shirt" in the cart
@@ -23,7 +23,7 @@ Feature: Preventing from claiming cart of a wrong user
         And they add product "Symfony T-Shirt" to the cart
         Then their cart total should be "$150.00"
 
-    @ui @no-api
+    @ui @javascript @no-api
     Scenario: Preventing anonymous user from claiming cart of logged in user
         Given I am logged in as "robb@stark.com"
         And I have product "PHP T-Shirt" in the cart


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

After the new, `v2.4.0` release of [FoS/SymfonyExtension](https://github.com/FriendsOfBehat/SymfonyExtension/releases/tag/v2.4.0), Sylius scenarios that use a dual session fail. This may be due to this change:
https://github.com/FriendsOfBehat/SymfonyExtension/pull/190

Running problematic tests with the `@javascript` seems to resolve this problem