### PR TITLE
Remove 1.11 from the refactor workflow

### DIFF
--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                branch: ["1.11", "1.12", "1.13"]
+                branch: ["1.12", "1.13"]
 
         steps:
             -


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

`1.11` is not actively maintained anymore, so there's no reason to keep it in the refactor workflow.
