### PR TITLE
[Maintenance][CI] Allow manually dispatching unstable workflow

### DIFF
--- a/.github/workflows/ci__unstable.yaml
+++ b/.github/workflows/ci__unstable.yaml
@@ -8,7 +8,12 @@ on:
                 required: false
                 type: boolean
                 default: false
-    workflow_dispatch: ~
+    workflow_dispatch:
+        inputs:
+            ignore-failure:
+                description: "Don't fail on error"
+                type: boolean
+                default: false
 
 concurrency:
     group: ci-${{ github.workflow }}-${{ github.ref }}-unstable


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | followup #14892                      |
| License         | MIT                                                          |

Trying to run the `Unstable` workflow manually resulted in:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/9448101/229496156-2694f756-b621-4716-ade7-3c1219f044a8.png">
<br>
Now we're asked whether to allow failure or not while running manually:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/9448101/229496559-426f8dc4-e6f5-4603-91c0-090e704c4e51.png">
