### PR TITLE
[Fix] Symfony container reanimation after friendsofsymfony/rest-bundle: 3.5.0 release

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,6 +35,7 @@ parameters:
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/DQL/**.php'
     ignoreErrors:
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'
+        - '/Method Symfony\\Component\\Serializer\\Normalizer\\NormalizerInterface\:\:supportsNormalization\(\) invoked with 3 parameters\, 1\-2 required\./'
         - '/Parameter \$templatingEngine of method Sylius\\Bundle\\AdminBundle\\Controller\\CustomerStatisticsController\:\:\_\_construct\(\) has invalid typehint type Symfony\\Bundle\\FrameworkBundle\\Templating\\EngineInterface\./'
         - '/Parameter \$templatingEngine of method Sylius\\Bundle\\AdminBundle\\Controller\\Dashboard\\StatisticsController\:\:\_\_construct\(\) has invalid typehint type Symfony\\Bundle\\FrameworkBundle\\Templating\\EngineInterface\./'
         - '/Parameter \$templatingEngine of method Sylius\\Bundle\\AdminBundle\\Controller\\DashboardController\:\:\_\_construct\(\) has invalid typehint type Symfony\\Bundle\\FrameworkBundle\\Templating\\EngineInterface\./'

--- a/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
@@ -15,11 +15,12 @@ namespace Sylius\Bundle\ApiBundle\Serializer;
 
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class FlattenExceptionNormalizer implements ContextAwareNormalizerInterface
 {
     public function __construct(
-        private ContextAwareNormalizerInterface $decorated,
+        private ContextAwareNormalizerInterface|NormalizerInterface $decorated,
         private RequestStack $requestStack,
         private string $newApiRoute,
     ) {

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -43,6 +43,7 @@
         "laminas/laminas-stdlib": "^3.2"
     },
     "conflict": {
+        "doctrine/annotations": "^2.0",
         "twig/twig": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11, 1.12 and 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | [Reference](https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2377/files#diff-d4b44e8c91108217ce008ebe22c2ca4cef95ce48b18295f4d2a6e48fe97cf8a7L25-R25)
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
