### PR TITLE
Make build notifier running always event on failed builds

### DIFF
--- a/.github/workflows/ci__full.yaml
+++ b/.github/workflows/ci__full.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
             type: full
     notify-about-build-status:
+        if: ${{ always() }}
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-customs, packages]
         runs-on: ubuntu-latest


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                    |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | n/a                      |
| License         | MIT                                                          |

I didn't know `needs` requires all jobs to finish successfully. The added line causes it will notify us even when the daily build fail 🫶🏼.
