### PR TITLE
[Maintenance] Fix schema update with longer UserOAuth tokens

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20230327121633.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20230327121633.php
@@ -25,7 +25,7 @@ final class Version20230327121633 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE sylius_user_oauth CHANGE access_token access_token VARCHAR(8192) DEFAULT NULL, CHANGE refresh_token refresh_token VARCHAR(8192) DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_user_oauth CHANGE access_token access_token TEXT DEFAULT NULL, CHANGE refresh_token refresh_token TEXT DEFAULT NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/UserOAuth.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/UserOAuth.orm.xml
@@ -23,8 +23,8 @@
 
         <field name="provider" type="string" />
         <field name="identifier" type="string" />
-        <field name="accessToken" column="access_token" type="string" nullable="true" length="8192" />
-        <field name="refreshToken" column="refresh_token" type="string" nullable="true" length="8192" />
+        <field name="accessToken" column="access_token" type="text" nullable="true" length="8192" />
+        <field name="refreshToken" column="refresh_token" type="text" nullable="true" length="8192" />
 
         <many-to-one field="user" target-entity="Sylius\Component\User\Model\UserInterface" inversed-by="oauthAccounts">
             <join-column name="user_id" referenced-column-name="id" />


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | somewhat                                                     |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | - |
| License         | MIT                                                          |

The new length was working fine with migrations and caused no issues when using `schema:update` after migrations, but for whatever reason, using only `schema:update` is throwing hissy-fits:

![image](https://user-images.githubusercontent.com/9448101/231735763-e056333a-bf32-4cf3-a119-e10f31bc83a8.png)
