### PR TITLE
Allow to reset admin user password via CLI

### DIFF
--- a/features/cli/change_admin_password.feature
+++ b/features/cli/change_admin_password.feature
@@ -1,0 +1,15 @@
+@change_admin_password @cli
+Feature: Changing an administrator's password via CLI
+    In order to login to my administrator account when I forget my password
+    As a administrator
+    I want to be able to change my administrator password via CLI
+
+    Background:
+        Given there is an administrator "sylius_change_password@example.com" identified by "sylius"
+
+    @cli
+    Scenario: Changing an administrator's password
+        When I want to change password
+        And I specify email as "sylius_change_password@example.com"
+        And I specify my new password as "newp@ssw0rd"
+        Then I should be able to log in as "sylius_change_password@example.com" authenticated by "newp@ssw0rd" password

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,6 +111,10 @@ parameters:
 			path: src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
 
 		-
+			message: "#^Method Sylius\\\\Bundle\\\\AdminBundle\\\\Command\\\\ChangeAdminUserPasswordCommand\\:\\:__construct\\(\\) has parameter \\$adminUserRepository with generic interface Sylius\\\\Component\\\\User\\\\Repository\\\\UserRepositoryInterface but does not specify its types\\: T$#"
+			count: 1
+			path: src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
+		-
 			message: "#^Method Sylius\\\\Bundle\\\\AdminBundle\\\\Controller\\\\CustomerStatisticsController\\:\\:__construct\\(\\) has parameter \\$customerRepository with generic interface Sylius\\\\Component\\\\Resource\\\\Repository\\\\RepositoryInterface but does not specify its types\\: T$#"
 			count: 1
 			path: src/Sylius/Bundle/AdminBundle/Controller/CustomerStatisticsController.php

--- a/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
+++ b/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Cli;
+
+use Behat\Behat\Context\Context;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Webmozart\Assert\Assert;
+
+final class ChangeAdminPasswordContext implements Context
+{
+    private const ADMIN_USER_CHANGE_PASSWORD = 'sylius:admin-user:change-password';
+
+    private Application $application;
+
+    private ?CommandTester $commandTester = null;
+
+    private $input = [];
+
+    public function __construct(
+        KernelInterface $kernel
+    ) {
+        $this->application = new Application($kernel);
+    }
+
+    /**
+     * @When I want to change password
+     */
+    public function iWantToChangePassword(): void
+    {
+        $command = $this->application->find(self::ADMIN_USER_CHANGE_PASSWORD);
+
+        $this->commandTester = new CommandTester($command);
+    }
+
+    /**
+     * @When I specify email as :email
+     */
+    public function iSpecifyEmailAs(string $email = ''): void
+    {
+        $this->input['email'] = $email;
+    }
+
+    /**
+     * @When I specify my new password as :password
+     */
+    public function iSpecifyMyNewPassword(string $password = ''): void
+    {
+        $this->input['password'] = $password;
+    }
+
+    /**
+     * @Then I should be able to log in as :email authenticated by :password password
+     */
+    public function iShouldBeAbleToLoginWithEmailAndPassword(string $email = '', string $password = ''): void
+    {
+        $this->commandTester->setInputs($this->input);
+        $this->commandTester->execute(['command' => self::ADMIN_USER_CHANGE_PASSWORD]);
+
+        Assert::contains($this->commandTester->getDisplay(), 'Admin user password has been changed successfully.');
+    }
+}

--- a/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
@@ -27,5 +27,9 @@
             <argument type="service" id="kernel" />
             <argument type="service" id="sylius.repository.order" />
         </service>
+
+        <service id="sylius.behat.context.cli.change_admin_password" class="Sylius\Behat\Context\Cli\ChangeAdminPasswordContext">
+            <argument type="service" id="kernel" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -63,6 +63,7 @@ imports:
 
     - suites/cli/canceling_unpaid_orders.yml
     - suites/cli/installer.yml
+    - suites/cli/change_admin_password.yml
     - suites/cli/showing_available_plugins.yml
 
     - suites/hybrid/cart/shopping_cart.yml

--- a/src/Sylius/Behat/Resources/config/suites/cli/change_admin_password.yml
+++ b/src/Sylius/Behat/Resources/config/suites/cli/change_admin_password.yml
@@ -1,0 +1,13 @@
+# This file is part of the Sylius package.
+# (c) Sylius Sp. z o.o.
+
+default:
+    suites:
+        change_admin_password:
+            contexts:
+                - sylius.behat.context.setup.admin_user
+                - sylius.behat.context.cli.change_admin_password
+
+
+            filters:
+                tags: "@change_admin_password&&@cli"

--- a/src/Sylius/Behat/Resources/config/suites/cli/change_admin_password.yml
+++ b/src/Sylius/Behat/Resources/config/suites/cli/change_admin_password.yml
@@ -8,6 +8,5 @@ default:
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.cli.change_admin_password
 
-
             filters:
                 tags: "@change_admin_password&&@cli"

--- a/src/Sylius/Bundle/AdminBundle/Command/AbstractAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/AbstractAdminUserCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+abstract class AbstractAdminUserCommand extends Command
+{
+    protected SymfonyStyle $io;
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function createEmailQuestion(): Question
+    {
+        $question = new Question('Email');
+        $question->setValidator(function (?string $email) {
+            if (!filter_var($email, \FILTER_VALIDATE_EMAIL) || $email === null) {
+                throw new \InvalidArgumentException('The email address provided is invalid. Please try again.');
+            }
+
+            return $email;
+        });
+        $question->setMaxAttempts(3);
+
+        return $question;
+    }
+
+    protected function createQuestionWithNonBlankValidator(string $askedQuestion, bool $hidden = false): Question
+    {
+        $question = new Question($askedQuestion);
+        $question->setValidator(function (?string $value) {
+            if ($value === null) {
+                throw new \InvalidArgumentException('The value cannot be empty.');
+            }
+
+            return $value;
+        });
+        $question->setMaxAttempts(3);
+
+        if ($hidden) {
+            $question->setHidden(true);
+        }
+
+        return $question;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
@@ -60,7 +60,7 @@ final class ChangeAdminUserPasswordCommand extends AbstractAdminUserCommand
         $this->passwordUpdater->updatePassword($adminUser);
         $this->adminUserRepository->add($adminUser);
 
-        $this->io->success('Admin user password has been successfully reset.');
+        $this->io->success('Admin user password has been changed successfully.');
 
         return Command::SUCCESS;
     }

--- a/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
@@ -29,8 +29,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class ChangeAdminUserPasswordCommand extends Command
 {
-    private SymfonyStyle $io;
-
     public function __construct(
         private UserRepositoryInterface $adminUserRepository,
         private PasswordUpdaterInterface $passwordUpdater
@@ -38,38 +36,34 @@ final class ChangeAdminUserPasswordCommand extends Command
         parent::__construct();
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output): void
-    {
-        $this->io = new SymfonyStyle($input, $output);
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
         if (!$input->isInteractive()) {
-            $this->io->error('This command must be run interactively.');
+            $io->error('This command must be run interactively.');
 
             return Command::FAILURE;
         }
 
-        $this->io->title('Change admin user password');
+        $io->title('Change admin user password');
 
-        $email = $this->io->askQuestion($this->createEmailQuestion());
+        $email = $io->askQuestion($this->createEmailQuestion());
 
         /** @var AdminUserInterface|null $adminUser */
         $adminUser = $this->adminUserRepository->findOneByEmail($email);
         if ($adminUser === null) {
-            $this->io->error(sprintf('Admin user with email address %s not found!', $email));
+            $io->error(sprintf('Admin user with email address %s not found!', $email));
 
             return Command::INVALID;
         }
 
-        $password = $this->io->askHidden('Password');
+        $password = $io->askHidden('Password');
         $adminUser->setPlainPassword($password);
 
         $this->passwordUpdater->updatePassword($adminUser);
         $this->adminUserRepository->add($adminUser);
 
-        $this->io->success('Admin user password has been successfully reset.');
+        $io->success('Admin user password has been successfully reset.');
 
         return Command::SUCCESS;
     }

--- a/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Command;
+
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Sylius\Component\User\Security\PasswordUpdaterInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'sylius:admin-user:change-password',
+    description: 'Change password of admin user'
+)]
+final class ChangeAdminUserPasswordCommand extends Command
+{
+    private SymfonyStyle $io;
+
+    public function __construct(
+        private UserRepositoryInterface $adminUserRepository,
+        private PasswordUpdaterInterface $passwordUpdater
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$input->isInteractive()) {
+            $this->io->error('This command must be run interactively.');
+
+            return Command::FAILURE;
+        }
+
+        $this->io->title('Change admin user password');
+
+        $email = $this->io->askQuestion($this->createEmailQuestion());
+
+        /** @var AdminUserInterface|null $adminUser */
+        $adminUser = $this->adminUserRepository->findOneByEmail($email);
+        if ($adminUser === null) {
+            $this->io->error(sprintf('Admin user with email address %s not found!', $email));
+
+            return Command::INVALID;
+        }
+
+        $password = $this->io->askHidden('Password');
+        $adminUser->setPlainPassword($password);
+
+        $this->passwordUpdater->updatePassword($adminUser);
+        $this->adminUserRepository->add($adminUser);
+
+        $this->io->success('Admin user password has been successfully reset.');
+
+        return Command::SUCCESS;
+    }
+
+    private function createEmailQuestion(): Question
+    {
+        $question = new Question('Email');
+        $question->setValidator(function (?string $email) {
+            if (!filter_var($email, FILTER_VALIDATE_EMAIL) || $email === null) {
+                throw new \InvalidArgumentException('The e-mail address provided is invalid. Please try again.');
+            }
+
+            return $email;
+        });
+        $question->setMaxAttempts(3);
+
+        return $question;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/ChangeAdminUserPasswordCommand.php
@@ -20,14 +20,12 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'sylius:admin-user:change-password',
     description: 'Change password of admin user'
 )]
-final class ChangeAdminUserPasswordCommand extends Command
+final class ChangeAdminUserPasswordCommand extends AbstractAdminUserCommand
 {
     public function __construct(
         private UserRepositoryInterface $adminUserRepository,
@@ -38,48 +36,32 @@ final class ChangeAdminUserPasswordCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
         if (!$input->isInteractive()) {
-            $io->error('This command must be run interactively.');
+            $this->io->error('This command must be run interactively.');
 
             return Command::FAILURE;
         }
 
-        $io->title('Change admin user password');
+        $this->io->title('Change admin user password');
 
-        $email = $io->askQuestion($this->createEmailQuestion());
+        $email = $this->io->askQuestion($this->createEmailQuestion());
 
         /** @var AdminUserInterface|null $adminUser */
         $adminUser = $this->adminUserRepository->findOneByEmail($email);
         if ($adminUser === null) {
-            $io->error(sprintf('Admin user with email address %s not found!', $email));
+            $this->io->error(sprintf('Admin user with email address %s not found!', $email));
 
             return Command::INVALID;
         }
 
-        $password = $io->askHidden('Password');
+        $password = $this->io->askQuestion($this->createQuestionWithNonBlankValidator('New password', true));
         $adminUser->setPlainPassword($password);
 
         $this->passwordUpdater->updatePassword($adminUser);
         $this->adminUserRepository->add($adminUser);
 
-        $io->success('Admin user password has been successfully reset.');
+        $this->io->success('Admin user password has been successfully reset.');
 
         return Command::SUCCESS;
-    }
-
-    private function createEmailQuestion(): Question
-    {
-        $question = new Question('Email');
-        $question->setValidator(function (?string $email) {
-            if (!filter_var($email, FILTER_VALIDATE_EMAIL) || $email === null) {
-                throw new \InvalidArgumentException('The e-mail address provided is invalid. Please try again.');
-            }
-
-            return $email;
-        });
-        $question->setMaxAttempts(3);
-
-        return $question;
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Command/CreateAdminUserCommand.php
@@ -19,8 +19,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Intl\Locales;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\HandleTrait;
@@ -30,22 +28,15 @@ use Symfony\Component\Messenger\MessageBusInterface;
     name: 'sylius:admin-user:create',
     description: 'Create a new admin user',
 )]
-final class CreateAdminUserCommand extends Command
+final class CreateAdminUserCommand extends AbstractAdminUserCommand
 {
     use HandleTrait;
-
-    private SymfonyStyle $io;
 
     public function __construct(MessageBusInterface $messageBus, private string $defaultLocaleCode)
     {
         $this->messageBus = $messageBus;
 
         parent::__construct();
-    }
-
-    protected function initialize(InputInterface $input, OutputInterface $output): void
-    {
-        $this->io = new SymfonyStyle($input, $output);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -105,40 +96,6 @@ final class CreateAdminUserCommand extends Command
         $adminUserData['enabled'] = $this->io->confirm('Do you want to enable this admin user?', true);
 
         return $adminUserData;
-    }
-
-    private function createEmailQuestion(): Question
-    {
-        $question = new Question('Email');
-        $question->setValidator(function (?string $email) {
-            if (!filter_var($email, \FILTER_VALIDATE_EMAIL) || $email === null) {
-                throw new \InvalidArgumentException('The email address provided is invalid. Please try again.');
-            }
-
-            return $email;
-        });
-        $question->setMaxAttempts(3);
-
-        return $question;
-    }
-
-    private function createQuestionWithNonBlankValidator(string $askedQuestion, bool $hidden = false): Question
-    {
-        $question = new Question($askedQuestion);
-        $question->setValidator(function (?string $value) {
-            if ($value === null) {
-                throw new \InvalidArgumentException('The value cannot be empty.');
-            }
-
-            return $value;
-        });
-        $question->setMaxAttempts(3);
-
-        if ($hidden) {
-            $question->setHidden(true);
-        }
-
-        return $question;
     }
 
     private function showSummary(array $adminUserData): void

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -41,6 +41,12 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Sylius\Bundle\AdminBundle\Command\ChangeAdminUserPasswordCommand">
+            <argument type="service" id="sylius.repository.admin_user" />
+            <argument type="service" id="sylius.security.password_updater" />
+            <tag name="console.command" />
+        </service>
+
         <service id="Sylius\Bundle\AdminBundle\MessageHandler\CreateAdminUserHandler">
             <argument type="service" id="sylius.repository.admin_user" />
             <argument type="service" id="sylius.factory.admin_user" />

--- a/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
@@ -52,7 +52,7 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_does_not_reset_password_when_admin_user_is_not_found(): void
+    public function it_does_not_change_password_when_admin_user_is_not_found(): void
     {
         $this
             ->userRepository
@@ -72,7 +72,7 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_resets_password_for_existing_admin_user(): void
+    public function it_changes_password_for_existing_admin_user(): void
     {
         $adminUser = new AdminUser();
 

--- a/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
@@ -30,7 +30,6 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     private UserRepositoryInterface $userRepository;
     private PasswordUpdaterInterface $passwordUpdater;
 
-
     protected function setUp(): void
     {
         parent::setUp();

--- a/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
@@ -46,13 +46,17 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     /** @test */
     public function it_does_not_reset_password_when_admin_user_is_not_found(): void
     {
-        $this->userRepository->expects($this->once())
+        $this
+            ->userRepository
+            ->expects($this->once())
             ->method('findOneByEmail')
             ->willReturn(null);
 
-        $this->command->setInputs([
-            'email' => self::EMAIL
-        ]);
+        $this
+            ->command
+            ->setInputs([
+                'email' => self::EMAIL
+            ]);
 
         $this->command->execute([]);
 
@@ -64,21 +68,29 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     {
         $adminUser = new AdminUser();
 
-        $this->userRepository->expects($this->once())
+        $this
+            ->userRepository
+            ->expects($this->once())
             ->method('findOneByEmail')
             ->willReturn($adminUser);
-        $this->userRepository->expects($this->once())
+        $this
+            ->userRepository
+            ->expects($this->once())
             ->method('add')
             ->with($adminUser);
 
-        $this->passwordUpdater->expects($this->once())
+        $this
+            ->passwordUpdater
+            ->expects($this->once())
             ->method('updatePassword')
             ->with($adminUser);
 
-        $this->command->setInputs([
-            'email' => self::EMAIL,
-            'password' => self::PASSWORD
-        ]);
+        $this
+            ->command
+            ->setInputs([
+                'email' => self::EMAIL,
+                'password' => self::PASSWORD
+            ]);
 
         $this->command->execute([]);
 

--- a/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
@@ -44,6 +44,14 @@ final class ChangeAdminUserPasswordCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_execute_in_non_interactive_mode(): void
+    {
+        $this->command->execute([], ['interactive' => false]);
+
+        self::assertSame(Command::FAILURE, $this->command->getStatusCode());
+    }
+
+    /** @test */
     public function it_does_not_reset_password_when_admin_user_is_not_found(): void
     {
         $this

--- a/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Command/ChangeAdminUserPasswordCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Command\ChangeAdminUserPasswordCommand;
+use Sylius\Component\Core\Model\AdminUser;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Sylius\Component\User\Security\PasswordUpdaterInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ChangeAdminUserPasswordCommandTest extends TestCase
+{
+    private const EMAIL = 'sylius@example.com';
+    private const PASSWORD = 'Password';
+
+    private CommandTester $command;
+    private UserRepositoryInterface $userRepository;
+    private PasswordUpdaterInterface $passwordUpdater;
+
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
+
+        $this->passwordUpdater = $this->createMock(PasswordUpdaterInterface::class);
+
+        $this->command = new CommandTester(
+            new ChangeAdminUserPasswordCommand($this->userRepository, $this->passwordUpdater),
+        );
+    }
+
+    /** @test */
+    public function it_does_not_reset_password_when_admin_user_is_not_found(): void
+    {
+        $this->userRepository->expects($this->once())
+            ->method('findOneByEmail')
+            ->willReturn(null);
+
+        $this->command->setInputs([
+            'email' => self::EMAIL
+        ]);
+
+        $this->command->execute([]);
+
+        self::assertSame(Command::INVALID, $this->command->getStatusCode());
+    }
+
+    /** @test */
+    public function it_resets_password_for_existing_admin_user(): void
+    {
+        $adminUser = new AdminUser();
+
+        $this->userRepository->expects($this->once())
+            ->method('findOneByEmail')
+            ->willReturn($adminUser);
+        $this->userRepository->expects($this->once())
+            ->method('add')
+            ->with($adminUser);
+
+        $this->passwordUpdater->expects($this->once())
+            ->method('updatePassword')
+            ->with($adminUser);
+
+        $this->command->setInputs([
+            'email' => self::EMAIL,
+            'password' => self::PASSWORD
+        ]);
+
+        $this->command->execute([]);
+
+        self::assertSame(Command::SUCCESS, $this->command->getStatusCode());
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | addition for #14571                      |
| License         | MIT                                                          |

With #14571 admin users can created via CLI, this PR adds a command to reset admin user passwords via CLI.