### PR TITLE
Add EmailMessagesProvider

### DIFF
--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -99,6 +99,10 @@
         </service>
 
         <service id="sylius.behat.email_checker" class="Sylius\Behat\Service\Checker\EmailChecker">
+            <argument type="service" id="Sylius\Behat\Service\Provider\EmailMessagesProviderInterface" />
+        </service>
+
+        <service id="Sylius\Behat\Service\Provider\EmailMessagesProviderInterface" class="Sylius\Behat\Service\Provider\EmailMessagesProvider">
             <argument type="service" id="test.mailer_pool" />
         </service>
 

--- a/src/Sylius/Behat/Service/Checker/EmailChecker.php
+++ b/src/Sylius/Behat/Service/Checker/EmailChecker.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Checker;
 
-use Psr\Cache\CacheItemPoolInterface;
-use Sylius\Behat\Service\MessageSendCacher;
+use Sylius\Behat\Service\Provider\EmailMessagesProviderInterface;
 use Symfony\Component\Mime\Email;
 use Webmozart\Assert\Assert;
 
 final class EmailChecker implements EmailCheckerInterface
 {
-    public function __construct(private CacheItemPoolInterface $cache)
+    public function __construct(private EmailMessagesProviderInterface $emailMessagesProvider)
     {
     }
 
     public function hasRecipient(string $recipient): bool
     {
-        $messages = $this->getMailerMessages();
+        $messages = $this->emailMessagesProvider->provide();
 
         foreach ($messages as $email) {
             if ($this->isMessageTo($email, $recipient)) {
@@ -41,7 +40,7 @@ final class EmailChecker implements EmailCheckerInterface
     {
         $this->assertRecipientIsValid($recipient);
 
-        $messages = $this->getMailerMessages();
+        $messages = $this->emailMessagesProvider->provide();
 
         foreach ($messages as $email) {
             if ($this->isMessageTo($email, $recipient)) {
@@ -61,7 +60,7 @@ final class EmailChecker implements EmailCheckerInterface
         $this->assertRecipientIsValid($recipient);
 
         $messagesCount = 0;
-        $messages = $this->getMailerMessages();
+        $messages = $this->emailMessagesProvider->provide();
 
         foreach ($messages as $email) {
             if ($this->isMessageTo($email, $recipient)) {
@@ -94,11 +93,5 @@ final class EmailChecker implements EmailCheckerInterface
             filter_var($recipient, \FILTER_VALIDATE_EMAIL),
             'Given recipient is not a valid email address.',
         );
-    }
-
-    /** @return Email[] */
-    private function getMailerMessages(): array
-    {
-        return $this->cache->hasItem(MessageSendCacher::CACHE_KEY) ? $this->cache->getItem(MessageSendCacher::CACHE_KEY)->get() : [];
     }
 }

--- a/src/Sylius/Behat/Service/Provider/EmailMessagesProvider.php
+++ b/src/Sylius/Behat/Service/Provider/EmailMessagesProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service\Provider;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Sylius\Behat\Service\MessageSendCacher;
+use Symfony\Component\Mime\Email;
+
+final class EmailMessagesProvider implements EmailMessagesProviderInterface
+{
+    public function __construct(private CacheItemPoolInterface $cache)
+    {
+    }
+
+    public function provide(): array
+    {
+        return $this->cache->hasItem(MessageSendCacher::CACHE_KEY) ? $this->cache->getItem(MessageSendCacher::CACHE_KEY)->get() : [];
+    }
+}

--- a/src/Sylius/Behat/Service/Provider/EmailMessagesProviderInterface.php
+++ b/src/Sylius/Behat/Service/Provider/EmailMessagesProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service\Provider;
+
+use Symfony\Component\Mime\Email;
+
+interface EmailMessagesProviderInterface
+{
+    /** @return Email[] */
+    public function provide(): array;
+}

--- a/src/Sylius/Behat/spec/Service/Provider/EmailMessagesProviderSpec.php
+++ b/src/Sylius/Behat/spec/Service/Provider/EmailMessagesProviderSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Behat\Service\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Sylius\Behat\Service\MessageSendCacher;
+use Sylius\Behat\Service\Provider\EmailMessagesProviderInterface;
+use Symfony\Component\Mime\Email;
+
+final class EmailMessagesProviderSpec extends ObjectBehavior
+{
+    function let(CacheItemPoolInterface $cacheItemPool): void
+    {
+        $this->beConstructedWith($cacheItemPool);
+    }
+
+    function it_implements_email_messages_provider_interface(): void
+    {
+        $this->shouldImplement(EmailMessagesProviderInterface::class);
+    }
+
+    function it_provides_email_messages(
+        CacheItemPoolInterface $cacheItemPool,
+        CacheItemInterface $cacheItem
+    ): void {
+        $emailMessages = [new Email(), new Email(), new Email()];
+        $cacheItem->get()->willReturn($emailMessages);
+
+        $cacheItemPool->hasItem(MessageSendCacher::CACHE_KEY)->willReturn(true);
+        $cacheItemPool->getItem(MessageSendCacher::CACHE_KEY)->willReturn($cacheItem);
+
+        $this->provide()->shouldReturn($emailMessages);
+    }
+
+    function it_returns_an_empty_array_if_cache_key_does_not_exist(CacheItemPoolInterface $cacheItemPool): void
+    {
+        $cacheItemPool->hasItem(MessageSendCacher::CACHE_KEY)->willReturn(false);
+
+        $this->provide()->shouldReturn([]);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                     |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
We need the "getMessages" method from EmailChecker to allow to check what messages contains even inside tags, which is impossible in hasMessageTo() method becouse of strip_tags() usage, using provider probably will solve this problem
