### PR TITLE
Only show "View More" button when there are accepted reviews

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Reviews/_viewMore.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Reviews/_viewMore.html.twig
@@ -1,3 +1,5 @@
-<a href="{{ path('sylius_shop_product_review_index', {'slug': product.slug, '_locale': product.translation.locale}) }}">
-    <div class="ui labeled icon button"><i class="icon list"></i> {{ 'sylius.ui.view_more'|trans }}</div>
-</a>
+{% if product.acceptedReviews.count is not same as(0) %}
+    <a href="{{ path('sylius_shop_product_review_index', {'slug': product.slug, '_locale': product.translation.locale}) }}">
+        <div class="ui labeled icon button"><i class="icon list"></i> {{ 'sylius.ui.view_more'|trans }}</div>
+    </a>
+{% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Reviews/_viewMore.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Reviews/_viewMore.html.twig
@@ -1,4 +1,4 @@
-{% if product.acceptedReviews.count is not same as(0) %}
+{% if product.acceptedReviews.count > 0 %}
     <a href="{{ path('sylius_shop_product_review_index', {'slug': product.slug, '_locale': product.translation.locale}) }}">
         <div class="ui labeled icon button"><i class="icon list"></i> {{ 'sylius.ui.view_more'|trans }}</div>
     </a>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | maybe                                                       |
| Deprecations?   | no |
| Related tickets | -                     |
| License         | MIT                                                          |

For me it didn't make a lot of sense that there is a 'view more' button under the list of recent reviews, if there are no reviews to be shown at all.
