### PR TITLE
Remove possibility to add Stripe as a payment method when package is missing

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -28,7 +28,8 @@
     "HWI\\Bundle\\OAuthBundle\\Security\\Core\\User\\OAuthAwareUserProviderInterface",
     "League\\Flysystem\\FilesystemOperator",
     "Symfony\\Component\\Security\\Core\\Encoder\\EncoderFactoryInterface",
-    "PHPUnit\\Framework\\ExpectationFailedException"
+    "PHPUnit\\Framework\\ExpectationFailedException",
+    "Stripe\\Stripe"
   ],
   "php-core-extensions" : [
     "Core",

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/UnregisterStripeGatewayTypePass.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/UnregisterStripeGatewayTypePass.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PayumBundle\DependencyInjection\Compiler;
+
+use Stripe\Stripe;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class UnregisterStripeGatewayTypePass implements CompilerPassInterface
+{
+    private const STRIPE_GATEWAY_TYPE_SERVICE_ID = 'sylius.form.type.gateway_configuration.stripe';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (class_exists(Stripe::class)) {
+            return;
+        }
+
+        $container->removeDefinition(self::STRIPE_GATEWAY_TYPE_SERVICE_ID);
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
+++ b/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PayumBundle;
 
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\InjectContainerIntoControllersPass;
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\RegisterGatewayConfigTypePass;
+use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\UnregisterStripeGatewayTypePass;
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\UseTweakedDoctrineStoragePass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
@@ -36,5 +37,6 @@ final class SyliusPayumBundle extends AbstractResourceBundle
         $container->addCompilerPass(new InjectContainerIntoControllersPass());
         $container->addCompilerPass(new RegisterGatewayConfigTypePass());
         $container->addCompilerPass(new UseTweakedDoctrineStoragePass());
+        $container->addCompilerPass(new UnregisterStripeGatewayTypePass(), priority: 128);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | closes #10655                      |
| License         | MIT                                                          |

I've added a compiler pass to PayumBundle to remove Stripe's Type when `stripe/stripe-php` package is not present. I had no idea how to test it, and I've noticed the other passes are not tested either. The logic is simple, so I decided it is not such a big deal to left it as is.
