### PR TITLE
Change the ApiPlatform Mapping prepend path

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -52,7 +52,7 @@ final class SyliusApiExtension extends Extension implements PrependExtensionInte
         /** @var array<string, array<string, string>> $metadata */
         $metadata = $container->getParameter('kernel.bundles_metadata');
 
-        $path = $metadata['SyliusApiBundle']['path'] . '/Resources/config/api_resources/';
+        $path = $metadata['SyliusApiBundle']['path'] . '/Resources/config/api_resources';
 
         $container->prependExtensionConfig('api_platform', ['mapping' => ['paths' => [$path]]]);
     }

--- a/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/SyliusApiExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/DependencyInjection/SyliusApiExtensionTest.php
@@ -112,7 +112,7 @@ final class SyliusApiExtensionTest extends AbstractExtensionTestCase
         $apiPlatformConfig = $this->container->getExtensionConfig('api_platform')[0];
 
         $this->assertSame($apiPlatformConfig['mapping']['paths'], [
-            __DIR__ . '../../Resources/config/api_resources/',
+            __DIR__ . '../../Resources/config/api_resources',
         ]);
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Since ApiPlatform `2.7` it loads resources' paths on its own. However, prepending comes **after** the paths detected by ApiPlatform. We don't have to remove it to keep support for lower versions of ApiPlatform (but we can remove prepending on `1.13` as we support only `2.7` and above).

By removing the trailing `/` we resolve the issue with duplicated path, as it'll be removed when already added.

![CleanShot 2023-04-03 at 10 19 26](https://user-images.githubusercontent.com/80641364/229452593-4a690c00-2742-4c4f-8f01-fcee7b74957b.png)

After applying my patch:
![CleanShot 2023-04-03 at 10 20 41](https://user-images.githubusercontent.com/80641364/229452714-c8329ab8-4fe2-4437-b74d-8523fb962eae.png)

