### PR TITLE
Add selecting only Behat scenarios with @javascript tag for JS-based CI

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -141,7 +141,7 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
 
             -   name: Run Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli&&~@api" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli&&~@api" --rerun 
+                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun 
 
             -   name: Upload Behat logs
                 uses: actions/upload-artifact@v3

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -141,7 +141,7 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
 
             -   name: Run Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@api" ||vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@api" --rerun 
+                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli&&~@api" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli&&~@api" --rerun 
 
             -   name: Upload Behat logs
                 uses: actions/upload-artifact@v3


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

From what we can see, I forgot to include only `@javascript` tag in JS-based workflows, so we've been running more tests than needed. 
