### PR TITLE
Add explicit mapping between product and reviews, and between product and attributes

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -126,3 +126,8 @@
 1. Due to optimizations of the Order's grid the `Sylius\Component\Core\Repository\OrderRepositoryInterface::createSearchListQueryBuilder` method bas been deprecated and replaced by `Sylius\Component\Core\Repository\OrderRepositoryInterface::createCriteriaAwareSearchListQueryBuilder`.
    Also `Sylius\Component\Core\Repository\OrderRepositoryInterface::createByCustomerIdQueryBuilder` has been deprecated and replaced by `Sylius\Component\Core\Repository\OrderRepositoryInterface::createByCustomerIdCriteriaAwareQueryBuilder` for the same reason. Both changes affect
    `sylius_admin_order` and `sylius_admin_customer_order` grids configuration.
+
+1. We have explicitly added relationships between product and reviews and between product and attributes in XML mappings.
+   Because of that, the subscribers `Sylius\Bundle\AttributeBundle\Doctrine\ORM\Subscriber\LoadMetadataSubscriber` 
+   and `Sylius\Bundle\ReviewBundle\Doctrine\ORM\Subscriber\LoadMetadataSubscriber` have changed so that it does not add 
+   a relationship if one already exists. If you have overwritten or decorated it, there may be a need to update it. 

--- a/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/Subscriber/LoadMetadataSubscriber.php
+++ b/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/Subscriber/LoadMetadataSubscriber.php
@@ -50,6 +50,10 @@ final class LoadMetadataSubscriber implements EventSubscriber
         ClassMetadataInfo $metadata,
         ClassMetadataFactory $metadataFactory,
     ): void {
+        if ($metadata->hasAssociation('subject')) {
+            return;
+        }
+
         /** @var ClassMetadataInfo $targetEntityMetadata */
         $targetEntityMetadata = $metadataFactory->getMetadataFor($subjectClass);
         $subjectMapping = [
@@ -64,7 +68,7 @@ final class LoadMetadataSubscriber implements EventSubscriber
             ]],
         ];
 
-        $this->mapManyToOne($metadata, $subjectMapping);
+        $metadata->mapManyToOne($subjectMapping);
     }
 
     private function mapAttributeOnAttributeValue(
@@ -72,6 +76,10 @@ final class LoadMetadataSubscriber implements EventSubscriber
         ClassMetadataInfo $metadata,
         ClassMetadataFactory $metadataFactory,
     ): void {
+        if ($metadata->hasAssociation('attribute')) {
+            return;
+        }
+
         /** @var ClassMetadataInfo $attributeMetadata */
         $attributeMetadata = $metadataFactory->getMetadataFor($attributeClass);
         $attributeMapping = [
@@ -84,11 +92,6 @@ final class LoadMetadataSubscriber implements EventSubscriber
             ]],
         ];
 
-        $this->mapManyToOne($metadata, $attributeMapping);
-    }
-
-    private function mapManyToOne(ClassMetadataInfo $metadata, array $subjectMapping): void
-    {
-        $metadata->mapManyToOne($subjectMapping);
+        $metadata->mapManyToOne($attributeMapping);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -35,6 +35,12 @@
             </cascade>
         </one-to-many>
 
+        <one-to-many field="reviews" target-entity="Sylius\Component\Review\Model\ReviewInterface" mapped-by="reviewSubject">
+            <cascade>
+                <cascade-all />
+            </cascade>
+        </one-to-many>
+
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
             <order-by>
                 <order-by-field name="id" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductReview.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductReview.orm.xml
@@ -13,6 +13,17 @@
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
 
-    <mapped-superclass name="Sylius\Component\Core\Model\ProductReview" table="sylius_product_review" />
+    <mapped-superclass name="Sylius\Component\Core\Model\ProductReview" table="sylius_product_review">
+        <many-to-one field="reviewSubject" target-entity="Sylius\Component\Product\Model\ProductInterface" inversed-by="reviews">
+            <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
+        </many-to-one>
+
+        <many-to-one field="author" target-entity="Sylius\Component\Customer\Model\CustomerInterface">
+            <join-column name="author_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
+            <cascade>
+                <cascade-persist />
+            </cascade>
+        </many-to-one>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeValue.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeValue.orm.xml
@@ -16,6 +16,14 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <mapped-superclass name="Sylius\Component\Product\Model\ProductAttributeValue" table="sylius_product_attribute_value" />
+    <mapped-superclass name="Sylius\Component\Product\Model\ProductAttributeValue" table="sylius_product_attribute_value">
+        <many-to-one field="subject" target-entity="Sylius\Component\Product\Model\ProductInterface" inversed-by="attributes">
+            <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="Sylius\Component\Attribute\Model\AttributeInterface">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" />
+        </many-to-one>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ReviewBundle/Doctrine/ORM/Subscriber/LoadMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ReviewBundle/Doctrine/ORM/Subscriber/LoadMetadataSubscriber.php
@@ -38,16 +38,22 @@ final class LoadMetadataSubscriber implements EventSubscriber
 
         foreach ($this->subjects as $subject => $class) {
             if ($class['review']['classes']['model'] === $metadata->getName()) {
-                $reviewableEntity = $class['subject'];
-                $reviewerEntity = $class['reviewer']['classes']['model'];
-                $reviewableEntityMetadata = $metadataFactory->getMetadataFor($reviewableEntity);
-                $reviewerEntityMetadata = $metadataFactory->getMetadataFor($reviewerEntity);
+                if (!$metadata->hasAssociation('reviewSubject')) {
+                    $reviewableEntity = $class['subject'];
+                    $reviewableEntityMetadata = $metadataFactory->getMetadataFor($reviewableEntity);
 
-                $metadata->mapManyToOne($this->createSubjectMapping($reviewableEntity, $subject, $reviewableEntityMetadata));
-                $metadata->mapManyToOne($this->createReviewerMapping($reviewerEntity, $reviewerEntityMetadata));
+                    $metadata->mapManyToOne($this->createSubjectMapping($reviewableEntity, $subject, $reviewableEntityMetadata));
+                }
+
+                if (!$metadata->hasAssociation('author')) {
+                    $reviewerEntity = $class['reviewer']['classes']['model'];
+                    $reviewerEntityMetadata = $metadataFactory->getMetadataFor($reviewerEntity);
+
+                    $metadata->mapManyToOne($this->createReviewerMapping($reviewerEntity, $reviewerEntityMetadata));
+                }
             }
 
-            if ($class['subject'] === $metadata->getName()) {
+            if ($class['subject'] === $metadata->getName() && !$metadata->hasAssociation('reviews')) {
                 $reviewEntity = $class['review']['classes']['model'];
 
                 $metadata->mapOneToMany($this->createReviewsMapping($reviewEntity));

--- a/src/Sylius/Bundle/ReviewBundle/spec/Doctrine/ORM/Subscriber/LoadMetadataSubscriberSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/Doctrine/ORM/Subscriber/LoadMetadataSubscriberSpec.php
@@ -66,7 +66,10 @@ final class LoadMetadataSubscriberSpec extends ObjectBehavior
         $classMetadataInfo->fieldMappings = ['id' => ['columnName' => 'id']];
         $metadataFactory->getMetadataFor('AcmeBundle\Entity\ReviewableModel')->willReturn($classMetadataInfo);
         $metadataFactory->getMetadataFor('AcmeBundle\Entity\ReviewerModel')->willReturn($classMetadataInfo);
+
         $metadata->getName()->willReturn('AcmeBundle\Entity\ReviewModel');
+        $metadata->hasAssociation('reviewSubject')->willReturn(false);
+        $metadata->hasAssociation('author')->willReturn(false);
 
         $metadata->mapManyToOne([
             'fieldName' => 'reviewSubject',
@@ -95,6 +98,25 @@ final class LoadMetadataSubscriberSpec extends ObjectBehavior
         $this->loadClassMetadata($eventArguments);
     }
 
+    function it_does_not_map_relation_for_review_model_if_the_relation_already_exists(
+        ClassMetadataFactory $metadataFactory,
+        ClassMetadata $metadata,
+        EntityManager $entityManager,
+        LoadClassMetadataEventArgs $eventArguments,
+    ): void {
+        $eventArguments->getClassMetadata()->willReturn($metadata);
+        $eventArguments->getEntityManager()->willReturn($entityManager);
+        $entityManager->getMetadataFactory()->willReturn($metadataFactory);
+
+        $metadata->getName()->willReturn('AcmeBundle\Entity\ReviewModel');
+        $metadata->hasAssociation('reviewSubject')->willReturn(true);
+        $metadata->hasAssociation('author')->willReturn(true);
+
+        $metadata->mapManyToOne(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($eventArguments);
+    }
+
     function it_maps_proper_relations_for_reviewable_model(
         ClassMetadataFactory $metadataFactory,
         ClassMetadata $metadata,
@@ -104,7 +126,9 @@ final class LoadMetadataSubscriberSpec extends ObjectBehavior
         $eventArguments->getClassMetadata()->willReturn($metadata);
         $eventArguments->getEntityManager()->willReturn($entityManager);
         $entityManager->getMetadataFactory()->willReturn($metadataFactory);
+
         $metadata->getName()->willReturn('AcmeBundle\Entity\ReviewableModel');
+        $metadata->hasAssociation('reviews')->willReturn(false);
 
         $metadata->mapOneToMany([
             'fieldName' => 'reviews',
@@ -116,7 +140,25 @@ final class LoadMetadataSubscriberSpec extends ObjectBehavior
         $this->loadClassMetadata($eventArguments);
     }
 
-    function it_skips_mapping_configuration_if_metadata_name_is_not_different(
+    function it_does_not_map_relations_for_reviewable_model_if_the_relation_already_exists(
+        ClassMetadataFactory $metadataFactory,
+        ClassMetadata $metadata,
+        EntityManager $entityManager,
+        LoadClassMetadataEventArgs $eventArguments,
+    ): void {
+        $eventArguments->getClassMetadata()->willReturn($metadata);
+        $eventArguments->getEntityManager()->willReturn($entityManager);
+        $entityManager->getMetadataFactory()->willReturn($metadataFactory);
+
+        $metadata->getName()->willReturn('AcmeBundle\Entity\ReviewableModel');
+        $metadata->hasAssociation('reviews')->willReturn(true);
+
+        $metadata->mapOneToMany(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($eventArguments);
+    }
+
+    function it_skips_mapping_configuration_if_metadata_name_is_different(
         ClassMetadataFactory $metadataFactory,
         ClassMetadata $metadata,
         EntityManager $entityManager,


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13|
| Bug fix?        | yes?                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no?                                                       |
| Deprecations?   | |
| Related tickets | |
| License         | MIT                                                          |

Due to problems with customising mappings in end applications, as subscribers are called at the very end, I declared explicitly the relationship between product and reviews and between product and attributes in XML mappings. Subscribers thus do not add these relationships, as they already exist.

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
