### PR TITLE
Performance improvement of SingleChannelContext

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
+++ b/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
@@ -55,4 +55,9 @@ class ChannelRepository extends EntityRepository implements ChannelRepositoryInt
             ->getResult(AbstractQuery::HYDRATE_ARRAY)
         ;
     }
+
+    public function countAll(): int
+    {
+        return $this->count([]);
+    }
 }

--- a/src/Sylius/Component/Channel/Context/SingleChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/SingleChannelContext.php
@@ -25,13 +25,14 @@ final class SingleChannelContext implements ChannelContextInterface
 
     public function getChannel(): ChannelInterface
     {
-        $channels = $this->channelRepository->findAll();
+        $channelsCount = $this->channelRepository->countAll();
 
-        if (1 !== count($channels)) {
+        if (1 !== $channelsCount) {
             throw new ChannelNotFoundException();
         }
-        $channel = reset($channels);
-        Assert::isInstanceOf($channel, ChannelInterface::class);
+
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneBy([]);
 
         return $channel;
     }

--- a/src/Sylius/Component/Channel/Repository/ChannelRepositoryInterface.php
+++ b/src/Sylius/Component/Channel/Repository/ChannelRepositoryInterface.php
@@ -34,4 +34,6 @@ interface ChannelRepositoryInterface extends RepositoryInterface
     public function findByName(string $name): iterable;
 
     public function findAllWithBasicData(): iterable;
+
+    public function countAll(): int;
 }

--- a/src/Sylius/Component/Channel/spec/Context/SingleChannelContextSpec.php
+++ b/src/Sylius/Component/Channel/spec/Context/SingleChannelContextSpec.php
@@ -35,7 +35,8 @@ final class SingleChannelContextSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         ChannelInterface $channel,
     ): void {
-        $channelRepository->findAll()->willReturn([$channel]);
+        $channelRepository->countAll()->willReturn(1);
+        $channelRepository->findOneBy([])->willReturn($channel);
 
         $this->getChannel()->shouldReturn($channel);
     }
@@ -43,17 +44,17 @@ final class SingleChannelContextSpec extends ObjectBehavior
     function it_throws_a_channel_not_found_exception_if_there_are_no_channels_defined(
         ChannelRepositoryInterface $channelRepository,
     ): void {
-        $channelRepository->findAll()->willReturn([]);
+        $channelRepository->countAll()->willReturn(0);
+        $channelRepository->findOneBy([])->shouldNotBeCalled();
 
         $this->shouldThrow(ChannelNotFoundException::class)->during('getChannel');
     }
 
     function it_throws_a_channel_not_found_exception_if_there_are_many_channels_defined(
         ChannelRepositoryInterface $channelRepository,
-        ChannelInterface $firstChannel,
-        ChannelInterface $secondChannel,
     ): void {
-        $channelRepository->findAll()->willReturn([$firstChannel, $secondChannel]);
+        $channelRepository->countAll()->willReturn(2);
+        $channelRepository->findOneBy([])->shouldNotBeCalled();
 
         $this->shouldThrow(ChannelNotFoundException::class)->during('getChannel');
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |                       |
| License         | MIT                                                          |

There is no need to fetch all channels only to check there is only one channel.