### PR TITLE
Fix error with being unable to add product review while being logged in using remember me

### DIFF
--- a/features/product/adding_product_reviews/adding_product_review_as_a_customer.feature
+++ b/features/product/adding_product_reviews/adding_product_review_as_a_customer.feature
@@ -7,12 +7,21 @@ Feature: Adding product review as a customer
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "Necronomicon"
-        And I am a logged in customer
 
     @ui @api
     Scenario: Adding product reviews as a logged in customer
+        Given I am a logged in customer
         When I want to review product "Necronomicon"
         And I leave a comment "Great book for every advanced sorcerer.", titled "Scary but astonishing"
         And I rate it with 5 points
+        And I add it
+        Then I should be notified that my review is waiting for the acceptation
+
+    @ui
+    Scenario: Adding product reviews as a logged in customer with remember me option
+        Given I am a logged in customer by using remember me option
+        When I want to review product "Necronomicon"
+        And I leave a comment "Great book for every advanced sorcerer.", titled "Scary but astonishing"
+        And I rate it with 3 points
         And I add it
         Then I should be notified that my review is waiting for the acceptation

--- a/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
@@ -67,4 +67,17 @@ final class ShopSecurityContext implements Context
 
         $this->sharedStorage->set('user', $user);
     }
+
+    /**
+     * @Given I am a logged in customer by using remember me option
+     */
+    public function iAmLoggedInCustomerByUsingRememberMeOption(): void
+    {
+        $userData = ['email' => 'sylius@example.com', 'password' => 'sylius', 'enabled' => true];
+
+        $user = $this->userFactory->create($userData);
+        $this->userRepository->add($user);
+
+        $this->securityService->logInWithRememberMe($user);
+    }
 }

--- a/src/Sylius/Behat/Service/RememberMeAwareSecurityServiceInterface.php
+++ b/src/Sylius/Behat/Service/RememberMeAwareSecurityServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service;
+
+use Sylius\Component\User\Model\UserInterface;
+
+interface RememberMeAwareSecurityServiceInterface extends SecurityServiceInterface
+{
+    public function logInWithRememberMe(UserInterface $user): void;
+}

--- a/src/Sylius/Behat/Service/SecurityService.php
+++ b/src/Sylius/Behat/Service/SecurityService.php
@@ -19,11 +19,12 @@ use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
 
-final class SecurityService implements SecurityServiceInterface
+final class SecurityService implements RememberMeAwareSecurityServiceInterface
 {
     private string $sessionTokenVariable;
 
@@ -44,6 +45,13 @@ final class SecurityService implements SecurityServiceInterface
         } else {
             $token = new UsernamePasswordToken($user, $user->getPassword(), $this->firewallContextName, $user->getRoles());
         }
+
+        $this->setToken($token);
+    }
+
+    public function logInWithRememberMe(UserInterface $user): void
+    {
+        $token = new RememberMeToken($user, $this->firewallContextName, 'secret');
 
         $this->setToken($token);
     }

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_form.html.twig
@@ -12,7 +12,7 @@
     {{ form_widget(form.comment, sylius_test_form_attribute('comment')|sylius_merge_recursive( {'attr': {'placeholder': 'sylius.ui.write_your_own_review'|trans}})) }}
     {{ form_errors(form.comment) }}
 </div>
-{% if not is_granted("IS_AUTHENTICATED_FULLY") %}
+{% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
     <div class="field">
         {{ form_widget(form.author.email, sylius_test_form_attribute('author-email')|sylius_merge_recursive( {'attr': {'placeholder': 'sylius.ui.email'|trans}})) }}
         {{ form_errors(form.author.email) }}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/14898 and https://github.com/Sylius/Sylius/issues/9430                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

As being said [here](https://github.com/Sylius/Sylius/issues/14898) we were checking access against `IS_AUTHENTICATED_FULLY` while creating product review and it leads to a problem, that prevents us from creating review while using remember me functionality:

![image](https://github.com/Sylius/Sylius/assets/53942444/4e07bb72-361f-417f-be9f-e2306fc75306)

By changing it to `IS_AUTHENTICATED_REMEMBERED` resolves the bug