### PR TITLE
[Maintenance][Psalm] Add LifecycleEventArgs to deprecated classes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,6 +30,9 @@ parameters:
         - 'src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingExceptionListener.php'
         - 'src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/CircularDependencyBreakingExceptionListenerPassTest.php'
         - 'src/Sylius/Bundle/CoreBundle/Tests/Listener/CircularDependencyBreakingExceptionListenerTest.php'
+
+        # To investigate, occurs after release of doctrine/orm 2.14, the processing of these classes ends with exit code 143
+        - 'src/Sylius/Bundle/CoreBundle/Doctrine/DQL/**.php'
     ignoreErrors:
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'
         - '/Parameter \$templatingEngine of method Sylius\\Bundle\\AdminBundle\\Controller\\CustomerStatisticsController\:\:\_\_construct\(\) has invalid typehint type Symfony\\Bundle\\FrameworkBundle\\Templating\\EngineInterface\./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -98,6 +98,7 @@
                 <referencedClass name="Symfony\Component\Security\Core\Encoder\EncoderAwareInterface" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedClass name="Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedClass name="Symfony\Component\Security\Core\Exception\UsernameNotFoundException" /> <!-- deprecated in Symfony 5.3 -->
+                <referencedClass name="Doctrine\ORM\Event\LifecycleEventArgs" /> <!-- deprecated in doctrine/orm 2.14 -->
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedInterface>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 and 1.12<!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

Reference:
https://github.com/doctrine/orm/releases/tag/2.14.0
<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
