### PR TITLE
Add note to UPGRADE-1.12 file about default order by for all entities

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,12 @@
+# UPGRADE FROM `v1.12.X` TO `v1.12.2`
+
+1. All entities and their relationships have a default order by identifier if no order is specified. You can disable
+   this behavior by setting the `sylius_core.order_by_identifier` parameter to `false`:
+```yaml
+sylius_core:
+    order_by_identifier: false
+```
+
 # UPGRADE FROM `v1.11.X` TO `v1.12.0`
 
 ## Main update


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | after #14685 |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
