### PR TITLE
Add calculating OrderItemsSubtotal to the Order model

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -51,3 +51,6 @@
 1. Not passing an instance of `Symfony\Component\PropertyAccess\PropertyAccessorInterface`
    to `Sylius\Bundle\CoreBundle\Validator\Constraints\HasEnabledEntityValidator`
    as the second argument is deprecated.
+
+1. Class `\Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator` has been deprecated. Order items subtotal calculation
+   is now available on the Order model `\Sylius\Component\Core\Model\Order::getItemsSubtotal`.

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
@@ -13,17 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Calculator;
 
+use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
+
+trigger_deprecation(
+    'sylius/sylius',
+    '1.13',
+    sprintf(
+        'Class "%s" is deprecated and will be removed in Sylius 2.0. Items subtotal calculations is now available by using %s::getSubtotalItems method.',
+        OrderItemsSubtotalCalculator::class,
+        Order::class,
+    ),
+);
 
 final class OrderItemsSubtotalCalculator implements OrderItemsSubtotalCalculatorInterface
 {
     public function getSubtotal(OrderInterface $order): int
     {
-        return array_reduce(
-            $order->getItems()->toArray(),
-            static fn (int $subtotal, OrderItemInterface $item): int => $subtotal + $item->getSubtotal(),
-            0,
-        );
+        return $order->getItemsSubtotal();
     }
 }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -335,6 +335,20 @@ class Order extends BaseOrder implements OrderInterface
         return $this->getTotalQuantity();
     }
 
+    public function getItemsSubtotal(): int
+    {
+        /** @var array<OrderItemInterface> $items */
+        $items = $this->getItems()->toArray();
+
+        return array_reduce(
+            $items,
+            static function (int $subtotal, OrderItemInterface $item): int {
+                return $subtotal + $item->getSubtotal();
+            },
+            0
+        );
+    }
+
     public function getCurrencyCode(): ?string
     {
         return $this->currencyCode;

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -110,6 +110,8 @@ interface OrderInterface extends
 
     public function getOrderPromotionTotal(): int;
 
+    public function getItemsSubtotal(): int;
+
     public function getTokenValue(): ?string;
 
     public function setTokenValue(?string $tokenValue): void;

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -415,6 +415,22 @@ final class OrderSpec extends ObjectBehavior
         $this->getPromotionSubjectCount()->shouldReturn(7);
     }
 
+    function it_counts_items_subtotal(OrderItemInterface $item1, OrderItemInterface $item2): void
+    {
+        $item1->getSubtotal()->willReturn(420);
+        $item1->getTotal()->willReturn(420);
+        $item1->setOrder($this)->will(function () {});
+
+        $item2->getSubtotal()->willReturn(666);
+        $item2->getTotal()->willReturn(666);
+        $item2->setOrder($this)->will(function () {});
+
+        $this->addItem($item1);
+        $this->addItem($item2);
+
+        $this->getItemsSubtotal()->shouldReturn(1086);
+    }
+
     function it_adds_and_removes_promotions(PromotionInterface $promotion): void
     {
         $this->addPromotion($promotion);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | 
| License         | MIT

The logic in `\Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator` is simple and can be moved to the model.