### PR TITLE
Add a conflict for doctrine/orm 2.15.2 and higher

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -56,7 +56,7 @@ references related issues.
   This version introduced a bug, which causes the `ForeignKeyConstraintViolationException` exception to not be thrown when trying to delete a resource with a foreign key constraint.
   References: https://github.com/doctrine/orm/issues/10752
 
-- `doctrine/orm:2.15.3 || 2.15.4`
+- `doctrine/orm:>=2.15.3`
 
   This version introduced a bug, causing the bulk editing not to work properly. When deleting two items at once, the second one is deleted and re-added to the database.
 

--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "api-platform/core": "2.7.0",
         "doctrine/doctrine-bundle": "2.3.0",
         "doctrine/migrations": "3.5.3",
-        "doctrine/orm": "2.15.2 || 2.15.3 || 2.15.4",
+        "doctrine/orm": ">= 2.15.2",
         "jms/serializer-bundle": "4.1.0",
         "lexik/jwt-authentication-bundle": "^2.18",
         "stof/doctrine-extensions-bundle": "1.8.0",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/intl": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "twig/twig": "^1.0 || ^3.0"
     },

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -42,7 +42,7 @@
         "symfony/form": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "config": {

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -42,7 +42,7 @@
         "twig/twig": "^2.12 || ^3.3"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2"
+        "doctrine/orm": ">= 2.15.2"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -33,7 +33,7 @@
         "symfony/templating": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "twig/twig": "^1.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -44,7 +44,7 @@
         "webmozart/assert": "^1.9"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "twig/twig": "^3.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -34,7 +34,7 @@
         "symfony/validator": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "twig/twig": "^1.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -33,7 +33,7 @@
         "symfony/templating": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "twig/twig": "^1.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -33,7 +33,7 @@
         "webmozart/assert": "^1.9"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "twig/twig": "^1.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/templating": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "twig/twig": "^1.0 || ^3.0"
     },

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -36,7 +36,7 @@
         "symfony/framework-bundle": "^5.4 || ^6.0"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
+        "doctrine/orm": ">= 2.15.2",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "twig/twig": "^3.0"
     },


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It became pointless to add a conflict for every single `doctrine/orm` version above `2.15.2`. For now, it'll conflict with every future release until we figure out where the problem is with newer versions.