### PR TITLE
Add a note about payment-related events

### DIFF
--- a/docs/book/orders/payments.rst
+++ b/docs/book/orders/payments.rst
@@ -158,6 +158,15 @@ You have most likely changed the PayPal credentials during the checkout process.
 Payment complete events
 -----------------------
 
+.. warning::
+
+    The following events are not a universal way to listen for a completed payment, as they are only dispatched by `ResourceController` at specific places, like completing the payment for a given order in the Admin Panel.
+    It means that `pre_complete` and `post_complete` events won't be triggered when a customer completes the payment by using, e.g., a payment gateway.
+
+.. tip::
+
+    If you are looking for a way to listen for completing the payment, consider :doc:`adding a new callback </customization/state_machine>` for a `sylius_order_payment` state machine on the `pay` transition.
+
 There are two events that are triggered on the payment complete action:
 
 +-------------------------------------+


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | closes #12541
| License         | MIT

We agreed there is no good way to resolve that issue in `1.x` version, so we decided to make the docs as clear as it's possible in that matter.

![CleanShot 2023-09-13 at 04 49 57](https://github.com/Sylius/Sylius/assets/80641364/98e48e24-3ef7-47d6-a392-845d0b6dba24)

P.S. I've created a task for considering how to fix this in later Sylius versions :).