### PR TITLE
Remove error suppression to fix unit tests

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\ErrorSuppressionFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 use SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -26,6 +27,7 @@ return static function (ECSConfig $config): void {
         InlineDocCommentDeclarationSniff::class . '.MissingVariable',
         InlineDocCommentDeclarationSniff::class . '.NoAssignment',
         VisibilityRequiredFixer::class => ['*Spec.php'],
+        ErrorSuppressionFixer::class => 'src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php',
         '**/var/*',
     ]);
     $config->ruleWithConfiguration(PhpdocSeparationFixer::class, ['groups' => [['Given', 'When', 'Then']]]);

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
@@ -28,7 +28,7 @@ final class CancelOrderStateMachineCallbackPass implements CompilerPassInterface
         $smConfigs = $container->getParameter('sm.configs');
 
         if (isset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'])) {
-            @trigger_error(
+            trigger_error(
                 sprintf(
                     'Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
                     'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
@@ -74,7 +74,9 @@ class CancelOrderStateMachineCallbackPassTest extends AbstractCompilerPassTestCa
         ],
     ];
 
-    public function test_it_triggers_deprecation_error_when_old_callback_name_is_used(): void
+
+    /** @test */
+    public function it_triggers_deprecation_error_when_old_callback_name_is_used(): void
     {
         $this->setParameter('sm.configs', $this->smConfigs);
 
@@ -88,7 +90,8 @@ class CancelOrderStateMachineCallbackPassTest extends AbstractCompilerPassTestCa
         $this->compile();
     }
 
-    public function test_it_converts_from_old_name_to_new_name(): void
+    /** @test */
+    public function it_converts_from_old_name_to_new_name(): void
     {
         $this->setParameter('sm.configs', $this->smConfigs);
         $this->expectDeprecation();


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

Last time ECS added the `@` operator to the `trigger_error` call. Because of it, unit tests can't test if the deprecation works.