### PR TITLE
Allow to use Twig Components with Template Events

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -152,10 +152,10 @@
             private string $name,
             private string $eventName,
             private ?string $template,
-    +       private ?string $component,
             private ?array $context,
             private ?int $priority,
             private ?bool $enabled,
+    +       private ?string $component,
         ) {
         }
     ```

--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -144,3 +144,18 @@
 
 1. The `sylius_admin_ajax_taxon_move` route has been deprecated. If you're relaying on it, consider migrating to new
     `sylius_admin_ajax_taxon_move_up` and `sylius_admin_ajax_taxon_move_down` routes.
+
+1. The constructor of `Sylius\Bundle\UiBundle\Registry\TemplateBlock` has been changed:
+
+    ```diff
+        public function __construct(
+            private string $name,
+            private string $eventName,
+            private ?string $template,
+    +       private ?string $component,
+            private ?array $context,
+            private ?int $priority,
+            private ?bool $enabled,
+        ) {
+        }
+    ```

--- a/composer.json
+++ b/composer.json
@@ -132,6 +132,7 @@
         "symfony/translation": "^5.4.21 || ^6.0",
         "symfony/translation-contracts": "^2.5",
         "symfony/twig-bundle": "^5.4.21 || ^6.0",
+        "symfony/ux-twig-component": "^2.11.2",
         "symfony/validator": "^5.4.21 || ^6.0",
         "symfony/webpack-encore-bundle": "^1.15",
         "symfony/yaml": "^5.4.21 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
         "symfony/translation": "^5.4.21 || ^6.0",
         "symfony/translation-contracts": "^2.5",
         "symfony/twig-bundle": "^5.4.21 || ^6.0",
-        "symfony/ux-twig-component": "^2.11.2",
+        "symfony/ux-twig-component": "^2.9.1",
         "symfony/validator": "^5.4.21 || ^6.0",
         "symfony/webpack-encore-bundle": "^1.15",
         "symfony/yaml": "^5.4.21 || ^6.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -59,4 +59,5 @@ return [
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
 ];

--- a/rector.php
+++ b/rector.php
@@ -2,21 +2,12 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return static function (ContainerConfigurator $containerConfigurator): void
+return static function (RectorConfig $config): void
 {
-    $containerConfigurator->import(LevelSetList::UP_TO_PHP_80);
-
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
-    $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
-
-    $services = $containerConfigurator->services();
-    $services->set(TypedPropertyRector::class);
-    $services->set(ClosureToArrowFunctionRector::class);
+    $config->sets([
+        LevelSetList::UP_TO_PHP_82
+    ]);
 };

--- a/src/Sylius/Bundle/AdminBundle/test/config/bundles.php
+++ b/src/Sylius/Bundle/AdminBundle/test/config/bundles.php
@@ -59,4 +59,5 @@ return [
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
     Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
     Sylius\Bundle\AdminBundle\SyliusAdminBundle::class => ['all' => true],
+    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
 ];

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/bundles.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/bundles.php
@@ -62,4 +62,5 @@ return [
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
 ];

--- a/src/Sylius/Bundle/CoreBundle/test/config/bundles.php
+++ b/src/Sylius/Bundle/CoreBundle/test/config/bundles.php
@@ -56,4 +56,5 @@ return [
     Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
+    Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
 ];

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ final class Configuration implements ConfigurationInterface
                                         ->booleanNode('enabled')->defaultNull()->end()
                                         ->arrayNode('context')->addDefaultsIfNotSet()->ignoreExtraKeys(false)->end()
                                         ->scalarNode('template')->defaultNull()->end()
+                                        ->scalarNode('component')->defaultNull()->end()
                                         ->integerNode('priority')->defaultNull()->end()
         ;
 

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -63,10 +63,10 @@ final class SyliusUiExtension extends Extension implements PrependExtensionInter
                     $details['name'],
                     $details['eventName'],
                     $details['template'],
-                    $details['component'],
                     $details['context'],
                     $details['priority'],
                     $details['enabled'],
+                    $details['component'],
                 ]);
             }
         }

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -58,7 +58,7 @@ final class SyliusUiExtension extends Extension implements PrependExtensionInter
             }
 
             foreach ($blocksPriorityQueue->toArray() as $details) {
-                /** @psalm-var array{name: string, eventName: string, template: string, context: array, priority: int, enabled: bool} $details */
+                /** @psalm-var array{name: string, eventName: string, template: string, component: string|null, context: array, priority: int, enabled: bool} $details */
                 $blocksForEvents[$eventName][$details['name']] = new Definition(TemplateBlock::class, [
                     $details['name'],
                     $details['eventName'],

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -63,6 +63,7 @@ final class SyliusUiExtension extends Extension implements PrependExtensionInter
                     $details['name'],
                     $details['eventName'],
                     $details['template'],
+                    $details['component'],
                     $details['context'],
                     $details['priority'],
                     $details['enabled'],

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
@@ -19,6 +19,7 @@ final class TemplateBlock
         private string $name,
         private string $eventName,
         private ?string $template,
+        private ?string $component,
         private ?array $context,
         private ?int $priority,
         private ?bool $enabled,
@@ -46,6 +47,19 @@ final class TemplateBlock
         }
 
         return $this->template;
+    }
+
+    public function getComponent(): string
+    {
+        if ($this->component === null) {
+            throw new \DomainException(sprintf(
+                'There is no component defined for block "%s" in event "%s".',
+                $this->name,
+                $this->eventName,
+            ));
+        }
+
+        return $this->component;
     }
 
     public function getContext(): array
@@ -77,6 +91,7 @@ final class TemplateBlock
             $this->name,
             $block->eventName,
             $block->template ?? $this->template,
+            $block->component ?? $this->component,
             $block->context ?? $this->context,
             $block->priority ?? $this->priority,
             $block->enabled ?? $this->enabled,

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
@@ -19,10 +19,10 @@ final class TemplateBlock
         private string $name,
         private string $eventName,
         private ?string $template,
-        private ?string $component,
         private ?array $context,
         private ?int $priority,
         private ?bool $enabled,
+        private ?string $component = null,
     ) {
     }
 
@@ -83,10 +83,10 @@ final class TemplateBlock
             $this->name,
             $block->eventName,
             $block->template ?? $this->template,
-            $block->component ?? $this->component,
             $block->context ?? $this->context,
             $block->priority ?? $this->priority,
             $block->enabled ?? $this->enabled,
+            $block->component ?? $this->component,
         );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
@@ -49,16 +49,8 @@ final class TemplateBlock
         return $this->template;
     }
 
-    public function getComponent(): string
+    public function getComponent(): ?string
     {
-        if ($this->component === null) {
-            throw new \DomainException(sprintf(
-                'There is no component defined for block "%s" in event "%s".',
-                $this->name,
-                $this->eventName,
-            ));
-        }
-
         return $this->component;
     }
 

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
@@ -23,30 +23,54 @@ final class HtmlDebugTemplateBlockRenderer implements TemplateBlockRendererInter
 
     public function render(TemplateBlock $templateBlock, array $context = []): string
     {
-        $shouldRenderHtmlDebug = strrpos($templateBlock->getTemplate(), '.html.twig') !== false;
+        $isTemplateBlockComponent = null !== $templateBlock->getComponent();
+        $shouldRenderHtmlDebug = $isTemplateBlockComponent || strrpos($templateBlock->getTemplate(), '.html.twig') !== false;
 
         $renderedParts = [];
 
-        if ($shouldRenderHtmlDebug) {
-            $renderedParts[] = sprintf(
-                '<!-- BEGIN BLOCK | event name: "%s", block name: "%s", template: "%s", priority: %d -->',
-                $templateBlock->getEventName(),
-                $templateBlock->getName(),
-                $templateBlock->getTemplate(),
-                $templateBlock->getPriority(),
-            );
+        if ($shouldRenderHtmlDebug && $isTemplateBlockComponent) {
+            $renderedParts[] = $this->getBeginBlockForComponent($templateBlock);
+        } elseif ($shouldRenderHtmlDebug) {
+            $renderedParts[] = $this->getBeginBlockForTemplate($templateBlock);
         }
 
         $renderedParts[] = $this->templateBlockRenderer->render($templateBlock, $context);
 
         if ($shouldRenderHtmlDebug) {
-            $renderedParts[] = sprintf(
-                '<!-- END BLOCK | event name: "%s", block name: "%s" -->',
-                $templateBlock->getEventName(),
-                $templateBlock->getName(),
-            );
+            $renderedParts[] = $this->getEndBlock($templateBlock);
         }
 
         return implode("\n", $renderedParts);
+    }
+
+    private function getBeginBlockForTemplate(TemplateBlock $templateBlock): string
+    {
+        return sprintf(
+            '<!-- BEGIN BLOCK | event name: "%s", block name: "%s", template: "%s", priority: %d -->',
+            $templateBlock->getEventName(),
+            $templateBlock->getName(),
+            $templateBlock->getTemplate(),
+            $templateBlock->getPriority(),
+        );
+    }
+
+    private function getBeginBlockForComponent(TemplateBlock $templateBlock): string
+    {
+        return sprintf(
+            '<!-- BEGIN BLOCK | event name: "%s", block name: "%s", component: "%s", priority: %d -->',
+            $templateBlock->getEventName(),
+            $templateBlock->getName(),
+            $templateBlock->getComponent(),
+            $templateBlock->getPriority(),
+        );
+    }
+
+    private function getEndBlock(TemplateBlock $templateBlock): string
+    {
+        return sprintf(
+            '<!-- END BLOCK | event name: "%s", block name: "%s" -->',
+            $templateBlock->getEventName(),
+            $templateBlock->getName(),
+        );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
@@ -26,19 +26,20 @@ final class HtmlDebugTemplateBlockRenderer implements TemplateBlockRendererInter
         $isTemplateBlockComponent = null !== $templateBlock->getComponent();
         $shouldRenderHtmlDebug = $isTemplateBlockComponent || strrpos($templateBlock->getTemplate(), '.html.twig') !== false;
 
+        if (!$shouldRenderHtmlDebug) {
+            return $this->templateBlockRenderer->render($templateBlock, $context);
+        }
+
         $renderedParts = [];
 
-        if ($shouldRenderHtmlDebug && $isTemplateBlockComponent) {
+        if ($isTemplateBlockComponent) {
             $renderedParts[] = $this->getBeginBlockForComponent($templateBlock);
-        } elseif ($shouldRenderHtmlDebug) {
+        } else {
             $renderedParts[] = $this->getBeginBlockForTemplate($templateBlock);
         }
 
         $renderedParts[] = $this->templateBlockRenderer->render($templateBlock, $context);
-
-        if ($shouldRenderHtmlDebug) {
-            $renderedParts[] = $this->getEndBlock($templateBlock);
-        }
+        $renderedParts[] = $this->getEndBlock($templateBlock);
 
         return implode("\n", $renderedParts);
     }

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -54,6 +54,17 @@ final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInter
      */
     private function shouldRenderHtmlDebug(array $templateBlocks): bool
     {
-        return count($templateBlocks) === 0 || count(array_filter($templateBlocks, static fn (TemplateBlock $templateBlock): bool => null !== $templateBlock->getComponent() || strrpos($templateBlock->getTemplate(), '.html.twig') !== false)) >= 1;
+        return count($templateBlocks) === 0 || $this->hasAnyBlockWithComponentOrTemplate($templateBlocks);
+    }
+
+    private function hasAnyBlockWithComponentOrTemplate(array $templateBlocks): bool
+    {
+        foreach ($templateBlocks as $templateBlock) {
+            if (null !== $templateBlock->getComponent() || strrpos($templateBlock->getTemplate(), '.html.twig') !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -57,6 +57,9 @@ final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInter
         return count($templateBlocks) === 0 || $this->hasAnyBlockWithComponentOrTemplate($templateBlocks);
     }
 
+    /**
+     * @param array<TemplateBlock> $templateBlocks
+     */
     private function hasAnyBlockWithComponentOrTemplate(array $templateBlocks): bool
     {
         foreach ($templateBlocks as $templateBlock) {

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -54,6 +54,6 @@ final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInter
      */
     private function shouldRenderHtmlDebug(array $templateBlocks): bool
     {
-        return count($templateBlocks) === 0 || count(array_filter($templateBlocks, static fn (TemplateBlock $templateBlock): bool => strrpos($templateBlock->getTemplate(), '.html.twig') !== false)) >= 1;
+        return count($templateBlocks) === 0 || count(array_filter($templateBlocks, static fn (TemplateBlock $templateBlock): bool => null !== $templateBlock->getComponent() || strrpos($templateBlock->getTemplate(), '.html.twig') !== false)) >= 1;
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace Sylius\Bundle\UiBundle\Renderer;
 
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
@@ -7,12 +18,15 @@ use Symfony\UX\TwigComponent\ComponentRendererInterface;
 
 final class TwigComponentBlockRenderer implements TemplateBlockRendererInterface
 {
-    public function __construct (
+    public function __construct(
         private TemplateBlockRendererInterface $decoratedRenderer,
         private ComponentRendererInterface $componentRenderer,
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     public function render(TemplateBlock $templateBlock, array $context = []): string
     {
         if (null === $templateBlock->getComponent()) {

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sylius\Bundle\UiBundle\Renderer;
+
+use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
+use Symfony\UX\TwigComponent\ComponentRendererInterface;
+
+final class TwigComponentBlockRenderer implements TemplateBlockRendererInterface
+{
+    public function __construct (
+        private TemplateBlockRendererInterface $decoratedRenderer,
+        private ComponentRendererInterface $componentRenderer,
+    ) {
+    }
+
+    public function render(TemplateBlock $templateBlock, array $context = []): string
+    {
+        if (null === $templateBlock->getComponent()) {
+            return $this->decoratedRenderer->render($templateBlock, $context);
+        }
+
+        return $this->componentRenderer->createAndRender($templateBlock->getComponent(), $templateBlock->getContext());
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
@@ -19,6 +19,6 @@ final class TwigComponentBlockRenderer implements TemplateBlockRendererInterface
             return $this->decoratedRenderer->render($templateBlock, $context);
         }
 
-        return $this->componentRenderer->createAndRender($templateBlock->getComponent(), $templateBlock->getContext());
+        return $this->componentRenderer->createAndRender($templateBlock->getComponent(), ['context' => $templateBlock->getContext()]);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigComponentBlockRenderer.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Symfony\UX\TwigComponent\ComponentRendererInterface;
 
+/** @internal */
 final class TwigComponentBlockRenderer implements TemplateBlockRendererInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/template_event.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/template_event.xml
@@ -22,6 +22,11 @@
             <argument type="tagged_iterator" tag="sylius.ui.template_event.context_provider" />
         </service>
 
+        <service id="Sylius\Bundle\UiBundle\Renderer\TwigComponentBlockRenderer" decorates="Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface" decoration-priority="1024">
+            <argument type="service" id=".inner" />
+            <argument type="service" id="ux.twig_component.component_renderer" />
+        </service>
+
         <service id="Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface" class="Sylius\Bundle\UiBundle\Renderer\DelegatingTemplateEventRenderer">
             <argument type="service" id="Sylius\Bundle\UiBundle\Registry\TemplateBlockRegistryInterface" />
             <argument type="service" id="Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface" />

--- a/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
@@ -41,11 +41,11 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             0,
             [
                 'first_event' => [
-                    'first_block' => new Definition(TemplateBlock::class, ['first_block', 'first_event', 'first.html.twig', null, [], 0, true]),
-                    'second_block' => new Definition(TemplateBlock::class, ['second_block', 'first_event', 'second.html.twig', null, ['foo' => 'bar'], 0, true]),
+                    'first_block' => new Definition(TemplateBlock::class, ['first_block', 'first_event', 'first.html.twig', [], 0, true, null]),
+                    'second_block' => new Definition(TemplateBlock::class, ['second_block', 'first_event', 'second.html.twig', ['foo' => 'bar'], 0, true, null]),
                 ],
                 'second_event' => [
-                    'another_block' => new Definition(TemplateBlock::class, ['another_block', 'second_event', 'another.html.twig', null, [], 0, true]),
+                    'another_block' => new Definition(TemplateBlock::class, ['another_block', 'second_event', 'another.html.twig', [], 0, true, null]),
                 ],
             ],
         );
@@ -69,10 +69,10 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             TemplateBlockRegistryInterface::class,
             0,
             ['event_name' => [
-                'first_block' => new Definition(TemplateBlock::class, ['first_block', 'event_name', 'first.html.twig', null, [], 5, true]),
-                'second_block' => new Definition(TemplateBlock::class, ['second_block', 'event_name', 'second.html.twig', null, [], 0, true]),
-                'third_block' => new Definition(TemplateBlock::class, ['third_block', 'event_name', 'third.html.twig', null, [], 0, true]),
-                'fourth_block' => new Definition(TemplateBlock::class, ['fourth_block', 'event_name', 'fourth.html.twig', null, [], -5, true]),
+                'first_block' => new Definition(TemplateBlock::class, ['first_block', 'event_name', 'first.html.twig', [], 5, true, null]),
+                'second_block' => new Definition(TemplateBlock::class, ['second_block', 'event_name', 'second.html.twig', [], 0, true, null]),
+                'third_block' => new Definition(TemplateBlock::class, ['third_block', 'event_name', 'third.html.twig', [], 0, true, null]),
+                'fourth_block' => new Definition(TemplateBlock::class, ['fourth_block', 'event_name', 'fourth.html.twig', [], -5, true, null]),
             ]],
         );
     }

--- a/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
@@ -41,11 +41,11 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             0,
             [
                 'first_event' => [
-                    'first_block' => new Definition(TemplateBlock::class, ['first_block', 'first_event', 'first.html.twig', [], 0, true]),
-                    'second_block' => new Definition(TemplateBlock::class, ['second_block', 'first_event', 'second.html.twig', ['foo' => 'bar'], 0, true]),
+                    'first_block' => new Definition(TemplateBlock::class, ['first_block', 'first_event', 'first.html.twig', null, [], 0, true]),
+                    'second_block' => new Definition(TemplateBlock::class, ['second_block', 'first_event', 'second.html.twig', null, ['foo' => 'bar'], 0, true]),
                 ],
                 'second_event' => [
-                    'another_block' => new Definition(TemplateBlock::class, ['another_block', 'second_event', 'another.html.twig', [], 0, true]),
+                    'another_block' => new Definition(TemplateBlock::class, ['another_block', 'second_event', 'another.html.twig', null, [], 0, true]),
                 ],
             ],
         );
@@ -69,10 +69,10 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             TemplateBlockRegistryInterface::class,
             0,
             ['event_name' => [
-                'first_block' => new Definition(TemplateBlock::class, ['first_block', 'event_name', 'first.html.twig', [], 5, true]),
-                'second_block' => new Definition(TemplateBlock::class, ['second_block', 'event_name', 'second.html.twig', [], 0, true]),
-                'third_block' => new Definition(TemplateBlock::class, ['third_block', 'event_name', 'third.html.twig', [], 0, true]),
-                'fourth_block' => new Definition(TemplateBlock::class, ['fourth_block', 'event_name', 'fourth.html.twig', [], -5, true]),
+                'first_block' => new Definition(TemplateBlock::class, ['first_block', 'event_name', 'first.html.twig', null, [], 5, true]),
+                'second_block' => new Definition(TemplateBlock::class, ['second_block', 'event_name', 'second.html.twig', null, [], 0, true]),
+                'third_block' => new Definition(TemplateBlock::class, ['third_block', 'event_name', 'third.html.twig', null, [], 0, true]),
+                'fourth_block' => new Definition(TemplateBlock::class, ['fourth_block', 'event_name', 'fourth.html.twig', null, [], -5, true]),
             ]],
         );
     }

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/Kernel.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/Kernel.php
@@ -16,12 +16,14 @@ namespace Sylius\Bundle\UiBundle\Tests\Functional;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sylius\Bundle\UiBundle\SyliusUiBundle;
 use Sylius\Bundle\UiBundle\Tests\Functional\src\CustomContextProvider;
+use Sylius\Bundle\UiBundle\Tests\Functional\src\SomeTwigComponent;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
 use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
 
 final class Kernel extends HttpKernel
@@ -37,12 +39,15 @@ final class Kernel extends HttpKernel
             new SonataBlockBundle(),
             new SyliusUiBundle(),
             new WebpackEncoreBundle(),
+            new TwigComponentBundle(),
         ];
     }
 
     protected function build(ContainerBuilder $container)
     {
         $container->register(CustomContextProvider::class)->addTag('sylius.ui.template_event.context_provider');
+
+        $container->register(SomeTwigComponent::class)->addTag('twig.component', ['template' => 'blocks/twigComponent/someTwigComponent.html.twig']);
 
         $container->loadFromExtension('framework', [
             'secret' => 'S0ME_SECRET',
@@ -113,6 +118,23 @@ final class Kernel extends HttpKernel
                         'context' => [
                             'option1' => 'foo',
                             'option2' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+            'template_event' => [
+                'blocks' => [
+                    'block' => [
+                        'component' => 'SomeTwigComponent',
+                    ],
+                ],
+            ],
+            'template_event_with_context' => [
+                'blocks' => [
+                    'block' => [
+                        'component' => 'SomeTwigComponent',
+                        'context' => [
+                            'foo' => 'bar',
                         ],
                     ],
                 ],

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/TemplateEventTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/TemplateEventTest.php
@@ -100,4 +100,27 @@ final class TemplateEventTest extends KernelTestCase
 
         Assert::assertSame($expectedLines, $renderedLines);
     }
+
+    /** @test */
+    public function it_renders_component(): void
+    {
+        $expectedLines = [
+            '<!-- BEGIN EVENT | event name: "template_event" -->',
+            '<!-- BEGIN BLOCK | event name: "template_event", block name: "block", component: "SomeTwigComponent", priority: 0 -->',
+            'Hello from the Twig Component :)',
+            'Context: no context',
+            '<!-- END BLOCK | event name: "template_event", block name: "block" -->',
+            '<!-- END EVENT | event name: "template_event" -->',
+            '<!-- BEGIN EVENT | event name: "template_event_with_context" -->',
+            '<!-- BEGIN BLOCK | event name: "template_event_with_context", block name: "block", component: "SomeTwigComponent", priority: 0 -->',
+            'Hello from the Twig Component :)',
+            'Context: foo=bar',
+            '<!-- END BLOCK | event name: "template_event_with_context", block name: "block" -->',
+            '<!-- END EVENT | event name: "template_event_with_context" -->',
+        ];
+
+        $renderedLines = array_values(array_filter(explode("\n", $this->twig->render('templateEventsButComponent.txt.twig'))));
+
+        Assert::assertSame($expectedLines, $renderedLines);
+    }
 }

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/src/SomeTwigComponent.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/src/SomeTwigComponent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\Tests\Functional\src;
+
+use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
+use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
+
+#[AsTwigComponent]
+final class SomeTwigComponent
+{
+    public array $context = [];
+
+    #[ExposeInTemplate]
+    public function getContextAsString(): string
+    {
+        if ([] === $this->context) {
+            return 'no context';
+        }
+
+        $result = [];
+
+        foreach ($this->context as $key => $value) {
+            $result[] = $key . '=' . $value;
+        }
+
+        return implode(', ', $result);
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/src/SomeTwigComponent.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/src/SomeTwigComponent.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Tests\Functional\src;

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/twigComponent/someTwigComponent.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/twigComponent/someTwigComponent.html.twig
@@ -1,0 +1,2 @@
+Hello from the Twig Component :)
+Context: {{ contextAsString }}

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/templateEventsButComponent.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/templateEventsButComponent.txt.twig
@@ -1,0 +1,2 @@
+{{ sylius_template_event('template_event') }}
+{{ sylius_template_event('template_event_with_context', { context: 'The king is dead, long live the king!' }) }}

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -40,6 +40,7 @@
         "symfony/security-core": "^5.4.21 || ^6.0",
         "symfony/security-bundle": "^5.4.21 || ^6.0",
         "symfony/templating": "^5.4.21 || ^6.0",
+        "symfony/ux-twig-component": "^2.11.2",
         "symfony/webpack-encore-bundle": "^1.15",
         "laminas/laminas-stdlib": "^3.3.1"
     },

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -40,7 +40,7 @@
         "symfony/security-core": "^5.4.21 || ^6.0",
         "symfony/security-bundle": "^5.4.21 || ^6.0",
         "symfony/templating": "^5.4.21 || ^6.0",
-        "symfony/ux-twig-component": "^2.11.2",
+        "symfony/ux-twig-component": "^2.9.1",
         "symfony/webpack-encore-bundle": "^1.15",
         "laminas/laminas-stdlib": "^3.3.1"
     },

--- a/src/Sylius/Bundle/UiBundle/spec/ContextProvider/DefaultContextProviderSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/ContextProvider/DefaultContextProviderSpec.php
@@ -26,7 +26,7 @@ final class DefaultContextProviderSpec extends ObjectBehavior
 
     function it_replaces_block_context_with_a_template_context(): void
     {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['foo' => 'quux', 'quuz' => 'corge'], 0, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['foo' => 'quux', 'quuz' => 'corge'], 0, true, null);
 
         $this
             ->provide(['foo' => 'bar', 'baz' => 'qux'], $templateBlock)
@@ -46,7 +46,7 @@ final class DefaultContextProviderSpec extends ObjectBehavior
         ;
 
         $this
-            ->supports(new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['foo' => 'quux', 'quuz' => 'corge'], 0, true))
+            ->supports(new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['foo' => 'quux', 'quuz' => 'corge'], 0, true, null))
             ->shouldReturn(true)
         ;
     }

--- a/src/Sylius/Bundle/UiBundle/spec/ContextProvider/DefaultContextProviderSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/ContextProvider/DefaultContextProviderSpec.php
@@ -26,7 +26,7 @@ final class DefaultContextProviderSpec extends ObjectBehavior
 
     function it_replaces_block_context_with_a_template_context(): void
     {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['foo' => 'quux', 'quuz' => 'corge'], 0, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['foo' => 'quux', 'quuz' => 'corge'], 0, true);
 
         $this
             ->provide(['foo' => 'bar', 'baz' => 'qux'], $templateBlock)
@@ -41,12 +41,12 @@ final class DefaultContextProviderSpec extends ObjectBehavior
     function it_supports_all_template_blocks(): void
     {
         $this
-            ->supports(new TemplateBlock('block_name', 'event_name', null, null, null, null))
+            ->supports(new TemplateBlock('block_name', 'event_name', null, null, null, null, null))
             ->shouldReturn(true)
         ;
 
         $this
-            ->supports(new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['foo' => 'quux', 'quuz' => 'corge'], 0, true))
+            ->supports(new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['foo' => 'quux', 'quuz' => 'corge'], 0, true))
             ->shouldReturn(true)
         ;
     }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
@@ -31,7 +31,7 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
 
     function it_returns_all_template_blocks(): void
     {
-        $templateBlock = new TemplateBlock('block_name', 'event', 'block.html.twig', null, [], 10, true);
+        $templateBlock = new TemplateBlock('block_name', 'event', 'block.html.twig', [], 10, true, null);
 
         $this->beConstructedWith(['event' => ['block_name' => $templateBlock]]);
 
@@ -40,9 +40,9 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
 
     function it_returns_enabled_template_blocks_for_a_given_event(): void
     {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'event', 'first.html.twig', null, [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'event', 'second.html.twig', null, [], 10, false);
-        $thirdTemplateBlock = new TemplateBlock('third_block', 'event', 'third.html.twig', null, [], 50, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'event', 'first.html.twig', [], 0, true, null);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'event', 'second.html.twig', [], 10, false, null);
+        $thirdTemplateBlock = new TemplateBlock('third_block', 'event', 'third.html.twig', [], 50, true, null);
 
         $this->beConstructedWith([
             'event' => [
@@ -60,25 +60,25 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
     function it_returns_enabled_template_blocks_for_multiple_events(): void
     {
         $this->beConstructedWith([
-            'generic_event' => ['block' => new TemplateBlock('block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, true)],
+            'generic_event' => ['block' => new TemplateBlock('block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true)],
             'specific_event_template' => ['block' => new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, null, null, null)],
-            'specific_event_context' => ['block' => new TemplateBlock('block', 'specific_event_context', null, null, ['other' => 'context'], null, null)],
-            'specific_event_priority' => ['block' => new TemplateBlock('block', 'specific_event_priority', null, null, null, 10, null)],
-            'specific_event_enabled' => ['block' => new TemplateBlock('block', 'specific_event_enabled', null, null, null, null, false)],
+            'specific_event_context' => ['block' => new TemplateBlock('block', 'specific_event_context', null, ['other' => 'context'], null, null, null)],
+            'specific_event_priority' => ['block' => new TemplateBlock('block', 'specific_event_priority', null, null, 10, null, null)],
+            'specific_event_enabled' => ['block' => new TemplateBlock('block', 'specific_event_enabled', null, null, null, false, null)],
         ]);
 
         $this->findEnabledForEvents(['specific_event_template', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, ['foo' => 'bar'], 0, true),
+            new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', ['foo' => 'bar'], 0, true, null),
         ]);
         $this->findEnabledForEvents(['specific_event_context', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_context', 'generic.html.twig', null, ['other' => 'context'], 0, true),
+            new TemplateBlock('block', 'specific_event_context', 'generic.html.twig', ['other' => 'context'], 0, true, null),
         ]);
         $this->findEnabledForEvents(['specific_event_priority', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_priority', 'generic.html.twig', null, ['foo' => 'bar'], 10, true),
+            new TemplateBlock('block', 'specific_event_priority', 'generic.html.twig', ['foo' => 'bar'], 10, true, null),
         ]);
         $this->findEnabledForEvents(['specific_event_enabled', 'generic_event'])->shouldReturn([]);
         $this->findEnabledForEvents(['specific_event_priority', 'specific_event_template', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_priority', 'specific.html.twig', null, ['foo' => 'bar'], 10, true),
+            new TemplateBlock('block', 'specific_event_priority', 'specific.html.twig', ['foo' => 'bar'], 10, true, null),
         ]);
     }
 
@@ -86,23 +86,23 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
     {
         $this->beConstructedWith([
             'generic_event' => [
-                'first_block' => new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 50, true),
-                'third_block' => new TemplateBlock('third_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], -10, true),
-                'second_block' => new TemplateBlock('second_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, true),
-                'invisible_block' => new TemplateBlock('invisible_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, false),
+                'first_block' => new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true, null),
+                'third_block' => new TemplateBlock('third_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], -10, true, null),
+                'second_block' => new TemplateBlock('second_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true, null),
+                'invisible_block' => new TemplateBlock('invisible_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, false, null),
             ],
             'specific_event' => [
-                'additional_block' => new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', null, [], 75, true),
-                'second_block' => new TemplateBlock('second_block', 'specific_event', null, null, null, null, false),
-                'third_block' => new TemplateBlock('third_block', 'specific_event', null, null, null, 100, null),
-                'invisible_block' => new TemplateBlock('invisible_block', 'specific_event', null, null, [], null, null),
+                'additional_block' => new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true, null),
+                'second_block' => new TemplateBlock('second_block', 'specific_event', null, null, null, false, null),
+                'third_block' => new TemplateBlock('third_block', 'specific_event', null, null, 100, null, null),
+                'invisible_block' => new TemplateBlock('invisible_block', 'specific_event', null, [], null, null, null),
             ],
         ]);
 
         $this->findEnabledForEvents(['specific_event', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('third_block', 'specific_event', 'generic.html.twig', null, ['foo' => 'bar'], 100, true),
-            new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', null, [], 75, true),
-            new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 50, true),
+            new TemplateBlock('third_block', 'specific_event', 'generic.html.twig', ['foo' => 'bar'], 100, true, null),
+            new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true, null),
+            new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true, null),
         ]);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
@@ -31,7 +31,7 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
 
     function it_returns_all_template_blocks(): void
     {
-        $templateBlock = new TemplateBlock('block_name', 'event', 'block.html.twig', [], 10, true);
+        $templateBlock = new TemplateBlock('block_name', 'event', 'block.html.twig', null, [], 10, true);
 
         $this->beConstructedWith(['event' => ['block_name' => $templateBlock]]);
 
@@ -40,9 +40,9 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
 
     function it_returns_enabled_template_blocks_for_a_given_event(): void
     {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'event', 'first.html.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'event', 'second.html.twig', [], 10, false);
-        $thirdTemplateBlock = new TemplateBlock('third_block', 'event', 'third.html.twig', [], 50, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'event', 'first.html.twig', null, [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'event', 'second.html.twig', null, [], 10, false);
+        $thirdTemplateBlock = new TemplateBlock('third_block', 'event', 'third.html.twig', null, [], 50, true);
 
         $this->beConstructedWith([
             'event' => [
@@ -60,25 +60,25 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
     function it_returns_enabled_template_blocks_for_multiple_events(): void
     {
         $this->beConstructedWith([
-            'generic_event' => ['block' => new TemplateBlock('block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true)],
-            'specific_event_template' => ['block' => new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, null, null)],
-            'specific_event_context' => ['block' => new TemplateBlock('block', 'specific_event_context', null, ['other' => 'context'], null, null)],
-            'specific_event_priority' => ['block' => new TemplateBlock('block', 'specific_event_priority', null, null, 10, null)],
-            'specific_event_enabled' => ['block' => new TemplateBlock('block', 'specific_event_enabled', null, null, null, false)],
+            'generic_event' => ['block' => new TemplateBlock('block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, true)],
+            'specific_event_template' => ['block' => new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, null, null, null)],
+            'specific_event_context' => ['block' => new TemplateBlock('block', 'specific_event_context', null, null, ['other' => 'context'], null, null)],
+            'specific_event_priority' => ['block' => new TemplateBlock('block', 'specific_event_priority', null, null, null, 10, null)],
+            'specific_event_enabled' => ['block' => new TemplateBlock('block', 'specific_event_enabled', null, null, null, null, false)],
         ]);
 
         $this->findEnabledForEvents(['specific_event_template', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', ['foo' => 'bar'], 0, true),
+            new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, ['foo' => 'bar'], 0, true),
         ]);
         $this->findEnabledForEvents(['specific_event_context', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_context', 'generic.html.twig', ['other' => 'context'], 0, true),
+            new TemplateBlock('block', 'specific_event_context', 'generic.html.twig', null, ['other' => 'context'], 0, true),
         ]);
         $this->findEnabledForEvents(['specific_event_priority', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_priority', 'generic.html.twig', ['foo' => 'bar'], 10, true),
+            new TemplateBlock('block', 'specific_event_priority', 'generic.html.twig', null, ['foo' => 'bar'], 10, true),
         ]);
         $this->findEnabledForEvents(['specific_event_enabled', 'generic_event'])->shouldReturn([]);
         $this->findEnabledForEvents(['specific_event_priority', 'specific_event_template', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('block', 'specific_event_priority', 'specific.html.twig', ['foo' => 'bar'], 10, true),
+            new TemplateBlock('block', 'specific_event_priority', 'specific.html.twig', null, ['foo' => 'bar'], 10, true),
         ]);
     }
 
@@ -86,23 +86,23 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
     {
         $this->beConstructedWith([
             'generic_event' => [
-                'first_block' => new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true),
-                'third_block' => new TemplateBlock('third_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], -10, true),
-                'second_block' => new TemplateBlock('second_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true),
-                'invisible_block' => new TemplateBlock('invisible_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, false),
+                'first_block' => new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 50, true),
+                'third_block' => new TemplateBlock('third_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], -10, true),
+                'second_block' => new TemplateBlock('second_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, true),
+                'invisible_block' => new TemplateBlock('invisible_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 0, false),
             ],
             'specific_event' => [
-                'additional_block' => new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true),
-                'second_block' => new TemplateBlock('second_block', 'specific_event', null, null, null, false),
-                'third_block' => new TemplateBlock('third_block', 'specific_event', null, null, 100, null),
-                'invisible_block' => new TemplateBlock('invisible_block', 'specific_event', null, [], null, null),
+                'additional_block' => new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', null, [], 75, true),
+                'second_block' => new TemplateBlock('second_block', 'specific_event', null, null, null, null, false),
+                'third_block' => new TemplateBlock('third_block', 'specific_event', null, null, null, 100, null),
+                'invisible_block' => new TemplateBlock('invisible_block', 'specific_event', null, null, [], null, null),
             ],
         ]);
 
         $this->findEnabledForEvents(['specific_event', 'generic_event'])->shouldIterateLike([
-            new TemplateBlock('third_block', 'specific_event', 'generic.html.twig', ['foo' => 'bar'], 100, true),
-            new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true),
-            new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true),
+            new TemplateBlock('third_block', 'specific_event', 'generic.html.twig', null, ['foo' => 'bar'], 100, true),
+            new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', null, [], 75, true),
+            new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', null, ['foo' => 'bar'], 50, true),
         ]);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
@@ -20,7 +20,7 @@ final class TemplateBlockSpec extends ObjectBehavior
 {
     function it_represents_a_template_block(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false, null);
 
         $this->getName()->shouldReturn('block_name');
         $this->getEventName()->shouldReturn('event_name');
@@ -36,29 +36,29 @@ final class TemplateBlockSpec extends ObjectBehavior
         $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', 'some_component',  null, null, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', 'some_component', ['foo' => 'bar'], 10, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', null, null, null, 'some_component'))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', ['foo' => 'bar'], 10, false, 'some_component'))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, [], null, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, [], 10, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, [], null, null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', [], 10, false, null))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, -5, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, ['foo' => 'bar'], -5, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, -5, null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], -5, false, null))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, null, true))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, true))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, true, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], 10, true, null))
         ;
     }
 
     function it_throws_an_exception_if_trying_to_overwrite_with_a_differently_named_block(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false, null);
 
         $this->shouldThrow(\DomainException::class)->during('overwriteWith', [new TemplateBlock('different_name', 'specific_event_name', null, null, null, null, null)]);
     }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
@@ -20,11 +20,12 @@ final class TemplateBlockSpec extends ObjectBehavior
 {
     function it_represents_a_template_block(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
 
         $this->getName()->shouldReturn('block_name');
         $this->getEventName()->shouldReturn('event_name');
         $this->getTemplate()->shouldReturn('block.html.twig');
+        $this->getComponent()->shouldReturn(null);
         $this->getContext()->shouldReturn(['foo' => 'bar']);
         $this->getPriority()->shouldReturn(10);
         $this->isEnabled()->shouldReturn(false);
@@ -32,39 +33,39 @@ final class TemplateBlockSpec extends ObjectBehavior
 
     function it_overwrites_a_template_block_with_an_another_template_block(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', null, null, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', ['foo' => 'bar'], 10, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', 'some_component',  null, null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', 'some_component', ['foo' => 'bar'], 10, false))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, [], null, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', [], 10, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, [], null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, [], 10, false))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, -5, null))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], -5, false))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, -5, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, ['foo' => 'bar'], -5, false))
         ;
 
         $this
-            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, true))
-            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], 10, true))
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, null, true))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, true))
         ;
     }
 
     function it_throws_an_exception_if_trying_to_overwrite_with_a_differently_named_block(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', null, ['foo' => 'bar'], 10, false);
 
-        $this->shouldThrow(\DomainException::class)->during('overwriteWith', [new TemplateBlock('different_name', 'specific_event_name', null, null, null, null)]);
+        $this->shouldThrow(\DomainException::class)->during('overwriteWith', [new TemplateBlock('different_name', 'specific_event_name', null, null, null, null, null)]);
     }
 
     function it_has_sensible_defaults(): void
     {
-        $this->beConstructedWith('block_name', 'event_name', null, null, null, null);
+        $this->beConstructedWith('block_name', 'event_name', null, null, null, null, null);
 
         $this->shouldThrow(\DomainException::class)->during('getTemplate');
         $this->getContext()->shouldReturn([]);

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
@@ -36,8 +36,8 @@ final class DelegatingTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry,
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'best_event_ever', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'best_event_ever', 'secondBlock.txt.twig', [], 0, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'best_event_ever', 'firstBlock.txt.twig', null, [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'best_event_ever', 'secondBlock.txt.twig', null, [], 0, true);
 
         $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
 

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
@@ -36,8 +36,8 @@ final class DelegatingTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry,
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'best_event_ever', 'firstBlock.txt.twig', null, [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'best_event_ever', 'secondBlock.txt.twig', null, [], 0, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'best_event_ever', 'firstBlock.txt.twig', [], 0, true, null);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'best_event_ever', 'secondBlock.txt.twig', [], 0, true, null);
 
         $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
 

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
@@ -32,7 +32,7 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
     function it_does_not_render_a_debug_html_comment_if_the_template_block_is_not_a_component_nor_a_twig_template(
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', null, null, null, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', null, null, true, null);
 
         $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
 
@@ -42,7 +42,7 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
     function it_renders_a_debug_html_comment_if_the_template_block_has_a_configured_component(
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', 'component_name', null, null, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', null, null, true, 'component_name');
 
         $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
 
@@ -56,7 +56,7 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
     function it_renders_a_debug_html_comment_if_the_template_block_has_a_configured_twig_template(
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'template.html.twig', null, [], null, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'template.html.twig', [], null, true, null);
 
         $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
 

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\UiBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface;
 
@@ -30,29 +29,41 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
         $this->shouldImplement(TemplateBlockRendererInterface::class);
     }
 
-    function it_renders_html_debug_comment_prepending_the_block_if_rendering_html_template(
+    function it_does_not_render_a_debug_html_comment_if_the_template_block_is_not_a_component_nor_a_twig_template(
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $templateBlockRenderer->render(Argument::cetera())->willReturn('Block content');
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', null, null, null, true);
 
-        $this->render(
-            new TemplateBlock('block_name', 'event_name', 'block.html.twig', [], 0, true),
-            ['foo' => 'bar'],
-        )->shouldReturn(
-            '<!-- BEGIN BLOCK | event name: "event_name", block name: "block_name", template: "block.html.twig", priority: 0 -->' . "\n" .
-            'Block content' . "\n" .
-            '<!-- END BLOCK | event name: "event_name", block name: "block_name" -->',
+        $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
+
+        $this->render($templateBlock, [])->shouldReturn('Rendered template');
+    }
+
+    function it_renders_a_debug_html_comment_if_the_template_block_has_a_configured_component(
+        TemplateBlockRendererInterface $templateBlockRenderer,
+    ): void {
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'some_content', 'component_name', null, null, true);
+
+        $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
+
+        $this->render($templateBlock, [])->shouldReturn(
+            '<!-- BEGIN BLOCK | event name: "event_name", block name: "block_name", component: "component_name", priority: 0 -->' . "\n" .
+            'Rendered template' . "\n" .
+            '<!-- END BLOCK | event name: "event_name", block name: "block_name" -->'
         );
     }
 
-    function it_does_not_render_html_debug_comment_prepending_the_block_if_rendering_non_html_template(
+    function it_renders_a_debug_html_comment_if_the_template_block_has_a_configured_twig_template(
         TemplateBlockRendererInterface $templateBlockRenderer,
     ): void {
-        $templateBlockRenderer->render(Argument::cetera())->willReturn('Block content');
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'template.html.twig', null, [], null, true);
 
-        $this->render(
-            new TemplateBlock('block_name', 'event_name', 'block.txt.twig', [], 0, true),
-            ['foo' => 'bar'],
-        )->shouldReturn('Block content');
+        $templateBlockRenderer->render($templateBlock, [])->willReturn('Rendered template');
+
+        $this->render($templateBlock, [])->shouldReturn(
+            '<!-- BEGIN BLOCK | event name: "event_name", block name: "block_name", template: "template.html.twig", priority: 0 -->' . "\n" .
+            'Rendered template' . "\n" .
+            '<!-- END BLOCK | event name: "event_name", block name: "block_name" -->'
+        );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
@@ -35,7 +35,7 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
         $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
-            new TemplateBlock('some_block_one', 'some_event', 'some content', null, null, null, true),
+            new TemplateBlock('some_block_one', 'some_event', 'some content', null, null, true, null),
         ]);
 
         $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
@@ -63,7 +63,7 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
         $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
-            new TemplateBlock('some_block_one', 'some_event', 'some content', 'SomeComponent', null, null, true),
+            new TemplateBlock('some_block_one', 'some_event', 'some content',  null, null, true, 'SomeComponent'),
         ]);
 
         $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
@@ -80,7 +80,7 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
         $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
-            new TemplateBlock('some_block_one', 'some_event', 'some_template.html.twig', null, null, null, true),
+            new TemplateBlock('some_block_one', 'some_event', 'some_template.html.twig', null, null, true, null),
         ]);
 
         $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\UiBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlockRegistryInterface;
 use Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface;
@@ -31,51 +30,65 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         $this->shouldImplement(TemplateEventRendererInterface::class);
     }
 
-    function it_renders_html_debug_comment_if_at_least_one_template_is_a_html_one(
+    function it_does_not_render_html_debug_comments_when_there_are_no_template_blocks_with_a_defined_component_nor_template(
         TemplateEventRendererInterface $templateEventRenderer,
-        TemplateBlockRegistryInterface $templateBlockRegistry,
+        TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'event_block', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'event_block', 'secondBlock.html.twig', [], 0, true);
+        $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
+            new TemplateBlock('some_block_one', 'some_event', 'some content', null, null, null, true),
+        ]);
 
-        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
+        $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
 
-        $templateEventRenderer->render(['best_event_ever'], ['foo' => 'bar'])->willReturn("First block\nSecond block");
+        $this->render(['event_name'])->shouldReturn('rendered_content');
+    }
 
-        $this->render(['best_event_ever'], ['foo' => 'bar'])->shouldReturn(
-            '<!-- BEGIN EVENT | event name: "best_event_ever" -->' . "\n" .
-            'First block' . "\n" .
-            'Second block' . "\n" .
-            '<!-- END EVENT | event name: "best_event_ever" -->',
+    function it_renders_html_debug_comment_when_no_template_block_passed(
+        TemplateEventRendererInterface $templateEventRenderer,
+        TemplateBlockRegistryInterface $templateBlockRegistry
+    ): void {
+        $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([]);
+
+        $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
+
+        $this->render(['event_name'])->shouldReturn(
+            '<!-- BEGIN EVENT | event name: "event_name" -->' . "\n" .
+            'rendered_content' . "\n" .
+            '<!-- END EVENT | event name: "event_name" -->'
         );
     }
 
-    function it_does_not_render_html_debug_comment_if_no_html_templates_are_found(
+    function it_renders_html_debug_comment_when_at_least_one_block_has_a_configured_component(
         TemplateEventRendererInterface $templateEventRenderer,
-        TemplateBlockRegistryInterface $templateBlockRegistry,
+        TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'event_block', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'event_block', 'secondBlock.txt.twig', [], 0, true);
+        $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
+            new TemplateBlock('some_block_one', 'some_event', 'some content', 'SomeComponent', null, null, true),
+        ]);
 
-        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
+        $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
 
-        $templateEventRenderer->render(['best_event_ever'], ['foo' => 'bar'])->willReturn("First block\nSecond block");
-
-        $this->render(['best_event_ever'], ['foo' => 'bar'])->shouldReturn("First block\nSecond block");
+        $this->render(['event_name'])->shouldReturn(
+            '<!-- BEGIN EVENT | event name: "event_name" -->' . "\n" .
+            'rendered_content' . "\n" .
+            '<!-- END EVENT | event name: "event_name" -->'
+        );
     }
 
-    function it_returns_html_debug_comment_if_no_blocks_are_found_for_an_event(
+    function it_renders_html_debug_comment_when_at_least_one_block_has_a_configured_twig_template(
         TemplateEventRendererInterface $templateEventRenderer,
-        TemplateBlockRegistryInterface $templateBlockRegistry,
+        TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([]);
+        $templateBlockRegistry->findEnabledForEvents(['event_name'])->willReturn([
+            new TemplateBlock('some_block_one', 'some_event', 'some_template.html.twig', null, null, null, true),
+        ]);
 
-        $templateEventRenderer->render(Argument::cetera())->willReturn('');
+        $templateEventRenderer->render(['event_name'], [])->willReturn('rendered_content');
 
-        $this->render(['best_event_ever'])->shouldReturn(
-            '<!-- BEGIN EVENT | event name: "best_event_ever" -->' . "\n" .
-            "\n" .
-            '<!-- END EVENT | event name: "best_event_ever" -->',
+        $this->render(['event_name'])->shouldReturn(
+            '<!-- BEGIN EVENT | event name: "event_name" -->' . "\n" .
+            'rendered_content' . "\n" .
+            '<!-- END EVENT | event name: "event_name" -->'
         );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
@@ -33,10 +33,10 @@ final class TwigComponentBlockRendererSpec extends ObjectBehavior
             'some_name',
             'some_event_name',
             'some_template',
-            null,
             ['some' => 'context'],
             0,
             true,
+            null,
         );
         $decoratedRenderer->render($someTemplateBlock, ['some' => 'context'])->shouldBeCalled();
 
@@ -50,10 +50,10 @@ final class TwigComponentBlockRendererSpec extends ObjectBehavior
             'some_name',
             'some_event_name',
             'some_template',
-            'some_component',
             ['some' => 'context'],
             0,
             true,
+            'some_component',
         );
         $componentRenderer->createAndRender('some_component', Argument::type('array'))->willReturn('some_rendered_component');
 

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace spec\Sylius\Bundle\UiBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace spec\Sylius\Bundle\UiBundle\Renderer;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
+use Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface;
+use Symfony\UX\TwigComponent\ComponentRendererInterface;
+
+final class TwigComponentBlockRendererSpec extends ObjectBehavior
+{
+    function let(TemplateBlockRendererInterface $decoratedRenderer, ComponentRendererInterface $componentRenderer): void
+    {
+        $this->beConstructedWith($decoratedRenderer, $componentRenderer);
+    }
+
+    function it_invokes_decorated_renderer_when_no_component_is_set(
+        TemplateBlockRendererInterface $decoratedRenderer,
+    ): void {
+        $someTemplateBlock = new TemplateBlock(
+            'some_name',
+            'some_event_name',
+            'some_template',
+            null,
+            ['some' => 'context'],
+            0,
+            true,
+        );
+        $decoratedRenderer->render($someTemplateBlock, ['some' => 'context'])->shouldBeCalled();
+
+        $this->render($someTemplateBlock, ['some' => 'context']);
+    }
+
+    function it_renders_a_component_when_component_is_set(
+        ComponentRendererInterface $componentRenderer,
+    ): void {
+        $someTemplateBlock = new TemplateBlock(
+            'some_name',
+            'some_event_name',
+            'some_template',
+            'some_component',
+            ['some' => 'context'],
+            0,
+            true,
+        );
+        $componentRenderer->createAndRender('some_component', ['some' => 'context'])->willReturn('some_rendered_component');
+
+        $this->render($someTemplateBlock, ['some' => 'context'])->shouldReturn('some_rendered_component');
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigComponentBlockRendererSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\UiBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface;
 use Symfony\UX\TwigComponent\ComponentRendererInterface;
@@ -54,7 +55,7 @@ final class TwigComponentBlockRendererSpec extends ObjectBehavior
             0,
             true,
         );
-        $componentRenderer->createAndRender('some_component', ['some' => 'context'])->willReturn('some_rendered_component');
+        $componentRenderer->createAndRender('some_component', Argument::type('array'))->willReturn('some_rendered_component');
 
         $this->render($someTemplateBlock, ['some' => 'context'])->shouldReturn('some_rendered_component');
     }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
@@ -43,7 +43,7 @@ final class TwigTemplateBlockRendererSpec extends ObjectBehavior
         ContextProviderInterface $firstContextProvider,
         ContextProviderInterface $secondContextProvider,
     ): void {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['sample' => 'Hi', 'switch' => true], 0, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['sample' => 'Hi', 'switch' => true], 0, true, null);
 
         $twig->render('block.txt.twig', ['sample' => 'Hello', 'switch' => true])->willReturn('Block content');
 

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
@@ -43,7 +43,7 @@ final class TwigTemplateBlockRendererSpec extends ObjectBehavior
         ContextProviderInterface $firstContextProvider,
         ContextProviderInterface $secondContextProvider,
     ): void {
-        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['sample' => 'Hi', 'switch' => true], 0, true);
+        $templateBlock = new TemplateBlock('block_name', 'event_name', 'block.txt.twig', null, ['sample' => 'Hi', 'switch' => true], 0, true);
 
         $twig->render('block.txt.twig', ['sample' => 'Hello', 'switch' => true])->willReturn('Block content');
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -882,6 +882,9 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/ux-twig-component": {
+        "version": "v2.11.2"
+    },
     "symfony/validator": {
         "version": "4.3",
         "recipe": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

```
sylius_ui:
	events:
		some_event:
			blocks:
				my_component_block:
					component: 'MyComponent'
					context:
						option1: foo
						option2: bar
```

If both `template` and `component` is defined, the `component` is taken into account.

![image](https://github.com/Sylius/Sylius/assets/80641364/014835b5-0ffa-4fb8-a6f4-2033804f4c6c)
![image](https://github.com/Sylius/Sylius/assets/80641364/2fd182f4-7a4a-4cfa-a827-cdd217c5bcb5)
