### PR TITLE
Add a missing orders prefix to routes in Admin Panel

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,8 @@
+# UPGRADE FROM `v1.12.X` TO `v1.12.5`
+
+1. For routes `sylius_admin_order_shipment_ship` and `sylius_admin_order_resend_confirmation_email` the missing "/orders"
+    prefix has been added. If you have been using these routes' paths directly, you need to update them.
+
 # UPGRADE FROM `v1.12.X` TO `v1.12.4`
 
 1. The default configuration of Symfony Messenger has changed,

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -112,7 +112,7 @@ sylius_admin_order_payment_refund:
             flash: sylius.payment.refunded
 
 sylius_admin_order_shipment_ship:
-    path: /{id}/ship
+    path: /orders/{id}/ship
     methods: [PUT]
     defaults:
         _controller: sylius.controller.shipment::updateAction
@@ -137,7 +137,7 @@ sylius_admin_order_shipment_ship:
                         id: $id
 
 sylius_admin_order_resend_confirmation_email:
-    path: /{id}/resend-confirmation-email
+    path: /orders/{id}/resend-confirmation-email
     methods: [GET]
     defaults:
         _controller: Sylius\Bundle\AdminBundle\Action\ResendOrderConfirmationEmailAction


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes (as defined in the issue)                                |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #12225, successor of #13237                      |
| License         | MIT                                                          |

Previous PR had more changes than needed. I'm opening a new one as I couldn't push the changes 🤷🏼‍♂️.
