### PR TITLE
Avoid displaying taxon names inside of autocomplete in different locales than the store

### DIFF
--- a/features/product/managing_products/select_taxons_for_product_in_a_different_locales.feature
+++ b/features/product/managing_products/select_taxons_for_product_in_a_different_locales.feature
@@ -1,0 +1,42 @@
+@managing_products
+Feature: Select taxon for product in different locales
+    In order to be consistent with the store's chosen locale
+    As an Administrator
+    I want to be able to choose only taxons from the current locale
+
+    Background:
+        Given the store operates on a channel named "Web"
+        And the store has many locales
+        And the store has "Category" taxonomy
+        And the "Category" taxon has child taxon "T-Shirts" in many locales
+        And the "T-Shirts" taxon has child taxon "Men-T-Shirts" in many locales
+        And the "T-Shirts" taxon has child taxon "Woman-T-Shirts" in many locales
+        And the "Category" taxon has child taxon "Jeans" in many locales
+        And the "Jeans" taxon has child taxon "Men-Jeans" in many locales
+        And the "Jeans" taxon has child taxon "Woman-Jeans" in many locales
+        And the store has a product "T-Shirt Batman"
+        And I am logged in as an administrator
+
+    @ui @javascript @no-api
+    Scenario: Choosing only taxons from the Polish locale
+        Given I am using "Polish (Poland)" locale for my panel
+        When I want to choose main taxon for product "T-Shirt Batman"
+        Then I should be able to choose taxon "Men-T-Shirts_PL" from the list
+        And I should be able to choose taxon "Woman-T-Shirts_PL" from the list
+        And I should not be able to choose taxon "Woman-T-Shirts_UA" from the list
+
+    @ui @javascript @no-api
+    Scenario: Choosing only taxons from the French locale
+        Given I am using "French (France)" locale for my panel
+        When I want to choose main taxon for product "T-Shirt Batman"
+        Then I should be able to choose taxon "Men-T-Shirts_FR" from the list
+        And I should be able to choose taxon "Woman-T-Shirts_FR" from the list
+        And I should not be able to choose taxon "Woman-T-Shirts_UA" from the list
+
+    @ui @javascript @no-api
+    Scenario: Choosing only taxons from the German locale
+        Given I am using "German (Germany)" locale for my panel
+        When I want to choose main taxon for product "T-Shirt Batman"
+        Then I should be able to choose taxon "Men-T-Shirts_DE" from the list
+        And I should be able to choose taxon "Woman-T-Shirts_DE" from the list
+        And I should not be able to choose taxon "Woman-T-Shirts_UA" from the list

--- a/src/Sylius/Behat/Context/Setup/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Setup/LocaleContext.php
@@ -47,6 +47,24 @@ final class LocaleContext implements Context
     }
 
     /**
+     * @Given the store has many locales
+     */
+    public function theStoreHasManyLocales(): void
+    {
+        $this->theStoreHasLocale('en_US');
+        $this->theStoreHasLocale('fr_FR');
+        $this->theStoreHasLocale('de_DE');
+        $this->theStoreHasLocale('es_ES');
+        $this->theStoreHasLocale('pl_PL');
+        $this->theStoreHasLocale('pt_PT');
+        $this->theStoreHasLocale('uk_UA');
+        $this->theStoreHasLocale('ja_JP');
+        $this->theStoreHasLocale('zh_CN');
+        $this->theStoreHasLocale('bg_BG');
+        $this->theStoreHasLocale('da_DK');
+    }
+
+    /**
      * @Given the locale :localeCode does not exist in the store
      */
     public function theStoreDoesNotHaveLocale($localeCode)

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -68,6 +68,31 @@ final class TaxonomyContext implements Context
     }
 
     /**
+     * @Given /^the ("[^"]+" taxon) has child taxon "([^"]+)" in many locales$/
+     */
+    public function theTaxonHasChildrenTaxonsInManyLocales(TaxonInterface $taxon, string $childTaxonName): void
+    {
+        $translationMap = [
+            "en_US" => $childTaxonName,
+            "fr_FR" => $childTaxonName . "_FR",
+            "de_DE" => $childTaxonName . "_DE",
+            "es_ES" => $childTaxonName . "_ES",
+            "pl_PL" => $childTaxonName . "_PL",
+            "pt_PT" => $childTaxonName . "_PT",
+            "uk_UA" => $childTaxonName . "_UA",
+            "cn_CN" => $childTaxonName . "_CN",
+            "ja_JP" => $childTaxonName . "_JP",
+            "bg_BG" => $childTaxonName . "_BG",
+            "da_DK" => $childTaxonName . "_DK",
+        ];
+
+        $taxon->addChild($this->createTaxonInManyLanguages($translationMap));
+
+        $this->objectManager->persist($taxon);
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^the ("[^"]+" taxon)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
      */
     public function theTaxonHasAnImageWithType(TaxonInterface $taxon, $imagePath, $imageType)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -597,6 +597,37 @@ final class ManagingProductsContext implements Context
     }
 
     /**
+     * @When I want to choose main taxon for product :product
+     */
+    public function iWantToChooseMainTaxonForProduct(ProductInterface $product): void
+    {
+        $this->iWantToModifyAProduct($product);
+
+        $currentPage = $this->resolveCurrentPage();
+        $currentPage->open(['id' => $product->getId()]);
+    }
+
+    /**
+     * @Then I should be able to choose taxon :taxonName from the list
+     */
+    public function iShouldBeAbleToChooseTaxonForThisProduct(string $taxonName): void
+    {
+        $currentPage = $this->resolveCurrentPage();
+
+        Assert::true($currentPage->isTaxonVisibleInMainTaxonList($taxonName));
+    }
+
+    /**
+     * @Then I should not be able to choose taxon :taxonName from the list
+     */
+    public function iShouldNotBeAbleToChooseTaxonForThisProduct(string $taxonName): void
+    {
+        $currentPage = $this->resolveCurrentPage();
+
+        Assert::false($currentPage->isTaxonVisibleInMainTaxonList($taxonName));
+    }
+
+    /**
      * @Then /^this product should have (?:a|an) "([^"]+)" option$/
      */
     public function thisProductShouldHaveOption($productOption)

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -130,6 +130,15 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         AutocompleteHelper::chooseValue($this->getSession(), $mainTaxonElement, $taxon->getName());
     }
 
+    public function isTaxonVisibleInMainTaxonList(string $taxonName): bool
+    {
+        $this->openTaxonBookmarks();
+
+        $mainTaxonElement = $this->getElement('main_taxon')->getParent();
+
+        return AutocompleteHelper::isValueVisible($this->getSession(), $mainTaxonElement, $taxonName);
+    }
+
     public function selectProductTaxon(TaxonInterface $taxon): void
     {
         $productTaxonsCodes = [];

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
@@ -51,6 +51,8 @@ interface UpdateSimpleProductPageInterface extends BaseUpdatePageInterface
 
     public function selectMainTaxon(TaxonInterface $taxon): void;
 
+    public function isTaxonVisibleInMainTaxonList(string $taxonName): bool;
+
     public function selectProductTaxon(TaxonInterface $taxon): void;
 
     public function unselectProductTaxon(TaxonInterface $taxon): void;

--- a/src/Sylius/Behat/Service/AutocompleteHelper.php
+++ b/src/Sylius/Behat/Service/AutocompleteHelper.php
@@ -46,6 +46,17 @@ abstract class AutocompleteHelper
         static::waitForElementToBeVisible($session, $element);
     }
 
+    public static function isValueVisible(Session $session, NodeElement $element, $value): bool
+    {
+        static::activateAutocompleteDropdown($session, $element);
+
+        $result = $element->find('css', sprintf('div.item:contains("%s")', $value));
+
+        static::waitForElementToBeVisible($session, $element);
+
+        return null !== $result;
+    }
+
     private static function activateAutocompleteDropdown(Session $session, NodeElement $element)
     {
         JQueryHelper::waitForAsynchronousActionsToFinish($session);

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -120,9 +120,16 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
 
     public function findByNamePart(string $phrase, ?string $locale = null, ?int $limit = null): array
     {
+        $subqueryBuilder = $this->createQueryBuilder('sq')
+            ->innerJoin('sq.translations', 'translation', 'WITH', 'translation.name LIKE :name')
+            ->groupBy('translation.translatable')
+        ;
+
+        $queryBuilder = $this->createQueryBuilder('o');
+
         /** @var TaxonInterface[] $results */
-        $results = $this->createTranslationBasedQueryBuilder($locale)
-            ->andWhere('translation.name LIKE :name')
+        $results = $queryBuilder
+            ->andWhere($queryBuilder->expr()->in('o', $subqueryBuilder->getDQL()))
             ->setParameter('name', '%' . $phrase . '%')
             ->setMaxResults($limit)
             ->getQuery()


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12  <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                     |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
There is a problem, that taxon autocomplete shows taxon names from different locales than we are using in our store, the image below shows `autem dolores quis` that comes from Mexico locale while the channel is in US locale

Before:
![image](https://github.com/Sylius/Sylius/assets/53942444/06bea33f-becd-4057-8d38-255579f78303)

After:
![image](https://github.com/Sylius/Sylius/assets/53942444/8b01245e-7a2f-4bd7-b245-63209fbe4d67)
