### PR TITLE
[Attributes] FloatType input type as a number instead of text

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/FloatAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/FloatAttributeType.php
@@ -29,6 +29,7 @@ final class FloatAttributeType extends AbstractType
         $resolver
             ->setDefaults([
                 'label' => false,
+                'html5' => true,
             ])
             ->setRequired('configuration')
             ->setDefined('locale_code')


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| Related tickets | Related to  https://github.com/Sylius/Sylius/pull/10690                    
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
By default the input type in NumberType is set to text, to change that to number We need to set html5 option to true, [ref](https://symfony.com/doc/current/reference/forms/types/number.html#html5)

