### PR TITLE
[FIX][Core][Checkout] Adding the isEnabled filter to the countries list in checkout while addressing.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/AddressTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/AddressTypeExtension.php
@@ -34,7 +34,7 @@ final class AddressTypeExtension extends AbstractTypeExtension
         /** @var ChannelInterface|null $channel */
         $channel = $options['channel'];
 
-        if ($channel === null || $channel->getCountries()->count() === 0) {
+        if ($channel === null || $channel->getEnabledCountries()->count() === 0) {
             return;
         }
 
@@ -43,7 +43,7 @@ final class AddressTypeExtension extends AbstractTypeExtension
         $countryCodeField = $builder->create(
             $oldCountryCodeField->getName(),
             $oldCountryCodeField->getType()->getInnerType()::class,
-            array_replace($oldCountryCodeField->getOptions(), ['choices' => $channel->getCountries()->toArray()]),
+            array_replace($oldCountryCodeField->getOptions(), ['choices' => $channel->getEnabledCountries()->toArray()]),
         );
 
         $builder->add($countryCodeField);

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -296,4 +296,9 @@ class Channel extends BaseChannel implements ChannelInterface
     {
         $this->channelPriceHistoryConfig = $channelPriceHistoryConfig;
     }
+
+    public function getEnabledCountries(): Collection
+    {
+        return $this->getCountries()->filter(fn (CountryInterface $country): bool => true === $country->isEnabled());
+    }
 }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -94,4 +94,11 @@ interface ChannelInterface extends
     public function setChannelPriceHistoryConfig(ChannelPriceHistoryConfigInterface $channelPriceHistoryConfig): void;
 
     public function getChannelPriceHistoryConfig(): ?ChannelPriceHistoryConfigInterface;
+
+    /**
+     * @return Collection|CountryInterface[]
+     *
+     * @return Collection<array-key, CountryInterface>
+     */
+    public function getEnabledCountries(): Collection;
 }

--- a/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Core\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\Channel as BaseChannel;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -194,5 +196,18 @@ final class ChannelSpec extends ObjectBehavior
     {
         $this->setChannelPriceHistoryConfig($config);
         $this->getChannelPriceHistoryConfig()->shouldReturn($config);
+    }
+
+    function it_returns_enabled_countries(CountryInterface $country1, CountryInterface $country2): void
+    {
+        $country1->isEnabled()->willReturn(true);
+        $country2->isEnabled()->willReturn(false);
+
+        $countries = new ArrayCollection([$country1, $country2]);
+
+        $this->addCountry($country1);
+        $this->addCountry($country2);
+
+        $this->getEnabledCountries()->shouldHaveCount(1);
     }
 }


### PR DESCRIPTION
This change restricts the list of available countries in the checkout->addressing step to those which are enabled. 
Currently, when completing the address in checkout, all countries that are assigned to a channel are displayed, regardless of whether the country is enabled (country.enabled). 

| Q                         | A                                    |
|-----------------|-----------------------|
| Branch?              | 2.0 & 1.14                   |
| Bug fix?              | yes                                |
| New feature?     | no                                  |
| BC breaks?        | no                                  |
| Deprecations?   | no                                  |
| Related tickets  | X                                    |
| License              | MIT                                |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Modified the country selection in address forms to display only active, enabled countries.
	- Enhanced channel functionality to accurately retrieve enabled countries for better user experience.
- **Tests**
	- Added tests to ensure that only enabled countries appear, verifying the new selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->