### PR TITLE
Lower the sylius.context.locale tag priority on RequestHeaderBasedLocalContext

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,9 @@
+# UPGRADE FROM `v1.12.X` TO `v1.12.8`
+
+1. The priority of the `sylius.context.locale` tag on the `Sylius\Bundle\LocaleBundle\Context\RequestHeaderBasedLocaleContext` service has been changed from `256` to `32`.
+    It means that this service has no longer the highest priority, and passing `Accept-Language` header on the UI won't override the locale set in the URL. If your app
+    depends on this behavior, you need to change the priority of the `sylius.context.locale` tag on the `Sylius\Bundle\LocaleBundle\Context\RequestHeaderBasedLocaleContext` directly in your app.
+
 # UPGRADE FROM `v1.12.X` TO `v1.12.5`
 
 1. For routes `sylius_admin_order_shipment_ship` and `sylius_admin_order_resend_confirmation_email` the missing "/orders"

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -42,7 +42,7 @@
         <service id="Sylius\Bundle\LocaleBundle\Context\RequestHeaderBasedLocaleContext">
             <argument type="service" id="request_stack" />
             <argument type="service" id="sylius.locale_provider" />
-            <tag name="sylius.context.locale" priority="256" />
+            <tag name="sylius.context.locale" priority="32" />
         </service>
 
         <service id="sylius.locale_provider" class="Sylius\Component\Locale\Provider\LocaleProvider">

--- a/tests/Functional/Bundles/LocaleBundle/Context/LocaleResolvingTest.php
+++ b/tests/Functional/Bundles/LocaleBundle/Context/LocaleResolvingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Functional\Bundles\LocaleBundle\Context;
+
+use Fidry\AliceDataFixtures\LoaderInterface;
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class LocaleResolvingTest extends KernelTestCase
+{
+    /** @test */
+    public function it_ignores_accept_language_header_when_locale_is_present_in_url(): void
+    {
+        $this->loadFixtures([
+            dirname(__DIR__, 3) . '/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml',
+        ]);
+
+        $request = Request::create(
+            uri: '/en_US/',
+            server: [
+                'HTTP_ACCEPT_LANGUAGE' => 'pl_PL',
+            ]
+        );
+
+        $this->bootKernel();
+        $kernel = $this->createKernel();
+
+        $response = $kernel->handle($request);
+        /** @var string $content */
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('Your cart is empty.', $content);
+    }
+
+    /** @test */
+    public function it_sets_locale_based_on_accept_language_header_when_no_locale_in_url_provided(): void
+    {
+        $this->loadFixtures([
+            dirname(__DIR__, 3) . '/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml',
+        ]);
+
+        $request = Request::create(
+            uri: '/admin/login',
+            server: [
+                'HTTP_ACCEPT_LANGUAGE' => 'pl_PL',
+            ]
+        );
+
+        $this->bootKernel();
+        $kernel = $this->createKernel();
+
+        $response = $kernel->handle($request);
+        /** @var string $content */
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('Nazwa użytkownika', $content);
+    }
+
+    /** @test */
+    public function it_redirects_to_default_locale_when_not_defined_in_the_request_nor_header(): void
+    {
+        $this->loadFixtures([
+            dirname(__DIR__, 3) . '/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml',
+        ]);
+
+        $request = Request::create(
+            uri: '/',
+        );
+
+        $this->bootKernel();
+        $kernel = $this->createKernel();
+
+        $response = $kernel->handle($request);
+        /** @var string $content */
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('Redirecting to /en_US/', $content);
+    }
+
+    private function loadFixtures(array $fixtureFiles): void
+    {
+        /** @var LoaderInterface $fixtureLoader */
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+
+        $fixtureLoader->load($fixtureFiles, [], [], PurgeMode::createDeleteMode());
+    }
+}

--- a/tests/Functional/CartCollectorTest.php
+++ b/tests/Functional/CartCollectorTest.php
@@ -15,20 +15,22 @@ namespace Sylius\Tests\Functional;
 
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use Sylius\Bundle\CoreBundle\Collector\CartCollector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Storage\CartStorageInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Sylius\Bundle\CoreBundle\Collector\CartCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Sylius\Component\Core\Storage\CartStorageInterface;
 
 final class CartCollectorTest extends KernelTestCase
 {
     /** @test */
     public function it_has_no_cart_when_no_channel_is_present(): void
     {
+        $this->loadFixtures([]);
+
         $collector = self::getContainer()->get(CartCollector::class);
         $collector->collect(new Request(), new Response());
 

--- a/tests/Functional/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml
+++ b/tests/Functional/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml
@@ -1,0 +1,36 @@
+Sylius\Component\Core\Model\Channel:
+    channel_web:
+        code: "WEB"
+        name: "Web Channel"
+        hostname: "localhost"
+        description: "Lorem ipsum"
+        baseCurrency: "@currency1"
+        defaultLocale: "@locale_en_US"
+        locales: ["@locale_en_US", "@locale_pl_PL"]
+        color: "black"
+        enabled: true
+        taxCalculationStrategy: "order_items_based"
+        
+    channel_mob:
+        code: "MOB"
+        name: "Mobile Channel"
+        hostname: "localhost"
+        description: "Lorem ipsum"
+        baseCurrency: "@currency1"
+        defaultLocale: "@locale_en_US"
+        locales: [ "@locale_en_US", "@locale_pl_PL" ]
+        color: "black"
+        enabled: true
+        taxCalculationStrategy: "order_items_based"
+
+Sylius\Component\Currency\Model\Currency:
+    currency1:
+        code: "EUR"
+    currency2:
+        code: "USD"
+
+Sylius\Component\Locale\Model\Locale:
+    locale_en_US:
+        code: "en_US"
+    locale_pl_PL:
+        code: "pl_PL"

--- a/tests/Functional/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml
+++ b/tests/Functional/fixtures/Bundles/LocaleBundle/Context/LocaleResolving/fixtures.yaml
@@ -4,30 +4,16 @@ Sylius\Component\Core\Model\Channel:
         name: "Web Channel"
         hostname: "localhost"
         description: "Lorem ipsum"
-        baseCurrency: "@currency1"
+        baseCurrency: "@currency_euro"
         defaultLocale: "@locale_en_US"
         locales: ["@locale_en_US", "@locale_pl_PL"]
         color: "black"
         enabled: true
         taxCalculationStrategy: "order_items_based"
-        
-    channel_mob:
-        code: "MOB"
-        name: "Mobile Channel"
-        hostname: "localhost"
-        description: "Lorem ipsum"
-        baseCurrency: "@currency1"
-        defaultLocale: "@locale_en_US"
-        locales: [ "@locale_en_US", "@locale_pl_PL" ]
-        color: "black"
-        enabled: true
-        taxCalculationStrategy: "order_items_based"
 
 Sylius\Component\Currency\Model\Currency:
-    currency1:
+    currency_euro:
         code: "EUR"
-    currency2:
-        code: "USD"
 
 Sylius\Component\Locale\Model\Locale:
     locale_en_US:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #14868
| License         | MIT

Once the `RequestHeaderBasedLocalContext` service introduced, it took a priority over the `RequestBasedLocaleContext` service.

AFAIR the main purpose of the `RequestHeaderBasedLocalContext` service was aimed to allow a language switching for the API, but it affected the UI part too. I decided to lower the priority, so URL is considered as a first.

Any tests will be delivered once I decide how to test it 🥶.