### PR TITLE
[Promotion] Ignore coupon based promotions when when processing an order with no coupon 

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PromotionRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PromotionRepository.php
@@ -47,4 +47,22 @@ class PromotionRepository extends BasePromotionRepository implements PromotionRe
 
         return $promotions;
     }
+
+    public function findActiveNonCouponBasedByChannel(ChannelInterface $channel): array
+    {
+        $promotions = $this->filterByActive($this->createQueryBuilder('o'))
+            ->andWhere(':channel MEMBER OF o.channels')
+            ->andWhere('o.couponBased = false')
+            ->setParameter('channel', $channel)
+            ->addOrderBy('o.priority', 'DESC')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $this->associationHydrator->hydrateAssociations($promotions, [
+            'rules',
+        ]);
+
+        return $promotions;
+    }
 }

--- a/src/Sylius/Component/Core/Provider/ActivePromotionsByChannelProvider.php
+++ b/src/Sylius/Component/Core/Provider/ActivePromotionsByChannelProvider.php
@@ -36,6 +36,10 @@ final class ActivePromotionsByChannelProvider implements PreQualifiedPromotionsP
             throw new \InvalidArgumentException('Order has no channel, but it should.');
         }
 
+        if (null === $subject->getPromotionCoupon()) {
+            return $this->promotionRepository->findActiveNonCouponBasedByChannel($channel);
+        }
+
         return $this->promotionRepository->findActiveByChannel($channel);
     }
 }

--- a/src/Sylius/Component/Core/Repository/PromotionRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/PromotionRepositoryInterface.php
@@ -23,4 +23,9 @@ interface PromotionRepositoryInterface extends BasePromotionRepositoryInterface
      * @return array|PromotionInterface[]
      */
     public function findActiveByChannel(ChannelInterface $channel): array;
+
+    /**
+     * @return array|PromotionInterface[]
+     */
+    public function findActiveNonCouponBasedByChannel(ChannelInterface $channel): array;
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | somewhat                                                     |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #14983 |
| License         | MIT                                                          |