### PR TITLE
Fixing conflicts with Api platform and sylius

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,7 +178,7 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "api-platform/core": "2.7.0",
+        "api-platform/core": "^2.7"
         "doctrine/doctrine-bundle": "2.3.0",
         "jms/serializer-bundle": "4.1.0",
         "symfony/framework-bundle": "5.4.5",


### PR DESCRIPTION
In 2.7 api platform has braking changes, for example filters in symfony api bundle are using some classes that doesn't exist in 2.7 
with "api-platform/core": "2.7.0" this version is skipped and 2.7.5 will be installed. this commit fix this issue

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11, 1.12 or 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | yes                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |


