### PR TITLE
[Behat] Fix minor mistake in names of scenarios for receiving discount according to promotions priorities

### DIFF
--- a/features/promotion/receiving_discount/receiving_discount_in_order_of_promotions_priority.feature
+++ b/features/promotion/receiving_discount/receiving_discount_in_order_of_promotions_priority.feature
@@ -9,7 +9,7 @@ Feature: Receiving discount in the order defined by promotions' priorities
         And the store has a product "The Pug Mug" priced at "$100.00"
 
     @ui @api
-    Scenario: Receiving fixed discount first when priority is greater
+    Scenario: Receiving percentage discount first when priority is higher
         Given there is a promotion "Cebula Deal" with priority 1
         And it gives "$10.00" discount to every order
         And there is a promotion "Santa's Gift" with priority 4
@@ -18,7 +18,7 @@ Feature: Receiving discount in the order defined by promotions' priorities
         Then my cart total should be "$70.00"
 
     @ui @api
-    Scenario: Receiving percentage discount first when priority is greater
+    Scenario: Receiving fixed discount first when priority is higher
         Given there is a promotion "Cebula Deal" with priority 5
         And it gives "$10.00" discount to every order
         And there is a promotion "Santa's Gift" with priority 2


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
