### PR TITLE
[Dependencies] Bump up API Platform to 2.7.10

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -28,14 +28,6 @@ references related issues.
    This version is causing a problem with returning null as token from `Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage`
    which leads to wrong solving path prefix by `Sylius\Bundle\ApiBundle\Provider\PathPrefixProvider` in API scenarios
 
- - `api-platform/core:2.7.0`:
-
-   The FQCN of `ApiPlatform\Core\Metadata\Resource\ResourceNameCollection` has changed to:
-   `ApiPlatform\Metadata\Resource\ResourceNameCollection` and due to this fact
-   `Sylius\Bundle\ApiBundle\Swagger\AcceptLanguageHeaderDocumentationNormalizer` 
-   references this class throws an exception
-  `Class "ApiPlatform\Core\Metadata\Resource\ResourceNameCollection" not found`
-
 - `doctrine/migrations:3.5.3`:
 
   This version is causing a problem with migrations and results in throwing a `Doctrine\Migrations\Exception\MetadataStorageError` exception e.g. when executing `sylius:install` command.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-hash": "*",
         "ext-intl": "*",
         "ext-json": "*",
-        "api-platform/core": "^2.6",
+        "api-platform/core": "^2.7.10",
         "babdev/pagerfanta-bundle": "^3.0",
         "behat/transliterator": "^1.3",
         "doctrine/collections": "^1.6",
@@ -178,7 +178,6 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "api-platform/core": "2.7.0",
         "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/migrations": "3.5.3",
         "jms/serializer-bundle": "4.1.0",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^8.0",
         "doctrine/dbal": "^2.7 || ^3.0",
-        "api-platform/core": "^2.6",
+        "api-platform/core": "^2.7.10",
         "enshrined/svg-sanitize": "^0.15.4",
         "lexik/jwt-authentication-bundle": "^2.11",
         "sylius/core-bundle": "^1.12",
@@ -48,7 +48,6 @@
         "theofidry/alice-data-fixtures": "^1.4"
     },
     "conflict": {
-        "api-platform/core": "2.7.0",
         "doctrine/dbal": "3.*",
         "doctrine/doctrine-bundle": "2.3.0",
         "lexik/jwt-authentication-bundle": "^2.18",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13|
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | continuation of #14842                       |
| License         | MIT                                                          |

As API Platform 2.6 is no longer supported and, what is more, has security vulnerabilities, I would like to bump up the currently supported version of the API Platform to at least 2.7.10

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
