### PR TITLE
Fix error because of missing key in array

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -7,7 +7,8 @@
         {% set attributes = {} %}
 
         {% for child in form %}
-            {% set code = child.vars.data.attribute.code %}
+            {# Required prefix for numeric keys (e.g., array_merge(['1' => 'a'], ['1' => 'a'])) #}
+            {% set code = '#' ~ child.vars.data.attribute.code %}
 
             {% if attributes[code] is not defined %}
                 {% set attributes = attributes|merge({ (code): [] }) %}
@@ -17,6 +18,7 @@
         {% endfor %}
 
         {% for key, attribute in attributes %}
+            {% set key = key|trim('#', 'left') %}
             <div class="attributes-group" data-attribute-code="{{ key }}">
                 <div class="attributes-header">
                     <strong>{{ attribute[0].value.vars.label }}</strong>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Fixes:
```
Twig\Error\RuntimeError:
Key "1" for array with keys "0" does not exist.

  at vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig:17
  at twig_get_attribute(object(Environment), object(Source), array(array()), '1', array(), 'array', false, false, false, 17)
     (var/cache/dev/twig/1b/1baa5c3c716a61dd8ad09237c64667675c8ea56ccca82c3e9e16fc90a2634874.php:102)
```
