### PR TITLE
Remove DecimalCalculator taxs from doc

### DIFF
--- a/docs/book/orders/taxation.rst
+++ b/docs/book/orders/taxation.rst
@@ -160,8 +160,7 @@ Built-in Calculators
 
 The already defined calculators in Sylius:
 
-* **DefaultCalculator** - calculates the ``amount`` with rounding.
-* **DecimalCalculator** - calculates the ``amount`` without rounding, which results in a distribution of decimal values among the items.
+* **DefaultCalculator** - calculate tax based on a given base amount and tax rate. The calculation varies depending on whether the tax rate is already included in the base price or not.
 
 Learn more
 ----------


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 or 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT   
<img width="971" alt="Capture d’écran 2023-08-19 à 12 04 53" src="https://github.com/Sylius/Sylius/assets/9056839/c061b1f4-22fb-455c-8ee6-116a88a05fcd">
                                                       |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


the DecimalCalculator doesn't exist anymore