### PR TITLE
Improve error handling while password resetting

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
@@ -115,9 +115,9 @@ final class ResettingPasswordContext implements Context
 
         $lastResponse = $this->client->getLastResponse();
 
-        Assert::same($lastResponse->getStatusCode(), Response::HTTP_INTERNAL_SERVER_ERROR);
+        Assert::same($lastResponse->getStatusCode(), Response::HTTP_NOT_FOUND);
         $message = $this->responseChecker->getError($lastResponse);
-        Assert::startsWith($message, 'Internal Server Error');
+        Assert::startsWith($message, 'No user found with reset token:');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -26,6 +26,7 @@ use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\HttpFoundation\Request as HTTPRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
 final class LoginContext implements Context
@@ -270,9 +271,9 @@ final class LoginContext implements Context
         $this->client->executeCustomRequest($this->request);
 
         // token is removed when used
-        Assert::same($this->client->getLastResponse()->getStatusCode(), 500);
+        Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_NOT_FOUND);
         $message = $this->responseChecker->getError($this->client->getLastResponse());
-        Assert::startsWith($message, 'Internal Server Error');
+        Assert::startsWith($message, 'No user found with reset token:');
     }
 
     private function addLocale(string $locale): void

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -41,6 +41,7 @@ api_platform:
         Sylius\Bundle\ApiBundle\Exception\OrderNoLongerEligibleForPromotion: 422
         Sylius\Bundle\ApiBundle\Exception\ZoneCannotBeRemoved: 422
         Sylius\Bundle\ApiBundle\Exception\ProvinceCannotBeRemoved: 422
+        Sylius\Bundle\UserBundle\Exception\UserNotFoundException: 404
         Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 400
     collection:
         pagination:

--- a/src/Sylius/Bundle/CoreBundle/Security/UserPasswordResetter.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserPasswordResetter.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Security;
 
+use Sylius\Bundle\UserBundle\Exception\UserNotFoundException;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\PasswordUpdaterInterface;
-use Webmozart\Assert\Assert;
 
 final class UserPasswordResetter implements UserPasswordResetterInterface
 {
@@ -27,12 +27,17 @@ final class UserPasswordResetter implements UserPasswordResetterInterface
     ) {
     }
 
+    /**
+     * @throws UserNotFoundException
+     */
     public function reset(string $token, string $password): void
     {
         /** @var UserInterface|null $user */
         $user = $this->userRepository->findOneBy(['passwordResetToken' => $token]);
 
-        Assert::notNull($user, 'No user found with reset token: ' . $token);
+        if (null === $user) {
+            throw new UserNotFoundException(message: sprintf('No user found with reset token: %s', $token));
+        }
 
         $lifetime = new \DateInterval($this->tokenTtl);
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Security/UserPasswordResetterSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Security/UserPasswordResetterSpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Bundle\CoreBundle\Security;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Security\UserPasswordResetterInterface;
+use Sylius\Bundle\UserBundle\Exception\UserNotFoundException;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\PasswordUpdaterInterface;
@@ -62,7 +63,7 @@ final class UserPasswordResetterSpec extends ObjectBehavior
         $passwordUpdater->updatePassword(Argument::any())->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(\InvalidArgumentException::class)
+            ->shouldThrow(UserNotFoundException::class)
             ->during('reset', ['TOKEN', 'newPassword'])
         ;
     }

--- a/src/Sylius/Bundle/UserBundle/Exception/UserNotFoundException.php
+++ b/src/Sylius/Bundle/UserBundle/Exception/UserNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UserBundle\Exception;
+
+use Webmozart\Assert\InvalidArgumentException;
+
+class UserNotFoundException extends InvalidArgumentException
+{
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | I'm not sure, I treat it more like a behavior change                                                       |
| New feature?    | as above                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | continuation of #14646                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
