### PR TITLE
Ignore push event on upmerge

### DIFF
--- a/.github/workflows/ci__minimal.yaml
+++ b/.github/workflows/ci__minimal.yaml
@@ -7,7 +7,9 @@ on:
             - "docs/**"
             - "*.md"
     workflow_dispatch: ~
-    push: ~
+    push:
+        branches-ignore:
+            - 'upmerge/**'
     
 concurrency:
     group: ci-${{ github.workflow }}-${{ github.ref }}-minimal


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

It'll prevent running minimal CI twice.