### PR TITLE
Fix the press enter cause attribute deletion

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -27,7 +27,12 @@ const controlAttributesList = function controlAttributesList() {
 };
 
 const modifyAttributesListOnSelectorElementDelete = function modifyAttributesListOnSelectorElementDelete(removedValue) {
-  $(`#attributesContainer .attributes-group[data-attribute-code="${removedValue}"]`).remove();
+  // Once the enter key pressed on any field in the product page cause an attribute deletion.
+  // When this bug occurs, the value of pageX is equal to 0. So if pageX is not equal to 0, it means the user clicked
+  // on the delete button, so the remove method should be called.
+  if (event.pageX != 0) {
+    $(`#attributesContainer .attributes-group[data-attribute-code="${removedValue}"]`).remove();
+  }
 };
 
 const modifySelectorOnAttributesListElementDelete = function modifySelectorOnAttributesListElementDelete() {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | Replacement of #12150 , #12308, fixes #11879 #11712                     |
| License         | MIT                                                          |

Bug present since 2018, report in 2020/2021/2022 
Still no correction, hope this PR will work...

Don't ask to do a regression test, done in April 2021, search when the function is created in the js file, it's been done on 15 Jun 2018 and no update since ( https://github.com/Sylius/Sylius/commit/72bda8f3cb74caaf1c25be7868f5e29c54a96972 )

the event.originalEvent.pageX != 0 seems to be another solution, as I detailled here : https://github.com/Sylius/Sylius/issues/11712
ClientX/ClientY PageX/PageY ScreenX/ScreenY are at 0 for the Enter pressed but with number when Button clicked
and if I check https://caniuse.com/?search=pageX it's seems to be used on many browser

@vvasiloi @lchrusciel @Zales0123

**Please** validate this PR to correct for once this bug present since 5 years (and nobody want to correct it ??!!)
Sorry to tag you all, but can you verify this PR
@AdamKasp @Arminek @CoderMaggie @czechmarcin @GSadee @jacquesbh @kulczy @mamazu @pamil @pjedrzejewski @Tomanhez 