### PR TITLE
Add if_array check in ProductAttributeValueNormalizer.php

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
@@ -84,7 +84,7 @@ final class ProductAttributeValueNormalizer implements ContextAwareNormalizerInt
         $values = [];
 
         foreach ($configuration['choices'] ?? [] as $uuid => $choice) {
-            if (in_array($uuid, $object->getValue())) {
+            if (is_array($object->getValue()) && in_array($uuid, $object->getValue())) {
                 $values[] = $choice[$object->getLocaleCode()]
                     ?? $choice[$this->localeProvider->getDefaultLocaleCode()]
                     ?? $choice[$this->defaultLocaleCode]

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductAttributeValueNormalizer.php
@@ -49,7 +49,7 @@ final class ProductAttributeValueNormalizer implements ContextAwareNormalizerInt
 
         switch ($object->getType()) {
             case SelectAttributeType::TYPE:
-                $data['value'] = $this->normalizeSelectValue($object, $context);
+                $data['value'] = $this->normalizeSelectValue($object);
 
                 break;
             case DateAttributeType::TYPE:
@@ -76,19 +76,26 @@ final class ProductAttributeValueNormalizer implements ContextAwareNormalizerInt
         return $data instanceof ProductAttributeValueInterface;
     }
 
-    private function normalizeSelectValue(ProductAttributeValueInterface $object, array $context): array
+    private function normalizeSelectValue(ProductAttributeValueInterface $object): array
     {
+        $value = $object->getValue();
+        if (!is_array($value)) {
+            return [];
+        }
+
         $attribute = $object->getAttribute();
         $configuration = $attribute->getConfiguration();
+        $defaultLocaleCode = $this->localeProvider->getDefaultLocaleCode();
 
         $values = [];
 
         foreach ($configuration['choices'] ?? [] as $uuid => $choice) {
-            if (is_array($object->getValue()) && in_array($uuid, $object->getValue())) {
+            if (in_array($uuid, $value)) {
                 $values[] = $choice[$object->getLocaleCode()]
-                    ?? $choice[$this->localeProvider->getDefaultLocaleCode()]
+                    ?? $choice[$defaultLocaleCode]
                     ?? $choice[$this->defaultLocaleCode]
-                    ?? reset($choice);
+                    ?? reset($choice)
+                ;
             }
         }
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueNormalizerSpec.php
@@ -105,6 +105,30 @@ final class ProductAttributeValueNormalizerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_serializes_product_attribute_select_values_when_attribute_has_no_value(
+        NormalizerInterface $normalizer,
+        ProductAttributeValueInterface $productAttributeValue,
+        ProductAttributeInterface $productAttribute,
+        LocaleProviderInterface $localeProvider,
+    ): void {
+        $normalizer
+            ->normalize($productAttributeValue, null, ['sylius_product_attribute_value_normalizer_already_called' => true])
+            ->willReturn([])
+        ;
+
+        $productAttributeValue->getType()->willReturn('select');
+        $productAttributeValue->getAttribute()->willReturn($productAttribute);
+
+        $productAttributeValue->getValue()->willReturn(null);
+
+        $productAttribute->getConfiguration()->shouldNotBeCalled();
+        $productAttributeValue->getLocaleCode()->shouldNotBeCalled();
+        $localeProvider->getDefaultLocaleCode()->shouldNotBeCalled();
+
+        $this->setNormalizer($normalizer);
+        $this->normalize($productAttributeValue, null, [])->shouldReturn(['value' => []]);
+    }
+
     function it_serializes_product_attribute_date_values(
         NormalizerInterface $normalizer,
         ProductAttributeValueInterface $productAttributeValue,


### PR DESCRIPTION
Adds if_array check to prevent in_array check on null.

**Issue**
We ran into an error when it tries to do an in_array check where $object->getValue returns null.

**How to reproduce**
* Have an attribute of type SELECT
* Have an attribute value which has json_value NULL
* When trying to normalize the entity it will throw an error because it tries to do an in_array check on null.


