### PR TITLE
Fix configuring amount for cart promotions item percentage discount actions

### DIFF
--- a/features/promotion/managing_promotions/adding_promotion_with_action.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action.feature
@@ -22,8 +22,8 @@ Feature: Adding a new promotion with action
     Scenario: Adding a promotion with item percentage discount
         When I want to create a new promotion
         And I specify its code as "promotion_for_all_product_items"
-        And I name it "-2.56% for all product items!"
-        And I add the "Item percentage discount" action configured with a percentage value of 2,56% for "United States" channel
+        And I name it "-20% for all product items!"
+        And I add the "Item percentage discount" action configured with a percentage value of 20% for "United States" channel
         And I add it
         Then I should be notified that it has been successfully created
-        And it should have "2.56%" of item percentage discount configured for "United States" channel
+        And it should have "20.00%" of item percentage discount configured for "United States" channel

--- a/features/promotion/managing_promotions/adding_promotion_with_action.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action.feature
@@ -17,3 +17,13 @@ Feature: Adding a new promotion with action
         And I add it
         Then I should be notified that it has been successfully created
         And the "$10.00 for all products!" promotion should appear in the registry
+
+    @ui @javascript
+    Scenario: Adding a promotion with item percentage discount
+        When I want to create a new promotion
+        And I specify its code as "promotion_for_all_product_items"
+        And I name it "-2.56% for all product items!"
+        And I add the "Item percentage discount" action configured with a percentage value of 2,56% for "United States" channel
+        And I add it
+        Then I should be notified that it has been successfully created
+        And it should have "2.56%" of item percentage discount configured for "United States" channel

--- a/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
+++ b/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
@@ -10,18 +10,26 @@ Feature: Seeing correct percentage discounts while editing promotion with action
         And this promotion gives "12.00%" discount to every order
         And I am logged in as an administrator
 
-    @ui @javascript
-    Scenario: Seeing the accurate percentage amount after editing the promotion including the value up to one decimal place
+    @ui
+    Scenario: Seeing an accurate percentage amount after editing the promotion including the value up to one decimal place
         When I want to modify a "Cheap Stuff" promotion
-        And I edit this promotion percentage action to have "2.50%"
+        And I edit this promotion percentage action to have "2.5%"
         And I save my changes
         Then I should be notified that it has been successfully edited
         And it should have "2.50%" of order percentage discount
 
-    @ui @javascript
-    Scenario: Seeing the accurate percentage amount after editing the promotion including the value up to two decimal places
+    @ui
+    Scenario: Seeing an accurate percentage amount after editing the promotion including the value up to two decimal places
         When I want to modify a "Cheap Stuff" promotion
         And I edit this promotion percentage action to have "2.56%"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And it should have "2.56%" of order percentage discount
+
+    @ui
+    Scenario: Seeing an accurate percentage amount after using a comma as a decimal separator
+        When I want to modify a "Cheap Stuff" promotion
+        And I edit this promotion percentage action to have "2,56%"
         And I save my changes
         Then I should be notified that it has been successfully edited
         And it should have "2.56%" of order percentage discount

--- a/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
+++ b/features/promotion/managing_promotions/seeing_correct_percantage_discounts_while_editing_promotion_with_action_and_decimal_places.feature
@@ -16,7 +16,7 @@ Feature: Seeing correct percentage discounts while editing promotion with action
         And I edit this promotion percentage action to have "2.50%"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And it should have "2.50%" discount
+        And it should have "2.50%" of order percentage discount
 
     @ui @javascript
     Scenario: Seeing the accurate percentage amount after editing the promotion including the value up to two decimal places
@@ -24,4 +24,4 @@ Feature: Seeing correct percentage discounts while editing promotion with action
         And I edit this promotion percentage action to have "2.56%"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And it should have "2.56%" discount
+        And it should have "2.56%" of order percentage discount

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -420,10 +420,10 @@ final class ManagingPromotionsContext implements Context
     /**
      * @When /^I edit (this promotion) percentage action to have "([^"]+)%"$/
      */
-    public function iEditCatalogPromotionToHaveDiscount(PromotionInterface $promotion, string $amount): void
+    public function iEditPromotionToHaveDiscount(PromotionInterface $promotion, string $amount): void
     {
         $this->updatePage->open(['id' => $promotion->getId()]);
-        $this->updatePage->specifyPercentageDiscountActionValue($amount);
+        $this->updatePage->specifyOrderPercentageDiscountActionValue($amount);
         $this->updatePage->saveChanges();
     }
 
@@ -726,11 +726,19 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
-     * @Then it should have :amount discount
+     * @Then it should have :amount of order percentage discount
      */
-    public function itShouldHaveDiscount(string $amount): void
+    public function itShouldHaveOfOrderPercentageDiscount(string $amount): void
     {
-        Assert::same($this->updatePage->getPercentageDiscountActionValue(), $amount);
+        Assert::same($this->updatePage->getOrderPercentageDiscountActionValue(), $amount);
+    }
+
+    /**
+     * @Then it should have :amount of item percentage discount configured for :channel channel
+     */
+    public function itShouldHaveOfItemPercentageDiscount(string $amount, ChannelInterface $channel): void
+    {
+        Assert::same($this->updatePage->getItemPercentageDiscountActionValue($channel->getCode()), $amount);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
@@ -134,14 +134,19 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getElement('action_field', ['%channelCode%' => $channelCode, '%field%' => $field])->setValue('');
     }
 
-    public function specifyPercentageDiscountActionValue(string $discount): void
+    public function getItemPercentageDiscountActionValue(string $channelCode): string
     {
-        $this->getElement('percentage_action_field')->setValue($discount);
+        return $this->getElement('action_field', ['%channelCode%' => $channelCode, '%field%' => 'percentage'])->getValue() . '%';
     }
 
-    public function getPercentageDiscountActionValue(): string
+    public function specifyOrderPercentageDiscountActionValue(string $discount): void
     {
-        $action = $this->getElement('percentage_action_field');
+        $this->getElement('order_percentage_action_field')->setValue($discount);
+    }
+
+    public function getOrderPercentageDiscountActionValue(): string
+    {
+        $action = $this->getElement('order_percentage_action_field');
 
         return $action->find('css', 'input')->getValue() . '%';
     }
@@ -179,7 +184,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             'ends_at_time' => '#sylius_promotion_endsAt_time',
             'exclusive' => '#sylius_promotion_exclusive',
             'name' => '#sylius_promotion_name',
-            'percentage_action_field' => '[id^="sylius_promotion_actions_"][id$="_configuration_percentage"]',
+            'order_percentage_action_field' => '[id^="sylius_promotion_actions_"][id$="_configuration_percentage"]',
             'priority' => '#sylius_promotion_priority',
             'rule_amount' => '[id^="sylius_promotion_rules_"][id$="_configuration_%channelCode%_amount"]',
             'rules' => '#rules',

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
@@ -53,9 +53,11 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
 
     public function removeActionFieldValue(string $channelCode, string $field): void;
 
-    public function specifyPercentageDiscountActionValue(string $discount): void;
+    public function getItemPercentageDiscountActionValue(string $channelCode): string;
 
-    public function getPercentageDiscountActionValue(): string;
+    public function specifyOrderPercentageDiscountActionValue(string $discount): void;
+
+    public function getOrderPercentageDiscountActionValue(): string;
 
     public function removeRuleAmount(string $channelCode): void;
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
@@ -29,6 +29,8 @@ final class UnitPercentageDiscountConfigurationType extends AbstractType
         $builder
             ->add('percentage', PercentType::class, [
                 'label' => 'sylius.form.promotion_action.percentage_discount_configuration.percentage',
+                'html5' => true,
+                'scale' => 2,
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
                     new Type(['type' => 'numeric', 'groups' => ['sylius']]),


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Same issue like [here](https://github.com/Sylius/Sylius/pull/15214)