### PR TITLE
[DX] Do not hardcode order state in order processors

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -43,7 +43,7 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
 
     public function process(OrderInterface $order): void
     {
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -37,7 +37,7 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
@@ -30,7 +30,7 @@ final class OrderPromotionProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -43,7 +43,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -46,7 +46,7 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -33,7 +33,7 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if (OrderInterface::STATE_CART !== $order->getState()) {
+        if (!$order->canBeProcessed()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -832,4 +832,15 @@ final class OrderSpec extends ObjectBehavior
         $this->getTaxIncludedTotal()->shouldReturn(1500);
         $this->getTaxExcludedTotal()->shouldReturn(800);
     }
+
+    function it_can_be_processed(): void
+    {
+        $this->setState(OrderInterface::STATE_CART);
+
+        $this->canBeProcessed()->shouldReturn(true);
+
+        $this->setState(OrderInterface::STATE_NEW);
+
+        $this->canBeProcessed()->shouldReturn(false);
+    }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\OrderProcessing;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -27,7 +28,7 @@ final class OrderAdjustmentsClearerSpec extends ObjectBehavior
 
     function it_removes_adjustments_with_default_types_from_order_recursively(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
@@ -45,7 +46,7 @@ final class OrderAdjustmentsClearerSpec extends ObjectBehavior
             AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
         ]);
 
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
@@ -53,15 +54,11 @@ final class OrderAdjustmentsClearerSpec extends ObjectBehavior
         $this->process($order);
     }
 
-    function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(OrderInterface $order): void
+    function it_does_nothing_if_the_order_cannot_be_processed(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
-        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
-        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
-        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
-        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldNotBeCalled();
-        $order->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldNotBeCalled();
+        $order->removeAdjustmentsRecursively(Argument::any())->shouldNotBeCalled();
 
         $this->process($order);
     }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
@@ -46,7 +46,7 @@ final class OrderPricesRecalculatorSpec extends ObjectBehavior
         ProductVariantInterface $variant,
         ProductVariantPricesCalculatorInterface $productVariantPriceCalculator,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $order->getCustomer()->willReturn($customer);
         $order->getChannel()->willReturn(null);
@@ -83,9 +83,9 @@ final class OrderPricesRecalculatorSpec extends ObjectBehavior
         ;
     }
 
-    function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(OrderInterface $order): void
+    function it_does_nothing_if_the_order_cannot_be_processed(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
         $order->getChannel()->shouldNotBeCalled();
         $order->getItems()->shouldNotBeCalled();

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPromotionProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPromotionProcessorSpec.php
@@ -32,18 +32,18 @@ final class OrderPromotionProcessorSpec extends ObjectBehavior
 
     function it_processes_promotions(PromotionProcessorInterface $promotionProcessor, OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $promotionProcessor->process($order)->shouldBeCalled();
 
         $this->process($order);
     }
 
-    function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(
+    function it_does_nothing_if_the_order_cannot_be_processed(
         PromotionProcessorInterface $promotionProcessor,
         OrderInterface $order,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
         $promotionProcessor->process($order)->shouldNotBeCalled();
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -54,7 +54,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ShippingMethodInterface $defaultShippingMethod,
         OrderItemInterface $orderItem,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $defaultShippingMethodResolver->getDefaultShippingMethod($shipment)->willReturn($defaultShippingMethod);
 
@@ -88,7 +88,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ShipmentInterface $shipment,
         OrderItemInterface $orderItem,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $defaultShippingMethodResolver->getDefaultShippingMethod($shipment)->willThrow(UnresolvedDefaultShippingMethodException::class);
 
@@ -127,7 +127,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         OrderItemInterface $orderItem,
         ProductVariantInterface $productVariant,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $defaultShippingMethodResolver->getDefaultShippingMethod($shipment)->willReturn($defaultShippingMethod);
 
@@ -157,7 +157,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ProductVariantInterface $productVariant,
         ShippingMethodInterface $shippingMethod,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $shipments->first()->willReturn($shipment);
 
@@ -197,7 +197,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith($defaultShippingMethodResolver, $shipmentFactory);
 
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $shipments->first()->willReturn($shipment);
 
@@ -230,7 +230,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         OrderItemUnitInterface $itemUnitWithoutShipment,
         ShippingMethodInterface $shippingMethod,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $shipments->first()->willReturn($shipment);
 
@@ -268,7 +268,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ShippingMethodInterface $firstShippingMethod,
         ShippingMethodInterface $secondShippingMethod,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $shipments->first()->willReturn($shipment);
 
@@ -298,9 +298,9 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $this->process($order);
     }
 
-    function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(OrderInterface $order): void
+    function it_does_nothing_if_the_order_cannot_be_processed(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
         $order->isEmpty()->shouldNotBeCalled();
         $order->getItems()->shouldNotBeCalled();

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
@@ -55,7 +55,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         TaxCalculationStrategyInterface $strategyOne,
         TaxCalculationStrategyInterface $strategyTwo,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->getShipments()->willReturn(new ArrayCollection([$shipment->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
@@ -86,7 +86,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         ZoneInterface $zone,
         TaxCalculationStrategyInterface $strategy,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->getShipments()->willReturn(new ArrayCollection([]));
         $order->isEmpty()->willReturn(false);
@@ -107,7 +107,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
 
     function it_does_not_process_taxes_if_there_is_no_order_item(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
         $order->removeAdjustments(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
         $order->getItems()->willReturn(new ArrayCollection([]));
         $order->getShipments()->willReturn(new ArrayCollection([]));
@@ -126,7 +126,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         OrderItemInterface $orderItem,
         AddressInterface $address,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->getShipments()->willReturn(new ArrayCollection([]));
         $order->isEmpty()->willReturn(false);
@@ -145,12 +145,12 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         $this->process($order);
     }
 
-    function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(
+    function it_does_nothing_if_the_order_cannot_be_processed(
         ZoneProviderInterface $defaultTaxZoneProvider,
         PrioritizedServiceRegistryInterface $strategyRegistry,
         OrderInterface $order,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
         $order->getItems()->shouldNotBeCalled();
         $order->getShipments()->shouldNotBeCalled();

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -38,7 +38,7 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
 
     function it_removes_existing_shipping_adjustments(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $order->getShipments()->willReturn(new ArrayCollection([]));
 
@@ -47,7 +47,7 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
 
     function it_does_not_apply_any_shipping_charge_if_order_has_no_shipments(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $order->getShipments()->willReturn(new ArrayCollection([]));
         $order->addAdjustment(Argument::any())->shouldNotBeCalled();
@@ -63,7 +63,7 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
         ShipmentInterface $shipment,
         ShippingMethodInterface $shippingMethod,
     ): void {
-        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->canBeProcessed()->willReturn(true);
 
         $adjustmentFactory->createNew()->willReturn($adjustment);
         $order->getShipments()->willReturn(new ArrayCollection([$shipment->getWrappedObject()]));
@@ -93,7 +93,7 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
 
     function it_does_nothing_if_the_order_is_in_a_state_different_than_cart(OrderInterface $order): void
     {
-        $order->getState()->willReturn(OrderInterface::STATE_NEW);
+        $order->canBeProcessed()->willReturn(false);
 
         $order->getShipments()->shouldNotBeCalled();
         $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldNotBeCalled();

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -315,6 +315,11 @@ class Order implements OrderInterface
         $this->recalculateTotal();
     }
 
+    public function canBeProcessed(): bool
+    {
+        return $this->state === self::STATE_CART;
+    }
+
     /**
      * Items total + Adjustments total.
      */

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -84,4 +84,6 @@ interface OrderInterface extends AdjustableInterface, ResourceInterface, Timesta
     public function getAdjustmentsTotalRecursively(?string $type = null): int;
 
     public function removeAdjustmentsRecursively(?string $type = null): void;
+
+    public function canBeProcessed(): bool;
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

Hello everyone 👋

While browsing our order processors, I figure out that they lack some extendability regarding whether they should be run or not. Most of them have hardcoded check if the `$state` is `cart` - which is a good default behavior, but does not have to be right for everyone (imagine we have a `draft` order, that we still want to process, but is not placed yet). If we want to change that, we would have to override the whole processor just to adjust/remove a simple if at the beginning. 

I think such information (whether the order is processable or not) can be a part of the `Order` entity itself. It's easy to override and we avoid some additional services. We could even go further and have other methods like this for specific cases, but let's start simple.

I believe the general rule of thumb regarding the DX and extendability should be "never use any primitive value directly in the condition in any service" (constant is also a value, as it's not easily replaceable :dancer:).

Cheers 🚀 🖖  