### PR TITLE
[UI] Remove redundant `#sylius_shipping_method_rules` selector

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -80,11 +80,6 @@ $(document).ready(() => {
       $(`select[name^="${name}[rules]"][name$="[type]"]`).last().change();
     }, 50);
   });
-  $('#sylius_shipping_method_rules > a[data-form-collection="add"]').on('click', () => {
-    setTimeout(() => {
-      $('select[name^="sylius_shipping_method[rules]"][name$="[type]"]').last().change();
-    }, 50);
-  });
 
   $(document).on('collection-form-add', () => {
     $('.sylius-autocomplete').each((index, element) => {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | after https://github.com/Sylius/Sylius/pull/14725                      |
| License         | MIT                                                          |