### PR TITLE
ApiBundle fixes in composer.js

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -32,6 +32,7 @@
         "symfony/messenger": "^5.4 || ^6.0"
     },
     "require-dev": {
+        "ext-sqlite3": "*",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "nelmio/alice": "^3.8",


### PR DESCRIPTION
Give exceptions, such as could not find a driver when commands create a test database. So I added the requirement in composer.js to fix it.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
