### PR TITLE
Fix LogicException in form validation

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
@@ -51,7 +51,7 @@ class OrderItemController extends ResourceController
             $configuration->getFormOptions(),
         );
 
-        if ($request->isMethod('POST') && $form->handleRequest($request)->isValid()) {
+        if ($request->isMethod('POST') && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             /** @var AddToCartCommandInterface $addToCartCommand */
             $addToCartCommand = $form->getData();
 

--- a/src/Sylius/Bundle/ShopBundle/Controller/ContactController.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/ContactController.php
@@ -46,7 +46,7 @@ final class ContactController
         $formType = $this->getSyliusAttribute($request, 'form', ContactType::class);
         $form = $this->formFactory->create($formType, null, $this->getFormOptions());
 
-        if ($request->isMethod('POST') && $form->handleRequest($request)->isValid()) {
+        if ($request->isMethod('POST') && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             $channel = $this->channelContext->getChannel();

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -51,7 +51,7 @@ class UserController extends ResourceController
         $formType = $this->getSyliusAttribute($request, 'form', UserChangePasswordType::class);
         $form = $this->createResourceForm($configuration, $formType, $changePassword);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             return $this->handleChangePassword($request, $configuration, $user, $changePassword->getNewPassword());
         }
 
@@ -100,7 +100,7 @@ class UserController extends ResourceController
         $formType = $this->getSyliusAttribute($request, 'form', UserResetPasswordType::class);
         $form = $this->createResourceForm($configuration, $formType, $passwordReset);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             return $this->handleResetPassword($request, $configuration, $user, $passwordReset->getPassword());
         }
 
@@ -213,7 +213,7 @@ class UserController extends ResourceController
             Assert::notNull($template, 'Template is not configured.');
         }
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $userRepository = $this->repository;
 
             /** @var UserRepositoryInterface $userRepository */


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                   |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14856                     |
| License         | MIT                                                          |

In a few controllers, a call to `form->isValid()` is made before calling `form->isSubmitted()`, leading to a `Symfony\Component\Form\Exception\LogicException` from Symfony, and therefore to the forms not being validated at all.