### PR TITLE
fix(layout): removed admin-layout__topbar height

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_layout.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_layout.scss
@@ -48,7 +48,6 @@ $layout-sidebar-width: 260px;
         left: 0;
         z-index: 998;
         width: 100%;
-        height: $layout-topbar-height;
     }
 
     .admin-layout__content {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | mentioned in #14714                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.11 or 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
