### PR TITLE
[Behat][API] Add "no-api" tag to the changing payment method page scenario

### DIFF
--- a/features/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
+++ b/features/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
@@ -11,7 +11,7 @@ Feature: Having good number of items in changing payment method page
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
 
-    @ui
+    @ui @no-api
     Scenario: Seeing correct quantity on payment retry page
         Given I have added 2 products "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13           |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

I mark this scenario as a `no-api` because in the API, "thank you" page with payment methods doesn't exist. There is a `GET
/api/v2/shop/payment-methods` endpoint but it's independent of the order.