### PR TITLE
[Migrations] Sylius-Standard installation fix

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
@@ -26,8 +26,7 @@ final class DeleteOrderItemAction
     public function __construct(
         private MessageBusInterface $commandBus,
         private OrderItemRepositoryInterface $orderItemRepository,
-    )
-    {
+    ) {
     }
 
     public function __invoke(Request $request): Response

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/Migrations/AbstractMigration.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/Migrations/AbstractMigration.php
@@ -54,7 +54,7 @@ abstract class AbstractMigration extends BaseAbstractMigration
          *
          * @psalm-suppress InvalidClass
          */
-        if (class_exists(\Doctrine\DBAL\Platforms\MySQLPlatform::class) && is_a($platform, \Doctrine\DBAL\Platforms\MySQLPlatform::class, true)) {
+        if ($this->classExistsCaseSensitive(\Doctrine\DBAL\Platforms\MySQLPlatform::class) && is_a($platform, \Doctrine\DBAL\Platforms\MySQLPlatform::class, true)) {
             return true;
         }
 
@@ -63,10 +63,15 @@ abstract class AbstractMigration extends BaseAbstractMigration
          *
          * @psalm-suppress InvalidClass
          */
-        if (class_exists(\Doctrine\DBAL\Platforms\MySqlPlatform::class) && is_a($platform, \Doctrine\DBAL\Platforms\MySqlPlatform::class, true)) {
+        if ($this->classExistsCaseSensitive(\Doctrine\DBAL\Platforms\MySqlPlatform::class) && is_a($platform, \Doctrine\DBAL\Platforms\MySqlPlatform::class, true)) {
             return true;
         }
 
         return false;
+    }
+
+    private function classExistsCaseSensitive(string $className): bool
+    {
+        return class_exists(strtolower($className)) && (new \ReflectionClass($className))->getName() === $className;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

The `bin/console sylius:install` command ends with the following error when using the PostgreSQL database:
<img width="1660" alt="image" src="https://user-images.githubusercontent.com/40125720/231223850-5f44fb63-4fa2-4799-828b-2cd8f65774b6.png">
