### PR TITLE
[API] Fix CommandDenormalizer ignoring custom property names

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -38,3 +38,4 @@ parameters:
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'
         - '/Class Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken constructor invoked with 4 parameters\, 2\-3 required./'
         - '/Method Symfony\\Component\\Serializer\\Normalizer\\NormalizerInterface\:\:supportsNormalization\(\) invoked with 3 parameters\, 1\-2 required\./'
+        - '/Symfony\\Component\\Serializer\\NameConverter\\NameConverterInterface::normalize\(\) invoked with 2 parameters, 1 required./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -185,6 +185,7 @@
                 <referencedFunction name="Symfony\Component\HttpKernel\Config\FileLocator::__construct" />
                 <referencedFunction name="Symfony\Contracts\EventDispatcher\EventDispatcherInterface::dispatch" />
                 <referencedFunction name="Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::__construct" /> <!-- removed parameter in Symfony 5.4 -->
+                <referencedFunction name="Symfony\Component\Serializer\NameConverter\NameConverterInterface::normalize" />
             </errorLevel>
             <errorLevel type="suppress">
                 <referencedFunction name="Doctrine\ORM\Query\Expr::andX" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -64,6 +64,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer">
             <argument type="service" id="api_platform.serializer.normalizer.item" />
+            <argument type="service" id="api_platform.name_converter" />
             <tag name="serializer.normalizer" />
         </service>
 

--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
@@ -14,18 +14,19 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Serializer;
 
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
-/**
- * @experimental
- */
+/** @experimental */
 final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 {
     private const OBJECT_TO_POPULATE = 'object_to_populate';
 
-    public function __construct(private DenormalizerInterface $itemNormalizer)
-    {
+    public function __construct(
+        private DenormalizerInterface $itemNormalizer,
+        private NameConverterInterface $nameConverter,
+    ) {
     }
 
     public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
@@ -39,23 +40,28 @@ final class CommandDenormalizer implements ContextAwareDenormalizerInterface
             return $this->itemNormalizer->denormalize($data, $type, $format, $context);
         }
 
-        $constructor = (new \ReflectionClass($context['input']['class']))->getConstructor();
+        $class = $context['input']['class'];
+        $constructor = (new \ReflectionClass($class))->getConstructor();
 
         if (null !== $constructor) {
-            $this->assertConstructorArgumentsPresence($constructor, $data);
+            $this->assertConstructorArgumentsPresence($constructor, $class, $data);
         }
 
         return $this->itemNormalizer->denormalize($data, $type, $format, $context);
     }
 
-    private function assertConstructorArgumentsPresence(\ReflectionMethod $constructor, $data): void
-    {
+    private function assertConstructorArgumentsPresence(
+        \ReflectionMethod $constructor,
+        string $class,
+        mixed $data
+    ): void {
         $parameters = $constructor->getParameters();
 
         $missingFields = [];
         foreach ($parameters as $parameter) {
-            if (!isset($data[$parameter->getName()]) && !($parameter->allowsNull() || $parameter->isDefaultValueAvailable())) {
-                $missingFields[] = $parameter->getName();
+            $name = $this->nameConverter->normalize($parameter->getName(), $class);
+            if (!isset($data[$name]) && !($parameter->allowsNull() || $parameter->isDefaultValueAvailable())) {
+                $missingFields[] = $name;
             }
         }
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
@@ -19,20 +19,28 @@ use Sylius\Bundle\ApiBundle\Command\Account\RegisterShopUser;
 use Sylius\Bundle\ApiBundle\Command\Account\VerifyCustomerAccount;
 use Sylius\Component\Core\Model\Customer;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class CommandDenormalizerSpec extends ObjectBehavior
 {
-    function let(DenormalizerInterface $baseNormalizer): void
+    function let(DenormalizerInterface $baseNormalizer, NameConverterInterface $nameConverter): void
     {
-        $this->beConstructedWith($baseNormalizer);
+        $this->beConstructedWith($baseNormalizer, $nameConverter);
     }
 
     function it_throws_exception_if_not_all_required_parameters_are_present_in_the_context(
         DenormalizerInterface $baseNormalizer,
+        NameConverterInterface $nameConverter,
     ): void {
         $baseNormalizer->denormalize(Argument::any())->shouldNotBeCalled();
+
+        $nameConverter->normalize('firstName', RegisterShopUser::class)->willReturn('firstName');
+        $nameConverter->normalize('lastName', RegisterShopUser::class)->willReturn('lastName');
+        $nameConverter->normalize('email', RegisterShopUser::class)->willReturn('email');
+        $nameConverter->normalize('password', RegisterShopUser::class)->willReturn('password');
+        $nameConverter->normalize('subscribedToNewsletter', RegisterShopUser::class)->willReturn('subscribedToNewsletter');
 
         $this
             ->shouldThrow(new MissingConstructorArgumentsException(
@@ -52,7 +60,14 @@ final class CommandDenormalizerSpec extends ObjectBehavior
 
     function it_denormalizes_data_if_all_required_parameters_are_specified(
         DenormalizerInterface $baseNormalizer,
+        NameConverterInterface $nameConverter,
     ): void {
+        $nameConverter->normalize('firstName', RegisterShopUser::class)->willReturn('firstName');
+        $nameConverter->normalize('lastName', RegisterShopUser::class)->willReturn('lastName');
+        $nameConverter->normalize('email', RegisterShopUser::class)->willReturn('email');
+        $nameConverter->normalize('password', RegisterShopUser::class)->willReturn('password');
+        $nameConverter->normalize('subscribedToNewsletter', RegisterShopUser::class)->willReturn('subscribedToNewsletter');
+
         $baseNormalizer
             ->denormalize(
                 ['firstName' => 'John', 'lastName' => 'Doe', 'email' => 'test@example.com', 'password' => 'pa$$word'],
@@ -65,6 +80,34 @@ final class CommandDenormalizerSpec extends ObjectBehavior
 
         $this->denormalize(
             ['firstName' => 'John', 'lastName' => 'Doe', 'email' => 'test@example.com', 'password' => 'pa$$word'],
+            Customer::class,
+            null,
+            ['input' => ['class' => RegisterShopUser::class]],
+        )->shouldReturn(['key' => 'value']);
+    }
+
+    function it_denormalizes_data_if_all_required_parameters_are_specified_based_on_their_normalized_names(
+        DenormalizerInterface $baseNormalizer,
+        NameConverterInterface $nameConverter,
+    ): void {
+        $baseNormalizer
+            ->denormalize(
+                ['first_name' => 'John', 'last_name' => 'Doe', 'email_address' => 'test@example.com', 'pass' => 'pa$$word'],
+                Customer::class,
+                null,
+                ['input' => ['class' => RegisterShopUser::class]],
+            )
+            ->willReturn(['key' => 'value'])
+        ;
+
+        $nameConverter->normalize('firstName', RegisterShopUser::class)->willReturn('first_name');
+        $nameConverter->normalize('lastName', RegisterShopUser::class)->willReturn('last_name');
+        $nameConverter->normalize('email', RegisterShopUser::class)->willReturn('email_address');
+        $nameConverter->normalize('password', RegisterShopUser::class)->willReturn('pass');
+        $nameConverter->normalize('subscribedToNewsletter', RegisterShopUser::class)->willReturn('hasNewsletter');
+
+        $this->denormalize(
+            ['first_name' => 'John', 'last_name' => 'Doe', 'email_address' => 'test@example.com', 'pass' => 'pa$$word'],
             Customer::class,
             null,
             ['input' => ['class' => RegisterShopUser::class]],


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

The CommandDenormalizer was ignoring custom serialized names when checking for required constructor argument so, for a mapping like:

> \<attribute name="productCode" serialized-name="product" \/\>

and request data

> { product: 'some-code' }

we would get a `MissingConstructorArgumentsException`, while it's perfectly fine for the serializer