### PR TITLE
use of the right bootstrap versions for theme bootstrap 

### DIFF
--- a/docs/book/themes/bootstrap-theme.rst
+++ b/docs/book/themes/bootstrap-theme.rst
@@ -69,7 +69,7 @@ Install missing BootstrapTheme dependencies
 .. code-block:: bash
 
     yarn add sass-loader@^7.0.0 node-sass lodash.throttle -D
-    yarn add bootstrap bootstrap.native glightbox axios form-serialize @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons
+    yarn add bootstrap@^4.5.0 bootstrap.native@^3.0.0 glightbox axios form-serialize @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons
 
 in ``theme/BootstrapChildTheme/assets`` create 2 files: ``entry.js`` and ``scss/index.scss``
 


### PR DESCRIPTION
yarn add bootstrap bootstrap.native installs the latest versions that are not compatible with the version of bootstrap used in the theme.  You have to specify the right version to install. 

This comes directly from the theme repository : https://github.com/SyliusCrafts/BootstrapTheme#installation

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.9, 1.10, 1.11, 1.12                |


