### PR TITLE
[DOCS] ApiBundle doc fixes

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/README.md
+++ b/src/Sylius/Bundle/ApiBundle/README.md
@@ -51,6 +51,7 @@ Testing
 
 To test locally, run commands:
 ```bash
+(apt install php-sqlite3)
 (cd src/Sylius/Bundle/ApiBundle && composer install)
 (cd src/Sylius/Bundle/ApiBundle/test && bin/console doctrine:database:create -e test)
 (cd src/Sylius/Bundle/ApiBundle/test && bin/console doctrine:schema:update --force -e test)


### PR DESCRIPTION
When commands create a test database, giving exceptions such as
`Could not find driver`. So I added the commands in order to fix.

it comes directly from repository:
https://github.com/Sylius/Sylius/tree/1.13/src/Sylius/Bundle/ApiBundle#testing

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
