### PR TITLE
Add a deprecation for the sylius_admin_ajax_taxon_move route

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -137,3 +137,6 @@
 
 1. Passing an instance of `Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface` as the first argument
     to `Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration\SelectAttributeChoicesCollectionType` has been deprecated.
+
+1. The `sylius_admin_ajax_taxon_move` route has been deprecated. If you're relaying on it, consider migrating to new
+    `sylius_admin_ajax_taxon_move_up` and `sylius_admin_ajax_taxon_move_down` routes.

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
@@ -60,6 +60,7 @@ sylius_admin_ajax_generate_taxon_slug:
         _controller: sylius.controller.taxon_slug::generateAction
         _format: json
 
+# This route is deprecated since Sylius 1.13.0 and will be removed in 2.0.0.
 sylius_admin_ajax_taxon_move:
     path: /{id}/move
     methods: [PUT]

--- a/src/Sylius/Bundle/TaxonomyBundle/Controller/TaxonPositionController.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Controller/TaxonPositionController.php
@@ -23,6 +23,9 @@ use Webmozart\Assert\Assert;
 
 final class TaxonPositionController
 {
+    /**
+     * @param TaxonRepositoryInterface<TaxonInterface> $taxonRepository
+     */
     public function __construct(
         private TaxonRepositoryInterface $taxonRepository,
         private ObjectManager $taxonManager,


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | n/a
| License         | MIT
