### PR TITLE
Add conflict to symfony/validator 5.4.25, 6.2.12 and 6.3.1

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -59,3 +59,8 @@ references related issues.
 - `doctrine/orm:2.15.3`
 
   This version introduced a bug, causing the bulk editing not to work properly. When deleting two items at once, the second one is deleted and re-added to the database.
+
+- `symfony/validator:5.4.25 || 6.2.12 || 6.3.1`
+
+  This version introduced a bug, causing validation constraints to not work.
+  References: https://github.com/symfony/symfony/issues/50780

--- a/composer.json
+++ b/composer.json
@@ -184,8 +184,9 @@
         "doctrine/orm": "2.15.2 || 2.15.3",
         "jms/serializer-bundle": "4.1.0",
         "lexik/jwt-authentication-bundle": "^2.18",
-        "symfony/framework-bundle": "5.4.5 || 6.2.8",
         "symfony/dependency-injection": "5.4.5",
+        "symfony/framework-bundle": "5.4.5 || 6.2.8",
+        "symfony/validator": "5.4.25 || 6.2.12 || 6.3.1",
         "liip/imagine-bundle": "2.7.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12  <!-- see the comment below -->                  |
| Bug fix?        | yes                                                     |
| New feature?    | no                                                      |
| BC breaks?      | no                                                   |
| Related tickets |    https://github.com/symfony/symfony/issues/50780                   |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
It's probably related to [this](https://github.com/symfony/validator/commit/81772c16452f67357c1a7afdbb6cc4f3985ae67b) change