### PR TITLE
Deprecate unused ProductOptionChoiceType

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -1,5 +1,8 @@
 # UPGRADE FROM `v1.12.X` TO `v1.13.0`
 
+1. Class `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionChoiceType` has been deprecated.
+   Use `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionAutocompleteType` instead.
+
 1. Starting with Sylius 1.13, the `SyliusPriceHistoryPlugin` is included.
    If you are currently using the plugin in your project, we recommend following the upgrade guide located [here](UPGRADE-FROM-1.12-WITH-PRICE-HISTORY-PLUGIN-TO-1.13.md).
 

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
@@ -25,6 +25,12 @@ final class ProductOptionChoiceType extends AbstractType
 {
     public function __construct(private RepositoryInterface $productOptionRepository)
     {
+        @trigger_deprecation(
+            'sylius/product-bundle',
+            '1.13',
+            'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            self::class
+        );
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                     |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Followed by https://github.com/Sylius/Sylius/pull/14806