### PR TITLE
[API] Fix admin's side can't create new taxonomy

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
@@ -36,5 +36,6 @@
         <property name="name" required="true" />
         <property name="slug" required="true" />
         <property name="description" required="false" />
+        <property name="locale" required="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
@@ -12,6 +12,7 @@
         <attribute name="code">
             <group>admin:taxon:read</group>
             <group>shop:taxon:read</group>
+            <group>admin:taxon:create</group>
         </attribute>
         <attribute name="name">
             <group>shop:taxon:read</group>
@@ -24,6 +25,7 @@
         </attribute>
         <attribute name="translations">
             <group>admin:taxon:read</group>
+            <group>admin:taxon:create</group>
         </attribute>
         <attribute name="children">
             <group>admin:taxon:read</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
@@ -16,18 +16,25 @@
             <group>shop:taxon:read</group>
             <group>admin:taxon_translation:read</group>
             <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:create</group>
         </attribute>
         <attribute name="description">
             <group>admin:taxon:read</group>
             <group>shop:taxon:read</group>
             <group>admin:taxon_translation:read</group>
             <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:create</group>
+        </attribute>
+        <attribute name="locale">
+            <group>admin:taxon:read</group>
+            <group>admin:taxon:create</group>
         </attribute>
         <attribute name="slug">
             <group>admin:taxon:read</group>
             <group>shop:taxon:read</group>
             <group>admin:taxon_translation:read</group>
             <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:create</group>
         </attribute>
     </class>
 </serializer>

--- a/tests/Api/Admin/TaxonsTest.php
+++ b/tests/Api/Admin/TaxonsTest.php
@@ -58,4 +58,33 @@ final class TaxonsTest extends JsonApiTestCase
             Response::HTTP_OK,
         );
     }
+
+    /** @test */
+    public function it_creates_a_taxon(): void
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yaml');
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        $this->client->request(
+            method: 'POST',
+            uri: '/api/v2/admin/taxons',
+            server: $header,
+            content: json_encode([
+                'code' => 'WATCHES',
+                'translations' => [
+                    'en_US' => [
+                        'name' => 'Watches',
+                        'slug' => 'watches',
+                        'locale' => 'en_US'
+                    ]
+                ]
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/taxon/post_taxon_response',
+            Response::HTTP_CREATED,
+        );
+    }
 }

--- a/tests/Api/Responses/Expected/admin/taxon/get_taxon_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/get_taxon_response.json
@@ -11,7 +11,8 @@
             "id": @integer@,
             "name": "Categories",
             "slug": "categories",
-            "description": "Some description Lorem ipsum dolor sit amet."
+            "description": "Some description Lorem ipsum dolor sit amet.",
+            "locale": "en_US"
         }
     },
     "children": [

--- a/tests/Api/Responses/Expected/admin/taxon/get_taxons_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/get_taxons_response.json
@@ -15,7 +15,8 @@
                     "id": @integer@,
                     "name": "Categories",
                     "slug": "categories",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 }
             },
             "children": [
@@ -36,7 +37,8 @@
                     "id": @integer@,
                     "name": "Mugs",
                     "slug": "categories/mugs",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -44,7 +46,8 @@
                     "id": @integer@,
                     "name": "Tassen",
                     "slug": "tassen",
-                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet."
+                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
+                    "locale": "de_DE"
                 }
             },
             "children": []
@@ -61,7 +64,8 @@
                     "id": @integer@,
                     "name": "Hats",
                     "slug": "categories/hats",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -69,7 +73,8 @@
                     "id": @integer@,
                     "name": "Hüte",
                     "slug": "hute",
-                    "description": null
+                    "description": null,
+                    "locale": "de_DE"
                 }
             },
             "children": []
@@ -86,7 +91,8 @@
                     "id": @integer@,
                     "name": "T-Shirts",
                     "slug": "categories/t-shirts",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -94,7 +100,8 @@
                     "id": @integer@,
                     "name": "T-Shirts",
                     "slug": "t-shirts",
-                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet."
+                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
+                    "locale": "de_DE"
                 }
             },
             "children": [
@@ -114,7 +121,8 @@
                     "id": @integer@,
                     "name": "Men T-Shirts",
                     "slug": "categories/t-shirts/men-t-shirts",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -122,7 +130,8 @@
                     "id": @integer@,
                     "name": "Männer T-Shirts",
                     "slug": "männer-t-shirts",
-                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet."
+                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
+                    "locale": "de_DE"
                 }
             },
             "children": []
@@ -139,7 +148,8 @@
                     "id": @integer@,
                     "name": "Women T-Shirts",
                     "slug": "categories/t-shirts/women-t-shirts",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -147,7 +157,8 @@
                     "id": @integer@,
                     "name": "Frauen T-Shirts",
                     "slug": "frauen-t-shirts",
-                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet."
+                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
+                    "locale": "de_DE"
                 }
             },
             "children": []
@@ -164,7 +175,8 @@
                     "id": @integer@,
                     "name": "Brands",
                     "slug": "brands",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 },
                 "de_DE": {
                     "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
@@ -172,7 +184,8 @@
                     "id": @integer@,
                     "name": "Marken",
                     "slug": "marken",
-                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet."
+                    "description": "Einige Beschreibung Lorem ipsum dolor sit amet.",
+                    "locale": "de_DE"
                 }
             },
             "children": []
@@ -189,7 +202,8 @@
                     "id": @integer@,
                     "name": "Yet another taxon",
                     "slug": "yet_another_taxons",
-                    "description": "Some description Lorem ipsum dolor sit amet."
+                    "description": "Some description Lorem ipsum dolor sit amet.",
+                    "locale": "en_US"
                 }
             },
             "children": []

--- a/tests/Api/Responses/Expected/admin/taxon/post_taxon_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/post_taxon_response.json
@@ -1,0 +1,19 @@
+{
+    "@context": "\/api\/v2\/contexts\/Taxon",
+    "@id": "\/api\/v2\/admin\/taxons\/WATCHES",
+    "@type": "Taxon",
+    "id": @integer@,
+    "code": "WATCHES",
+    "children": [],
+    "translations": {
+        "en_US": {
+            "@id": "\/api\/v2\/admin\/taxon-translations\/@integer@",
+            "@type": "TaxonTranslation",
+            "id": @integer@,
+            "name": "Watches",
+            "slug": "watches",
+            "description": null,
+            "locale": "en_US"
+        }
+    }
+}


### PR DESCRIPTION
I fixed the admin's side can't create new taxon.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
