### PR TITLE
Make the User class compatible with Symfony 6 to use encoder_name

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,8 @@
+# UPGRADE FROM `v1.12.11` TO `v1.12.12`
+
+1. The `Sylius\Component\User\Model\UserInterface` extends the `Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface`
+   interface to fix the compatibility with Symfony 6.
+
 # UPGRADE FROM `v1.12.10` TO `v1.12.11`
 
 1. Due to a bug that was causing the removal of promotion configurations for promotions [REF](https://github.com/Sylius/Sylius/issues/15201),
@@ -36,9 +41,6 @@
 1. The `src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_treeWithButtons.html.twig` template has been updated to
     implement new changing taxon's position logic. If you have overridden this template, you need to update it.
     If you want to check what has changed, you might use [this PR](https://github.com/Sylius/Sylius/pull/15272) as a reference.
-
-1. The `Sylius\Component\User\Model\UserInterface` extends the `Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface`
-    interface to fix the compatibilty with Symfony 6.
 
 # UPGRADE FROM `v1.12.9` TO `v1.12.10`
 

--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -37,6 +37,9 @@
     implement new changing taxon's position logic. If you have overridden this template, you need to update it.
     If you want to check what has changed, you might use [this PR](https://github.com/Sylius/Sylius/pull/15272) as a reference.
 
+1. The `Sylius\Component\User\Model\UserInterface` extends the `Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface`
+    interface to fix the compatibilty with Symfony 6.
+
 # UPGRADE FROM `v1.12.9` TO `v1.12.10`
 
 1. The `Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor` constructor has been changed:

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -383,6 +383,11 @@ class User implements UserInterface, \Stringable
         $this->encoderName = $encoderName;
     }
 
+    public function getPasswordHasherName(): ?string
+    {
+        return $this->getEncoderName();
+    }
+
     /**
      * The serialized data have to contain the fields used by the equals method and the username.
      */

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -19,6 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 use Sylius\Component\Resource\Model\ToggleableInterface;
 use SyliusLabs\Polyfill\Symfony\Security\Core\Encoder\EncoderAwareInterface;
 use SyliusLabs\Polyfill\Symfony\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
 
 interface UserInterface extends
     AdvancedUserInterface,
@@ -27,7 +28,8 @@ interface UserInterface extends
     \Serializable,
     TimestampableInterface,
     ToggleableInterface,
-    EncoderAwareInterface
+    EncoderAwareInterface,
+    PasswordHasherAwareInterface
 {
     public const DEFAULT_ROLE = 'ROLE_USER';
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #15286                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
