### PR TITLE
[API] API Platform's default exception mappings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
         <ini name="error_reporting" value="-1" />
 
         <!-- ###+ symfony/framework-bundle ### -->
+        <env name="APP_DEBUG" value="0"/>
         <env name="APP_ENV" value="test"/>
         <env name="SHELL_VERBOSITY" value="-1" />
         <!-- ###- symfony/framework-bundle ### -->

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -35,6 +35,14 @@ api_platform:
                 name: "%sylius.api.authorization_header%"
                 type: header
     exception_to_status:
+        # Default API Platform exception to status code mapping
+        ApiPlatform\Exception\FilterValidationException: 400
+        ApiPlatform\Exception\InvalidArgumentException: 400
+        ApiPlatform\Validator\Exception\ValidationException: 422
+        Doctrine\ORM\OptimisticLockException: 409
+        Symfony\Component\Serializer\Exception\ExceptionInterface: 400
+
+        # Sylius exception to status code mapping
         SM\SMException: 422
         Sylius\Bundle\ApiBundle\Exception\CannotRemoveCurrentlyLoggedInUser: 422
         Sylius\Bundle\ApiBundle\Exception\OrderItemNotFoundException: 422

--- a/tests/Api/JsonApiGenericRequestValidationTestCase.php
+++ b/tests/Api/JsonApiGenericRequestValidationTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class JsonApiGenericRequestValidationTestCase extends JsonApiTestCase
+{
+    /** @test */
+    public function it_returns_a_bad_request_response_code_if_request_body_is_not_valid_json(): void
+    {
+        $this->client->request(
+            method: 'POST',
+            uri: '/api/v2/shop/orders',
+            server: self::CONTENT_TYPE_HEADER,
+            content: 'Malformed JSON: the provided JSON payload is not properly formatted.'
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'malformed_json_response',
+            Response::HTTP_BAD_REQUEST,
+        );
+    }
+}

--- a/tests/Api/Responses/Expected/malformed_json_response.json
+++ b/tests/Api/Responses/Expected/malformed_json_response.json
@@ -1,0 +1,6 @@
+{
+    "@context": "\/api\/v2\/contexts\/Error",
+    "@type": "hydra:Error",
+    "hydra:title": "An error occurred",
+    "hydra:description": "Syntax error"
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.12 and 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

According to this doc: https://api-platform.com/docs/core/errors/#converting-php-exceptions-to-http-errors
we were missing the API Platform's default exception mappings to status, as YAML overwrites the default config

An incorrectly sent JSON by a client ends up with a 500 HTTP status code, which in production does not inform the client of the reason.

Before (lack of JSON object):
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/40125720/231375258-232d2af5-4414-48e2-8877-63bcc153b0d1.png">
 After: 
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/40125720/231376223-ba1315d9-eb71-4e19-9904-e096c762d420.png">
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/40125720/231376330-194f7440-a5a5-423e-8eb1-a14694ebf52c.png">
