### PR TITLE
Add php-http/message-factory as a dev dependency to fix tests

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -44,7 +44,8 @@
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^8.5",
         "symfony/dependency-injection": "^5.4 || ^6.0",
-        "symfony/dotenv": "^5.4 || ^6.0"
+        "symfony/dotenv": "^5.4 || ^6.0",
+        "php-http/message-factory": "^1.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

In `php-http/message:1.16.0` the package `php-http/message-factory` has been removed from the list of dependencies. We use it to check backward compatibility, so I added it as a dev deps to AdminBundle, what will fix our CI.