### PR TITLE
Update symfony/service-contracts in composer.json to update Sylius to 1.12.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
         "symfony/security-csrf": "^5.4 || ^6.0",
         "symfony/security-http": "^5.4 || ^6.0",
         "symfony/serializer": "^5.4 || ^6.0",
-        "symfony/service-contracts": "^2.5",
+        "symfony/service-contracts": "^2.5 || ^3.0",
         "symfony/string": "^5.4 || ^6.0",
         "symfony/templating": "^5.4 || ^6.0",
         "symfony/translation": "^5.4 || ^6.0",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -33,7 +33,7 @@
         "sylius/money-bundle": "^1.12",
         "sylius/order": "^1.12",
         "sylius/resource-bundle": "^1.9",
-        "symfony/service-contracts": "^2.5",
+        "symfony/service-contracts": "^2.5 || ^3.0",
         "symfony/framework-bundle": "^5.4 || ^6.0",
         "symfony/templating": "^5.4 || ^6.0"
     },

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -50,7 +50,7 @@
         "sylius/taxation": "^1.12",
         "sylius/taxonomy": "^1.12",
         "sylius/user": "^1.12",
-        "symfony/service-contracts": "^2.5",
+        "symfony/service-contracts": "^2.5 || ^3.0",
         "symfony/http-foundation": "^5.4 || ^6.0",
         "symfony/mime": "^5.4 || ^6.0",
         "symfony/string": "^5.4 || ^6.0",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no --> |
| Related tickets |  PR #15162                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

I can't update a Sylius project I have from 1.12.9 to 1.12.10 because of `symfony/service-contracts`  which only accepts version: ^2.5 and i have 3.3.0.

See below the response I get when doing `composer update sylius/sylius:1.12.10`

```bash
Problem 1
    - Root composer.json requires sylius/sylius ^1.12 -> satisfiable by sylius/sylius[v1.12.10].
    - sylius/sylius v1.12.10 requires symfony/service-contracts ^2.5 -> found symfony/service-contracts[v2.5.0, v2.5.1, v2.5.2] but the package is fixed to v3.3.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```
