### PR TITLE
Fix rendering admin creation form with errors

### DIFF
--- a/features/user/managing_administrators/adding_avatar_to_administrator.feature
+++ b/features/user/managing_administrators/adding_avatar_to_administrator.feature
@@ -13,3 +13,12 @@ Feature: Adding an avatar to an administrator
         When I upload the "troll.jpg" image as my avatar
         Then I should see the "troll.jpg" image as my avatar
         And I should see the "troll.jpg" avatar image in the top bar next to my name
+
+    @ui @no-api
+    Scenario: Avatar is not added when there is any validation error
+        When I want to create a new administrator
+        And I upload the "troll.jpg" image as the avatar
+        And I specify its email as "Ted"
+        And I try to add it
+        Then I should be notified that this email is not valid
+        And I should not see any image as the avatar

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
@@ -145,7 +145,7 @@ final class ManagingAdministratorsContext implements Context
     }
 
     /**
-     * @When /^I (?:|upload|update) the "([^"]+)" image as (my) avatar$/
+     * @When /^I (?:upload|update) the "([^"]+)" image as (my) avatar$/
      */
     public function iUploadTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
@@ -190,7 +190,15 @@ final class ManagingAdministratorsContext implements Context
     }
 
     /**
-     * @When /^I (?:|upload|update) the "([^"]+)" image as (my) avatar$/
+     * @When I upload the :avatar image as the avatar
+     */
+    public function iUploadTheImageAsTheAvatar(string $avatar): void
+    {
+        $this->createPage->attachAvatar($avatar);
+    }
+
+    /**
+     * @When /^I (?:upload|update) the "([^"]+)" image as (my) avatar$/
      */
     public function iUploadTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
@@ -330,6 +338,14 @@ final class ManagingAdministratorsContext implements Context
 
         Assert::false($this->topBarElement->hasAvatarInMainBar($avatarPath));
         Assert::true($this->topBarElement->hasDefaultAvatarInMainBar());
+    }
+
+    /**
+     * @Then I should not see any image as the avatar
+     */
+    public function iShouldNotSeeAnyImageAsTheAvatar(): void
+    {
+        Assert::false($this->createPage->isAvatarAttached());
     }
 
     private function getAdministrator(AdminUserInterface $administrator): AdminUserInterface

--- a/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
@@ -17,6 +17,20 @@ use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
+    public function isAvatarAttached(): bool
+    {
+        return $this->getElement('add_avatar')->has('css', 'img');
+    }
+
+    public function attachAvatar(string $path): void
+    {
+        $filesPath = $this->getParameter('files_path');
+
+        $imageForm = $this->getElement('add_avatar')->find('css', 'input[type="file"]');
+
+        $imageForm->attachFile($filesPath . $path);
+    }
+
     public function enable(): void
     {
         $this->getElement('enabled')->check();
@@ -45,6 +59,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
+            'add_avatar' => '#add-avatar',
             'email' => '#sylius_admin_user_email',
             'enabled' => '#sylius_admin_user_enabled',
             'locale_code' => '#sylius_admin_user_localeCode',

--- a/src/Sylius/Behat/Page/Admin/Administrator/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/CreatePageInterface.php
@@ -17,6 +17,10 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
+    public function isAvatarAttached(): bool;
+
+    public function attachAvatar(string $path): void;
+
     public function enable(): void;
 
     public function specifyUsername(string $username): void;

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/AdminUser/Form/_avatar.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/AdminUser/Form/_avatar.html.twig
@@ -2,8 +2,12 @@
     <label>{{ 'sylius.ui.avatar'|trans }}</label>
     {{ form_row(form.avatar, {'label': false}) }}
 </div>
-{% if admin_user.avatar is not null %}
-    <button formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': app.request.attributes.get('id'), '_csrf_token': csrf_token(app.request.attributes.get('id'))}) }}" type="submit" class="ui icon red labeled button">
+{% if admin_user.avatar is not null and admin_user.id is not null %}
+    <button
+        formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': csrf_token(admin_user.id)}) }}"
+        type="submit"
+        class="ui icon red labeled button"
+    >
         <i class="icon trash"></i> {{ 'sylius.ui.delete'|trans }}
     </button>
 {% endif %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces #13241
| License         | MIT

Previously, when an avatar was added while creating a new administrator, once any error occurred, Sylius was throwing `500` due to being unable to create a CSRF token for the delete button.