### PR TITLE
[Order] Fix partially refunded payement preventing order to still be …

### DIFF
--- a/src/Sylius/Component/Core/StateResolver/OrderStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderStateResolver.php
@@ -39,7 +39,8 @@ final class OrderStateResolver implements StateResolverInterface
     private function canOrderBeFulfilled(OrderInterface $order): bool
     {
         return
-            OrderPaymentStates::STATE_PAID === $order->getPaymentState() &&
+            (OrderPaymentStates::STATE_PAID === $order->getPaymentState() ||
+            OrderPaymentStates::STATE_PARTIALLY_REFUNDED === $order->getPaymentState()) &&
             OrderShippingStates::STATE_SHIPPED === $order->getShippingState()
         ;
     }


### PR DESCRIPTION
…fulfilled

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        |yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                       |
| License         | MIT                                                          |

Here is the case :
- Imagine a customer order 2 units of an item
- Order is completed 
- Payment is made
- Customer now realize they ordered twice the item while they wanted only 1 unit and ask the extra item to be refunded
- Refund is made, the payment is now in `partially refunded` status

In this state, the order is stuck in `ready to ship` state and can't be fulfilled anymore
