### PR TITLE
[Maintenance] Update dev symfony version to 5.4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -256,7 +256,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "^6.0"
+            "require": "5.4.*"
         }
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

On 1.12 we were using Symfony ^6.0 by default, while on 1.13 it was 5.4.*.
This discrepancy is extremely annoying when you frequently switch between the two.