### PR TITLE
Add missing final keywords to Spec tests

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
-class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
+final class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 {
     function let(
         RequestStack $requestStack,

--- a/src/Sylius/Bundle/ApiBundle/spec/DataPersister/CountryDataPersisterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataPersister/CountryDataPersisterSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
-class CountryDataPersisterSpec extends ObjectBehavior
+final class CountryDataPersisterSpec extends ObjectBehavior
 {
     function let(
         ContextAwareDataPersisterInterface $decoratedDataPersister,

--- a/src/Sylius/Bundle/ApiBundle/spec/DataPersister/ZoneDataPersisterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataPersister/ZoneDataPersisterSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
-class ZoneDataPersisterSpec extends ObjectBehavior
+final class ZoneDataPersisterSpec extends ObjectBehavior
 {
     function let(
         ContextAwareDataPersisterInterface $decoratedDataPersister,

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ZoneDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ZoneDenormalizerSpec.php
@@ -24,7 +24,7 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-class ZoneDenormalizerSpec extends ObjectBehavior
+final class ZoneDenormalizerSpec extends ObjectBehavior
 {
     function let(IriConverterInterface $iriConverter): void
     {

--- a/src/Sylius/Component/Addressing/spec/Checker/CountryProvincesDeletionCheckerSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Checker/CountryProvincesDeletionCheckerSpec.php
@@ -21,7 +21,7 @@ use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Addressing\Model\ZoneMemberInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-class CountryProvincesDeletionCheckerSpec extends ObjectBehavior
+final class CountryProvincesDeletionCheckerSpec extends ObjectBehavior
 {
     function let(
         RepositoryInterface $zoneMemberRepository,

--- a/src/Sylius/Component/Addressing/spec/Checker/ZoneDeletionCheckerSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Checker/ZoneDeletionCheckerSpec.php
@@ -19,7 +19,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Addressing\Model\ZoneMemberInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
-class ZoneDeletionCheckerSpec extends ObjectBehavior
+final class ZoneDeletionCheckerSpec extends ObjectBehavior
 {
     function let(RepositoryInterface $zoneMemberRepository): void
     {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | n/a                      |
| License         | MIT                                                          |

During CI refactor, I've fixed PHPArkitect. It was complaining about missing final keywords, so I add id as a separate PR before opening a PR with new CI 💃🏼.