### PR TITLE
Prevent skipping choosing payment step once skipping payment step allowed, but no payment method is available

### DIFF
--- a/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -37,3 +37,11 @@ Feature: Skipping payment step when only one payment method is available
         And I complete the shipping step with first shipping method
         Then I should be on the checkout complete step
         And my order's payment method should be "Paypal Express Checkout"
+
+    @ui @api
+    Scenario: Preventing skipping the payment method choosing step when no payment method is available
+        Given the store has disabled all payment methods
+        When I add product "Guards! Guards!" to the cart
+        And I complete addressing step with email "guest@example.com" and "United States" based billing address
+        And I complete the shipping step with first shipping method
+        Then I should be on the checkout payment step

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -48,6 +48,21 @@ final class PaymentContext implements Context
     }
 
     /**
+     * @Given the store has disabled all payment methods
+     */
+    public function theStoreHasDisabledAllPaymentMethods(): void
+    {
+        $paymentMethods = $this->paymentMethodRepository->findAll();
+
+        /** @var PaymentMethodInterface $paymentMethod */
+        foreach ($paymentMethods as $paymentMethod) {
+            $paymentMethod->setEnabled(false);
+        }
+
+        $this->paymentMethodManager->flush();
+    }
+
+    /**
      * @Given /^the store allows paying (\w+) for (all channels)$/
      */
     public function storeAllowsPayingForAllChannels($paymentMethodName, array $channels)

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
@@ -28,7 +28,7 @@ final class OrderPaymentMethodSelectionRequirementChecker implements OrderPaymen
             return false;
         }
 
-        if (!$order->getChannel()->isSkippingPaymentStepAllowed()) {
+        if (!$order->getChannel()->isSkippingPaymentStepAllowed() || $order->getPayments()->isEmpty()) {
             return true;
         }
 

--- a/src/Sylius/Component/Core/spec/Checker/OrderPaymentMethodSelectionRequirementCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Checker/OrderPaymentMethodSelectionRequirementCheckerSpec.php
@@ -37,9 +37,11 @@ final class OrderPaymentMethodSelectionRequirementCheckerSpec extends ObjectBeha
     function it_says_that_payment_method_has_to_be_selected_if_order_total_is_bigger_than_0(
         OrderInterface $order,
         ChannelInterface $channel,
+        PaymentInterface $payment,
     ): void {
         $order->getTotal()->willReturn(1000);
         $order->getChannel()->willReturn($channel);
+        $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
         $channel->isSkippingPaymentStepAllowed()->willReturn(false);
 
         $this->isPaymentMethodSelectionRequired($order)->shouldReturn(true);
@@ -55,9 +57,11 @@ final class OrderPaymentMethodSelectionRequirementCheckerSpec extends ObjectBeha
     function it_says_that_payment_method_has_to_be_selected_if_skipping_payment_step_is_disabled(
         OrderInterface $order,
         ChannelInterface $channel,
+        PaymentInterface $payment,
     ): void {
         $order->getTotal()->willReturn(1000);
         $order->getChannel()->willReturn($channel);
+        $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
 
         $channel->isSkippingPaymentStepAllowed()->willReturn(false);
 
@@ -94,6 +98,22 @@ final class OrderPaymentMethodSelectionRequirementCheckerSpec extends ObjectBeha
         $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
 
         $paymentMethodsResolver->getSupportedMethods($payment)->willReturn([$paymentMethod1, $paymentMethod2]);
+        $channel->isSkippingPaymentStepAllowed()->willReturn(true);
+
+        $this->isPaymentMethodSelectionRequired($order)->shouldReturn(true);
+    }
+
+    public function it_says_that_payment_method_has_to_be_selected_if_skipping_payment_step_is_enabled_but_there_are_no_payment_methods_available(
+        OrderInterface $order,
+        ChannelInterface $channel,
+        PaymentInterface $payment,
+        PaymentMethodsResolverInterface $paymentMethodsResolver,
+    ): void {
+        $order->getTotal()->willReturn(1000);
+        $order->getChannel()->willReturn($channel);
+        $order->getPayments()->willReturn(new ArrayCollection([$payment->getWrappedObject()]));
+
+        $paymentMethodsResolver->getSupportedMethods($payment)->willReturn([]);
         $channel->isSkippingPaymentStepAllowed()->willReturn(true);
 
         $this->isPaymentMethodSelectionRequired($order)->shouldReturn(true);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11677
| License         | MIT

