### PR TITLE
[API] Priorities in data transformers

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/CommandDataTransformerPass.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/CommandDataTransformerPass.php
@@ -28,7 +28,11 @@ final class CommandDataTransformerPass implements CompilerPassInterface
 
         $taggedServices = $container->findTaggedServiceIds('sylius.api.command_data_transformer');
 
-        foreach ($taggedServices as $key => $value) {
+        uasort($taggedServices, function (array $firstTag, array $secondTag) {
+            return ($secondTag[0]['priority'] ?? 0) <=> ($firstTag[0]['priority'] ?? 0);
+        });
+
+        foreach ($taggedServices as $key => $attributes) {
             $commandDataTransformersChainDefinition->addArgument(new Reference($key));
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -47,7 +47,7 @@
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\DataTransformer\OrderTokenValueAwareInputCommandDataTransformer">
-            <tag name="sylius.api.command_data_transformer" />
+            <tag name="sylius.api.command_data_transformer" priority="1000" />
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\DataTransformer\ShipmentIdAwareInputCommandDataTransformer">

--- a/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/Compiler/CommandDataTransformerPassTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/Compiler/CommandDataTransformerPassTest.php
@@ -20,9 +20,7 @@ use Symfony\Component\DependencyInjection\Definition;
 
 final class CommandDataTransformerPassTest extends AbstractCompilerPassTestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function it_collects_tagged_command_data_transformer_services(): void
     {
         $this->setDefinition(
@@ -46,6 +44,45 @@ final class CommandDataTransformerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'sylius.api.data_transformer.command_aware_input_data_transformer',
             1,
+            'sylius.api.command_data_transformer.service.second',
+        );
+    }
+
+    /** @test */
+    public function it_collects_tagged_command_data_transformer_services_with_priorities(): void
+    {
+        $this->setDefinition(
+            'sylius.api.command_data_transformer.service.first',
+            (new Definition())->addTag('sylius.api.command_data_transformer', ['priority' => 20]),
+        );
+
+        $this->setDefinition(
+            'sylius.api.command_data_transformer.service.second',
+            (new Definition())->addTag('sylius.api.command_data_transformer', ['priority' => 10]),
+        );
+
+        $this->setDefinition(
+            'sylius.api.command_data_transformer.service.third',
+            (new Definition())->addTag('sylius.api.command_data_transformer', ['priority' => 30]),
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sylius.api.data_transformer.command_aware_input_data_transformer',
+            0,
+            'sylius.api.command_data_transformer.service.third',
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sylius.api.data_transformer.command_aware_input_data_transformer',
+            1,
+            'sylius.api.command_data_transformer.service.first',
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sylius.api.data_transformer.command_aware_input_data_transformer',
+            2,
             'sylius.api.command_data_transformer.service.second',
         );
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

When implementing the new DataTransformer for the Sylius API, we sometimes need to rely on data already set on the command by other data transformers - e.g. on the cart token value. Currently, data transformers are called in the order of their registration, which makes mentioned case hard to implement. 
I've also added a very high priority to the `OrderTokenValueAwareInputCommandDataTransformer`, as I believe it's the most important transformer, providing the basic data to operate in the checkout flow and should probably always be called first 🖖 

Let me know what you think about such an improvement 🫡