### PR TITLE
[Channel] Add "order by" to the "find by" methods

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
+++ b/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
@@ -19,23 +19,25 @@ use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 
 class ChannelRepository extends EntityRepository implements ChannelRepositoryInterface
 {
+    private const ORDER_BY = ['id' => 'ASC'];
+
     public function findOneByHostname(string $hostname): ?ChannelInterface
     {
-        return $this->findOneBy(['hostname' => $hostname]);
+        return $this->findOneBy(['hostname' => $hostname], self::ORDER_BY);
     }
 
     public function findOneEnabledByHostname(string $hostname): ?ChannelInterface
     {
-        return $this->findOneBy(['hostname' => $hostname, 'enabled' => true]);
+        return $this->findOneBy(['hostname' => $hostname, 'enabled' => true], self::ORDER_BY);
     }
 
     public function findOneByCode(string $code): ?ChannelInterface
     {
-        return $this->findOneBy(['code' => $code]);
+        return $this->findOneBy(['code' => $code], self::ORDER_BY);
     }
 
     public function findByName(string $name): iterable
     {
-        return $this->findBy(['name' => $name]);
+        return $this->findBy(['name' => $name], self::ORDER_BY);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12               |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/actions/runs/4529570438/jobs/7977521181                      |
| License         | MIT                                                          |

It is not handled by the `OrderByIdentifierSqlWalker` because these queries are generated by `Doctrine\ORM\Persisters\Entity\EntityPersister`. I've added `ORDER_BY` to fix the issue. The other way to fix it is to use `createQueryBuilder` instead.