### PR TITLE
[Taxonomy][Form] Taxon slug generator including parent slug also in update mode

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
@@ -4,7 +4,7 @@
         {{ form_widget(slugField, {'attr': {'data-url': path('sylius_admin_ajax_generate_taxon_slug'), 'data-parent': app.request.attributes.get('id')}}) }}
     {% else %}
     <div class="ui action input">
-        {{ form_widget(slugField, {'attr': {'readonly': 'readonly', 'data-url': path('sylius_admin_ajax_generate_taxon_slug'), 'data-parent': resource.parent.id}}) }}
+        {{ form_widget(slugField, {'attr': {'readonly': 'readonly', 'data-url': path('sylius_admin_ajax_generate_taxon_slug'), 'data-parent': resource.parent ? resource.parent.id : null}}) }}
         <span class="ui icon button toggle-taxon-slug-modification">
             <i class="lock icon"></i>
         </span>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
@@ -4,7 +4,7 @@
         {{ form_widget(slugField, {'attr': {'data-url': path('sylius_admin_ajax_generate_taxon_slug'), 'data-parent': app.request.attributes.get('id')}}) }}
     {% else %}
     <div class="ui action input">
-        {{ form_widget(slugField, {'attr': {'readonly': 'readonly', 'data-url': path('sylius_admin_ajax_generate_taxon_slug')}}) }}
+        {{ form_widget(slugField, {'attr': {'readonly': 'readonly', 'data-url': path('sylius_admin_ajax_generate_taxon_slug'), 'data-parent': resource.parent.id}}) }}
         <span class="ui icon button toggle-taxon-slug-modification">
             <i class="lock icon"></i>
         </span>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets |                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This PR proposes to include the slug prefix of the parent taxon also when editing, at present this is done only when creating, while when editing an existing taxon the generated slug, when requested, will be exclusively of the taxon's name excluding the prefix of the parent taxon.