### PR TITLE
Prevent throwing 500 while finalizing an order when at least one item has become tracked

### DIFF
--- a/features/order/managing_orders/handling_order_payment/finalizing_order_payment.feature
+++ b/features/order/managing_orders/handling_order_payment/finalizing_order_payment.feature
@@ -10,7 +10,7 @@ Feature: Finalizing order payment
         And the store ships everywhere for Free
         And the store allows paying with "Cash on Delivery"
         And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
-        And the customer bought a single "Angel T-Shirt"
+        And the customer bought 5 "Angel T-Shirt" products
         And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
@@ -21,6 +21,14 @@ Feature: Finalizing order payment
         When I mark this order as paid
         Then I should be notified that the order's payment has been successfully completed
         And it should have payment state "Completed"
+
+    @ui
+    Scenario: Finalizing order's payment when at least one item has become tracked after the purchase
+        Given I view the summary of the order "#00000666"
+        And the "Angel T-Shirt" product's inventory has become tracked with 2 items
+        When I mark this order as paid
+        Then I should be notified that the order's payment could not be finalized due to insufficient stock
+        And it should have payment state "New"
 
     @ui
     Scenario: Unable to finalize completed order's payment

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -753,6 +753,19 @@ final class OrderContext implements Context
     }
 
     /**
+     * @Given the :product product's inventory has become tracked with :numberOfItems items
+     */
+    public function theProductSInventoryHasBecameTrackedWithItems(ProductInterface $product, int $numberOfItems): void
+    {
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $product->getVariants()->first();
+        $productVariant->setTracked(true);
+        $productVariant->setOnHand($numberOfItems);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @param string $transition
      */
     private function applyShipmentTransitionOnOrder(OrderInterface $order, $transition)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -532,6 +532,17 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then I should be notified that the order's payment could not be finalized due to insufficient stock
+     */
+    public function iShouldBeNotifiedThatTheOrderSPaymentCouldNotBeFinalizedDueToInsufficientStock()
+    {
+        $this->notificationChecker->checkNotification(
+            'The payment cannot be completed due to insufficient stock of the',
+            NotificationType::failure(),
+        );
+    }
+
+    /**
      * @Then I should be notified that the order's payment has been successfully refunded
      */
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyRefunded()

--- a/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
+
+final class PaymentPreCompleteListener
+{
+    public function __construct (
+        private AvailabilityCheckerInterface $availabilityChecker,
+    ) {
+    }
+
+    public function checkStockAvailability(ResourceControllerEvent $event): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $event->getSubject();
+        $orderItems = $payment->getOrder()->getItems();
+
+        foreach ($orderItems as $orderItem) {
+            $variant = $orderItem->getVariant();
+
+            if (!$this->availabilityChecker->isStockSufficient($variant, $orderItem->getQuantity())) {
+                $event->setMessageType('error');
+                $event->setMessage('sylius.resource.payment.cannot_be_completed');
+                $event->setMessageParameters(['%productVariantCode%' => $variant->getCode()]);
+                $event->stopPropagation();
+
+                break;
+            }
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -96,6 +96,11 @@
             <tag name="kernel.event_listener" event="sylius.taxon.pre_delete" method="handleRemovingRootTaxonAtPositionZero" />
         </service>
 
+        <service id="Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener">
+            <argument type="service" id="Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface" />
+            <tag name="kernel.event_listener" event="sylius.payment.pre_complete" method="checkStockAvailability" />
+        </service>
+
         <service id="Sylius\Bundle\CoreBundle\EventListener\ProductDeletionListener">
             <argument type="service" id="request_stack" />
             <argument type="service" id="Sylius\Component\Core\Promotion\Updater\Rule\ContainsProductRuleUpdater" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/flashes.en.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/flashes.en.yaml
@@ -1,0 +1,4 @@
+sylius:
+    resource:
+        payment:
+            cannot_be_completed: 'The payment cannot be completed due to insufficient stock of the "%productVariantCode%" product.'


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | closes #10313
| License         | MIT

