### PR TITLE
Enable Sylius API for app environments

### DIFF
--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -11,7 +11,7 @@ parameters:
     sylius_core.public_dir: '%kernel.project_dir%/public'
 
 sylius_api:
-    enabled: false
+    enabled: true
 
 sylius_shop:
     product_grid:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

The `config` directory is not used outside the `Sylius/Sylius` repository, so we can safely enable the API in all envs, to make it available in the Bunnyshell's environments.