### PR TITLE
Fix a wrong function name in the AuthenticationSuccessListenerSpec

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/spec/EventListener/AuthenticationSuccessListenerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/EventListener/AuthenticationSuccessListenerSpec.php
@@ -28,7 +28,7 @@ final class AuthenticationSuccessListenerSpec extends ObjectBehavior
         $this->beConstructedWith($iriConverter);
     }
 
-    function it_adds_customers_id_to_shop_authentication_token_response(
+    function it_adds_customers_to_shop_authentication_token_response(
         IriConverterInterface $iriConverter,
         ShopUserInterface $shopUser,
         CustomerInterface $customer,


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | replaces https://github.com/Sylius/Sylius/pull/14759|
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
