### PR TITLE
[API] Prepend configuration with API Platform mapping

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -15,11 +15,12 @@ namespace Sylius\Bundle\ApiBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /** @experimental */
-final class SyliusApiExtension extends Extension
+final class SyliusApiExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -39,5 +40,20 @@ final class SyliusApiExtension extends Extension
         if ($container->hasParameter('api_platform.enable_swagger_ui') && $container->getParameter('api_platform.enable_swagger_ui')) {
             $loader->load('integrations/swagger.xml');
         }
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $this->prependApiPlatformMapping($container);
+    }
+
+    private function prependApiPlatformMapping(ContainerBuilder $container): void
+    {
+        /** @var array<string, array<string, string>> $metadata */
+        $metadata = $container->getParameter('kernel.bundles_metadata');
+
+        $path = $metadata['SyliusApiBundle']['path'] . '/Resources/config/api_resources/';
+
+        $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$path]]]);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/config.yaml
@@ -17,7 +17,6 @@ api_platform:
     enable_docs: false
     mapping:
         paths:
-            - '%kernel.api_bundle_path%/Resources/config/api_resources'
             - '%kernel.project_dir%/config/api_platform'
 
 sylius_api:

--- a/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/SyliusApiExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/SyliusApiExtensionTest.php
@@ -19,33 +19,33 @@ use Sylius\Bundle\ApiBundle\DependencyInjection\SyliusApiExtension;
 
 final class SyliusApiExtensionTest extends AbstractExtensionTestCase
 {
-    /**
-     * @test
-     */
-    public function it_loads_swagger_integration_if_it_is_turned_on()
+    /** @test */
+    public function it_loads_swagger_integration_if_it_is_turned_on(): void
     {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
         $this->setParameter('api_platform.enable_swagger_ui', true);
         $this->load();
 
         $this->assertContainerBuilderHasService('api_platform.swagger.action.ui', SwaggerUiAction::class);
     }
 
-    /**
-     * @test
-     */
-    public function it_does_not_load_swagger_integration_if_it_is_turned_off()
+    /** @test */
+    public function it_does_not_load_swagger_integration_if_it_is_turned_off(): void
     {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
         $this->setParameter('api_platform.enable_swagger_ui', false);
         $this->load();
 
         $this->assertContainerBuilderNotHasService('api_platform.swagger.action.ui');
     }
 
-    /**
-     * @test
-     */
-    public function it_does_not_load_swagger_integration_if_it_does_not_exists()
+    /** @test */
+    public function it_does_not_load_swagger_integration_if_it_does_not_exists(): void
     {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
         $this->load();
 
         $this->assertContainerBuilderNotHasService('api_platform.swagger.action.ui');
@@ -54,6 +54,8 @@ final class SyliusApiExtensionTest extends AbstractExtensionTestCase
     /** @test */
     public function it_loads_filter_eager_loading_extension_restricted_operations_configuration_properly(): void
     {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
         $this->load([
             'filter_eager_loading_extension' => [
                 'restricted_resources' => [
@@ -93,9 +95,25 @@ final class SyliusApiExtensionTest extends AbstractExtensionTestCase
     /** @test */
     public function it_loads_default_filter_eager_loading_extension_restricted_operations_configuration_properly(): void
     {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
         $this->load();
 
         $this->assertContainerBuilderHasParameter('sylius_api.filter_eager_loading_extension.restricted_resources', []);
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_api_platform_mapping(): void
+    {
+        $this->container->setParameter('kernel.bundles_metadata', ['SyliusApiBundle' => ['path' => __DIR__ . '../..']]);
+
+        $this->load();
+
+        $apiPlatformConfig = $this->container->getExtensionConfig('api_platform')[0];
+
+        $this->assertSame($apiPlatformConfig['mapping']['paths'], [
+            __DIR__ . '../../Resources/config/api_resources/',
+        ]);
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no?                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no|
| Related tickets | |
| License         | MIT                                                          |

In order not to have to configure the API Platform mapping path to the vendor [in the end application](https://github.com/Sylius/Sylius-Standard/blob/1.12/config/packages/api_platform.yaml#L4), I would like to add the path to the API configuration in the ApiBundle extension.
<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
