### PR TITLE
[UX] Fix cart button on small screens

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
@@ -25,11 +25,14 @@ import './sylius-variants-prices';
 $(document).ready(() => {
   $('.popup-js').popup();
 
-  $('.cart.button')
-    .popup({
-      popup: $('.cart.popup'),
-      on: 'click',
-    });
+  $('.cart.button').popup({
+    popup: $('.cart.popup'),
+    on: 'click',
+    onUnplaceable() {
+      window.location.href = $('#sylius-go-to-cart').attr('href');
+    },
+    silent: true,
+  });
 
   $('.star.rating').rating({
     fireOnInit: true,
@@ -85,6 +88,6 @@ $(document).ready(() => {
     slidesToScroll: 1,
     prevArrow: $('.carousel-left'),
     nextArrow: $('.carousel-right'),
-    appendArrows: false
+    appendArrows: false,
   });
 });

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Widget/_popup.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Widget/_popup.html.twig
@@ -9,7 +9,7 @@
         {% endfor %}
         <div class="item"><strong>{{ 'sylius.ui.subtotal'|trans }}</strong>: {{ money.convertAndFormat(cart.itemsTotal) }}</div>
     </div>
-    <a href="{{ path('sylius_shop_cart_summary') }}" class="ui fluid basic text button">{{ 'sylius.ui.view_and_edit_cart'|trans }}</a>
+    <a href="{{ path('sylius_shop_cart_summary') }}" id="sylius-go-to-cart" class="ui fluid basic text button">{{ 'sylius.ui.view_and_edit_cart'|trans }}</a>
     <div class="ui divider"></div>
     <a href="{{ path('sylius_shop_checkout_start') }}" class="ui fluid primary button">{{ 'sylius.ui.checkout'|trans }}</a>
 {% endif %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 |
| Bug fix?        | yes                                                       |
| New feature?    | yes?                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14229 |
| License         | MIT                                                          |

Clicking the cart button when the screen cannot accommodate the popup will now redirect to the cart instead of throwing a console error and doing nothing.