### PR TITLE
Add missing admin:taxon:update group to TaxonTranslation's locale field

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
@@ -41,6 +41,7 @@
         <attribute name="locale">
             <group>admin:taxon:read</group>
             <group>admin:taxon:create</group>
+            <group>admin:taxon:update</group>
         </attribute>
         <attribute name="slug">
             <group>admin:taxon:read</group>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | yes, but only existing on `1.13`
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes a bug introduced in #15259
| License         | MIT

