### PR TITLE
Run test against doctrine 2.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4 || ^2.0",
         "doctrine/migrations": "^3.0",
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "doctrine/persistence": "^2.3",
         "egulias/email-validator": "^3.1",
         "enshrined/svg-sanitize": "^0.15.4",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -37,7 +37,7 @@
         "twig/twig": "^1.0 || ^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -31,7 +31,7 @@
         "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "^1.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -36,7 +36,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "egulias/email-validator": "^3.1",
         "sylius/customer": "^1.12",
         "sylius/resource-bundle": "^1.9",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -37,7 +37,7 @@
         "twig/twig": "^1.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "^1.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -36,7 +36,7 @@
         "twig/twig": "^1.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -40,7 +40,7 @@
         "twig/twig": "^1.0 || ^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -35,7 +35,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -35,7 +35,7 @@
         "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "mockery/mockery": "^1.4",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -40,7 +40,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -40,7 +40,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -39,7 +39,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -38,7 +38,7 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4 || ^6.0"

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -38,7 +38,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "egulias/email-validator": "^3.1",
         "sylius-labs/polyfill-symfony-event-dispatcher": "^1.0.1",
         "sylius-labs/polyfill-symfony-framework-bundle": "^1.0 || ^1.1",

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "2.15.*@dev",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9"
     },


### PR DESCRIPTION
With the merge of https://github.com/doctrine/orm/pull/10554:

We are now able to test Sylius against the changes of Doctrine ORM 2.15.