### PR TITLE
Allows `row_attr` on form rows

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -1,7 +1,14 @@
 {% extends 'form_div_layout.html.twig' %}
 
 {% block form_row -%}
-    <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
+    {% set row_attr=row_attr|merge({'class': row_attr.class|default ~ ' field'}) %}
+    {% if required %}
+        {% set row_attr=row_attr|merge({'class': row_attr.class|default ~ ' required'}) %}
+    {% endif %}
+    {% if (not compound or force_error|default(false)) and not valid %}
+        {% set row_attr=row_attr|merge({'class': row_attr.class|default ~ ' error'}) %}
+    {% endif %}
+    <div {% with {attr: row_attr} %}{{ block('attributes') }}{% endwith %}>
         {{- form_label(form) -}}
         {{- form_widget(form) -}}
         {{- form_help(form) -}}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | none                      |
| License         | MIT                                                          |

This PR allows to use `row_attr` of each `form_row` which wasn't possible with the current code.
