### PR TITLE
Improve testing unstable dependencies in CI

### DIFF
--- a/.github/workflows/ci__full.yaml
+++ b/.github/workflows/ci__full.yaml
@@ -41,10 +41,16 @@ jobs:
         uses: ./.github/workflows/ci_packages.yaml
         with:
             type: full
+    unstable:
+        name: Unstable
+        needs: static-checks
+        uses: ./.github/workflows/ci__unstable.yaml
+        with:
+            ignore-failure: false
     notify-about-build-status:
         if: ${{ always() }}
         name: "Notify about build status"
-        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-custom, packages]
+        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-custom, packages, unstable]
         runs-on: ubuntu-latest
         timeout-minutes: 5
 
@@ -73,6 +79,7 @@ jobs:
                         ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} End-to-End (PostgreSQL)
                         ${{ needs.e2e-custom.result == 'success' && ':+1:' || ':x:' }} End-to-End (Custom)
                         ${{ needs.packages.result == 'success' && ':+1:' || ':x:' }} Packages
+                        ${{ needs.unstable.result == 'success' && ':+1:' || ':x:' }} Unstable
 
                         _ _ _ _ _ _ _
                     color: "danger"

--- a/.github/workflows/ci__minimal.yaml
+++ b/.github/workflows/ci__minimal.yaml
@@ -47,3 +47,10 @@ jobs:
         uses: ./.github/workflows/ci_packages.yaml
         with:
             type: minimal
+    unstable:
+        if: contains(github.event.pull_request.title, '[Unstable]')
+        name: Unstable
+        needs: static-checks
+        uses: ./.github/workflows/ci__unstable.yaml
+        with:
+            ignore-failure: true

--- a/.github/workflows/ci__unstable.yaml
+++ b/.github/workflows/ci__unstable.yaml
@@ -1,0 +1,28 @@
+name: Continuous Integration (Unstable)
+
+on:
+    workflow_call:
+        inputs:
+            ignore-failure:
+                description: "Don't fail on error"
+                required: false
+                type: boolean
+                default: false
+    workflow_dispatch: ~
+
+concurrency:
+    group: ci-${{ github.workflow }}-${{ github.ref }}-unstable
+    cancel-in-progress: true
+
+jobs:
+    e2e-unstable:
+        name: End-to-end tests (Unstable)
+        uses: ./.github/workflows/ci_e2e-unstable.yaml
+        with:
+            ignore-failure: ${{ inputs.ignore-failure }}
+    packages-unstable:
+        name: Packages (Unstable)
+        uses: ./.github/workflows/ci_packages-unstable.yaml
+        with:
+            type: minimal
+            ignore-failure: ${{ inputs.ignore-failure }}

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -1,11 +1,17 @@
-name: End-to-End (Custom)
+name: End-to-End (Unstable)
 
 on:
+    workflow_call:
+        inputs:
+            ignore-failure:
+                description: "Don't fail on error"
+                required: false
+                type: boolean
+                default: false
     workflow_dispatch: ~
-    workflow_call: ~
 
 jobs:
-    behat-no-js-unstable-symfony:
+    behat-no-js-unstable:
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
         timeout-minutes: 45
@@ -39,7 +45,7 @@ jobs:
             -   name: Change minimum-stability to dev
                 run: |
                     composer config minimum-stability dev
-                    composer config prefer-stable true
+                    composer config prefer-stable false
 
             -   name: Build application
                 uses: jakubtobiasz/SyliusBuildTestAppAction@v2.0
@@ -53,11 +59,11 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     
             -   name: Run PHPUnit
-                continue-on-error: true
+                continue-on-error: ${{ inputs.ignore-failure }}
                 run: vendor/bin/phpunit --colors=always
 
             -   name: Run non-JS Behat
-                continue-on-error: true
+                continue-on-error: ${{ inputs.ignore-failure }}
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@todo&&~@cli&&~@no-postgres" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@todo&&~@cli&&~@no-postgres" --rerun
 
             -   name: Upload logs

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -1,0 +1,80 @@
+name: Packages (Unstable)
+
+on:
+    workflow_dispatch: ~
+    workflow_call:
+        inputs:
+            type:
+                description: "Type of the build"
+                required: true
+                type: string
+            ignore-failure:
+                description: "Don't fail on error"
+                required: false
+                type: boolean
+                default: false
+
+jobs:
+    get-matrix:
+        runs-on: ubuntu-latest
+        name: "Get matrix"
+        outputs:
+            matrix: ${{ steps.matrix.outputs.prop }}
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: "Get matrix"
+                id: matrix
+                uses: notiz-dev/github-action-json-property@release
+                with:
+                    path: '.github/workflows/matrix.json'
+                    prop_path: '${{ inputs.type }}.packages'
+
+    test_unstable:
+        needs: get-matrix
+        runs-on: ubuntu-latest
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (Unstable Dependencies)"
+        timeout-minutes: 25
+        
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+
+        env:
+            COMPOSER_ROOT_VERSION: "dev-master"
+            SYMFONY_VERSION: "${{ matrix.symfony }}"
+            UNSTABLE: "yes"
+
+        steps:
+            -
+                uses: actions/checkout@v3
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    coverage: none
+
+            -   name: Restrict Symfony version
+                run: |
+                    composer global config --no-plugins allow-plugins.symfony/flex true
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.18.5"
+                    composer config extra.symfony.require "${{ matrix.symfony }}"
+
+            -   name: Get Composer cache directory
+                id: composer-cache
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: Cache Composer
+                uses: actions/cache@v3
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-"
+                    restore-keys: |
+                        "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-"
+
+            -   name: Install dependencies
+                run: composer update --no-interaction --no-scripts
+
+            -   name: "Run pipeline"
+                continue-on-error: ${{ inputs.ignore-failure }}
+                run: find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c . | xargs -0 vendor/bin/robo ci:packages

--- a/.github/workflows/ci_packages.yaml
+++ b/.github/workflows/ci_packages.yaml
@@ -23,7 +23,7 @@ jobs:
                 with:
                     path: '.github/workflows/matrix.json'
                     prop_path: '${{ inputs.type }}.packages'
-                    
+
     get-matrix-swiftmailer:
         runs-on: ubuntu-latest
         name: "Get matrix (Swiftmailer)"
@@ -51,6 +51,7 @@ jobs:
         env:
             COMPOSER_ROOT_VERSION: "dev-master"
             SYMFONY_VERSION: "${{ matrix.symfony }}"
+            UNSTABLE: "no"
 
         steps:
             -
@@ -86,7 +87,7 @@ jobs:
 
             -   name: "Run pipeline"
                 run: find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c . | xargs -0 vendor/bin/robo ci:packages
-                
+    
     test_with_swiftmailer:
         needs: get-matrix-swiftmailer
         runs-on: ubuntu-latest
@@ -102,6 +103,7 @@ jobs:
             COMPOSER_ROOT_VERSION: "dev-master"
             SYMFONY_VERSION: "${{ matrix.symfony }}"
             USE_SWIFTMAILER: "yes"
+            UNSTABLE: "no"
             PACKAGES: '["Bundle/CoreBundle", "Bundle/ApiBundle", "Bundle/AdminBundle"]'
 
         steps:

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -49,6 +49,7 @@ class RoboFile extends Tasks
     {
         $symfonyVersion = getenv('SYMFONY_VERSION');
         $useSwiftmailer = getenv('USE_SWIFTMAILER');
+        $unstable = getenv('UNSTABLE');
         $packagePath = sprintf('%s/src/Sylius/%s', self::ROOT_DIR, $package);
 
         if (false === $symfonyVersion) {
@@ -66,6 +67,11 @@ class RoboFile extends Tasks
                 ->exec('composer require --no-progress --no-update --no-scripts --no-plugins "sylius/mailer-bundle:^1.8"')
                 ->exec('composer require --no-progress --no-update --no-scripts --no-plugins "symfony/swiftmailer-bundle:^3.4"')
             ;
+        }
+
+        if (self::YES === $unstable) {
+            $task->exec('composer config minimum-stability dev');
+            $task->exec('composer config prefer-stable false');
         }
 
         $task


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

The unstable build is run on every PR, but any error is silent, so you have to check manually whether it doesn't fail with the upcoming releases of packages. I left this option mainly because we want an easy way to check whether our fix works.

Also, I run the unstable build on our full build (executed once per day), where the errors are reported, so we'll know that some of the upcoming release of packages may fail with Sylius.