### PR TITLE
Fix attributes creation while the default locale is not available in our store

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,6 +1,8 @@
 # UPGRADE FROM `v1.12.9` TO `v1.12.10`
 
-1. The `Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration\SelectAttributeChoicesCollectionType` constructor has been removed as it is not used anymore.
+1. The `Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration\SelectAttributeChoicesCollectionType` only
+    constructor argument has been made optional and is `null` by default, subsequently the first argument of
+    `sylius.form.type.attribute_type.select.choices_collection` has been removed.
 
 # UPGRADE FROM `v1.12.8` TO `v1.12.9`
 

--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,7 @@
+# UPGRADE FROM `v1.12.9` TO `v1.12.10`
+
+1. The `Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration\SelectAttributeChoicesCollectionType` constructor has been removed as it is not used anymore.
+
 # UPGRADE FROM `v1.12.8` TO `v1.12.9`
 
 1. The `Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor` constructor has been changed:

--- a/features/product/managing_product_attributes/seeing_correct_select_attribute_values_in_different_locale_than_default_one.feature
+++ b/features/product/managing_product_attributes/seeing_correct_select_attribute_values_in_different_locale_than_default_one.feature
@@ -1,7 +1,7 @@
 @managing_product_attributes
 Feature: Seeing correct select attribute values in different locale than default one
     In order to see correct attribute values in different locale than default one
-    As and Administrator
+    As an Administrator
     I should be able to create attribute with values in different locale than default one
 
     Background:
@@ -16,4 +16,4 @@ Feature: Seeing correct select attribute values in different locale than default
         And I add value "Banana Skin" in "French (France)"
         And I add it
         Then I should be notified that it has been successfully created
-        And it should see value "Banana Skin"
+        And I should see the value "Banana Skin"

--- a/features/product/managing_product_attributes/seeing_correct_select_attribute_values_in_different_locale_than_default_one.feature
+++ b/features/product/managing_product_attributes/seeing_correct_select_attribute_values_in_different_locale_than_default_one.feature
@@ -1,0 +1,19 @@
+@managing_product_attributes
+Feature: Seeing correct select attribute values in different locale than default one
+    In order to see correct attribute values in different locale than default one
+    As and Administrator
+    I should be able to create attribute with values in different locale than default one
+
+    Background:
+        Given the store is available in "French (France)"
+        And I am logged in as an administrator
+
+    @ui @javascript
+    Scenario: Seeing correct attribute values in different locale than default one
+        When I want to create a new select product attribute
+        And I specify its code as "mug_material"
+        And I name it "Mug material" in "French (France)"
+        And I add value "Banana Skin" in "French (France)"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And it should see value "Banana Skin"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -365,9 +365,9 @@ final class ManagingProductAttributesContext implements Context
     }
 
     /**
-     * @Then /^it should see value "([^"]*)"/
+     * @Then I should see the value :value
      */
-    public function theSelectAttributeShouldHaveValueInLocale(string $value): void
+    public function iShouldSeeTheValue(string $value): void
     {
         Assert::true($this->updatePage->hasAttributeValue($value));
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -365,6 +365,14 @@ final class ManagingProductAttributesContext implements Context
     }
 
     /**
+     * @Then /^it should see value "([^"]*)"/
+     */
+    public function theSelectAttributeShouldHaveValueInLocale(string $value): void
+    {
+        Assert::true($this->updatePage->hasAttributeValue($value));
+    }
+
+    /**
      * @Then /^(this product attribute) should have value "([^"]*)"/
      */
     public function theSelectAttributeShouldHaveValue(ProductAttributeInterface $productAttribute, string $value): void

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration;
 
 use Ramsey\Uuid\Uuid;
+use Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -22,6 +23,15 @@ use Symfony\Component\Form\FormEvents;
 
 class SelectAttributeChoicesCollectionType extends AbstractType
 {
+    private ?string $defaultLocaleCode = null;
+
+    public function __construct(?TranslationLocaleProviderInterface $localeProvider = null)
+    {
+        if (null !== $localeProvider) {
+            $this->defaultLocaleCode = $localeProvider->getDefaultLocaleCode();
+        }
+    }
+
     /**
      * @psalm-suppress InvalidScalarArgument Some weird magic going on here, not sure about refactor
      */
@@ -37,6 +47,10 @@ class SelectAttributeChoicesCollectionType extends AbstractType
                     if (!is_int($key)) {
                         $fixedData[$key] = $this->resolveValues($values);
 
+                        continue;
+                    }
+
+                    if ($this->defaultLocaleCode !== null && !array_key_exists($this->defaultLocaleCode, $values)) {
                         continue;
                     }
 
@@ -73,6 +87,11 @@ class SelectAttributeChoicesCollectionType extends AbstractType
         return Uuid::uuid1()->toString();
     }
 
+    /**
+     * @param array<array-key, mixed|null> $values
+     *
+     * @return array<string, mixed>
+     */
     private function resolveValues(array $values): array
     {
         $fixedValues = [];

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration;
 
 use Ramsey\Uuid\Uuid;
-use Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -23,13 +22,6 @@ use Symfony\Component\Form\FormEvents;
 
 class SelectAttributeChoicesCollectionType extends AbstractType
 {
-    private string $defaultLocaleCode;
-
-    public function __construct(TranslationLocaleProviderInterface $localeProvider)
-    {
-        $this->defaultLocaleCode = $localeProvider->getDefaultLocaleCode();
-    }
-
     /**
      * @psalm-suppress InvalidScalarArgument Some weird magic going on here, not sure about refactor
      */
@@ -45,10 +37,6 @@ class SelectAttributeChoicesCollectionType extends AbstractType
                     if (!is_int($key)) {
                         $fixedData[$key] = $this->resolveValues($values);
 
-                        continue;
-                    }
-
-                    if (!array_key_exists($this->defaultLocaleCode, $values)) {
                         continue;
                     }
 

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -62,6 +62,7 @@ abstract class AttributeValueType extends AbstractResourceType
             })
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
                 $attributeValue = $event->getData();
+                $localeCode = $attributeValue['localeCode'];
 
                 if (!isset($attributeValue['attribute'])) {
                     return;
@@ -72,7 +73,7 @@ abstract class AttributeValueType extends AbstractResourceType
                     return;
                 }
 
-                $this->addValueField($event->getForm(), $attribute);
+                $this->addValueField($event->getForm(), $attribute, $localeCode);
             })
         ;
 

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/services/attribute_types.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/services/attribute_types.xml
@@ -65,7 +65,6 @@
         </service>
 
         <service id="sylius.form.type.attribute_type.select.choices_collection" class="Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration\SelectAttributeChoicesCollectionType">
-            <argument id="sylius.translation_locale_provider" type="service"/>
             <tag name="form.type" />
         </service>
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes [#X](https://github.com/Sylius/Sylius/issues/12112)                     |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
