### PR TITLE
[API] Product filter no longer crashes when using multiple taxons

### DIFF
--- a/features/product/viewing_products/viewing_products_from_specific_taxon.feature
+++ b/features/product/viewing_products/viewing_products_from_specific_taxon.feature
@@ -18,6 +18,18 @@ Feature: Viewing products from a specific taxon
         Then I should see the product "T-Shirt Banana"
         And I should not see the product "Plastic Tomato"
 
+    @api
+    Scenario: Searching products by multiple taxons
+        When I browse products from "Funny" and "T-Shirts" taxons
+        Then I should see the product "T-Shirt Banana"
+        And I should see the product "Plastic Tomato"
+
+    @api
+    Scenario: Searching products by multiple taxons when one of them doesn't have any products
+        When I browse products from "T-Shirts" and "Sad" taxons
+        Then I should see the product "T-Shirt Banana"
+        And I should not see the product "Plastic Tomato"
+
     @ui @api
     Scenario: Viewing information about empty list of products from a given taxon
         When I browse products from taxon "Sad"

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -129,6 +129,20 @@ final class ProductContext implements Context
     }
 
     /**
+     * @When /^I browse products from ("([^"]+)" and "([^"]+)" taxons)$/
+     */
+    public function iBrowseProductsFromProductTaxonCodes(iterable $taxons): void
+    {
+        $this->client->index(Resources::PRODUCTS);
+
+        foreach ($taxons as $taxon) {
+            $this->client->addFilter('productTaxons.taxon.code[]', $taxon->getCode());
+        }
+
+        $this->client->filter();
+    }
+
+    /**
      * @When I browse products from non existing taxon
      */
     public function iBrowseProductsFromNonExistingTaxon(): void

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsByTaxonExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsByTaxonExtension.php
@@ -51,8 +51,13 @@ final class ProductsByTaxonExtension implements ContextAwareQueryCollectionExten
         $this->addSortingToQuery($queryBuilder, $taxonCode, $queryNameGenerator);
     }
 
-    private function addSortingToQuery(QueryBuilder $queryBuilder, string $taxonCode, QueryNameGeneratorInterface $queryNameGenerator): void
+    /**
+     * @param array<string>|string $taxonCode
+     */
+    private function addSortingToQuery(QueryBuilder $queryBuilder, array|string $taxonCode, QueryNameGeneratorInterface $queryNameGenerator): void
     {
+        $taxonCode = is_array($taxonCode) ? $taxonCode : [$taxonCode];
+
         $rootAlias = $queryBuilder->getRootAliases()[0];
         $taxonCodeParameterName = $queryNameGenerator->generateParameterName('taxonCode');
         $productTaxonAliasName = $queryNameGenerator->generateJoinAlias('productTaxons');
@@ -71,7 +76,7 @@ final class ProductsByTaxonExtension implements ContextAwareQueryCollectionExten
                 $taxonAliasName,
                 'WITH',
                 $queryBuilder->expr()->andX(
-                    $queryBuilder->expr()->eq(sprintf('%s.code', $taxonAliasName), sprintf(':%s', $taxonCodeParameterName)),
+                    $queryBuilder->expr()->in(sprintf('%s.code', $taxonAliasName), sprintf(':%s', $taxonCodeParameterName)),
                     $queryBuilder->expr()->eq(sprintf('%s.enabled', $taxonAliasName), 'true'),
                 ),
             )

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsByTaxonExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsByTaxonExtensionSpec.php
@@ -98,12 +98,12 @@ final class ProductsByTaxonExtensionSpec extends ObjectBehavior
         $queryBuilder->addSelect('productTaxons')->shouldBeCalled()->willReturn($queryBuilder);
         $queryBuilder->leftJoin('o.productTaxons', 'productTaxons', 'WITH', 'productTaxons.product = o.id')->shouldBeCalled()->willReturn($queryBuilder);
         $expr->andX(Argument::type(Expr\Comparison::class), Argument::type(Expr\Comparison::class))->willReturn($andx);
-        $expr->eq('taxon.code', ':taxonCode')->shouldBeCalled()->willReturn($comparison);
+        $expr->in('taxon.code', ':taxonCode')->shouldBeCalled()->willReturn($comparison);
         $expr->eq('taxon.enabled', 'true')->shouldBeCalled()->willReturn($comparison);
         $queryBuilder->expr()->willReturn($expr->getWrappedObject());
         $queryBuilder->leftJoin('productTaxons.taxon', 'taxon', 'WITH', Argument::type(Andx::class))->shouldBeCalled()->willReturn($queryBuilder);
         $queryBuilder->orderBy('productTaxons.position', 'ASC')->shouldBeCalled()->willReturn($queryBuilder);
-        $queryBuilder->setParameter('taxonCode', 't_shirts')->shouldBeCalled()->willReturn($queryBuilder);
+        $queryBuilder->setParameter('taxonCode', ['t_shirts'])->shouldBeCalled()->willReturn($queryBuilder);
 
         $this->applyToCollection($queryBuilder, $queryNameGenerator, ProductInterface::class, 'get', ['filters' => ['productTaxons.taxon.code' => 't_shirts']]);
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                   |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | [#15107](https://github.com/Sylius/Sylius/issues/15107)                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
