### PR TITLE
Improve SEO

### DIFF
--- a/docs/_themes/sylius_rtd_theme/layout.html
+++ b/docs/_themes/sylius_rtd_theme/layout.html
@@ -22,6 +22,16 @@
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
   {% endif %}
 
+  {#- CANONICAL URL (deprecated) #}
+  {%- if theme_canonical_url and not pageurl %}
+  <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+  {%- endif -%}
+
+  {#- CANONICAL URL #}
+  {%- if pageurl %}
+  <link rel="canonical" href="{{ pageurl|e }}" />
+  {%- endif -%}
+
   {# CSS #}
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
 

--- a/docs/book/contributing/documentation/format.rst
+++ b/docs/book/contributing/documentation/format.rst
@@ -51,47 +51,6 @@ the highlighted pseudo-language:
 
     A list of supported languages is available on the `Pygments website`_.
 
-.. _docs-configuration-blocks:
-
-Configuration Blocks
-~~~~~~~~~~~~~~~~~~~~
-
-Whenever you show a configuration, you must use the ``configuration-block``
-directive to show the configuration in all supported configuration formats
-(``PHP``, ``YAML``, and ``XML``)
-
-.. code-block:: rst
-
-    .. configuration-block::
-
-        .. code-block:: yaml
-
-            # Configuration in YAML
-
-        .. code-block:: xml
-
-            <!-- Configuration in XML //-->
-
-        .. code-block:: php
-
-            // Configuration in PHP
-
-The previous reST snippet renders as follow:
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        # Configuration in YAML
-
-    .. code-block:: xml
-
-        <!-- Configuration in XML //-->
-
-    .. code-block:: php
-
-        // Configuration in PHP
-
 The current list of supported formats are the following:
 
 +-----------------+-------------+

--- a/docs/book/contributing/documentation/standards.rst
+++ b/docs/book/contributing/documentation/standards.rst
@@ -82,8 +82,7 @@ Code Examples
 Formats
 ~~~~~~~
 
-Configuration examples should show recommended formats using
-:ref:`configuration blocks <docs-configuration-blocks>`. The recommended formats
+Configuration examples should show recommended formats using code-block`. The recommended formats
 (and their orders) are:
 
 * **Configuration** (including services and routing): YAML

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,6 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
-    'sensio.sphinx.configurationblock',
-    'sensio.sphinx.phpcode',
     'sphinx_copybutton',
     'sphinxcontrib-redirects',
     'ultimatereplacement'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,3 @@ pyOpenSSL
 requests[security]
 sphinx-copybutton
 sphinx-autobuild
-git+https://github.com/fabpot/sphinx-php.git


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | yes                                                       |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/14817                      |
| License         | MIT                                                          |


SEO of documentation has always been a problem so I dug a bit and it appears canonical URL does not exist in headers, which is essential. I also dropped the configuration-block as they block sphinx to 1.8.5 and the documentation does NOT use them.

https://docs.readthedocs.io/en/latest/guides/technical-docs-seo-guide.html