### PR TITLE
[Maintenance] Deprecate using `parentId` in TaxonSlugController

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -7,6 +7,9 @@
 1. Class `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionChoiceType` has been deprecated.
    Use `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionAutocompleteType` instead.
 
+1. Using `parentId` query parameter to generate slug in `Sylius\Bundle\TaxonomyBundle\Controller\TaxonSlugController` has been deprecated.
+   Use the `parentCode` query parameter instead.
+
 1. Starting with Sylius 1.13, the `SyliusPriceHistoryPlugin` is included.
    If you are currently using the plugin in your project, we recommend following the upgrade guide located [here](UPGRADE-FROM-1.12-WITH-PRICE-HISTORY-PLUGIN-TO-1.13.md).
 

--- a/src/Sylius/Bundle/TaxonomyBundle/Controller/TaxonSlugController.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Controller/TaxonSlugController.php
@@ -62,6 +62,12 @@ final class TaxonSlugController
 
         $parentId = $request->query->get('parentId');
         if (null !== $parentId) {
+            trigger_deprecation(
+                'sylius/taxonomy-bundle',
+                '1.13',
+                'Using "parentId" for slug generation is deprecated and will not be possible in 2.0. Use "parentCode" instead.'
+            );
+
             return $this->taxonRepository->find($parentId);
         }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes  |
| Related tickets | continues #15252                      |
| License         | MIT                                                          |