### PR TITLE
Add tax rate list API

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="%sylius.model.tax_rate.class%" shortName="TaxRate">
+        <attribute name="route_prefix">admin</attribute>
+
+        <attribute name="validation_groups">sylius</attribute>
+
+        <collectionOperations>
+            <collectionOperation name="admin_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:tax_rate:read</attribute>
+                </attribute>
+            </collectionOperation>
+        </collectionOperations>
+
+        <itemOperations>
+            <itemOperation name="admin_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">admin:tax_rate:read</attribute>
+                </attribute>
+            </itemOperation>
+        </itemOperations>
+
+        <property name="id" identifier="false" writable="false" />
+        <property name="code" identifier="true" required="true" />
+        <property name="createdAt" writable="false" />
+        <property name="updatedAt" writable="false" />
+        <property name="name" writable="true" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+>
+    <class name="Sylius\Component\Taxation\Model\TaxRate">
+        <attribute name="id">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="code">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="name">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="zone">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="includedInPrice">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="category">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="amount">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="amount">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="startDate">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+        <attribute name="endDate">
+            <group>admin:tax_rate:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/tests/Api/Admin/TaxRatesTest.php
+++ b/tests/Api/Admin/TaxRatesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Admin;
+
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Sylius\Tests\Api\Utils\AdminUserLoginTrait;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TaxRatesTest extends JsonApiTestCase
+{
+    use AdminUserLoginTrait;
+
+    /** @test */
+    public function it_gets_a_tax_rate(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['authentication/api_administrator.yaml', 'tax_rate.yaml']);
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        $taxRate = $fixtures['sales_tax'];
+
+        $this->client->request(
+            method: 'GET',
+            uri: sprintf('/api/v2/admin/tax-rates/%s', $taxRate->getCode()),
+            server: $header,
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/tax_rate/get_tax_rate_response',
+            Response::HTTP_OK,
+        );
+    }
+}

--- a/tests/Api/DataFixtures/ORM/tax_rate.yaml
+++ b/tests/Api/DataFixtures/ORM/tax_rate.yaml
@@ -1,0 +1,33 @@
+Sylius\Component\Core\Model\TaxRate:
+    sales_tax:
+        code: sales_tax
+        name: 'Sales Tax 20\\%'
+        calculator: 'flat_rate'
+        category: "@tax_category_default"
+        zone: '@zone_eu_1'
+    regular_tax:
+        code: regular_tax
+        name: 'Regular Tax 20\\%'
+        calculator: 'flat_rate'
+        category: '@tax_category_special'
+        zone: '@zone_eu_1'
+
+Sylius\Component\Taxation\Model\TaxCategory:
+    tax_category_default:
+        code: 'default'
+        name: 'Default'
+    tax_category_special:
+        code: 'special'
+        name: 'Special'
+        description: 'For peculiar places'
+
+Sylius\Component\Addressing\Model\ZoneMember:
+    member_{NL, BE}:
+        code: <current()>
+
+Sylius\Component\Addressing\Model\Zone:
+    zone_eu_1:
+        code: EU
+        name: European Union
+        type: country
+        members: ["@member_NL", "@member_BE"]

--- a/tests/Api/DataFixtures/ORM/zones.yml
+++ b/tests/Api/DataFixtures/ORM/zones.yml
@@ -1,0 +1,10 @@
+Sylius\Component\Addressing\Model\ZoneMember:
+    member_{NL, BE}:
+        code: <current()>
+
+Sylius\Component\Addressing\Model\Zone:
+    zone_eu_1:
+        code: EU
+        name: European Union
+        type: country
+        members: ["@member_NL", "@member_BE"]

--- a/tests/Api/Responses/Expected/admin/tax_rate/get_tax_rate_response.json
+++ b/tests/Api/Responses/Expected/admin/tax_rate/get_tax_rate_response.json
@@ -1,0 +1,16 @@
+{
+    "@context": "\/api\/v2\/contexts\/TaxRate",
+    "@id": "\/api\/v2\/admin\/tax-rates\/sales_tax",
+    "@type": "TaxRate",
+    "zone": "\/api\/v2\/admin\/zones\/EU",
+    "id": "@integer@",
+    "code": "sales_tax",
+    "category": "\/api\/v2\/admin\/tax-categories\/default",
+    "name": "Sales Tax 20\\%",
+    "includedInPrice": false,
+    "amount": 0,
+    "startDate": null,
+    "endDate": null,
+    "createdAt": @date@,
+    "updatedAt": @date@
+}


### PR DESCRIPTION
I added tax rate list API with tests.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
