### PR TITLE
Improve loading taxons

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
@@ -9,7 +9,7 @@ sylius_admin_partial_taxon_tree:
         _sylius:
             template: $template
             repository:
-                method: findRootNodes
+                method: findHydratedRootNodes
             permission: true
 
 sylius_admin_partial_taxon_show:

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -31,6 +31,8 @@ interface TaxonRepositoryInterface extends RepositoryInterface
      */
     public function findRootNodes(): array;
 
+    public function findHydratedRootNodes(): array;
+
     public function findOneBySlug(string $slug, string $locale): ?TaxonInterface;
 
     /**


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes/closes #11145                      |
| License         | MIT                                                          |

Previously when loading taxons we've been performing plenty of queries due to lazy loading. Changing fetch mode to eager seemed not to work, and also wasn't a desired solution. Two-step hydration instead solved the problem.

I am unable to include "before" results as debug toolbar can't finish loading :|. So as reference, let's use the screenshots from #11145. For 5000 taxons we were executing about ~12.000 queries (it depends on the level of nesting and other factors). For 1000 taxons locally, I've got about 2.000 queries.

Here are the results for 2.000 taxons (in the shop enabled is about 1/3 of that):

Admin Panel:
<img width="159" alt="CleanShot 2022-12-21 at 12 55 37@2x" src="https://user-images.githubusercontent.com/80641364/208899596-1b02c50c-2ecc-48f5-ac1d-f76d56d4c6aa.png">

Shop:
<img width="141" alt="CleanShot 2022-12-21 at 12 56 04@2x" src="https://user-images.githubusercontent.com/80641364/208899679-949d89ea-6691-42f0-ad52-805d7011d6cc.png">




