### PR TITLE
Fix dependency security vulerability for enshrined/svg-sanitize package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/orm": "^2.13",
         "doctrine/persistence": "^2.3",
         "egulias/email-validator": "^3.1",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "fakerphp/faker": "^1.10",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
         "friendsofsymfony/rest-bundle": "^3.0",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.0",
         "doctrine/dbal": "^2.7 || ^3.0",
         "api-platform/core": "^2.6",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "lexik/jwt-authentication-bundle": "^2.11",
         "sylius/core-bundle": "^1.12",
         "symfony/messenger": "^5.4 || ^6.0"

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "enshrined/svg-sanitize": "^0.15.4",
+        "enshrined/svg-sanitize": "^0.15.4 || ^0.16",
         "knplabs/gaufrette": "^0.10 || ^0.11",
         "league/flysystem": "^2.4",
         "payum/payum": "^1.7.2",

--- a/symfony.lock
+++ b/symfony.lock
@@ -159,7 +159,7 @@
         "version": "2.1.19"
     },
     "enshrined/svg-sanitize": {
-        "version": "0.15.4"
+        "version": "0.16.0"
     },
     "fakerphp/faker": {
         "version": "v1.12.0"


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | port of #14871
| License         | MIT

The initial idea was to upmerge changes from `1.11` but while reviving CI we decided to no more upmerge `1.11` to `1.12`. That's why I had to port changes from #14871 manually.