### PR TITLE
Allow to define a priority on autoconfigured order processors and cart contexts

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -12,3 +12,32 @@
 
 4. Not passing `Doctrine\Persistence\ObjectManager` to `Sylius\Component\Core\Updater\UnpaidOrdersStateUpdater`
    as a fifth argument is deprecated.
+
+5. To allow to autoconfigure order processors and cart context and define a priority for them in `1.13` we have introduced
+   `Sylius\Bundle\OrderBundle\Attribute\AsCartContext` and `Sylius\Bundle\OrderBundle\Attribute\AsOrderProcessor` attributes. By default, Sylius still configures them using interfaces, but this way you cannot define a priority.
+   If you want to define a priority, you need to set the following configuration in your `_sylius.yaml` file:
+   ```yaml
+   sylius_core:
+       autoconfigure_with_attributes: true
+   ```
+   and use one of the new attributes accordingly to a type of your class, e.g.:
+   ```php
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\OrderProcessor;
+
+    use Sylius\Bundle\OrderBundle\Attribute\AsOrderProcessor;
+    use Sylius\Component\Order\Model\OrderInterface;
+    use Sylius\Component\Order\Processor\OrderProcessorInterface;
+
+    #[AsOrderProcessor(priority: 10)] //priority is optional
+    //#[AsOrderProcessor] can be used as well
+    final class OrderProcessorWithAttributeStub implements OrderProcessorInterface
+    {
+        public function process(OrderInterface $order): void
+        {
+        }
+    }
+   ```

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ final class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
+                ->scalarNode('autoconfigure_with_attributes')->defaultFalse()->end()
                 ->booleanNode('prepend_doctrine_migrations')->defaultTrue()->end()
                 ->booleanNode('shipping_address_based_taxation')->defaultFalse()->end()
                 ->booleanNode('order_by_identifier')->defaultTrue()->end()

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -93,6 +93,7 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
         $this->prependHwiOauth($container);
         $this->prependDoctrineMigrations($container);
         $this->prependJmsSerializerIfAdminApiBundleIsNotPresent($container);
+        $this->prependSyliusOrderBundle($container, $config);
     }
 
     protected function getMigrationsNamespace(): string
@@ -158,6 +159,17 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
             'property_naming' => [
                 'id' => 'jms_serializer.identical_property_naming_strategy',
             ],
+        ]);
+    }
+
+    private function prependSyliusOrderBundle(ContainerBuilder $container, array $config): void
+    {
+        if (!$container->hasExtension('sylius_order')) {
+            return;
+        }
+
+        $container->prependExtensionConfig('sylius_order', [
+            'autoconfigure_with_attributes' => $config['autoconfigure_with_attributes'] ?? false,
         ]);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -94,6 +94,26 @@ final class ConfigurationTest extends TestCase
         );
     }
 
+    /** @test */
+    public function it_does_not_autoconfigure_with_attributes_by_default(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [[]],
+            ['autoconfigure_with_attributes' => false],
+            'autoconfigure_with_attributes',
+        );
+    }
+
+    /** @test */
+    public function it_allows_to_enable_autoconfiguring_with_attributes(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['autoconfigure_with_attributes' => true]],
+            ['autoconfigure_with_attributes' => true],
+            'autoconfigure_with_attributes',
+        );
+    }
+
     protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -17,6 +17,7 @@ use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExten
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\DefinitionHasTagConstraint;
 use Sylius\Bundle\CoreBundle\DependencyInjection\SyliusCoreExtension;
+use Sylius\Bundle\OrderBundle\DependencyInjection\SyliusOrderExtension;
 use Sylius\Component\Core\Filesystem\Adapter\FilesystemAdapterInterface;
 use Sylius\Component\Core\Filesystem\Adapter\FlysystemFilesystemAdapter;
 use Sylius\Component\Core\Filesystem\Adapter\GaufretteFilesystemAdapter;
@@ -68,6 +69,33 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
     public function it_autoconfigures_prepending_doctrine_migrations_with_proper_migrations_path_for_dev_env(): void
     {
         $this->testPrependingDoctrineMigrations('dev');
+    }
+
+    /**
+     * @test
+     * @dataProvider provideAutoconfigureWithAttributesData
+     */
+    public function it_prepends_sylius_order_bundle_configuration_with_proper_values(bool $value, bool $orderBundleValue): void
+    {
+        $this->container->setParameter('kernel.environment', 'dev');
+        $this->container->registerExtension(new SyliusOrderExtension());
+        $this->container->loadFromExtension('sylius_core', [
+            'autoconfigure_with_attributes' => $value,
+        ]);
+        $this->container->loadFromExtension('sylius_order', [
+            'autoconfigure_with_attributes' => $orderBundleValue,
+        ]);
+
+        $this->load();
+
+        $syliusOrderConfig = $this->container->getExtensionConfig('sylius_order');
+        $this->assertEquals($value, $syliusOrderConfig[0]['autoconfigure_with_attributes']);
+    }
+
+    public static function provideAutoconfigureWithAttributesData(): iterable
+    {
+        yield [true, false];
+        yield [false, true];
     }
 
     /** @test */

--- a/src/Sylius/Bundle/OrderBundle/Attribute/AsCartContext.php
+++ b/src/Sylius/Bundle/OrderBundle/Attribute/AsCartContext.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsCartContext
+{
+    public function __construct (
+        private int $priority = 0,
+    ) {
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Attribute/AsOrderProcessor.php
+++ b/src/Sylius/Bundle/OrderBundle/Attribute/AsOrderProcessor.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsOrderProcessor
+{
+    public function __construct (
+        private int $priority = 0,
+    ) {
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ final class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
+                ->scalarNode('autoconfigure_with_attributes')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\DependencyInjection;
 
+use Sylius\Bundle\OrderBundle\Attribute\AsCartContext;
+use Sylius\Bundle\OrderBundle\Attribute\AsOrderProcessor;
 use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterCartContextsPass;
 use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterProcessorsPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
@@ -38,13 +41,33 @@ final class SyliusOrderExtension extends AbstractResourceExtension
         $container->setParameter('sylius_order.cart_expiration_period', $config['expiration']['cart']);
         $container->setParameter('sylius_order.order_expiration_period', $config['expiration']['order']);
 
-        $container
-            ->registerForAutoconfiguration(CartContextInterface::class)
-            ->addTag(RegisterCartContextsPass::CART_CONTEXT_SERVICE_TAG)
-        ;
-        $container
-            ->registerForAutoconfiguration(OrderProcessorInterface::class)
-            ->addTag(RegisterProcessorsPass::PROCESSOR_SERVICE_TAG)
-        ;
+        $this->registerAutoconfiguration($container, $config['autoconfigure_with_attributes']);
+    }
+
+    private function registerAutoconfiguration(ContainerBuilder $container, bool $autoconfigureWithAttributes): void
+    {
+        if (true === $autoconfigureWithAttributes) {
+            $container->registerAttributeForAutoconfiguration(
+                AsCartContext::class,
+                static function (ChildDefinition $definition, AsCartContext $attribute): void {
+                    $definition->addTag(RegisterCartContextsPass::CART_CONTEXT_SERVICE_TAG, ['priority' => $attribute->getPriority()]);
+                }
+            );
+            $container->registerAttributeForAutoconfiguration(
+                AsOrderProcessor::class,
+                static function (ChildDefinition $definition, AsOrderProcessor $attribute): void {
+                    $definition->addTag(RegisterProcessorsPass::PROCESSOR_SERVICE_TAG, ['priority' => $attribute->getPriority()]);
+                }
+            );
+        } else {
+            $container
+                ->registerForAutoconfiguration(CartContextInterface::class)
+                ->addTag(RegisterCartContextsPass::CART_CONTEXT_SERVICE_TAG)
+            ;
+            $container
+                ->registerForAutoconfiguration(OrderProcessorInterface::class)
+                ->addTag(RegisterProcessorsPass::PROCESSOR_SERVICE_TAG)
+            ;
+        }
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Tests/Stub/CartContextWithAttributeStub.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Stub/CartContextWithAttributeStub.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Tests\Stub;
+
+
+use Sylius\Bundle\OrderBundle\Attribute\AsCartContext;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Model\Order;
+use Sylius\Component\Order\Model\OrderInterface;
+
+#[AsCartContext(priority: 20)]
+final class CartContextWithAttributeStub implements CartContextInterface
+{
+    public function getCart(): OrderInterface
+    {
+        return new Order();
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Tests/Stub/OrderProcessorWithAttributeStub.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Stub/OrderProcessorWithAttributeStub.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Tests\Stub;
+
+
+use Sylius\Bundle\OrderBundle\Attribute\AsOrderProcessor;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+
+#[AsOrderProcessor(priority: 10)]
+final class OrderProcessorWithAttributeStub implements OrderProcessorInterface
+{
+    public function process(OrderInterface $order): void
+    {
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | successor of #14819                       |
| License         | MIT                                                          |

> **NOTE:** The previous Sylius' behavior is behaved and is default one!

Previously autoconfigured order processors and cart contexts had been configured with 0 priority, and it couldn't be changed. To make this possible, I've created two attributes: `AsOrderProcessor` and `AsCartContext`. When we add a given attribute, our class receives a corresponding tag. Unlike with interfaces, with attributes we're able to define a priority which is passed as a tag's attribute.

To use this feature, we have to adjust our `_sylius.yaml` by adding:
```yaml
sylius_core:
    autoconfigure_with_attributes: true
```

And applying `[AsOrderProcessor]` or `[AsCartContext]` attribute on the top of our order processors and/or cart contexts :).