### PR TITLE
[Shipment] Reduce amount of queries during shipping eligibility checking

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShippingMethodRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShippingMethodRepository.php
@@ -39,6 +39,8 @@ class ShippingMethodRepository extends BaseShippingMethodRepository implements S
     public function findEnabledForZonesAndChannel(array $zones, ChannelInterface $channel): array
     {
         return $this->createEnabledForChannelQueryBuilder($channel)
+            ->addSelect('rules')
+            ->leftJoin('o.rules', 'rules')
             ->andWhere('o.zone IN (:zones)')
             ->setParameter('zones', $zones)
             ->addOrderBy('o.position', 'ASC')

--- a/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
+++ b/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
@@ -30,4 +30,16 @@ class ShippingMethodRepository extends EntityRepository implements ShippingMetho
             ->getResult()
         ;
     }
+
+    public function findEnabledWithRules(): array
+    {
+        return $this->createQueryBuilder('o')
+            ->addSelect('rules')
+            ->leftJoin('o.rules', 'rules')
+            ->andWhere('o.enabled = :enabled')
+            ->setParameter('enabled', true)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
 }

--- a/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
@@ -22,4 +22,9 @@ interface ShippingMethodRepositoryInterface extends RepositoryInterface
      * @return ShippingMethodInterface[]
      */
     public function findByName(string $name, string $locale): array;
+
+    /**
+     * @return ShippingMethodInterface[]
+     */
+    public function findEnabledWithRules(): array;
 }

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -15,21 +15,30 @@ namespace Sylius\Component\Shipping\Resolver;
 
 use Doctrine\Persistence\ObjectRepository;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Repository\ShippingMethodRepositoryInterface;
 
 final class ShippingMethodsResolver implements ShippingMethodsResolverInterface
 {
     public function __construct(
-        private ObjectRepository $shippingMethodRepository,
+        private ObjectRepository|ShippingMethodRepositoryInterface $shippingMethodRepository,
         private ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
     ) {
+        if (!$this->shippingMethodRepository instanceof ShippingMethodRepositoryInterface) {
+            @trigger_error(sprintf(
+                'Not implementing "%s" in "%s" is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                ShippingMethodRepositoryInterface::class,
+                get_debug_type($this->shippingMethodRepository)
+            ), E_USER_DEPRECATED);
+        }
     }
 
     public function getSupportedMethods(ShippingSubjectInterface $subject): array
     {
         $methods = [];
 
-        foreach ($this->shippingMethodRepository->findBy(['enabled' => true]) as $shippingMethod) {
+        foreach ($this->getEnabledShippingMethods() as $shippingMethod) {
             if ($this->eligibilityChecker->isEligible($subject, $shippingMethod)) {
                 $methods[] = $shippingMethod;
             }
@@ -41,5 +50,17 @@ final class ShippingMethodsResolver implements ShippingMethodsResolverInterface
     public function supports(ShippingSubjectInterface $subject): bool
     {
         return true;
+    }
+
+    /**
+     * @return ShippingMethodInterface[]
+     */
+    private function getEnabledShippingMethods(): array
+    {
+        if ($this->shippingMethodRepository instanceof ShippingMethodRepositoryInterface) {
+            return $this->shippingMethodRepository->findEnabledWithRules();
+        }
+
+        return $this->shippingMethodRepository->findBy(['enabled' => true]);
     }
 }

--- a/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Shipping\Resolver;
 
 use Doctrine\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Shipping\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
@@ -23,7 +24,7 @@ use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 final class ShippingMethodsResolverSpec extends ObjectBehavior
 {
     function let(
-        ObjectRepository $methodRepository,
+        ShippingMethodRepositoryInterface $methodRepository,
         ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
     ): void {
         $this->beConstructedWith($methodRepository, $eligibilityChecker);
@@ -35,7 +36,7 @@ final class ShippingMethodsResolverSpec extends ObjectBehavior
     }
 
     function it_returns_all_methods_eligible_for_given_subject(
-        ObjectRepository $methodRepository,
+        ShippingMethodRepositoryInterface $methodRepository,
         ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
         ShippingSubjectInterface $subject,
         ShippingMethodInterface $method1,
@@ -43,7 +44,7 @@ final class ShippingMethodsResolverSpec extends ObjectBehavior
         ShippingMethodInterface $method3,
     ): void {
         $methods = [$method1, $method2, $method3];
-        $methodRepository->findBy(['enabled' => true])->shouldBeCalled()->willReturn($methods);
+        $methodRepository->findEnabledWithRules()->shouldBeCalled()->willReturn($methods);
 
         $eligibilityChecker->isEligible($subject, $method1)->shouldBeCalled()->willReturn(true);
         $eligibilityChecker->isEligible($subject, $method2)->shouldBeCalled()->willReturn(true);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                   |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

Small performance improvement. Currently, due to lazy loading, every shipping method will generate the amount of queries equal to 1 + amount of rules defined for it for each add-to-cart. With my proposal, we are reducing it to one. 

Researched with Backfire thanks to Fusonic GmbH :) 

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The question is, should it be opened to 1.12? But I'm adding a deprecation notice, so I've preferred to add it to the next minor.
