### PR TITLE
Fix dependency security vulerability for enshrined/svg-sanitize package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/migrations": "^3.0",
         "doctrine/orm": "^2.13",
         "egulias/email-validator": "^3.1",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "fakerphp/faker": "^1.9",
         "friendsofsymfony/rest-bundle": "^3.0",
         "gedmo/doctrine-extensions": "^3.2",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.0",
         "doctrine/dbal": "^2.7",
         "api-platform/core": "^2.6",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "lexik/jwt-authentication-bundle": "^2.6",
         "sylius/core-bundle": "^1.7",
         "symfony/messenger": "^4.4 || ^5.4"

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "knplabs/gaufrette": "^0.8 || ^0.9 || ^0.10 || ^0.11",
         "payum/payum": "^1.6",
         "php-http/guzzle6-adapter": "^2.0",

--- a/symfony.lock
+++ b/symfony.lock
@@ -159,7 +159,7 @@
         "version": "2.1.19"
     },
     "enshrined/svg-sanitize": {
-        "version": "0.15.4"
+        "version": "0.16.0"
     },
     "fakerphp/faker": {
         "version": "v1.12.0"


### PR DESCRIPTION
Fix dependency security vulerability for enshrined/svg-sanitize package
(CVE-2023-28426)

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.11                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes CVE-2023-28426                      |
| License         | MIT                                                          |

