### PR TITLE
Fix configuring amount for catalog promotions fixed discount actions

### DIFF
--- a/features/promotion/managing_catalog_promotions/adding_catalog_promotion_with_fixed_discount_where_amount_is_decimal_number_with_comma.feature
+++ b/features/promotion/managing_catalog_promotions/adding_catalog_promotion_with_fixed_discount_where_amount_is_decimal_number_with_comma.feature
@@ -1,0 +1,20 @@
+@managing_catalog_promotions
+Feature: Adding a new catalog promotion with fixed discount where amount is a decimal number with comma
+    In order to be able to create catalog promotions with fixed discount where amount is a decimal number with comma
+    As an Administrator
+    I want to be able to add a new catalog promotion with fixed discount where amount is a decimal number with comma without errors
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And I am logged in as an administrator
+
+    @ui @no-api @javascript
+    Scenario: Adding a new catalog promotion with fixed discount and amount with comma
+        When I want to create a new catalog promotion
+        And I specify its code as "winter_sale"
+        And I name it "Winter sale"
+        And I add action that gives "$10,25" of fixed discount in the "United States" channel
+        And I add it
+        Then there should be 1 new catalog promotion on the list
+        And it should have "winter_sale" code and "Winter sale" name
+        And the "Winter sale" catalog promotion should have "$10.25" of fixed discount in the "United States" channel

--- a/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -216,7 +216,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CatalogPromotionActionInterface::class, $catalogPromotionAction);
         $this->assertSame('fixed_discount', $catalogPromotionAction->getType());
-        $this->assertSame(['WEB_US' => ['amount' => null]], $catalogPromotionAction->getConfiguration());
+        $this->assertSame(['WEB_US' => ['amount' => 10]], $catalogPromotionAction->getConfiguration());
     }
 
     /** @test */

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionAction/FixedDiscountActionConfigurationType.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction;
 
 use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
-use Sylius\Bundle\PromotionBundle\Form\DataTransformer\MoneyIntToLocalizedStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Type;
 
 final class FixedDiscountActionConfigurationType extends AbstractType
 {
@@ -26,17 +26,11 @@ final class FixedDiscountActionConfigurationType extends AbstractType
         $builder
             ->add('amount', MoneyType::class, [
                 'label' => 'sylius.ui.amount',
+                'constraints' => [
+                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                ],
                 'currency' => $options['currency'],
             ])
-        ;
-
-        $builder
-            ->get('amount')
-            ->resetViewTransformers()
-            ->resetModelTransformers()
-            ->addViewTransformer(new MoneyIntToLocalizedStringTransformer(
-                divisor: $options['divisor'],
-            ))
         ;
     }
 
@@ -45,9 +39,6 @@ final class FixedDiscountActionConfigurationType extends AbstractType
         $resolver
             ->setRequired('currency')
             ->setAllowedTypes('currency', 'string')
-            ->setDefaults([
-                'divisor' => 100,
-            ])
         ;
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                     |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes [#X](https://github.com/Sylius/Sylius/issues/15193)                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
it is now possible to configure decimal amounts with comma without validation errors