### PR TITLE
[Admin] Fix inability of sorting promotion coupons and catalog promotions

### DIFF
--- a/features/promotion/managing_catalog_promotions/sorting_catalog_promotions.feature
+++ b/features/promotion/managing_catalog_promotions/sorting_catalog_promotions.feature
@@ -43,28 +43,28 @@ Feature: Sorting listed catalog promotion
         Then I should see 3 catalog promotions on the list
         And the first catalog promotion should have code "c"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting catalog promotion by start date in ascending order
         When I browse catalog promotions
         And I sort catalog promotions by ascending "start date"
         Then I should see 3 catalog promotions on the list
         And the first catalog promotion should have code "not-b"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting catalog promotion by start date in descending order
         When I browse catalog promotions
         And I sort catalog promotions by descending "start date"
         Then I should see 3 catalog promotions on the list
         And the first catalog promotion should have code "a"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting catalog promotion by end date in ascending order
         When I browse catalog promotions
         And I sort catalog promotions by ascending "end date"
         Then I should see 3 catalog promotions on the list
         And the first catalog promotion should have code "a"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting catalog promotion by end date in descending order
         When I browse catalog promotions
         And I sort catalog promotions by descending "end date"

--- a/features/promotion/managing_catalog_promotions/sorting_catalog_promotions.feature
+++ b/features/promotion/managing_catalog_promotions/sorting_catalog_promotions.feature
@@ -1,0 +1,86 @@
+@managing_catalog_promotions
+Feature: Sorting listed catalog promotion
+    In order to change the order by which catalog promotions are displayed
+    As an Administrator
+    I want to sort catalog promotions
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And there is a catalog promotion with "a" code and "A" name
+        And the catalog promotion "A" starts at "10-01-2023"
+        And this catalog promotion is disabled
+        And there is a catalog promotion with "not-b" code and "B" name
+        And the catalog promotion "B" ended "10-02-2023"
+        And there is a catalog promotion with "c" code and "C" name
+        And the catalog promotion "C" operates between "01-01-2023" and "01-03-2023"
+        And its priority is 2
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Catalog promotions are sorted by ascending code by default
+        When I browse catalog promotions
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "a"
+
+    @ui
+    Scenario: Changing the code sorting order to descending
+        When I browse catalog promotions
+        And I sort catalog promotions by descending code
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "not-b"
+
+    @ui
+    Scenario: Sorting catalog promotions by name in ascending order
+        When I browse catalog promotions
+        And I sort catalog promotions by ascending name
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "a"
+
+    @ui
+    Scenario: Sorting catalog promotion by name in descending order
+        When I browse catalog promotions
+        And I sort catalog promotions by descending name
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "c"
+
+    @ui
+    Scenario: Sorting catalog promotion by start date in ascending order
+        When I browse catalog promotions
+        And I sort catalog promotions by ascending "start date"
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "not-b"
+
+    @ui
+    Scenario: Sorting catalog promotion by start date in descending order
+        When I browse catalog promotions
+        And I sort catalog promotions by descending "start date"
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "a"
+
+    @ui
+    Scenario: Sorting catalog promotion by end date in ascending order
+        When I browse catalog promotions
+        And I sort catalog promotions by ascending "end date"
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "a"
+
+    @ui
+    Scenario: Sorting catalog promotion by end date in descending order
+        When I browse catalog promotions
+        And I sort catalog promotions by descending "end date"
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "c"
+
+    @ui
+    Scenario: Sorting catalog promotion by priority in ascending order
+        When I browse catalog promotions
+        And I sort catalog promotions by ascending priority
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "not-b"
+
+    @ui
+    Scenario: Sorting catalog promotion by priority in descending order
+        When I browse catalog promotions
+        And I sort catalog promotions by descending priority
+        Then I should see 3 catalog promotions on the list
+        And the first catalog promotion should have code "c"

--- a/features/promotion/managing_coupons/sorting_coupons.feature
+++ b/features/promotion/managing_coupons/sorting_coupons.feature
@@ -1,0 +1,89 @@
+@managing_promotion_coupons
+Feature: Sorting listed coupons
+    In order to change the order by which coupons are displayed
+    As an Administrator
+    I want to sort promotion coupons
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And there is a promotion "Special Sale"
+        And this promotion has coupon "X"
+        And this coupon can be used 3 times per customer with overall usage limit of 42
+        And this coupon expires on "12-01-2023"
+        And this promotion has coupon "Y"
+        And this coupon can be used 5 times
+        And this coupon has been used 3 times
+        And this promotion has coupon "Z"
+        And this coupon can be used 1 time per customer
+        And this coupon has been used 1 time
+        And this coupon expires on "20-02-2023"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Coupons are sorted by descending number of uses by default
+        When I want to view all coupons of this promotion
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Y"
+
+    @ui
+    Scenario: Changing the number of uses sorting order to ascending
+        Given I am browsing coupons of this promotion
+        When I sort coupons by ascending number of uses
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "X"
+
+    @ui
+    Scenario: Sorting coupons by code in descending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by descending code
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Z"
+
+    @ui
+    Scenario: Sorting coupons by code in ascending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by ascending code
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "X"
+
+    @ui
+    Scenario: Sorting coupons by usage limit in descending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by descending usage limit
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "X"
+
+    @ui
+    Scenario: Sorting coupons by usage limit in ascending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by ascending usage limit
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Z"
+
+    @ui
+    Scenario: Sorting coupons by usage limit per customer in descending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by descending usage limit per customer
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "X"
+
+    @ui
+    Scenario: Sorting coupons by usage limit per customer in ascending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by ascending usage limit per customer
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Y"
+
+    @ui
+    Scenario: Sorting coupons by expiration date in descending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by descending expiration date
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Z"
+
+    @ui
+    Scenario: Sorting coupons by expiration date in ascending order
+        Given I am browsing coupons of this promotion
+        When I sort coupons by ascending expiration date
+        Then I should see 3 coupons on the list
+        And the first coupon should have code "Y"

--- a/features/promotion/managing_coupons/sorting_coupons.feature
+++ b/features/promotion/managing_coupons/sorting_coupons.feature
@@ -46,42 +46,42 @@ Feature: Sorting listed coupons
         Then I should see 3 coupons on the list
         And the first coupon should have code "X"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by usage limit in descending order
         Given I am browsing coupons of this promotion
         When I sort coupons by descending usage limit
         Then I should see 3 coupons on the list
         And the first coupon should have code "X"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by usage limit in ascending order
         Given I am browsing coupons of this promotion
         When I sort coupons by ascending usage limit
         Then I should see 3 coupons on the list
         And the first coupon should have code "Z"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by usage limit per customer in descending order
         Given I am browsing coupons of this promotion
         When I sort coupons by descending usage limit per customer
         Then I should see 3 coupons on the list
         And the first coupon should have code "X"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by usage limit per customer in ascending order
         Given I am browsing coupons of this promotion
         When I sort coupons by ascending usage limit per customer
         Then I should see 3 coupons on the list
         And the first coupon should have code "Y"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by expiration date in descending order
         Given I am browsing coupons of this promotion
         When I sort coupons by descending expiration date
         Then I should see 3 coupons on the list
         And the first coupon should have code "Z"
 
-    @ui
+    @ui @no-postgres
     Scenario: Sorting coupons by expiration date in ascending order
         Given I am browsing coupons of this promotion
         When I sort coupons by ascending expiration date

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -327,6 +327,61 @@ final class PromotionContext implements Context
     }
 
     /**
+     * @Given /^(this promotion) has coupon "([^"]+)"$/
+     */
+    public function thisPromotionHasCoupon(PromotionInterface $promotion, string $couponCode): void
+    {
+        $coupon = $this->createCoupon($couponCode);
+        $promotion->addCoupon($coupon);
+
+        $this->sharedStorage->set('coupon', $coupon);
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @Given /^(this coupon) can be used (\d+) times? per customer$/
+     * @Given /^(this coupon) has no per customer usage limit$/
+     */
+    public function thisCouponCanBeUsedTimesPerCustomer(PromotionCouponInterface $coupon, ?int $usageLimit = null): void
+    {
+        $coupon->setPerCustomerUsageLimit($usageLimit);
+
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @Given /^(this coupon) can be used (\d+) times per customer with overall usage limit of (\d+)$/
+     */
+    public function thisCouponCanBeUsedTimesPerCustomerWithOverallUsageLimitOf(
+        PromotionCouponInterface $coupon,
+        int $perCustomerUsageLimit,
+        int $overallUsageLimit,
+    ): void {
+        $this->thisCouponCanBeUsedTimesPerCustomer($coupon, $perCustomerUsageLimit);
+        $this->thisCouponCanBeUsedNTimes($coupon, $overallUsageLimit);
+    }
+
+    /**
+     * @Given /^(this coupon) has been used (\d+) times?$/
+     */
+    public function thisCouponHasBeenUsedTimes(PromotionCouponInterface $coupon, int $used): void
+    {
+        $coupon->setUsed($used);
+
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @Given /^(this coupon) expires (on "[^"]+")$/
+     */
+    public function thisCouponExpiresOn(PromotionCouponInterface $coupon, \DateTimeInterface $date): void
+    {
+        $coupon->setExpiresAt($date);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order$/
      */
     public function itGivesFixedDiscountToEveryOrder(PromotionInterface $promotion, int $discount): void

--- a/src/Sylius/Behat/Context/Transform/DateTimeContext.php
+++ b/src/Sylius/Behat/Context/Transform/DateTimeContext.php
@@ -21,6 +21,7 @@ final class DateTimeContext implements Context
      * @Transform :date
      * @Transform :startsDate
      * @Transform :endsDate
+     * @Transform /^on "([^"]+)"$/
      */
     public function getDate($date)
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -686,6 +686,17 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I sort catalog promotions by :order :field
+     */
+    public function iSortCatalogPromotionByOrderField(string $order, string $field): void
+    {
+        $this->indexPage->sortBy(
+            lcfirst(str_replace(' ', '', ucwords($field))),
+            $order === 'descending' ? 'desc' : 'asc',
+        );
+    }
+
+    /**
      * @Then I should be notified that a discount amount should be between 0% and 100%
      */
     public function iShouldBeNotifiedThatADiscountAmountShouldBeBetween0And100Percent(): void
@@ -720,7 +731,15 @@ final class ManagingCatalogPromotionsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::same($this->indexPage->countItems(), $amount);
+        $this->iShouldSeeCountCatalogPromotionsOnTheList($amount);
+    }
+
+    /**
+     * @Then I should see :count catalog promotions on the list
+     */
+    public function iShouldSeeCountCatalogPromotionsOnTheList(int $count): void
+    {
+        Assert::same($this->indexPage->countItems(), $count);
     }
 
     /**
@@ -1201,6 +1220,14 @@ final class ManagingCatalogPromotionsContext implements Context
             $this->indexPage->isSingleResourceOnPage(['name' => $name]),
             sprintf('Catalog promotion with name "%s" has been found, but should not.', $name),
         );
+    }
+
+    /**
+     * @Then the first catalog promotion should have code :code
+     */
+    public function theFirstCatalogPromotionShouldHaveCode(string $code): void
+    {
+        Assert::same($this->indexPage->getColumnFields('code')[0], $code);
     }
 
     private function createCatalogPromotion(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -38,6 +38,7 @@ final class ManagingPromotionCouponsContext implements Context
     }
 
     /**
+     * @Given /^I am browsing coupons of (this promotion)$/
      * @Given /^I browse coupons of (this promotion)$/
      * @When /^I want to view all coupons of (this promotion)$/
      * @When /^I browse all coupons of ("[^"]+" promotion)$/
@@ -231,6 +232,46 @@ final class ManagingPromotionCouponsContext implements Context
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
+    }
+
+    /**
+     * @When /^I sort coupons by (ascending|descending) number of uses$/
+     */
+    public function iSortCouponsByNumberOfUses(string $order): void
+    {
+        $this->sortBy($order, 'used');
+    }
+
+    /**
+     * @When /^I sort coupons by (ascending|descending) code$/
+     */
+    public function iSortCouponsByCode(string $order): void
+    {
+        $this->sortBy($order, 'code');
+    }
+
+    /**
+     * @When /^I sort coupons by (ascending|descending) usage limit$/
+     */
+    public function iSortCouponsByUsageLimit(string $order): void
+    {
+        $this->sortBy($order, 'usageLimit');
+    }
+
+    /**
+     * @When /^I sort coupons by (ascending|descending) usage limit per customer$/
+     */
+    public function iSortCouponsByPerCustomerUsageLimit(string $order): void
+    {
+        $this->sortBy($order, 'perCustomerUsageLimit');
+    }
+
+    /**
+     * @When /^I sort coupons by (ascending|descending) expiration date$/
+     */
+    public function iSortCouponsByExpirationDate(string $order): void
+    {
+        $this->sortBy($order, 'expiresAt');
     }
 
     /**
@@ -452,5 +493,26 @@ final class ManagingPromotionCouponsContext implements Context
     public function iShouldSeeTheCouponInTheList(string $couponCode): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $couponCode]));
+    }
+
+    /**
+     * @Then I should see :count coupons on the list
+     */
+    public function iShouldSeeCountCouponsOnTheList(int $count): void
+    {
+        Assert::same($this->indexPage->countItems(), $count);
+    }
+
+    /**
+     * @Then the first coupon should have code :code
+     */
+    public function theFirstCouponShouldHaveCode(string $code): void
+    {
+        Assert::same($this->indexPage->getColumnFields('code')[0], $code);
+    }
+
+    private function sortBy(string $order, string $field): void
+    {
+        $this->indexPage->sortBy($field, str_starts_with($order, 'de') ? 'desc' : 'asc');
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
@@ -24,7 +24,7 @@ interface IndexPageInterface extends SymfonyPageInterface
 
     public function getColumnFields(string $columnName): array;
 
-    public function sortBy(string $fieldName): void;
+    public function sortBy(string $fieldName, ?string $order = null): void;
 
     public function deleteResourceOnPage(array $parameters): void;
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/catalog_promotion.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/catalog_promotion.yaml
@@ -8,6 +8,8 @@ sylius_grid:
                 name: doctrine/orm
                 options:
                     class: "%sylius.model.catalog_promotion.class%"
+            sorting:
+                code: asc
             fields:
                 code:
                     type: string

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion_coupon.yml
@@ -9,6 +9,8 @@ sylius_grid:
                         method: createQueryBuilderByPromotionId
                         arguments:
                             promotionId: $promotionId
+            sorting:
+                used: desc
             fields:
                 code:
                     type: string


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no?                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14131 |
| License         | MIT                                                          |

Inb4 someone asks why there's no API coverage or `no-api` tags:
- sorting is possible via API so `no-api` does not apply
- coupons have no crud in API ATM
- catalog promotions have no sorting specified in API

The 2 last points would be doable in this PR, but then it would have to go to 1.13 since new features would be introduced, and I see no point in blocking the bugfix part alone for 1.12.