### PR TITLE
Be able to have attribute values with same labels

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/SelectAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/SelectAttributeType.php
@@ -80,7 +80,7 @@ final class SelectAttributeType extends AbstractType
 
                     foreach ($options['configuration']['choices'] as $key => $choice) {
                         if (isset($choice[$localeCode]) && '' !== $choice[$localeCode] && null !== $choice[$localeCode]) {
-                            $choices[$key] = $choice[$localeCode];
+                            $choices[$key] = sprintf('%s (%s)', $choice[$localeCode], $key);
 
                             continue;
                         }
@@ -89,7 +89,7 @@ final class SelectAttributeType extends AbstractType
                             continue;
                         }
 
-                        $choices[$key] = $choice[$this->defaultLocaleCode];
+                        $choices[$key] = sprintf('%s (%s)', $choice[$this->defaultLocaleCode], $key);
                     }
 
                     $choices = array_flip($choices);

--- a/src/Sylius/Bundle/AttributeBundle/Tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/Tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
@@ -33,7 +33,7 @@ final class SelectAttributeTypeTest extends TypeTestCase
      */
     public function it_return_all_choices(): void
     {
-        $this->assertChoicesLabels(['value 1'], [
+        $this->assertChoicesLabels(['value 1 (val1)'], [
             'configuration' => [
                 'multiple' => false,
                 'min' => null,


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | none                      |
| License         | MIT                                                          |

This is not the best idea to have identical values but sometimes when you have external APIs which create value and some people who does not verify the quality of the data, this case can be produced.

The flip and the ksort remove some possible values.

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
