### PR TITLE
Allow ProductAttributeValueNormalizer to return a null value

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
@@ -49,7 +49,7 @@ final class ProductAttributeValueNormalizer implements ContextAwareNormalizerInt
         $data['value'] = match ($object->getType()) {
             SelectAttributeType::TYPE => $this->normalizeSelectValue($object, $context),
             DateAttributeType::TYPE => $object->getValue()->format('Y-m-d'),
-            default => $data['value'],
+            default => $data['value'] ?? null,
         };
 
         return $data;

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
@@ -86,10 +86,11 @@ final class ProductAttributeValueNormalizerSpec extends ObjectBehavior
                     'de_DE' => 'de text4',
                     'zu_ZA' => 'zu text4',
                 ],
+                'uuid5' => [],
             ],
         ]);
 
-        $productAttributeValue->getValue()->willReturn(['uuid1', 'uuid2', 'uuid3', 'uuid4']);
+        $productAttributeValue->getValue()->willReturn(['uuid1', 'uuid2', 'uuid3', 'uuid4', 'uuid5']);
 
         $productAttributeValue->getLocaleCode()->willReturn('pl_PL');
         $localeProvider->getDefaultLocaleCode()->willReturn('fr_FR');
@@ -101,6 +102,7 @@ final class ProductAttributeValueNormalizerSpec extends ObjectBehavior
                 'fr text2',
                 'en text3',
                 'de text4',
+                null
             ],
         ]);
     }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
@@ -86,7 +86,9 @@ final class ProductAttributeValueNormalizerSpec extends ObjectBehavior
                     'de_DE' => 'de text4',
                     'zu_ZA' => 'zu text4',
                 ],
-                'uuid5' => [],
+                'uuid5' => [
+                    'fr_FR' => null
+                ],
             ],
         ]);
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #14748                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
