### PR TITLE
Default ORDER BY for all entities and their relationships

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -1,3 +1,12 @@
+# UPGRADE FROM `v1.11.11` TO `v1.11.12`
+
+1. All entities and their relationships have a default order by identifier if no order is specified. You can disable
+this behavior by setting the `sylius_core.order_by_identifier` parameter to `false`:
+```yaml
+sylius_core:
+    order_by_identifier: false
+```
+
 # UPGRADE FROM `v1.11.7` TO `v1.11.8`
 
 1. Cloning `Sylius\Component\Order\Model\Adjustment` resets values of fields `id`, `createdAt` and `updatedAt`.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,6 +33,7 @@ parameters:
 
         # To investigate, occurs after release of doctrine/orm 2.14, the processing of these classes ends with exit code 143
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/DQL/**.php'
+        - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/**.php'
     ignoreErrors:
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'
         - '/Method Symfony\\Component\\Serializer\\Normalizer\\NormalizerInterface\:\:supportsNormalization\(\) invoked with 3 parameters\, 1\-2 required\./'

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Country.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Country.orm.xml
@@ -30,7 +30,8 @@
                 <cascade-all/>
             </cascade>
             <order-by>
-                <order-by-field name="name" direction="ASC" />
+                <order-by-field name="name" />
+                <order-by-field name="id" />
             </order-by>
         </one-to-many>
     </mapped-superclass>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -27,6 +27,9 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
                 ->booleanNode('prepend_doctrine_migrations')->defaultTrue()->end()
                 ->booleanNode('shipping_address_based_taxation')->defaultFalse()->end()
+                ->booleanNode('order_by_identifier')->defaultTrue()->end()
                 ->booleanNode('process_shipments_before_recalculating_prices')
                     ->setDeprecated('sylius/sylius', '1.10', 'The "%path%.%node%" parameter is deprecated and will be removed in 2.0.')
                     ->defaultFalse()

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -57,6 +57,7 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
         $loader->load('services.xml');
 
         $container->setParameter('sylius_core.taxation.shipping_address_based_taxation', $config['shipping_address_based_taxation']);
+        $container->setParameter('sylius_core.order_by_identifier', $config['order_by_identifier']);
         $container->setParameter('sylius_core.catalog_promotions.batch_size', $config['catalog_promotions']['batch_size']);
 
         $env = $container->getParameter('kernel.environment');

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/OrderByIdentifierSqlWalker.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/OrderByIdentifierSqlWalker.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Doctrine\ORM\SqlWalker;
+
+use Doctrine\ORM\Query\AST\AggregateExpression;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\OrderByClause;
+use Doctrine\ORM\Query\AST\OrderByItem;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\SqlWalker;
+
+final class OrderByIdentifierSqlWalker extends SqlWalker
+{
+    public function walkSelectStatement(SelectStatement $ast)
+    {
+        $dqlAlias = $this->getDqlAlias();
+
+        if (null !== $dqlAlias && $this->isOrderByIdentifierAllowed($ast)) {
+            $this->appendOrderByIdentifier($ast, $dqlAlias);
+        }
+
+        return parent::walkSelectStatement($ast);
+    }
+
+    private function appendOrderByIdentifier(SelectStatement $ast, string $dqlAlias): void
+    {
+        $metadata = $this->getMetadataForDqlAlias($dqlAlias);
+
+        $expression = new PathExpression(
+            PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,
+            $dqlAlias,
+            $metadata->getSingleIdentifierFieldName()
+        );
+        $expression->type = PathExpression::TYPE_STATE_FIELD;
+
+        $orderById = new OrderByItem($expression);
+        $orderById->type = 'ASC';
+
+        if (null === $ast->orderByClause) {
+            $ast->orderByClause = new OrderByClause([$orderById]);
+
+            return;
+        }
+
+        $ast->orderByClause->orderByItems[] = $orderById;
+    }
+
+    /**
+     * @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.13/cookbook/dql-custom-walkers.html#extending-dql-in-doctrine-orm-custom-ast-walkers
+     */
+    private function getDqlAlias(): ?string
+    {
+        foreach ($this->getQueryComponents() as $dqlAlias => $queryComponent) {
+            if (null === ($queryComponent['parent'] ?? null) && 0 === ($queryComponent['nestingLevel'] ?? 0)) {
+                return $dqlAlias;
+            }
+        }
+
+        return null;
+    }
+
+    private function isOrderByIdentifierAllowed(SelectStatement $ast): bool
+    {
+        // false if not sure the identifier is added to the GROUP BY clause
+        if (null !== $ast->groupByClause) {
+            return false;
+        }
+
+        $expression = current($ast->selectClause->selectExpressions)->expression;
+
+        // false if aggregate functions is used
+        return !$expression instanceof AggregateExpression && !$expression instanceof FunctionNode;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/OrderByIdentifierSqlWalker.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/OrderByIdentifierSqlWalker.php
@@ -23,15 +23,15 @@ use Doctrine\ORM\Query\SqlWalker;
 
 final class OrderByIdentifierSqlWalker extends SqlWalker
 {
-    public function walkSelectStatement(SelectStatement $ast)
+    public function walkSelectStatement(SelectStatement $AST)
     {
         $dqlAlias = $this->getDqlAlias();
 
-        if (null !== $dqlAlias && $this->isOrderByIdentifierAllowed($ast)) {
-            $this->appendOrderByIdentifier($ast, $dqlAlias);
+        if (null !== $dqlAlias && $this->isOrderByIdentifierAllowed($AST)) {
+            $this->appendOrderByIdentifier($AST, $dqlAlias);
         }
 
-        return parent::walkSelectStatement($ast);
+        return parent::walkSelectStatement($AST);
     }
 
     private function appendOrderByIdentifier(SelectStatement $ast, string $dqlAlias): void
@@ -62,6 +62,7 @@ final class OrderByIdentifierSqlWalker extends SqlWalker
      */
     private function getDqlAlias(): ?string
     {
+        /** @psalm-suppress UndefinedDocblockClass */
         foreach ($this->getQueryComponents() as $dqlAlias => $queryComponent) {
             if (null === ($queryComponent['parent'] ?? null) && 0 === ($queryComponent['nestingLevel'] ?? 0)) {
                 return $dqlAlias;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/CatalogPromotion.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/CatalogPromotion.orm.xml
@@ -17,6 +17,10 @@
 >
     <mapped-superclass name="Sylius\Component\Core\Model\CatalogPromotion" table="sylius_catalog_promotion">
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_catalog_promotion_channels">
                 <join-columns>
                     <join-column name="catalog_promotion_id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -38,6 +38,10 @@
             <join-column name="menu_taxon_id" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
         </many-to-one>
         <many-to-many field="currencies" target-entity="Sylius\Component\Currency\Model\CurrencyInterface" fetch="EAGER">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_channel_currencies">
                 <join-columns>
                     <join-column name="channel_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
@@ -34,6 +34,10 @@
         </field>
         <field name="channelCode" column="channel_code" type="string" />
         <many-to-many field="appliedPromotions" target-entity="Sylius\Component\Promotion\Model\CatalogPromotionInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_channel_pricing_catalog_promotions">
                 <join-columns>
                     <join-column name="channel_pricing_id" nullable="false"/>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Customer.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Customer.orm.xml
@@ -31,11 +31,19 @@
         </one-to-one>
 
         <one-to-many field="orders" target-entity="Sylius\Component\Order\Model\OrderInterface" mapped-by="customer">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all />
             </cascade>
         </one-to-many>
         <one-to-many field="addresses" target-entity="Sylius\Component\Addressing\Model\AddressInterface" mapped-by="customer">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all />
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -46,12 +46,20 @@
         </many-to-one>
 
         <one-to-many field="payments" target-entity="Sylius\Component\Payment\Model\PaymentInterface" mapped-by="order" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>
         </one-to-many>
 
         <one-to-many field="shipments" target-entity="Sylius\Component\Shipping\Model\ShipmentInterface" mapped-by="order" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>
@@ -65,6 +73,10 @@
         </many-to-one>
 
         <many-to-many field="promotions" target-entity="Sylius\Component\Promotion\Model\PromotionInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_promotion_order">
                 <join-columns>
                     <join-column name="order_id" referenced-column-name="id" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/PaymentMethod.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/PaymentMethod.orm.xml
@@ -18,6 +18,10 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\PaymentMethod" table="sylius_payment_method">
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_payment_method_channels">
                 <join-columns>
                     <join-column name="payment_method_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -26,12 +26,20 @@
         </field>
 
         <one-to-many field="productTaxons" target-entity="Sylius\Component\Core\Model\ProductTaxonInterface" mapped-by="product" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>
         </one-to-many>
 
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_product_channels">
                 <join-columns>
                     <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
@@ -47,6 +55,10 @@
         </many-to-one>
 
         <one-to-many field="images" target-entity="Sylius\Component\Core\Model\ProductImageInterface" mapped-by="owner" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductImage.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductImage.orm.xml
@@ -17,6 +17,10 @@
             <join-column name="owner_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
         </many-to-one>
         <many-to-many field="productVariants" target-entity="Sylius\Component\Product\Model\ProductVariantInterface" inversed-by="images">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_product_image_product_variants">
                 <join-columns>
                     <join-column name="image_id" referenced-column-name="id" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -39,6 +39,10 @@
             orphan-removal="true"
             index-by="channelCode"
         >
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>
@@ -48,6 +52,10 @@
             target-entity="Sylius\Component\Core\Model\ProductImageInterface"
             mapped-by="productVariants"
         >
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-persist/>
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Promotion.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Promotion.orm.xml
@@ -19,6 +19,10 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Promotion" table="sylius_promotion">
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_promotion_channels">
                 <join-columns>
                     <join-column name="promotion_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
@@ -20,6 +20,10 @@
         <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
 
         <one-to-many field="adjustments" target-entity="Sylius\Component\Core\Model\AdjustmentInterface" mapped-by="shipment" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
@@ -26,6 +26,10 @@
         </many-to-one>
 
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_shipping_method_channels">
                 <join-columns>
                     <join-column name="shipping_method_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -26,6 +26,10 @@
         </field>
 
         <one-to-many field="images" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="owner" orphan-removal="true">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <cascade>
                 <cascade-all/>
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -50,7 +50,9 @@ final class SyliusCoreBundle extends AbstractResourceBundle
     {
         parent::boot();
 
-        $this->setSqlWalker();
+        if ($this->container->getParameter('sylius_core.order_by_identifier')) {
+            $this->setDefaultOutputWalker(OrderByIdentifierSqlWalker::class);
+        }
 
         $factory = InflectorFactory::create();
         $factory->withPluralRules(new Ruleset(
@@ -87,14 +89,14 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         return 'Sylius\Component\Core\Model';
     }
 
-    private function setSqlWalker(): void
+    private function setDefaultOutputWalker(string $outputWalkerClass): void
     {
         $this->container
             ->get('doctrine.orm.entity_manager')
             ->getConfiguration()
             ->setDefaultQueryHint(
                 Query::HINT_CUSTOM_OUTPUT_WALKER,
-                OrderByIdentifierSqlWalker::class
+                $outputWalkerClass,
             )
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -20,6 +20,7 @@ use Doctrine\Inflector\Rules\Substitution;
 use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Transformations;
 use Doctrine\Inflector\Rules\Word;
+use Doctrine\ORM\Query;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\CancelOrderStateMachineCallbackPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\BackwardsCompatibility\ResolveShopUserTargetEntityPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBreakingErrorListenerPass;
@@ -30,6 +31,7 @@ use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LiipImageFiltersPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterTaxCalculationStrategiesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterUriBasedSectionResolverPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\TranslatableEntityLocalePass;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\SqlWalker\OrderByIdentifierSqlWalker;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Resource\Metadata\Metadata;
@@ -47,6 +49,8 @@ final class SyliusCoreBundle extends AbstractResourceBundle
     public function boot(): void
     {
         parent::boot();
+
+        $this->setSqlWalker();
 
         $factory = InflectorFactory::create();
         $factory->withPluralRules(new Ruleset(
@@ -81,5 +85,17 @@ final class SyliusCoreBundle extends AbstractResourceBundle
     protected function getModelNamespace(): string
     {
         return 'Sylius\Component\Core\Model';
+    }
+
+    private function setSqlWalker(): void
+    {
+        $this->container
+            ->get('doctrine.orm.entity_manager')
+            ->getConfiguration()
+            ->setDefaultQueryHint(
+                Query::HINT_CUSTOM_OUTPUT_WALKER,
+                OrderByIdentifierSqlWalker::class
+            )
+        ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -43,6 +43,36 @@ final class ConfigurationTest extends TestCase
     }
 
     /** @test */
+    public function it_enables_order_by_identifier_by_default(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [[]],
+            ['order_by_identifier' => true],
+            'order_by_identifier',
+        );
+    }
+
+    /** @test */
+    public function it_allows_to_enable_order_by_identifier(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['order_by_identifier' => true]],
+            ['order_by_identifier' => true],
+            'order_by_identifier',
+        );
+    }
+
+    /** @test */
+    public function it_allows_to_disable_order_by_identifier(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['order_by_identifier' => false]],
+            ['order_by_identifier' => false],
+            'order_by_identifier',
+        );
+    }
+
+    /** @test */
     public function it_throws_an_exception_if_value_other_then_integer_is_declared_as_batch_size(): void
     {
         $this->assertConfigurationIsInvalid([['catalog_promotions' => ['batch_size' => 'rep']]]);

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -86,6 +86,28 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
     }
 
     /** @test */
+    public function it_loads_default_order_by_identifier_parameter_value_properly(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load();
+
+        $this->assertContainerBuilderHasParameter('sylius_core.order_by_identifier', true);
+    }
+
+    /** @test */
+    public function it_loads_order_by_identifier_parameter_value_properly(): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+
+        $this->load(['order_by_identifier' => true]);
+        $this->assertContainerBuilderHasParameter('sylius_core.order_by_identifier', true);
+
+        $this->load(['order_by_identifier' => false]);
+        $this->assertContainerBuilderHasParameter('sylius_core.order_by_identifier', false);
+    }
+
+    /** @test */
     public function it_loads_batch_size_parameter_value_properly(): void
     {
         $this->container->setParameter('kernel.environment', 'dev');

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -33,12 +33,18 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <one-to-many field="adjustments" target-entity="Sylius\Component\Order\Model\AdjustmentInterface" mapped-by="order" orphan-removal="true">
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <field name="itemsTotal" column="items_total" type="integer" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -37,12 +37,18 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <one-to-many field="units" target-entity="Sylius\Component\Order\Model\OrderItemUnitInterface" mapped-by="orderItem" orphan-removal="true">
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
@@ -31,6 +31,9 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -24,6 +24,9 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <one-to-many field="variants" target-entity="Sylius\Component\Product\Model\ProductVariantInterface" mapped-by="product" orphan-removal="true">
@@ -31,7 +34,8 @@
                 <cascade-all />
             </cascade>
             <order-by>
-                <order-by-field name="position" direction="ASC" />
+                <order-by-field name="position" />
+                <order-by-field name="id" />
             </order-by>
         </one-to-many>
 
@@ -40,7 +44,8 @@
                 <cascade-persist />
             </cascade>
             <order-by>
-                <order-by-field name="position" direction="ASC" />
+                <order-by-field name="position" />
+                <order-by-field name="id" />
             </order-by>
             <join-table name="sylius_product_options">
                 <join-columns>
@@ -52,6 +57,15 @@
             </join-table>
         </many-to-many>
 
+        <one-to-many field="associations" target-entity="Sylius\Component\Product\Model\ProductAssociationInterface" mapped-by="owner" orphan-removal="true">
+            <cascade>
+                <cascade-all/>
+            </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+        </one-to-many>
+
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>
         </field>
@@ -60,12 +74,6 @@
             <gedmo:timestampable on="update"/>
         </field>
         <field name="enabled" column="enabled" type="boolean" />
-
-        <one-to-many field="associations" target-entity="Sylius\Component\Product\Model\ProductAssociationInterface" mapped-by="owner" orphan-removal="true">
-            <cascade>
-                <cascade-all/>
-            </cascade>
-        </one-to-many>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAssociation.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAssociation.orm.xml
@@ -43,6 +43,10 @@
         </many-to-one>
 
         <many-to-many field="associatedProducts" target-entity="Sylius\Component\Product\Model\ProductInterface">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_product_association_product">
                 <join-columns>
                     <join-column name="association_id" referenced-column-name="id" nullable="false" unique="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOption.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOption.orm.xml
@@ -36,7 +36,12 @@
         </field>
 
         <one-to-many target-entity="Sylius\Component\Product\Model\ProductOptionValueInterface" mapped-by="option" field="values" orphan-removal="true">
-            <cascade><cascade-all /></cascade>
+            <cascade>
+                <cascade-all />
+            </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -38,6 +38,10 @@
         </many-to-one>
 
         <many-to-many target-entity="Sylius\Component\Product\Model\ProductOptionValueInterface" field="optionValues">
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
+
             <join-table name="sylius_product_variant_option_value">
                 <join-columns>
                     <join-column name="variant_id" referenced-column-name="id" unique="false" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/CatalogPromotion.orm.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/CatalogPromotion.orm.xml
@@ -39,11 +39,17 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
         <one-to-many field="actions" target-entity="Sylius\Component\Promotion\Model\CatalogPromotionActionInterface" mapped-by="catalogPromotion" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/Promotion.orm.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/Promotion.orm.xml
@@ -39,16 +39,25 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
         <one-to-many field="rules" target-entity="Sylius\Component\Promotion\Model\PromotionRuleInterface" mapped-by="promotion" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
         <one-to-many field="actions" target-entity="Sylius\Component\Promotion\Model\PromotionActionInterface" mapped-by="promotion" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <field name="createdAt" column="created_at" type="datetime">

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/Shipment.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/Shipment.orm.xml
@@ -30,6 +30,9 @@
             <cascade>
                 <cascade-persist/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <field name="createdAt" column="created_at" type="datetime">

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
@@ -27,6 +27,9 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <field name="categoryRequirement" column="category_requirement" type="integer" />

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxCategory.orm.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxCategory.orm.xml
@@ -28,6 +28,9 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
 
         <field name="createdAt" column="created_at" type="datetime">

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -37,7 +37,8 @@
                 <cascade-persist />
             </cascade>
             <order-by>
-                <order-by-field name="position" direction="ASC" />
+                <order-by-field name="position" />
+                <order-by-field name="id" />
             </order-by>
         </one-to-many>
 

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/User.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/User.orm.xml
@@ -47,6 +47,9 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="id" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 </doctrine-mapping>

--- a/tests/Functional/AbstractOrmTestCase.php
+++ b/tests/Functional/AbstractOrmTestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\ORMSetup;
+use PHPUnit\Framework\TestCase;
+use Sylius\Tests\Functional\Doctrine\Mock\ConnectionMock;
+use Sylius\Tests\Functional\Doctrine\Mock\DriverMock;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+abstract class AbstractOrmTestCase extends TestCase
+{
+    protected function getTestOrmConfiguration(): Configuration
+    {
+        $config = new Configuration();
+
+        $config->setProxyDir(__DIR__ . '/../Doctrine/Proxies');
+        $config->setProxyNamespace('Sylius\Tests\Functional\Doctrine\Proxies');
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCache(new ArrayAdapter());
+        $config->setMetadataDriverImpl(ORMSetup::createDefaultAnnotationDriver());
+
+        return $config;
+    }
+
+    protected function getTestOrmConnection($config): Connection
+    {
+        return DriverManager::getConnection([
+            'driverClass'  => DriverMock::class,
+            'wrapperClass' => ConnectionMock::class,
+            'user'=> 'sylius',
+            'password' => 'sylius',
+        ], $config);
+    }
+}

--- a/tests/Functional/Doctrine/Dump/Model.php
+++ b/tests/Functional/Doctrine/Dump/Model.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Dump;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="model")
+ */
+class Model
+{
+    public function __construct(
+        /**
+         * @Column(type="integer")
+         * @Id
+         * @GeneratedValue
+         */
+        public int $id,
+
+        /**
+         * @Column(length=250)
+         */
+        public string $email
+    ) {
+    }
+}

--- a/tests/Functional/Doctrine/Mock/ConnectionMock.php
+++ b/tests/Functional/Doctrine/Mock/ConnectionMock.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+
+class ConnectionMock extends Connection
+{
+    /** @var DatabasePlatformMock */
+    private $_platformMock;
+
+    public function __construct(array $params = [], ?Driver $driver = null, ?Configuration $config = null, ?EventManager $eventManager = null)
+    {
+        $this->_platformMock = new DatabasePlatformMock();
+
+        parent::__construct($params, $driver ?? new DriverMock(), $config, $eventManager);
+    }
+
+    public function getDatabasePlatform()
+    {
+        return $this->_platformMock;
+    }
+}

--- a/tests/Functional/Doctrine/Mock/DatabasePlatformMock.php
+++ b/tests/Functional/Doctrine/Mock/DatabasePlatformMock.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class DatabasePlatformMock extends AbstractPlatform
+{
+    public function supportsIdentityColumns(): bool
+    {
+        return true;
+    }
+
+    public function getBooleanTypeDeclarationSQL(array $field)
+    {
+    }
+
+    public function getIntegerTypeDeclarationSQL(array $field)
+    {
+    }
+
+    public function getBigIntTypeDeclarationSQL(array $field)
+    {
+    }
+
+    public function getSmallIntTypeDeclarationSQL(array $field)
+    {
+    }
+
+    protected function _getCommonIntegerTypeDeclarationSQL(array $columnDef)
+    {
+    }
+
+    public function getVarcharTypeDeclarationSQL(array $field)
+    {
+    }
+
+    public function getClobTypeDeclarationSQL(array $field)
+    {
+    }
+
+    public function getName(): string
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    protected function initializeDoctrineTypeMappings()
+    {
+    }
+
+    public function getBlobTypeDeclarationSQL(array $field)
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+
+    public function getCurrentDatabaseExpression(): string
+    {
+        throw DBALException::notSupported(__METHOD__);
+    }
+}

--- a/tests/Functional/Doctrine/Mock/DriverConnectionMock.php
+++ b/tests/Functional/Doctrine/Mock/DriverConnectionMock.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\ParameterType;
+
+class DriverConnectionMock implements Connection
+{
+    public function prepare($prepareString): Statement
+    {
+        return new StatementMock();
+    }
+
+    public function query(?string $sql = null): Result
+    {
+        return new DriverResultMock();
+    }
+
+    public function quote($input, $type = ParameterType::STRING)
+    {
+    }
+
+    public function exec($statement): int
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function lastInsertId($name = null)
+    {
+    }
+
+    public function beginTransaction()
+    {
+    }
+
+    public function commit()
+    {
+    }
+
+    public function rollBack()
+    {
+    }
+}

--- a/tests/Functional/Doctrine/Mock/DriverMock.php
+++ b/tests/Functional/Doctrine/Mock/DriverMock.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+
+class DriverMock implements Driver
+{
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
+    {
+        return new DriverConnectionMock();
+    }
+
+    public function getDatabasePlatform()
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function getSchemaManager(Connection $conn, ?AbstractPlatform $platform = null): AbstractSchemaManager
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function getExceptionConverter(): ExceptionConverter
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function getName()
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+
+    public function getDatabase(Connection $conn)
+    {
+        throw new \BadMethodCallException('Not implemented');
+    }
+}

--- a/tests/Functional/Doctrine/Mock/DriverResultMock.php
+++ b/tests/Functional/Doctrine/Mock/DriverResultMock.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use BadMethodCallException;
+use Doctrine\DBAL\Driver\Result;
+
+/**
+ * This class is mostly copied from {@link https://github.com/doctrine/orm/blob/2.14.x/tests/Doctrine/Tests/Mocks/DriverResultMock.php}
+ */
+class DriverResultMock implements Result
+{
+    private array $resultSet;
+
+    /**
+     * Creates a new mock statement that will serve the provided fake result set to clients.
+     *
+     * @param array $resultSet The faked SQL result set.
+     */
+    public function __construct(array $resultSet = [])
+    {
+        $this->resultSet = $resultSet;
+    }
+
+    public function fetchNumeric()
+    {
+        $row = $this->fetchAssociative();
+
+        return $row === false ? false : array_values($row);
+    }
+
+    public function fetchAssociative()
+    {
+        $current = current($this->resultSet);
+        next($this->resultSet);
+
+        return $current;
+    }
+
+    public function fetchOne()
+    {
+        $row = $this->fetchNumeric();
+
+        return $row ? $row[0] : false;
+    }
+
+    public function fetchAllNumeric(): array
+    {
+        $values = [];
+        while (($row = $this->fetchNumeric()) !== false) {
+            $values[] = $row;
+        }
+
+        return $values;
+    }
+
+    public function fetchAllAssociative(): array
+    {
+        $resultSet = $this->resultSet;
+        reset($resultSet);
+
+        return $resultSet;
+    }
+
+    public function fetchFirstColumn(): array
+    {
+        throw new BadMethodCallException('Not implemented');
+    }
+
+    public function rowCount(): int
+    {
+        return 0;
+    }
+
+    public function columnCount(): int
+    {
+        $resultSet = $this->resultSet;
+
+        return count(reset($resultSet) ?: []);
+    }
+
+    public function free(): void
+    {
+    }
+}

--- a/tests/Functional/Doctrine/Mock/StatementMock.php
+++ b/tests/Functional/Doctrine/Mock/StatementMock.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Doctrine\Mock;
+
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+use EmptyIterator;
+use IteratorAggregate;
+use Traversable;
+
+class StatementMock implements IteratorAggregate, Statement
+{
+    public function bindValue($param, $value, $type = null)
+    {
+    }
+
+    public function bindParam($column, &$variable, $type = null, $length = null)
+    {
+    }
+
+    public function execute($params = null): Result
+    {
+        return new DriverResultMock();
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new EmptyIterator();
+    }
+}

--- a/tests/Functional/OrderByIdentifierSqlWalkerTest.php
+++ b/tests/Functional/OrderByIdentifierSqlWalkerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\SqlWalker\OrderByIdentifierSqlWalker;
+
+class OrderByIdentifierSqlWalkerTest extends AbstractOrmTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $config = $this->getTestOrmConfiguration();
+        $this->entityManager = new EntityManager($this->getTestOrmConnection($config), $config);
+    }
+
+    /** @test */
+    public function it_appends_order_by_identifier_to_the_query(): void
+    {
+        self::assertStringEndsWith(
+            'ORDER BY m0_.id ASC',
+            $this->generateSql(
+                'select u from Sylius\Tests\Functional\Doctrine\Dump\Model u'
+            )
+        );
+
+        self::assertStringEndsWith(
+            'ORDER BY m0_.email DESC, m0_.id ASC',
+            $this->generateSql(
+                'select u from Sylius\Tests\Functional\Doctrine\Dump\Model u order by u.email desc'
+            )
+        );
+    }
+
+    /** @test */
+    public function it_does_not_append_order_by_identifier_to_the_query_if_query_is_grouped(): void
+    {
+        self::assertStringEndsWith(
+            'GROUP BY m0_.email',
+            $this->generateSql(
+                'select u from Sylius\Tests\Functional\Doctrine\Dump\Model u group by u.email'
+            )
+        );
+    }
+
+    /** @test */
+    public function it_does_not_append_order_by_identifier_to_the_query_if_aggregate_function_is_used(): void
+    {
+        self::assertStringEndsWith(
+            'FROM model m0_',
+            $this->generateSql(
+                'select max(u) from Sylius\Tests\Functional\Doctrine\Dump\Model u'
+            )
+        );
+    }
+
+    private function generateSql(string $dqlToBeTested): string
+    {
+        $treeWalkers = [OrderByIdentifierSqlWalker::class];
+
+        return $this->entityManager
+            ->createQuery($dqlToBeTested)
+            ->setHint(Query::HINT_CUSTOM_TREE_WALKERS, $treeWalkers)
+            ->useQueryCache(false)
+            ->getSQL()
+        ;
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 |
| Bug fix?        | yes (fixes sorting rows for postgres)                                                       |
| New feature?    | yes (adds default order by)                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

This PR introduces `OrderByIdentifierSqlWalker` and adds the default `order by` to the ORM configurations for all relationships.