### PR TITLE
Remove ApiPlatform 2.6.x from CI

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -5,12 +5,12 @@
         {
           "php": "8.0",
           "symfony": "^5.4",
-          "api-platform": "~2.6.0"
+          "api-platform": "^2.7.10"
         },
         {
           "php": "8.1",
           "symfony": "^6.0",
-          "api-platform": "^2.7"
+          "api-platform": "^2.7.10"
         }
       ]
     },
@@ -35,7 +35,7 @@
         {
           "php": "8.0",
           "symfony": "^5.4",
-          "api-platform": "~2.6.0",
+          "api-platform": "^2.7.10",
           "mysql": "5.7",
           "twig": "^2.12",
           "dbal": "^2.7"
@@ -43,7 +43,7 @@
         {
           "php": "8.1",
           "symfony": "^6.0",
-          "api-platform": "^2.7",
+          "api-platform": "^2.7.10",
           "mysql": "8.0",
           "twig": "^3.3",
           "dbal": "^3.0"
@@ -89,14 +89,7 @@
     "static-checks": {
       "php": [ "8.0", "8.1" ],
       "symfony": [ "^5.4", "^6.0" ],
-      "api-platform": [ "^2.7" ],
-      "include": [
-        {
-          "php": "8.1",
-          "symfony": "^6.0",
-          "api-platform": "~2.6.0"
-        }
-      ]
+      "api-platform": [ "^2.7.10" ]
     },
     "e2e-mariadb": {
       "php": [ "8.0", "8.1" ],
@@ -107,7 +100,7 @@
     "e2e-mysql": {
       "php": [ "8.0", "8.1" ],
       "symfony": [ "^5.4", "^6.0" ],
-      "api-platform": [ "^2.7" ],
+      "api-platform": [ "^2.7.10" ],
       "mysql": [ "5.7", "8.0" ],
       "twig": [ "^3.3" ],
       "dbal": [ "^3.0" ],
@@ -115,7 +108,7 @@
         {
           "php": "8.0",
           "symfony": "^5.4",
-          "api-platform": "^2.7",
+          "api-platform": "^2.7.10",
           "mysql": "5.7",
           "twig": "^2.12",
           "dbal": "^3.0"
@@ -123,7 +116,7 @@
         {
           "php": "8.0",
           "symfony": "^5.4",
-          "api-platform": "^2.7",
+          "api-platform": "^2.7.10",
           "mysql": "5.7",
           "twig": "^2.12",
           "dbal": "^2.7"
@@ -131,7 +124,7 @@
         {
           "php": "8.1",
           "symfony": "^5.4",
-          "api-platform": "~2.6.0",
+          "api-platform": "^2.7.10",
           "mysql": "8.0",
           "twig": "^3.3",
           "dbal": "^3.0"
@@ -139,7 +132,7 @@
         {
           "php": "8.1",
           "symfony": "^6.0",
-          "api-platform": "~2.6.0",
+          "api-platform": "^2.7.10",
           "mysql": "8.0",
           "twig": "^3.3",
           "dbal": "^3.0"


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

`2.6` is not supported anymore, and `2.6.8` is reporting a security issue. We're going to drop `2.6` in `1.13`.