### PR TITLE
[Maintenance] Remove depractions from OrderPaymentProcessor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -31,12 +31,6 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
         /** @var array<string> $unprocessableOrderStates */
         private array $unprocessableOrderStates = [],
     ) {
-        if ($this->orderPaymentsRemover === null) {
-            @trigger_error(sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated since Sylius 1.12 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
-        }
-        if ([] === $this->unprocessableOrderStates) {
-            @trigger_error(sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated since Sylius 1.12 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
-        }
     }
 
     public function process(BaseOrderInterface $order): void


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | somewhat                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

An oversight, deprecations shouldn't be added in a patch version.