### PR TITLE
Fix percentage discount's decimal rounding issue 

### DIFF
--- a/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/creating_catalog_promotion.feature
@@ -34,7 +34,7 @@ Feature: Creating a catalog promotion
         Then there should be 1 new catalog promotion on the list
         And it should have "winter_sale" code and "Winter sale" name
         And "Winter sale" catalog promotion should apply to "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
-        And it should have "50%" discount
+        And it should have "50.00%" discount
         And it should be active
         And "PHP T-Shirt" variant and "Kotlin T-Shirt" variant should be discounted
 
@@ -52,7 +52,7 @@ Feature: Creating a catalog promotion
         Then there should be 1 new catalog promotion on the list
         And it should have "winter_sale" code and "Winter sale" name
         And "Winter sale" catalog promotion should apply to "PHP T-Shirt" variant and "Kotlin T-Shirt" variant
-        And it should have "50%" discount
+        And it should have "50.00%" discount
         And it should be inactive
         And "PHP T-Shirt" variant and "Kotlin T-Shirt" variant should not be discounted
 

--- a/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/editing_catalog_promotion.feature
@@ -74,7 +74,7 @@ Feature: Editing catalog promotion
     Scenario: Editing catalog promotion action
         When I edit "Christmas sale" catalog promotion to have "40%" discount
         Then I should be notified that it has been successfully edited
-        And this catalog promotion should have "40%" percentage discount
+        And this catalog promotion should have "40.00%" percentage discount
 
     @api @ui @javascript
     Scenario: Editing catalog promotion action to be a fixed discount

--- a/features/promotion/managing_catalog_promotions/seeing_correct_percantage_discounts_while_editing_catalog_promotion.feature
+++ b/features/promotion/managing_catalog_promotions/seeing_correct_percantage_discounts_while_editing_catalog_promotion.feature
@@ -1,0 +1,32 @@
+@managing_catalog_promotions
+Feature: Seeing correct percentage discounts while editing catalog promotion
+    In order to see the accurate percentage amount while editing the catalog promotion
+    As a store owner
+    I want to see the correct percentage amount while editing the catalog promotion with decimal places
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has "Clothes" taxonomy
+        And the store has a "T-Shirt" configurable product
+        And this product belongs to "Clothes"
+        And this product has "PHP T-Shirt" variant priced at "$20.00"
+        And this product has "Kotlin T-Shirt" variant priced at "$40.00"
+        And there is a catalog promotion with "christmas_sale" code and "Christmas sale" name
+        And it applies on "PHP T-Shirt" variant
+        And it reduces price by "30%"
+        And it is enabled
+        And I am logged in as an administrator
+
+    @api @ui @javascript
+    Scenario: Seeing the accurate percentage amount after editing the catalog promotion including the value up to one decimal place
+        When I edit "Christmas sale" catalog promotion to have "2.5%" discount
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this catalog promotion should have "2.50%" percentage discount
+
+    @api @ui @javascript
+    Scenario: Seeing the accurate percentage amount after editing the catalog promotion including the value up to two decimal places
+        When I edit "Christmas sale" catalog promotion to have "2.56%" discount
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this catalog promotion should have "2.56%" percentage discount

--- a/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
+++ b/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
@@ -1,0 +1,27 @@
+@managing_promotions
+Feature: Seeing correct percentage discounts while editing promotion with action and decimal places
+    In order to see the accurate percentage amount while editing the promotion
+    As a store owner
+    I want to see the correct percentage amount while editing the promotion with decimal places
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And there is a promotion "Cheap Stuff"
+        And this promotion gives "12.00%" discount to every order
+        And I am logged in as an administrator
+
+    @ui @javascript
+    Scenario: Seeing the accurate percentage amount after editing the promotion including the value up to one decimal place
+        When I want to modify a "Cheap Stuff" promotion
+        And I edit this promotion percentage action to have "2.50%"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And it should have "2.50%" discount
+
+    @ui @javascript
+    Scenario: Seeing the accurate percentage amount after editing the promotion including the value up to two decimal places
+        When I want to modify a "Cheap Stuff" promotion
+        And I edit this promotion percentage action to have "2.56%"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And it should have "2.56%" discount

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -418,6 +418,16 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
+     * @When /^I edit (this promotion) percentage action to have "([^"]+)%"$/
+     */
+    public function iEditCatalogPromotionToHaveDiscount(PromotionInterface $promotion, string $amount): void
+    {
+        $this->updatePage->open(['id' => $promotion->getId()]);
+        $this->updatePage->specifyPercentageDiscountActionValue($amount);
+        $this->updatePage->saveChanges();
+    }
+
+    /**
      * @Then the code field should be disabled
      */
     public function theCodeFieldShouldBeDisabled()
@@ -713,6 +723,14 @@ final class ManagingPromotionsContext implements Context
     public function iShouldSeeTheRuleConfigurationForm()
     {
         Assert::true($this->createPage->checkIfRuleConfigurationFormIsVisible(), 'Cart promotion rule configuration form is not visible.');
+    }
+
+    /**
+     * @Then /^it should have "([^"]+)%" discount$/
+     */
+    public function itShouldHaveDiscount(string $amount): void
+    {
+        Assert::same($this->updatePage->getPercentageDiscountActionValue(), $amount);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
@@ -134,6 +134,18 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getElement('action_field', ['%channelCode%' => $channelCode, '%field%' => $field])->setValue('');
     }
 
+    public function specifyPercentageDiscountActionValue(string $discount): void
+    {
+        $this->getElement('percentage_action_field')->setValue($discount);
+    }
+
+    public function getPercentageDiscountActionValue(): string
+    {
+        $action = $this->getElement('percentage_action_field');
+
+        return $action->find('css', 'input')->getValue();
+    }
+
     public function removeRuleAmount(string $channelCode): void
     {
         $this->getElement('rule_amount', ['%channelCode%' => $channelCode])->setValue('');
@@ -158,6 +170,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     {
         return [
             'action_field' => '[id^="sylius_promotion_actions_"][id$="_configuration_%channelCode%_%field%"]',
+            'percentage_action_field' => '[id^="sylius_promotion_actions_"][id$="_configuration_percentage"]',
             'actions' => '#actions',
             'applies_to_discounted' => '#sylius_promotion_appliesToDiscounted',
             'code' => '#sylius_promotion_code',

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
@@ -53,6 +53,10 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
 
     public function removeActionFieldValue(string $channelCode, string $field): void;
 
+    public function specifyPercentageDiscountActionValue(string $discount): void;
+
+    public function getPercentageDiscountActionValue(): string;
+
     public function removeRuleAmount(string $channelCode): void;
 
     public function getActionValidationErrorsCount(string $channelCode): int;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -268,7 +268,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('percentage_discount', $catalogPromotionAction->getType());
-        $this->assertSame(['amount' => null], $catalogPromotionAction->getConfiguration());
+        $this->assertSame(['amount' => 0.1], $catalogPromotionAction->getConfiguration());
     }
 
     protected function setUp(): void

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type\Action;
 
-use Sylius\Bundle\PromotionBundle\Form\DataTransformer\PercentFloatToLocalizedStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -28,6 +27,8 @@ final class PercentageDiscountConfigurationType extends AbstractType
         $builder
             ->add('percentage', PercentType::class, [
                 'label' => 'sylius.form.promotion_action.percentage_discount_configuration.percentage',
+                'html5' => true,
+                'scale' => 2,
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
                     new Type(['type' => 'numeric', 'groups' => ['sylius']]),
@@ -40,7 +41,6 @@ final class PercentageDiscountConfigurationType extends AbstractType
                 ],
             ])
         ;
-        $builder->get('percentage')->resetViewTransformers()->addViewTransformer(new PercentFloatToLocalizedStringTransformer());
     }
 
     public function getBlockPrefix(): string

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/PercentageDiscountActionConfigurationType.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction;
 
-use Sylius\Bundle\PromotionBundle\Form\DataTransformer\PercentFloatToLocalizedStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -27,6 +26,8 @@ final class PercentageDiscountActionConfigurationType extends AbstractType
         $builder
             ->add('amount', PercentType::class, [
                 'label' => 'sylius.ui.amount',
+                'html5' => true,
+                'scale' => 2,
                 'constraints' => [
                     new NotBlank([
                         'groups' => 'sylius',
@@ -40,13 +41,6 @@ final class PercentageDiscountActionConfigurationType extends AbstractType
                     ]),
                 ],
             ])
-        ;
-
-        $builder
-            ->get('amount')
-            ->resetViewTransformers()
-            ->resetModelTransformers()
-            ->addViewTransformer(new PercentFloatToLocalizedStringTransformer())
         ;
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12  <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                     |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/11977                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

`Rounding of 2.5%` 
- The correct amount is saved to the database, but when we try to edit the actual amount it is showing rounded value without decimal places

before:

![image](https://github.com/Sylius/Sylius/assets/53942444/feda7b28-d46d-4188-8a5f-ccd57007f9bf)

after:

![image](https://github.com/Sylius/Sylius/assets/53942444/862718ce-0a35-46f4-9ac7-5b407e168d15)

