### PR TITLE
[Fix] Request stack with null request

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -72,7 +72,8 @@ final class ZoneMemberIntegrityListener
         // bc-layer for Symfony 4
         if (!method_exists(RequestStack::class, 'getSession')) {
             $request = $this->requestStack->getMasterRequest();
-            Assert::notNull($request);
+            Assert::notNull($request, 'No request available to get a Session !');
+
             return $request->getSession();
         }
 

--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -18,6 +18,7 @@ use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -71,7 +72,11 @@ final class ZoneMemberIntegrityListener
     {
         // bc-layer for Symfony 4
         if (!method_exists(RequestStack::class, 'getSession')) {
-            return $this->requestStack->getMasterRequest()->getSession();
+            $request = $this->requestStack->getMasterRequest();
+            if (null === $request) {
+                throw new SessionNotFoundException();
+            }
+            return $request->getSession();
         }
 
         return $this->requestStack->getSession();

--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -18,7 +18,6 @@ use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -73,9 +72,7 @@ final class ZoneMemberIntegrityListener
         // bc-layer for Symfony 4
         if (!method_exists(RequestStack::class, 'getSession')) {
             $request = $this->requestStack->getMasterRequest();
-            if (null === $request) {
-                throw new SessionNotFoundException();
-            }
+            Assert::notNull($request);
             return $request->getSession();
         }
 

--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -72,7 +72,7 @@ final class ZoneMemberIntegrityListener
         // bc-layer for Symfony 4
         if (!method_exists(RequestStack::class, 'getSession')) {
             $request = $this->requestStack->getMasterRequest();
-            Assert::notNull($request, 'No request available to get a Session !');
+            Assert::notNull($request, 'No main request available to get a session !');
 
             return $request->getSession();
         }

--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -19,6 +19,7 @@ use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -161,6 +162,50 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
+            ->during('protectFromRemovingProvinceWithinCountry', [$event])
+        ;
+    }
+
+    function it_throws_an_exception_if_no_session_is_available_during_zone_protection(
+        ZoneInterface $zone,
+        GenericEvent $event,
+        ZoneDeletionCheckerInterface $zoneDeletionChecker,
+        RequestStack $requestStack,
+    ): void {
+        $event->getSubject()->willReturn($zone);
+
+        $zoneDeletionChecker->isDeletable($zone)->willReturn(false);
+
+        if (!method_exists(RequestStack::class, 'getSession')) {
+            $requestStack->getMasterRequest()->willReturn(null);
+        } else {
+            $requestStack->getSession()->willThrow(new SessionNotFoundException());
+        }
+
+        $this
+            ->shouldThrow(SessionNotFoundException::class)
+            ->during('protectFromRemovingZone', [$event])
+        ;
+    }
+
+    function it_throws_an_exception_if_no_session_is_available_during_province_protection(
+        CountryInterface $country,
+        GenericEvent $event,
+        CountryProvincesDeletionCheckerInterface $countryProvincesDeletionChecker,
+        RequestStack $requestStack,
+    ): void {
+        $event->getSubject()->willReturn($country);
+
+        $countryProvincesDeletionChecker->isDeletable($country)->willReturn(false);
+
+        if (!method_exists(RequestStack::class, 'getSession')) {
+            $requestStack->getMasterRequest()->willReturn(null);
+        } else {
+            $requestStack->getSession()->willThrow(new SessionNotFoundException());
+        }
+
+        $this
+            ->shouldThrow(SessionNotFoundException::class)
             ->during('protectFromRemovingProvinceWithinCountry', [$event])
         ;
     }

--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\AddressingBundle\EventListener;
 
+use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface;
 use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
@@ -178,14 +179,20 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         if (!method_exists(RequestStack::class, 'getSession')) {
             $requestStack->getMasterRequest()->willReturn(null);
+
+            // SessionNotFoundException is not available in Symfony 4.4
+            $this
+                ->shouldThrow(InvalidArgumentException::class)
+                ->during('protectFromRemovingZone', [$event])
+            ;
         } else {
             $requestStack->getSession()->willThrow(new SessionNotFoundException());
-        }
 
-        $this
-            ->shouldThrow(SessionNotFoundException::class)
-            ->during('protectFromRemovingZone', [$event])
-        ;
+            $this
+                ->shouldThrow(SessionNotFoundException::class)
+                ->during('protectFromRemovingZone', [$event])
+            ;
+        }
     }
 
     function it_throws_an_exception_if_no_session_is_available_during_province_protection(
@@ -200,13 +207,19 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         if (!method_exists(RequestStack::class, 'getSession')) {
             $requestStack->getMasterRequest()->willReturn(null);
+
+            // SessionNotFoundException is not available in Symfony 4.4
+            $this
+                ->shouldThrow(InvalidArgumentException::class)
+                ->during('protectFromRemovingProvinceWithinCountry', [$event])
+            ;
         } else {
             $requestStack->getSession()->willThrow(new SessionNotFoundException());
-        }
 
-        $this
-            ->shouldThrow(SessionNotFoundException::class)
-            ->during('protectFromRemovingProvinceWithinCountry', [$event])
-        ;
+            $this
+                ->shouldThrow(SessionNotFoundException::class)
+                ->during('protectFromRemovingProvinceWithinCountry', [$event])
+            ;
+        }
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\AddressingBundle\EventListener;
 
-use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Checker\CountryProvincesDeletionCheckerInterface;
 use Sylius\Component\Addressing\Checker\ZoneDeletionCheckerInterface;
@@ -182,7 +181,7 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
             // SessionNotFoundException is not available in Symfony 4.4
             $this
-                ->shouldThrow(InvalidArgumentException::class)
+                ->shouldThrow(\InvalidArgumentException::class)
                 ->during('protectFromRemovingZone', [$event])
             ;
         } else {
@@ -210,7 +209,7 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
             // SessionNotFoundException is not available in Symfony 4.4
             $this
-                ->shouldThrow(InvalidArgumentException::class)
+                ->shouldThrow(\InvalidArgumentException::class)
                 ->during('protectFromRemovingProvinceWithinCountry', [$event])
             ;
         } else {

--- a/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/FlattenExceptionNormalizer.php
@@ -29,13 +29,16 @@ final class FlattenExceptionNormalizer implements ContextAwareNormalizerInterfac
     public function supportsNormalization($data, $format = null, array $context = [])
     {
         if (method_exists($this->requestStack, 'getMainRequest')) {
-            $path = $this->requestStack->getMainRequest()->getPathInfo();
+            $request = $this->requestStack->getMainRequest();
         } else {
-            /** @phpstan-ignore-next-line */
-            $path = $this->requestStack->getMasterRequest()->getPathInfo();
+            $request = $this->requestStack->getMasterRequest();
         }
 
-        if (str_starts_with($path, $this->newApiRoute)) {
+        if (null === $request) {
+            return false;
+        }
+
+        if (str_starts_with($request->getPathInfo(), $this->newApiRoute)) {
             return false;
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Serializer/HydraErrorNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/HydraErrorNormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Serializer;
 
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -35,13 +36,16 @@ final class HydraErrorNormalizer implements NormalizerInterface, CacheableSuppor
     public function supportsNormalization($data, $format = null)
     {
         if (method_exists($this->requestStack, 'getMainRequest')) {
-            $path = $this->requestStack->getMainRequest()->getPathInfo();
+            $request = $this->requestStack->getMainRequest();
         } else {
-            /** @phpstan-ignore-next-line */
-            $path = $this->requestStack->getMasterRequest()->getPathInfo();
+            $request = $this->requestStack->getMasterRequest();
         }
 
-        if (!str_starts_with($path, $this->newApiRoute)) {
+        if (null === $request) {
+            return false;
+        }
+
+        if (!str_starts_with($request->getPathInfo(), $this->newApiRoute)) {
             return false;
         }
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
@@ -72,4 +72,21 @@ final class FlattenExceptionNormalizerSpec extends ObjectBehavior
 
         $this->supportsNormalization('data', 'format', ['context']);
     }
+
+    function it_doesnt_support_normalization_when_no_request_is_available(
+        ContextAwareNormalizerInterface $normalizer,
+        RequestStack $requestStack,
+    ): void {
+        $this->beConstructedWith($normalizer, $requestStack, '/api/v2');
+
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $requestStack->getMainRequest()->willReturn(null);
+        } else {
+            $requestStack->getMasterRequest()->willReturn(null);
+        }
+
+        $normalizer->supportsNormalization('data', 'format', ['context'])->shouldNotBeCalled();
+
+        $this->supportsNormalization('data', 'format', ['context']);
+    }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class HydraErrorNormalizerSpec extends ObjectBehavior
@@ -83,5 +84,22 @@ final class HydraErrorNormalizerSpec extends ObjectBehavior
         $normalizer->hasCacheableSupportsMethod()->shouldBeCalled();
 
         $this->hasCacheableSupportsMethod();
+    }
+
+    function it_doesnt_support_normalization_when_no_request_is_available(
+        ContextAwareNormalizerInterface $normalizer,
+        RequestStack $requestStack,
+    ): void {
+        $this->beConstructedWith($normalizer, $requestStack, '/api/v2');
+
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $requestStack->getMainRequest()->willReturn(null);
+        } else {
+            $requestStack->getMasterRequest()->willReturn(null);
+        }
+
+        $normalizer->supportsNormalization('data', 'format')->shouldNotBeCalled();
+
+        $this->supportsNormalization('data', 'format');
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderCustomerIpListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderCustomerIpListener.php
@@ -30,6 +30,13 @@ final class OrderCustomerIpListener
         $subject = $event->getSubject();
         Assert::isInstanceOf($subject, OrderInterface::class);
 
-        $this->ipAssigner->assign($subject, $this->requestStack->getMasterRequest());
+        if (method_exists($this->requestStack, 'getMainRequest')) {
+            $request = $this->requestStack->getMainRequest();
+        } else {
+            $request = $this->requestStack->getMasterRequest();
+        }
+        Assert::notNull($request);
+
+        $this->ipAssigner->assign($subject, $request);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
@@ -35,7 +35,12 @@ final class OrderCustomerIpListenerSpec extends ObjectBehavior
         RequestStack $requestStack,
     ): void {
         $event->getSubject()->willReturn($order);
-        $requestStack->getMasterRequest()->willReturn($request);
+
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $requestStack->getMainRequest()->willReturn($request);
+        } else {
+            $requestStack->getMasterRequest()->willReturn($request);
+        }
 
         $ipAssigner->assign($order, $request)->shouldBeCalled();
 
@@ -45,6 +50,25 @@ final class OrderCustomerIpListenerSpec extends ObjectBehavior
     function it_throws_exception_if_event_subject_is_not_order(GenericEvent $event): void
     {
         $event->getSubject()->willReturn('badObject');
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('assignCustomerIpToOrder', [$event])
+        ;
+    }
+
+    function it_throws_exception_if_request_is_null(
+        OrderInterface $order,
+        GenericEvent $event,
+        RequestStack $requestStack,
+    ): void {
+        $event->getSubject()->willReturn($order);
+
+        if (method_exists(RequestStack::class, 'getMainRequest')) {
+            $requestStack->getMainRequest()->willReturn(null);
+        } else {
+            $requestStack->getMasterRequest()->willReturn(null);
+        }
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14727                      |
| License         | MIT                                                          |

Add missing PHPSpec tests when `Request` can be `null` when getting it form the `@request_stack` service.
