### PR TITLE
Adjust FlattenException and HydraError normalizers to Symfony 5.4

### DIFF
--- a/UPGRADE-API-1.12.md
+++ b/UPGRADE-API-1.12.md
@@ -1,3 +1,32 @@
+# UPGRADE FROM `v1.12.1` TO `v1.12.2`
+
+1. So far, on production environment when any non-validation related error occurred, the `FOS\RestBundle\Serializer\Normalizer\FlattenExceptionHandler` was used, even on API Platform endpoints.
+   Now, depending on the path of the request, the `FOS\RestBundle\Serializer\Normalizer\FlattenExceptionHandler` or `ApiPlatform\Hydra\Serializer\ErrorNormalizer` is used. If your code
+   rely on the previous behavior, you should add the following configuration to your `config/packages/_sylius.yaml` file:
+    ```yaml
+    sylius_api:
+        legacy_error_handling: true
+    ```
+
+   Example response before bugfix:
+    ```json
+    {
+        "code": 500,
+        "message": "Internal Server Error"
+    }
+    ```
+
+   Example response after bugfix:
+    ```json
+    {
+        "@context": "/api/v2/contexts/Error",
+        "@type": "hydra:Error",
+        "hydra:title": "An error occurred",
+        "hydra:description": "Internal Server Error"
+    }
+    ```
+   The status code is passed along the response as an HTTP status code, and the `message` value is returned in a `hydra:description` field.
+
 # UPGRADE FROM `v1.11.X` TO `v1.12.0`
 
 1. The `Sylius\Bundle\ApiBundle\DataProvider\CartShippingMethodsSubresourceDataProvider` has been removed and replaced by `Sylius\Bundle\ApiBundle\DataProvider\ShippingMethodsCollectionDataProvider`.

--- a/psalm.xml
+++ b/psalm.xml
@@ -40,6 +40,7 @@
                 <referencedClass name="Symfony\Component\Security\Core\Encoder\EncoderAwareInterface" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedClass name="Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedClass name="Symfony\Component\Security\Core\Exception\UsernameNotFoundException" /> <!-- deprecated in Symfony 5.3 -->
+                <referencedClass name="Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface" /> <!-- deprecated in Symfony 6.1, probably a bug in psalm, as this is referenced as DeprecatedClass, not an interface -->
                 <referencedClass name="Symfony\Component\HttpFoundation\RequestMatcher" /> <!-- deprecated in Symfony 6.2 -->
             </errorLevel>
         </DeprecatedClass>

--- a/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
@@ -117,7 +117,7 @@ final class ResettingPasswordContext implements Context
 
         Assert::same($lastResponse->getStatusCode(), Response::HTTP_INTERNAL_SERVER_ERROR);
         $message = $this->responseChecker->getError($lastResponse);
-        Assert::startsWith($message, 'No user found with reset token: ');
+        Assert::startsWith($message, 'Internal Server Error');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -272,7 +272,7 @@ final class LoginContext implements Context
         // token is removed when used
         Assert::same($this->client->getLastResponse()->getStatusCode(), 500);
         $message = $this->responseChecker->getError($this->client->getLastResponse());
-        Assert::startsWith($message, 'No user found with reset token: ');
+        Assert::startsWith($message, 'Internal Server Error');
     }
 
     private function addLocale(string $locale): void

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -247,9 +247,10 @@ final class ProductVariantContext implements Context
      */
     public function iShouldNotSeeVariant(ProductVariantInterface $variant): void
     {
-        $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
+        $response = $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
+
         Assert::same(
-            $content['code'],
+            $response->getStatusCode(),
             404,
             sprintf('%s variant should be disabled', $variant->getName()),
         );

--- a/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
@@ -25,14 +25,9 @@ final class FlattenExceptionNormalizer implements ContextAwareNormalizerInterfac
     ) {
     }
 
-    public function supportsNormalization($data, $format = null, array $context = [])
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
-        if (method_exists($this->requestStack, 'getMainRequest')) {
-            $path = $this->requestStack->getMainRequest()->getPathInfo();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $path = $this->requestStack->getMasterRequest()->getPathInfo();
-        }
+        $path = $this->requestStack->getMainRequest()->getPathInfo();
 
         if (str_starts_with($path, $this->newApiRoute)) {
             return false;

--- a/src/Sylius/Bundle/ApiBundle/Serializer/HydraErrorNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/HydraErrorNormalizer.php
@@ -32,14 +32,9 @@ final class HydraErrorNormalizer implements NormalizerInterface, CacheableSuppor
         return $this->decorated->normalize($object, $format, $context);
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
-        if (method_exists($this->requestStack, 'getMainRequest')) {
-            $path = $this->requestStack->getMainRequest()->getPathInfo();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $path = $this->requestStack->getMasterRequest()->getPathInfo();
-        }
+        $path = $this->requestStack->getMainRequest()->getPathInfo();
 
         if (!str_starts_with($path, $this->newApiRoute)) {
             return false;

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
@@ -40,12 +40,7 @@ final class FlattenExceptionNormalizerSpec extends ObjectBehavior
 
         $request->getPathInfo()->willReturn('/api/v2/products');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            /** @phpstan-ignore-next-line */
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $normalizer->supportsNormalization('data', 'format', ['context'])->shouldNotBeCalled();
 
@@ -61,15 +56,10 @@ final class FlattenExceptionNormalizerSpec extends ObjectBehavior
 
         $request->getPathInfo()->willReturn('/api/v1/products');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            /** @phpstan-ignore-next-line */
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
-        $normalizer->supportsNormalization('data', 'format', ['context'])->shouldBeCalled();
+        $normalizer->supportsNormalization('data', 'format', ['context'])->shouldBeCalled()->willReturn(true);
 
-        $this->supportsNormalization('data', 'format', ['context']);
+        $this->supportsNormalization('data', 'format', ['context'])->shouldReturn(true);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
@@ -39,16 +39,11 @@ final class HydraErrorNormalizerSpec extends ObjectBehavior
 
         $request->getPathInfo()->willReturn('/api/v1/resource');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            /** @phpstan-ignore-next-line */
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $normalizer->supportsNormalization('data', 'format')->shouldNotBeCalled();
 
-        $this->supportsNormalization('data', 'format');
+        $this->supportsNormalization('data', 'format')->shouldReturn(false);
     }
 
     function it_calls_decorated_support_normalize_method_when_path_starts_with_new_api_route(
@@ -60,16 +55,11 @@ final class HydraErrorNormalizerSpec extends ObjectBehavior
 
         $request->getPathInfo()->willReturn('/api/v2/resource');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            /** @phpstan-ignore-next-line */
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
-        $normalizer->supportsNormalization('data', 'format')->shouldBeCalled();
+        $normalizer->supportsNormalization('data', 'format')->shouldBeCalled()->willReturn(true);
 
-        $this->supportsNormalization('data', 'format');
+        $this->supportsNormalization('data', 'format')->shouldReturn(true);
     }
 
     function it_decorates_has_cacheable_supports_method(


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | continuation of #14642                    |
| License         | MIT                                                          |

Some clean-ups to adjust to Symfony 5.4 standards 💃🏻.
