### PR TITLE
Fix cart styles after coupon form submission failure

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
@@ -737,18 +737,21 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
     margin-top: 220px !important;
 }
 
-[data-route="sylius_shop_cart_summary"] .ui.two.column.stackable.grid {
+[data-route="sylius_shop_cart_summary"] .ui.two.column.stackable.grid,
+[data-route="sylius_shop_cart_save"] .ui.two.column.stackable.grid {
     margin-top: 20px;
     margin-bottom: 10px;
 }
 
-[data-route="sylius_shop_cart_summary"] .ui.segment {
+[data-route="sylius_shop_cart_summary"] .ui.segment,
+[data-route="sylius_shop_cart_save"] .ui.segment {
     border: 0;
     box-shadow: none;
     padding: 0;
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table tbody td,
+[data-route="sylius_shop_cart_save"] .column:first-child .table tbody td,
 [data-route="sylius_shop_checkout_complete"] form table tbody td,
 [data-route="sylius_shop_account_order_show"] table tbody td {
     border: 0 !important;
@@ -757,6 +760,7 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table thead th,
+[data-route="sylius_shop_cart_save"] .column:first-child .table thead th,
 [data-route="sylius_shop_checkout_complete"] form table thead th,
 [data-route="sylius_shop_account_order_show"] table thead th {
     border: none !important;
@@ -768,6 +772,8 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table th:nth-child(2),
 [data-route="sylius_shop_cart_summary"] .column:first-child .table td:nth-child(2),
+[data-route="sylius_shop_cart_save"] .column:first-child .table th:nth-child(2),
+[data-route="sylius_shop_cart_save"] .column:first-child .table td:nth-child(2),
 [data-route="sylius_shop_checkout_complete"] form table th:nth-child(2),
 [data-route="sylius_shop_checkout_complete"] form table td:nth-child(2),
 [data-route="sylius_shop_account_order_show"] table th:nth-child(2),
@@ -777,6 +783,7 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table th:nth-child(3),
+[data-route="sylius_shop_cart_save"] .column:first-child .table th:nth-child(3),
 [data-route="sylius_shop_checkout_complete"] form table th:nth-child(3),
 [data-route="sylius_shop_account_order_show"] table th:nth-child(3) {
     text-align: left !important;
@@ -784,12 +791,14 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table th:nth-child(4),
+[data-route="sylius_shop_cart_save"] .column:first-child .table th:nth-child(4),
 [data-route="sylius_shop_checkout_complete"] form table th:nth-child(4),
 [data-route="sylius_shop_account_order_show"] table th:nth-child(4) {
     text-align: right !important;
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table .sylius-product-name,
+[data-route="sylius_shop_cart_save"] .column:first-child .table .sylius-product-name,
 [data-route="sylius_shop_checkout_complete"] form table .sylius-product-name,
 [data-route="sylius_shop_account_order_show"] table .sylius-product-name {
     font-size: 0.9em !important;
@@ -798,6 +807,7 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table .image,
+[data-route="sylius_shop_cart_save"] .column:first-child .table .image,
 [data-route="sylius_shop_checkout_complete"] form table .image,
 [data-route="sylius_shop_account_order_show"] table .image {
     width: 100px !important;
@@ -806,25 +816,30 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
 }
 
 [data-route="sylius_shop_cart_summary"] .column:first-child .table .sub.header,
+[data-route="sylius_shop_cart_save"] .column:first-child .table .sub.header,
 [data-route="sylius_shop_checkout_complete"] form table .sub.header,
 [data-route="sylius_shop_account_order_show"] table .sub.header {
     color: #adadad !important;
 }
 
-[data-route="sylius_shop_cart_summary"] .column:first-child .table .sylius-cart-remove-button {
+[data-route="sylius_shop_cart_summary"] .column:first-child .table .sylius-cart-remove-button,
+[data-route="sylius_shop_cart_save"] .column:first-child .table .sylius-cart-remove-button {
     background: transparent;
     border: 1px solid #eee;
 }
 
-[data-route="sylius_shop_cart_summary"] .column:first-child .table .sylius-total {
+[data-route="sylius_shop_cart_summary"] .column:first-child .table .sylius-total,
+[data-route="sylius_shop_cart_save"] .column:first-child .table .sylius-total {
     font-weight: 700;
 }
 
-[data-route="sylius_shop_cart_summary"] .five.column:last-child {
+[data-route="sylius_shop_cart_summary"] .five.column:last-child,
+[data-route="sylius_shop_cart_save"] .five.column:last-child {
     padding-left: 50px !important;
 }
 
-[data-route="sylius_shop_cart_summary"] .column:last-child .ui.dividing.header {
+[data-route="sylius_shop_cart_summary"] .column:last-child .ui.dividing.header,
+[data-route="sylius_shop_cart_save"] .column:last-child .ui.dividing.header {
     border: 0;
     font-size: 1em;
     color: #999;
@@ -834,11 +849,13 @@ header .ui.three.column.stackable.grid > .column:nth-child(3) .button span {
     border-bottom: 2px solid #eee;
 }
 
-[data-route="sylius_shop_cart_summary"] .column:last-child .table td {
+[data-route="sylius_shop_cart_summary"] .column:last-child .table td,
+[data-route="sylius_shop_cart_save"] .column:last-child .table td {
     padding: 16px 0;
 }
 
-[data-route="sylius_shop_cart_summary"] .column:last-child .table .header td {
+[data-route="sylius_shop_cart_summary"] .column:last-child .table .header td,
+[data-route="sylius_shop_cart_save"] .column:last-child .table .header td {
     padding-top: 30px !important;
 }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                   |
| Bug fix?        |  yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets |  |
| License         | MIT                                                          |

When you are on the cart page and submit the "apply coupon" form and the form errors (e.g. coupon code not valid) then the cart styles are broken. 

This is because when viewing the cart the data-route is set to "sylius_shop_cart_summary". When the coupon code error is shown, the data-route is set to "sylius_shop_cart_save" and thus the specific styles for the "sylius_shop_cart_summary" data-route don't match, see the screenshot:

![broken styles](https://github.com/Sylius/Sylius/assets/596449/384430d8-7cf0-4b63-af3c-aa75c8d3a8a7)

This PR makes sure that all styles for the "sylius_shop_cart_summary" data-route also work for the "sylius_shop_cart_save" data-route, see:

![fixed styles](https://github.com/Sylius/Sylius/assets/596449/9fd8892c-f42e-4440-8ce6-29b905fc6cb0)



