### PR TITLE
Refactor not to use RequestStack::getMasterRequest()

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,12 +30,6 @@ parameters:
         - 'src/Sylius/Bundle/CoreBundle/Application/Kernel.php'
         - 'src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php'
 
-        # Symfony 4.4-specific issues
-        - 'src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/CircularDependencyBreakingExceptionListenerPass.php'
-        - 'src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingExceptionListener.php'
-        - 'src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/CircularDependencyBreakingExceptionListenerPassTest.php'
-        - 'src/Sylius/Bundle/CoreBundle/Tests/Listener/CircularDependencyBreakingExceptionListenerTest.php'
-
         # To investigate, occurs after release of doctrine/orm 2.14, the processing of these classes ends with exit code 143
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/DQL/**.php'
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/**.php'

--- a/psalm.xml
+++ b/psalm.xml
@@ -62,7 +62,6 @@
                 <referencedMethod name="Payum\Core\Model\GatewayConfigInterface::setFactoryName" />
                 <referencedMethod name="Sylius\Component\Mailer\Sender\SenderInterface::send"/>
                 <referencedMethod name="Symfony\Component\HttpFoundation\JsonResponse::create" /> <!-- deprecated in Symfony 5.1 -->
-                <referencedMethod name="Symfony\Component\HttpFoundation\RequestStack::getMasterRequest" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedMethod name="Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest" /> <!-- deprecated in Symfony 5.3 -->
                 <referencedMethod name="Symfony\Component\Security\Core\Authentication\Token\AbstractToken::isAuthenticated" /> <!-- deprecated in Symfony 5.4 -->
                 <referencedMethod name="Symfony\Component\Security\Core\Authentication\Token\TokenInterface::getUsername" /> <!-- deprecated in Symfony 5.3 -->

--- a/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/EventListener/ZoneMemberIntegrityListener.php
@@ -69,14 +69,6 @@ final class ZoneMemberIntegrityListener
 
     private function getSession(): SessionInterface
     {
-        // bc-layer for Symfony 4
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $request = $this->requestStack->getMasterRequest();
-            Assert::notNull($request, 'No main request available to get a session !');
-
-            return $request->getSession();
-        }
-
         return $this->requestStack->getSession();
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/EventListener/ZoneMemberIntegrityListenerSpec.php
@@ -48,12 +48,7 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         $zoneDeletionChecker->isDeletable($zone)->willReturn(false);
 
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $requestStack->getMasterRequest()->willReturn($request);
-            $request->getSession()->willReturn($session);
-        } else {
-            $requestStack->getSession()->willReturn($session);
-        }
+        $requestStack->getSession()->willReturn($session);
 
         $session->getBag('flashes')->willReturn($flashes);
 
@@ -78,12 +73,7 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
         ZoneInterface $zone,
         Request $request,
     ): void {
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $requestStack->getMasterRequest()->willReturn($request);
-            $request->getSession()->willReturn($session);
-        } else {
-            $requestStack->getSession()->willReturn($session);
-        }
+        $requestStack->getSession()->willReturn($session);
 
         $event->getSubject()->willReturn($zone);
 
@@ -118,12 +108,7 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         $countryProvincesDeletionChecker->isDeletable($country)->willReturn(false);
 
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $requestStack->getMasterRequest()->willReturn($request);
-            $request->getSession()->willReturn($session);
-        } else {
-            $requestStack->getSession()->willReturn($session);
-        }
+        $requestStack->getSession()->willReturn($session);
 
         $session->getBag('flashes')->willReturn($flashes);
 
@@ -176,22 +161,12 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         $zoneDeletionChecker->isDeletable($zone)->willReturn(false);
 
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $requestStack->getMasterRequest()->willReturn(null);
+        $requestStack->getSession()->willThrow(new SessionNotFoundException());
 
-            // SessionNotFoundException is not available in Symfony 4.4
-            $this
-                ->shouldThrow(\InvalidArgumentException::class)
-                ->during('protectFromRemovingZone', [$event])
-            ;
-        } else {
-            $requestStack->getSession()->willThrow(new SessionNotFoundException());
-
-            $this
-                ->shouldThrow(SessionNotFoundException::class)
-                ->during('protectFromRemovingZone', [$event])
-            ;
-        }
+        $this
+            ->shouldThrow(SessionNotFoundException::class)
+            ->during('protectFromRemovingZone', [$event])
+        ;
     }
 
     function it_throws_an_exception_if_no_session_is_available_during_province_protection(
@@ -204,21 +179,11 @@ class ZoneMemberIntegrityListenerSpec extends ObjectBehavior
 
         $countryProvincesDeletionChecker->isDeletable($country)->willReturn(false);
 
-        if (!method_exists(RequestStack::class, 'getSession')) {
-            $requestStack->getMasterRequest()->willReturn(null);
+        $requestStack->getSession()->willThrow(new SessionNotFoundException());
 
-            // SessionNotFoundException is not available in Symfony 4.4
-            $this
-                ->shouldThrow(\InvalidArgumentException::class)
-                ->during('protectFromRemovingProvinceWithinCountry', [$event])
-            ;
-        } else {
-            $requestStack->getSession()->willThrow(new SessionNotFoundException());
-
-            $this
-                ->shouldThrow(SessionNotFoundException::class)
-                ->during('protectFromRemovingProvinceWithinCountry', [$event])
-            ;
-        }
+        $this
+            ->shouldThrow(SessionNotFoundException::class)
+            ->during('protectFromRemovingProvinceWithinCountry', [$event])
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Context/TokenValueBasedCartContext.php
+++ b/src/Sylius/Bundle/ApiBundle/Context/TokenValueBasedCartContext.php
@@ -50,12 +50,7 @@ final class TokenValueBasedCartContext implements CartContextInterface
 
     private function getMainRequest(): Request
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            $mainRequest = $this->requestStack->getMainRequest();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $mainRequest = $this->requestStack->getMasterRequest();
-        }
+        $mainRequest = $this->requestStack->getMainRequest();
         if (null === $mainRequest) {
             throw new CartNotFoundException('There is no main request on request stack.');
         }

--- a/src/Sylius/Bundle/ApiBundle/spec/Context/TokenValueBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Context/TokenValueBasedCartContextSpec.php
@@ -43,11 +43,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
         $request->attributes = new ParameterBag(['tokenValue' => 'TOKEN_VALUE']);
         $request->getRequestUri()->willReturn('/api/v2/orders/TOKEN_VALUE');
 
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
         $orderRepository->findCartByTokenValue('TOKEN_VALUE')->willReturn($cart);
 
         $this->getCart()->shouldReturn($cart);
@@ -55,11 +51,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_there_is_no_master_request_on_request_stack(RequestStack $requestStack): void
     {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this
             ->shouldThrow(new CartNotFoundException('There is no main request on request stack.'))
@@ -74,11 +66,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
         $request->attributes = new ParameterBag([]);
         $request->getRequestUri()->willReturn('/orders');
 
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $this
             ->shouldThrow(new CartNotFoundException('The main request is not an API request.'))
@@ -93,11 +81,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
         $request->attributes = new ParameterBag([]);
         $request->getRequestUri()->willReturn('/api/v2/orders');
 
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $this
             ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart, as there is no passed token value.'))
@@ -113,11 +97,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
         $request->attributes = new ParameterBag(['tokenValue' => 'TOKEN_VALUE']);
         $request->getRequestUri()->willReturn('/api/v2/orders/TOKEN_VALUE');
 
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
         $orderRepository->findCartByTokenValue('TOKEN_VALUE')->willReturn(null);
 
         $this

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/FlattenExceptionNormalizerSpec.php
@@ -69,11 +69,7 @@ final class FlattenExceptionNormalizerSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith($normalizer, $requestStack, '/api/v2');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $normalizer->supportsNormalization('data', 'format', ['context'])->shouldNotBeCalled();
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/HydraErrorNormalizerSpec.php
@@ -82,11 +82,7 @@ final class HydraErrorNormalizerSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith($normalizer, $requestStack, '/api/v2');
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $normalizer->supportsNormalization('data', 'format')->shouldNotBeCalled();
 

--- a/src/Sylius/Bundle/ChannelBundle/Context/FakeChannel/FakeChannelContext.php
+++ b/src/Sylius/Bundle/ChannelBundle/Context/FakeChannel/FakeChannelContext.php
@@ -51,12 +51,7 @@ final class FakeChannelContext implements ChannelContextInterface
      */
     private function getMainRequest(): Request
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            $mainRequest = $this->requestStack->getMainRequest();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $mainRequest = $this->requestStack->getMasterRequest();
-        }
+        $mainRequest = $this->requestStack->getMainRequest();
         if (null === $mainRequest) {
             throw new ChannelNotFoundException();
         }

--- a/src/Sylius/Bundle/ChannelBundle/spec/Context/FakeChannel/FakeChannelContextSpec.php
+++ b/src/Sylius/Bundle/ChannelBundle/spec/Context/FakeChannel/FakeChannelContextSpec.php
@@ -45,11 +45,7 @@ final class FakeChannelContextSpec extends ObjectBehavior
         Request $request,
         ChannelInterface $channel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $fakeChannelCodeProvider->getCode($request)->willReturn('CHANNEL_CODE');
 
@@ -60,11 +56,7 @@ final class FakeChannelContextSpec extends ObjectBehavior
 
     function it_throws_a_channel_not_found_exception_if_there_is_no_master_request(RequestStack $requestStack): void
     {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this->shouldThrow(ChannelNotFoundException::class)->during('getChannel');
     }
@@ -75,11 +67,7 @@ final class FakeChannelContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $fakeChannelCodeProvider->getCode($request)->willReturn(null);
 
@@ -94,11 +82,7 @@ final class FakeChannelContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $fakeChannelCodeProvider->getCode($request)->willReturn('CHANNEL_CODE');
 

--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestBasedLocaleContext.php
@@ -26,12 +26,7 @@ final class RequestBasedLocaleContext implements LocaleContextInterface
 
     public function getLocaleCode(): string
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            $request = $this->requestStack->getMainRequest();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $request = $this->requestStack->getMasterRequest();
-        }
+        $request = $this->requestStack->getMainRequest();
         if (null === $request) {
             throw new LocaleNotFoundException('No main request available.');
         }

--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
@@ -27,8 +27,7 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface
 
     public function getLocaleCode(): string
     {
-        $request = $this->getMainRequest();
-
+        $request = $this->requestStack->getMainRequest();
         if (null === $request) {
             throw new LocaleNotFoundException('No main request available.');
         }
@@ -44,15 +43,5 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface
         }
 
         return $localeCode;
-    }
-
-    private function getMainRequest(): ?Request
-    {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            return $this->requestStack->getMainRequest();
-        }
-
-        /** @phpstan-ignore-next-line */
-        return $this->requestStack->getMasterRequest();
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/spec/Context/RequestBasedLocaleContextSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Context/RequestBasedLocaleContextSpec.php
@@ -35,11 +35,7 @@ final class RequestBasedLocaleContextSpec extends ObjectBehavior
 
     function it_throws_locale_not_found_exception_if_master_request_is_not_found(RequestStack $requestStack): void
     {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this->shouldThrow(LocaleNotFoundException::class)->during('getLocaleCode');
     }
@@ -48,11 +44,7 @@ final class RequestBasedLocaleContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $request->attributes = new ParameterBag();
 
@@ -64,11 +56,7 @@ final class RequestBasedLocaleContextSpec extends ObjectBehavior
         LocaleProviderInterface $localeProvider,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $request->attributes = new ParameterBag(['_locale' => 'en_US']);
 
@@ -82,12 +70,7 @@ final class RequestBasedLocaleContextSpec extends ObjectBehavior
         LocaleProviderInterface $localeProvider,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
-
+        $requestStack->getMainRequest()->willReturn($request);
         $request->attributes = new ParameterBag(['_locale' => 'pl_PL']);
 
         $localeProvider->getAvailableLocalesCodes()->willReturn(['pl_PL', 'de_DE']);

--- a/src/Sylius/Bundle/LocaleBundle/spec/Context/RequestHeaderBasedLocaleContextSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Context/RequestHeaderBasedLocaleContextSpec.php
@@ -35,11 +35,7 @@ final class RequestHeaderBasedLocaleContextSpec extends ObjectBehavior
 
     function it_throws_locale_not_found_exception_if_main_request_is_not_found(RequestStack $requestStack): void
     {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this->shouldThrow(LocaleNotFoundException::class)->during('getLocaleCode');
     }
@@ -48,11 +44,7 @@ final class RequestHeaderBasedLocaleContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $request->headers = new HeaderBag();
 
@@ -64,11 +56,7 @@ final class RequestHeaderBasedLocaleContextSpec extends ObjectBehavior
         LocaleProviderInterface $localeProvider,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $request->headers = new HeaderBag(['ACCEPT_LANGUAGE' => 'en_US']);
 
@@ -82,11 +70,7 @@ final class RequestHeaderBasedLocaleContextSpec extends ObjectBehavior
         LocaleProviderInterface $localeProvider,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request);
-        }
+        $requestStack->getMainRequest()->willReturn($request);
 
         $request->headers = new HeaderBag(['Accept-Language' => 'pl_PL']);
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
@@ -59,11 +59,7 @@ final class OrderCustomerIpListenerSpec extends ObjectBehavior
     ): void {
         $event->getSubject()->willReturn($order);
 
-        if (method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)

--- a/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/CachedPerRequestChannelContext.php
@@ -30,13 +30,7 @@ final class CachedPerRequestChannelContext implements ChannelContextInterface
 
     public function getChannel(): ChannelInterface
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            $objectIdentifier = $this->requestStack->getMainRequest();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $objectIdentifier = $this->requestStack->getMasterRequest();
-        }
-
+        $objectIdentifier = $this->requestStack->getMainRequest();
         if (null === $objectIdentifier) {
             return $this->decoratedChannelContext->getChannel();
         }

--- a/src/Sylius/Component/Channel/Context/RequestBased/ChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/RequestBased/ChannelContext.php
@@ -45,12 +45,7 @@ final class ChannelContext implements ChannelContextInterface
 
     private function getMainRequest(): Request
     {
-        if (\method_exists($this->requestStack, 'getMainRequest')) {
-            $mainRequest = $this->requestStack->getMainRequest();
-        } else {
-            /** @phpstan-ignore-next-line */
-            $mainRequest = $this->requestStack->getMasterRequest();
-        }
+        $mainRequest = $this->requestStack->getMainRequest();
         if (null === $mainRequest) {
             throw new \UnexpectedValueException('There are not any requests on request stack');
         }

--- a/src/Sylius/Component/Channel/spec/Context/CachedPerRequestChannelContextSpec.php
+++ b/src/Sylius/Component/Channel/spec/Context/CachedPerRequestChannelContextSpec.php
@@ -38,11 +38,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         Request $request,
         ChannelInterface $channel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request, $request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request, $request);
-        }
+        $requestStack->getMainRequest()->willReturn($request, $request);
 
         $decoratedChannelContext->getChannel()->willReturn($channel)->shouldBeCalledTimes(1);
 
@@ -58,11 +54,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         ChannelInterface $firstChannel,
         ChannelInterface $secondChannel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($firstRequest, $secondRequest);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($firstRequest, $secondRequest);
-        }
+        $requestStack->getMainRequest()->willReturn($firstRequest, $secondRequest);
 
         $decoratedChannelContext->getChannel()->willReturn($firstChannel, $secondChannel);
 
@@ -78,11 +70,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         ChannelInterface $firstChannel,
         ChannelInterface $secondChannel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($firstRequest, $secondRequest, $firstRequest);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($firstRequest, $secondRequest, $firstRequest);
-        }
+        $requestStack->getMainRequest()->willReturn($firstRequest, $secondRequest, $firstRequest);
 
         $decoratedChannelContext->getChannel()->willReturn($firstChannel, $secondChannel)->shouldBeCalledTimes(2);
 
@@ -97,11 +85,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         ChannelInterface $firstChannel,
         ChannelInterface $secondChannel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null, null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null, null);
-        }
+        $requestStack->getMainRequest()->willReturn(null, null);
 
         $decoratedChannelContext->getChannel()->willReturn($firstChannel, $secondChannel)->shouldBeCalledTimes(2);
 
@@ -114,11 +98,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $request,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($request, $request);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($request, $request);
-        }
+        $requestStack->getMainRequest()->willReturn($request, $request);
 
         $decoratedChannelContext->getChannel()->willThrow(ChannelNotFoundException::class)->shouldBeCalledTimes(1);
 
@@ -131,11 +111,7 @@ final class CachedPerRequestChannelContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         ChannelInterface $channel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null, null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null, null);
-        }
+        $requestStack->getMainRequest()->willReturn(null, null);
 
         $decoratedChannelContext
             ->getChannel()

--- a/src/Sylius/Component/Channel/spec/Context/RequestBased/ChannelContextSpec.php
+++ b/src/Sylius/Component/Channel/spec/Context/RequestBased/ChannelContextSpec.php
@@ -39,11 +39,7 @@ final class ChannelContextSpec extends ObjectBehavior
         Request $masterRequest,
         ChannelInterface $channel,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($masterRequest);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($masterRequest);
-        }
+        $requestStack->getMainRequest()->willReturn($masterRequest);
 
         $requestResolver->findChannel($masterRequest)->willReturn($channel);
 
@@ -55,11 +51,7 @@ final class ChannelContextSpec extends ObjectBehavior
         RequestStack $requestStack,
         Request $masterRequest,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn($masterRequest);
-        } else {
-            $requestStack->getMasterRequest()->willReturn($masterRequest);
-        }
+        $requestStack->getMainRequest()->willReturn($masterRequest);
 
         $requestResolver->findChannel($masterRequest)->willReturn(null);
 
@@ -69,11 +61,7 @@ final class ChannelContextSpec extends ObjectBehavior
     function it_throws_a_channel_not_found_exception_if_there_is_no_master_request(
         RequestStack $requestStack,
     ): void {
-        if (\method_exists(RequestStack::class, 'getMainRequest')) {
-            $requestStack->getMainRequest()->willReturn(null);
-        } else {
-            $requestStack->getMasterRequest()->willReturn(null);
-        }
+        $requestStack->getMainRequest()->willReturn(null);
 
         $this->shouldThrow(ChannelNotFoundException::class)->during('getChannel');
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

As we no longer support Symfony lower than 5.4
<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
