### PR TITLE
Fix applying catalog promotions when there is no applied promotions and price differ from original price

### DIFF
--- a/features/promotion/applying_catalog_promotions/applying_catalog_promotions_based_on_product_original_price.feature
+++ b/features/promotion/applying_catalog_promotions/applying_catalog_promotions_based_on_product_original_price.feature
@@ -1,0 +1,18 @@
+@applying_catalog_promotions
+Feature: Applying catalog promotions based on the product's original price
+    In order to see proper discounts independent of previous promotions
+    As a Visitor
+    I want to see discounted products in the catalog based on their original price
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "T-Shirt"
+        And this product's price is "$100.00"
+        And the product "T-Shirt" has original price "$120.00"
+        And there is a catalog promotion "Winter sale" that reduces price by "90%" and applies on "T-Shirt" variant
+
+    @api @ui
+    Scenario: Applying simple catalog promotions
+        When I view product "T-Shirt"
+        Then I should see the product price "$12.00"
+        And I should see the product original price "$120.00"

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsByTaxonExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsByTaxonExtension.php
@@ -64,13 +64,13 @@ final class ProductsByTaxonExtension implements ContextAwareQueryCollectionExten
                 sprintf('%s.productTaxons', $rootAlias),
                 $productTaxonAliasName,
                 'WITH',
-                sprintf('%s.product = %s.id', $productTaxonAliasName, $rootAlias)
+                sprintf('%s.product = %s.id', $productTaxonAliasName, $rootAlias),
             )
             ->leftJoin(
                 sprintf('%s.taxon', $productTaxonAliasName),
                 $taxonAliasName,
                 'WITH',
-                sprintf('%s.code = :%s', $taxonAliasName, $taxonCodeParameterName)
+                sprintf('%s.code = :%s', $taxonAliasName, $taxonCodeParameterName),
             )
             ->orderBy(sprintf('%s.position', $productTaxonAliasName), 'ASC')
             ->setParameter($taxonCodeParameterName, $taxonCode)

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsByTaxonExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsByTaxonExtensionSpec.php
@@ -89,7 +89,7 @@ final class ProductsByTaxonExtensionSpec extends ObjectBehavior
         $queryNameGenerator->generateJoinAlias('taxon')->shouldBeCalled()->willReturn('taxon');
 
         $queryBuilder->getRootAliases()->willReturn(['o']);
-        $queryBuilder->addSelect('productTaxons')->shouldBeCalled()->willReturn($queryBuilder);;
+        $queryBuilder->addSelect('productTaxons')->shouldBeCalled()->willReturn($queryBuilder);
         $queryBuilder->leftJoin('o.productTaxons', 'productTaxons', 'WITH', 'productTaxons.product = o.id')->shouldBeCalled()->willReturn($queryBuilder);
         $queryBuilder->leftJoin('productTaxons.taxon', 'taxon', 'WITH', 'taxon.code = :taxonCode')->shouldBeCalled()->willReturn($queryBuilder);
         $queryBuilder->orderBy('productTaxons.position', 'ASC')->shouldBeCalled()->willReturn($queryBuilder);

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Applicator/ActionBasedDiscountApplicator.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Applicator/ActionBasedDiscountApplicator.php
@@ -40,6 +40,10 @@ final class ActionBasedDiscountApplicator implements ActionBasedDiscountApplicat
             }
         }
 
+        if ($channelPricing->getAppliedPromotions()->isEmpty() && $channelPricing->getOriginalPrice() !== null) {
+            $channelPricing->setPrice($channelPricing->getOriginalPrice());
+        }
+
         try {
             $price = $this->priceCalculator->calculate($channelPricing, $action);
         } catch (ActionBasedPriceCalculatorNotFoundException) {

--- a/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Applicator/ActionBasedDiscountApplicatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Applicator/ActionBasedDiscountApplicatorSpec.php
@@ -231,5 +231,4 @@ final class ActionBasedDiscountApplicatorSpec extends ObjectBehavior
 
         $this->applyDiscountOnChannelPricing($catalogPromotion, $action, $channelPricing);
     }
-
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Applicator/ActionBasedDiscountApplicatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Applicator/ActionBasedDiscountApplicatorSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\CatalogPromotion\Applicator;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Applicator\ActionBasedDiscountApplicatorInterface;
@@ -49,6 +50,7 @@ final class ActionBasedDiscountApplicatorSpec extends ObjectBehavior
         $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
         $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
 
+        $channelPricing->getAppliedPromotions()->shouldBeCalled();
         $channelPricing->getOriginalPrice()->willReturn(300);
 
         $priceCalculator->calculate($channelPricing, $action)->willReturn(100);
@@ -91,6 +93,8 @@ final class ActionBasedDiscountApplicatorSpec extends ObjectBehavior
         $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
         $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
 
+        $channelPricing->getAppliedPromotions()->shouldBeCalled();
+
         $channelPricing->getOriginalPrice()->willReturn(200);
 
         $channelPricing->getPrice()->shouldNotBeCalled();
@@ -115,6 +119,8 @@ final class ActionBasedDiscountApplicatorSpec extends ObjectBehavior
     ): void {
         $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
         $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+
+        $channelPricing->getAppliedPromotions()->shouldBeCalled();
 
         $channelPricing->getOriginalPrice()->willReturn(null);
 
@@ -150,4 +156,80 @@ final class ActionBasedDiscountApplicatorSpec extends ObjectBehavior
 
         $this->applyDiscountOnChannelPricing($catalogPromotion, $action, $channelPricing);
     }
+
+    function it_sets_price_as_original_price_when_there_are_no_applied_promotions_and_original_price_is_specified(
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $action,
+        ChannelPricingInterface $channelPricing,
+        DiscountApplicationCriteriaInterface $minimumPriceCriteria,
+        DiscountApplicationCriteriaInterface $exclusiveCriteria,
+        CatalogPromotionPriceCalculatorInterface $priceCalculator,
+    ): void {
+        $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+        $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+
+        $channelPricing->getAppliedPromotions()->willReturn(new ArrayCollection());
+        $channelPricing->getOriginalPrice()->willReturn(300);
+
+        $channelPricing->setPrice(300)->shouldBeCalled();
+
+        $priceCalculator->calculate($channelPricing, $action)->willReturn(100);
+
+        $channelPricing->setPrice(100)->shouldBeCalled();
+        $channelPricing->addAppliedPromotion($catalogPromotion)->shouldBeCalled();
+
+        $this->applyDiscountOnChannelPricing($catalogPromotion, $action, $channelPricing);
+    }
+
+    function it_does_not_set_price_as_original_price_when_there_are_applied_promotions_and_original_price_is_specified(
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $action,
+        ChannelPricingInterface $channelPricing,
+        DiscountApplicationCriteriaInterface $minimumPriceCriteria,
+        DiscountApplicationCriteriaInterface $exclusiveCriteria,
+        CatalogPromotionPriceCalculatorInterface $priceCalculator,
+    ): void {
+        $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+        $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+
+        $channelPricing->getAppliedPromotions()->willReturn(new ArrayCollection([$catalogPromotion->getWrappedObject()]));
+        $channelPricing->getOriginalPrice()->willReturn(300);
+
+        $channelPricing->setPrice(300)->shouldNotBeCalled();
+
+        $priceCalculator->calculate($channelPricing, $action)->willReturn(100);
+
+        $channelPricing->setPrice(100)->shouldBeCalled();
+        $channelPricing->addAppliedPromotion($catalogPromotion)->shouldBeCalled();
+
+        $this->applyDiscountOnChannelPricing($catalogPromotion, $action, $channelPricing);
+    }
+
+    function it_does_not_set_price_as_original_price_when_there_are_no_applied_promotions_and_original_price_is_not_specified(
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $action,
+        ChannelPricingInterface $channelPricing,
+        DiscountApplicationCriteriaInterface $minimumPriceCriteria,
+        DiscountApplicationCriteriaInterface $exclusiveCriteria,
+        CatalogPromotionPriceCalculatorInterface $priceCalculator,
+    ): void {
+        $minimumPriceCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+        $exclusiveCriteria->isApplicable($catalogPromotion, ['action' => $action, 'channelPricing' => $channelPricing])->willReturn(true);
+
+        $channelPricing->getAppliedPromotions()->willReturn(new ArrayCollection());
+        $channelPricing->getOriginalPrice()->willReturn(null);
+
+        $channelPricing->setPrice(300)->shouldNotBeCalled();
+
+        $channelPricing->getPrice()->willReturn(200);
+        $channelPricing->setOriginalPrice(200)->shouldBeCalled();
+
+        $priceCalculator->calculate($channelPricing, $action)->willReturn(100);
+
+        $channelPricing->setPrice(100)->shouldBeCalled();
+        $channelPricing->addAppliedPromotion($catalogPromotion)->shouldBeCalled();
+
+        $this->applyDiscountOnChannelPricing($catalogPromotion, $action, $channelPricing);
+    }
+
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
For now when applying the catalog promotion for product where there is no catalog promotion and the original price differ from price, the discount is applied on price instead of the original price
