### PR TITLE
Deprecate ContainsProductRuleUpdater and TotalOfItemsFromTaxonRuleUpdater

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -1,5 +1,9 @@
 # UPGRADE FROM `v1.12.X` TO `v1.13.0`
 
+1. Class `Sylius\Component\Core\Promotion\Updater\Rule\TotalOfItemsFromTaxonRuleUpdater` has been deprecated, as it is no more used.
+
+1. Class `Sylius\Component\Core\Promotion\Updater\Rule\ContainsProductRuleUpdater` has been deprecated, as it is no more used.
+
 1. Class `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionChoiceType` has been deprecated.
    Use `Sylius\Bundle\ProductBundle\Form\Type\ProductOptionAutocompleteType` instead.
 

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
@@ -22,6 +22,11 @@ final class ContainsProductRuleUpdater implements ProductAwareRuleUpdaterInterfa
 {
     public function __construct(private RepositoryInterface $promotionRuleRepository)
     {
+        @trigger_deprecation(
+            'sylius/core',
+            '1.13', 'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            self::class
+        );
     }
 
     public function updateAfterProductDeletion(ProductInterface $product): array

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
@@ -22,6 +22,11 @@ final class TotalOfItemsFromTaxonRuleUpdater implements TaxonAwareRuleUpdaterInt
 {
     public function __construct(private RepositoryInterface $promotionRuleRepository)
     {
+        @trigger_deprecation(
+            'sylius/core',
+            '1.13', 'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            self::class
+        );
     }
 
     public function updateAfterDeletingTaxon(TaxonInterface $taxon): array


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                     |
| BC breaks?      | no                                                       |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
followed by https://github.com/Sylius/Sylius/pull/15277 as this class is no more used.