### PR TITLE
Allow product variants to have extra option values

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
@@ -39,12 +39,17 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
             throw new UnexpectedTypeException($value, ProductVariantInterface::class);
         }
 
+        $configuredOptionValues = array_filter(
+            $value->getOptionValues()->toArray(),
+            fn (ProductOptionValueInterface $productOptionValue): bool => $this->product->hasOption($productOptionValue->getOption()),
+        );
+
         return array_combine(
             array_map(
                 fn (ProductOptionValueInterface $productOptionValue): string => (string) $productOptionValue->getOptionCode(),
-                $value->getOptionValues()->toArray(),
+                $configuredOptionValues,
             ),
-            $value->getOptionValues()->toArray(),
+            $configuredOptionValues,
         );
     }
 

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueCollectionType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueCollectionType.php
@@ -48,9 +48,9 @@ final class ProductOptionValueCollectionType extends AbstractType
             $builder->add((string) $option->getCode(), ProductOptionValueChoiceType::class, [
                 'label' => $option->getName() ?: $option->getCode(),
                 'option' => $option,
-                'data' => $this->getDefaultDataOption($option, $options['data']),
-                'property_path' => '[' . $i . ']',
                 'block_name' => 'entry',
+                'getter' => fn (Collection $data) => $this->getDefaultDataOption($option, $data),
+                'setter' => fn (Collection $data, ?ProductOptionValueInterface $value) => $this->setDataOption($data, $value),
             ]);
         }
     }
@@ -89,5 +89,23 @@ final class ProductOptionValueCollectionType extends AbstractType
         }
 
         return null;
+    }
+
+    private function setDataOption(Collection $data, ?ProductOptionValueInterface $optionValue): void
+    {
+        if (null === $optionValue) {
+            return;
+        }
+
+        foreach ($data as $option) {
+            if ($option->getOption()->getCode() === $optionValue->getOption()->getCode()) {
+                $data->removeElement($option);
+                $data->add($optionValue);
+
+                return;
+            }
+        }
+
+        $data->add($optionValue);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no/maybe                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

### Context

Our Sylius website requires more option values to be configured for product variants than the number of enabled options defined in the product configuration. Those are set using CSV imports. This is necessary to provide customers with more detailed information in the cart, checkout, and other sections of the website.

For instance, let's consider a website with two available options, _finish_, and _color_. Suppose we have two products, _Product A - Glassy finish_, and _Product B - Matt finish_, each configured with only the _color_ option, and each variant defines a _color_ option value. To provide more information to the customer about the _finish_ used by the product (without setting attributes), we need to add the corresponding _finish_ option value (_glossy_ or _matt_) to each variant. As a result, if the customer selects Product A in blue, they will see "Glassy | Blue" in their cart.

However, Sylius does not currently support this configuration. Setting more option values than the enabled ones in the product can cause two potential issues. 
- Firstly, the back office may remove an option value from a variant, depending on its order in the optionValues collection. 
- Secondly, when adding to the cart, a not-found error can be returned even if the proper variant exists.

### PR Content

This PR resolves the possibility to handle more options values than the enabled ones in the product, by:

1. **Changing the way the form collection type handles the access of the option values list** (_ProductOptionValueCollectionType_):

When saving the product variant form, the option field accesses the collection of optionValues directly by an index that starts from 0. This could potentially lead to the override of any other defined option values.

2. **Fixing potential bug on variants matching** (_ProductVariantToProductOptionsTransformer_):

When adding a product variant to the cart using a variant selection match, each variant is compared with the first variant option values in the collection. Technically, as the _Form::submit()_ will merge the normData object, if one of the variant collections contains more option values than the others, those options will be used as a comparison for other variants. This can lead to not found errors and confusion in the _AddToCartType_.

To resolve this issue, filtering the option values to only include those enabled from the product options can prevent the above problem from occurring.