### PR TITLE
Add a custom workflow for Symfony 6.3

### DIFF
--- a/.github/workflows/ci_e2e-custom.yaml
+++ b/.github/workflows/ci_e2e-custom.yaml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [ "8.1" ]
-                symfony: [ "^6.2" ]
+                symfony: [ "^6.3" ]
                 mysql: [ "8.0" ]
 
         env:
@@ -35,8 +35,10 @@ jobs:
                     key:  "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
                     restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
 
-            -   name: Change minimum-stability to beta
-                run: composer config minimum-stability beta
+            -   name: Change minimum-stability to dev
+                run: |
+                    composer config minimum-stability dev
+                    composer config prefer-stable true
 
             -   name: Build application
                 uses: jakubtobiasz/SyliusBuildTestAppAction@v2.0


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | successor of #14599                      |
| License         | MIT                                                          |

In #14599 Mateusz also added a build for Symfony 6.1, but I'm against it as we already have plenty of builds. 6.1 will lose active support, so I prefer to stay with current `^6.0` constraint.

Wdyt?
