### PR TITLE
Revert "Add conflict for doctrine/orm:2.14.2"

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -50,8 +50,3 @@ references related issues.
 
   This version is missing the service alias `validator.expression`
   which causes ValidatorException exception to be thrown when using `Expression` constraint. 
-
-- `doctrine/orm:2.14.2`:
-
-  This version introduces not configurable XML validation causing errors when using XML mapping files and gedmo extensions. 
-- Reference: https://github.com/doctrine/DoctrineBundle/issues/1643

--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,6 @@
         "api-platform/core": "2.7.0",
         "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/migrations": "3.5.3",
-        "doctrine/orm": "2.14.2",
         "jms/serializer-bundle": "4.1.0",
         "lexik/jwt-authentication-bundle": "^2.18",
         "symfony/framework-bundle": "5.4.5 || 6.2.8",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

This reverts commit de58169f5803bb72ff27dc82f08b8434c000e3b5.

