### PR TITLE
Updated UPGRADE-1.11.md to add a BC Break on channel pricing

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -177,6 +177,11 @@ stock form type extensions without you having to explicitly specify their priori
 default values, you might have to review priorities of your own form type extensions, as well as any that you have overridden.
 Please note that **unlike state machine callbacks**, form extension priorities are being executed in descending order. 
 
+#### Channel pricing view
+
+All form fields are now hardcoded into the `AdminBundle/Resources/views/ProductVariant/Tab/_channelPricings.html.twig` view.
+If you have custom properties which were previously rendered automatically you now have to override this view in `templates/bundles/SyliusAdminBundle/ProductVariant/Tab/_channelPricings.html.twig`.
+
 ### API v2
 
 For changes according to the API v2, please visit [API v2 upgrade file](UPGRADE-API-1.11.md).


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11, 1.12, 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | None                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Related to this change: https://github.com/Sylius/Sylius/pull/13209

Or maybe I should edit the _channelPricings.html.twig template to go back to the old behavior?