### PR TITLE
[Maintenance] Change `trigger_error` to `trigger_deprecation`

### DIFF
--- a/app/TestAppKernel.php
+++ b/app/TestAppKernel.php
@@ -15,6 +15,10 @@
 
 declare(strict_types=1);
 
-@trigger_error('The "TestAppKernel" class located at "app/TestAppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/sylius',
+    '1.3',
+    'The "TestAppKernel" class located at "app/TestAppKernel.php" is deprecated. Use "Kernel" class located at "src/Kernel.php" instead.',
+);
 
 class_alias(Kernel::class, TestAppKernel::class);

--- a/app/config/_container_deprecation.php
+++ b/app/config/_container_deprecation.php
@@ -18,5 +18,5 @@ declare(strict_types=1);
 trigger_deprecation(
     'sylius/sylius',
     '1.3',
-    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.',
+    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated.',
 );

--- a/app/config/_container_deprecation.php
+++ b/app/config/_container_deprecation.php
@@ -15,4 +15,8 @@
 
 declare(strict_types=1);
 
-@trigger_error('Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/sylius',
+    '1.3',
+    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.',
+);

--- a/app/config/_routing_deprecation.php
+++ b/app/config/_routing_deprecation.php
@@ -17,6 +17,10 @@ declare(strict_types=1);
 
 use Symfony\Component\Routing\RouteCollection;
 
-@trigger_error('Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/sylius',
+    '1.3',
+    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.',
+);
 
 return new RouteCollection();

--- a/app/config/_routing_deprecation.php
+++ b/app/config/_routing_deprecation.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\RouteCollection;
 trigger_deprecation(
     'sylius/sylius',
     '1.3',
-    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.',
+    'Importing files from Sylius/Sylius\'s "app/config" directory is deprecated.',
 );
 
 return new RouteCollection();

--- a/docs/book/organization/backward-compatibility-promise.rst
+++ b/docs/book/organization/backward-compatibility-promise.rst
@@ -92,15 +92,18 @@ relevant classes, methods, properties:
 The deprecation message should indicate the version in which the class/method was
 deprecated and how the feature was replaced (whenever possible).
 
-A PHP ``\E_USER_DEPRECATED`` error must also be triggered to help people with
+A PHP deprecation must also be triggered to help people with
 the migration:
 
 .. code-block:: php
 
     trigger_deprecation(
-        'XXX() is deprecated since version 2.X and will be removed in 2.Y. Use XXX instead.',
-        \E_USER_DEPRECATED
+        'sylius/some-package', // package name
+        '1.X', // package version
+        'XXX is deprecated since version 1.X and will be removed in 2.Y. Use YYY instead.', // message
     );
+
+You should not use the @trigger_error() function.
 
 .. _Semantic Versioning: https://semver.org/
 .. _Symfony's Backward Compatibility Promise: https://symfony.com/doc/current/contributing/code/bc.html

--- a/docs/book/organization/backward-compatibility-promise.rst
+++ b/docs/book/organization/backward-compatibility-promise.rst
@@ -97,7 +97,7 @@ the migration:
 
 .. code-block:: php
 
-    @trigger_error(
+    trigger_deprecation(
         'XXX() is deprecated since version 2.X and will be removed in 2.Y. Use XXX instead.',
         \E_USER_DEPRECATED
     );

--- a/docs/book/organization/backward-compatibility-promise.rst
+++ b/docs/book/organization/backward-compatibility-promise.rst
@@ -93,14 +93,14 @@ The deprecation message should indicate the version in which the class/method wa
 deprecated and how the feature was replaced (whenever possible).
 
 A PHP deprecation must also be triggered to help people with
-the migration:
+the migration, for instance:
 
 .. code-block:: php
 
     trigger_deprecation(
         'sylius/some-package', // package name
-        '1.X', // package version
-        'XXX is deprecated since version 1.X and will be removed in 2.Y. Use YYY instead.', // message
+        '1.x', // package version
+        'A is deprecated and will be removed in Sylius 2.0. Use B instead.', // message
     );
 
 You should not use the @trigger_error() function.

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,11 +41,15 @@
                 <referencedClass name="Http\Message\MessageFactory" /> <!-- deprecated in HttpMessage 1.1 -->
                 <referencedClass name="Payum\Core\Action\GatewayAwareAction" />
                 <referencedClass name="Payum\Core\Security\GenericTokenFactoryInterface" />
-                <referencedClass name="Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface" />
                 <referencedClass name="Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper" />
                 <referencedClass name="Sylius\Bundle\CoreBundle\Twig\ProductVariantsPricesExtension" />
+                <referencedClass name="Sylius\Bundle\ShippingBundle\Provider\Calendar"/>
+                <referencedClass name="Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator"/>
+                <referencedClass name="Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension"/>
                 <referencedClass name="Sylius\Bundle\UserBundle\Security\UserPasswordEncoder"/>
                 <referencedClass name="Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" />
+                <referencedClass name="Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface" />
+                <referencedClass name="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker"/>
                 <referencedClass name="Sylius\Component\User\Security\UserPasswordEncoderInterface" />
                 <referencedClass name="Symfony\Component\HttpFoundation\RequestMatcher" /> <!-- deprecated in Symfony 6.2 -->
                 <referencedClass name="Symfony\Component\Routing\RouteCollectionBuilder" /> <!-- deprecated in Symfony 5.1 -->

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
@@ -25,7 +25,11 @@ final class ZoneChoiceType extends AbstractType
     public function __construct(private RepositoryInterface $zoneRepository, private array $scopeTypes = [])
     {
         if (count($scopeTypes) === 0) {
-            @trigger_error('Not passing scopeTypes thru constructor is deprecated in Sylius 1.5 and it will be removed in Sylius 2.0');
+            trigger_deprecation(
+                'sylius/addressing-bundle',
+                '1.5',
+                'Not passing $scopeTypes through constructor is deprecated in Sylius 1.5 and it will be removed in Sylius 2.0',
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
@@ -28,7 +28,7 @@ final class ZoneChoiceType extends AbstractType
             trigger_deprecation(
                 'sylius/addressing-bundle',
                 '1.5',
-                'Not passing $scopeTypes through constructor is deprecated in Sylius 1.5 and it will be removed in Sylius 2.0',
+                'Not passing $scopeTypes through constructor is deprecated and it prohibited in Sylius 2.0.',
             );
         }
     }

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
@@ -38,7 +38,7 @@ final class RenderResetPasswordPageAction
         private string $tokenTtl,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
@@ -41,7 +41,7 @@ final class RenderResetPasswordPageAction
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 FlashBagInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RenderResetPasswordPageAction.php
@@ -38,7 +38,14 @@ final class RenderResetPasswordPageAction
         private string $tokenTtl,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                FlashBagInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
@@ -37,7 +37,7 @@ final class RequestPasswordResetAction
         private Environment $twig,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
@@ -40,7 +40,7 @@ final class RequestPasswordResetAction
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 FlashBagInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/RequestPasswordResetAction.php
@@ -37,7 +37,14 @@ final class RequestPasswordResetAction
         private Environment $twig,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                FlashBagInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
@@ -39,7 +39,7 @@ final class ResetPasswordAction
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 FlashBagInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
@@ -36,7 +36,14 @@ final class ResetPasswordAction
         private Environment $twig,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                FlashBagInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/Account/ResetPasswordAction.php
@@ -36,7 +36,7 @@ final class ResetPasswordAction
         private Environment $twig,
     ) {
         if ($this->requestStackOrFlashBag instanceof FlashBagInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', FlashBagInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -39,7 +39,7 @@ final class ResendOrderConfirmationEmailAction
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 SessionInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -36,7 +36,14 @@ final class ResendOrderConfirmationEmailAction
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendOrderConfirmationEmailAction.php
@@ -36,7 +36,7 @@ final class ResendOrderConfirmationEmailAction
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -39,7 +39,7 @@ final class ResendShipmentConfirmationEmailAction
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 SessionInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -36,7 +36,14 @@ final class ResendShipmentConfirmationEmailAction
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -36,7 +36,7 @@ final class ResendShipmentConfirmationEmailAction
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
@@ -41,7 +41,7 @@ final class ImpersonateUserController
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.4',
-                'Passing RouterInterface as the fourth argument is deprecated since 1.4 and will be prohibited in 2.0',
+                'Passing a $router as the fourth argument is deprecated and will be prohibited in Sylius 2.0',
             );
         }
         $this->router = $router;

--- a/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
@@ -38,7 +38,11 @@ final class ImpersonateUserController
         private string $authorizationRole,
     ) {
         if (null !== $router) {
-            @trigger_error('Passing RouterInterface as the fourth argument is deprecated since 1.4 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.4',
+                'Passing RouterInterface as the fourth argument is deprecated since 1.4 and will be prohibited in 2.0',
+            );
         }
         $this->router = $router;
     }

--- a/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
@@ -38,7 +38,7 @@ final class NotificationController
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.13',
-                'Using a service that does not implement "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                'Using a service that does not implement "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
                 ClientInterface::class,
                 self::class,
             );
@@ -48,7 +48,7 @@ final class NotificationController
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.13',
-                'Using a service that does not implement "%s" as a 2nd argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                'Using a service that does not implement "%s" as a 2nd argument of "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
                 RequestFactoryInterface::class,
                 self::class,
             );
@@ -58,7 +58,7 @@ final class NotificationController
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.13',
-                'Not passing a service that implements "%s" as a 5th argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                'Not passing a service that implements "%s" as a 5th argument of "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
                 StreamFactoryInterface::class,
                 self::class,
             );

--- a/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/NotificationController.php
@@ -35,15 +35,33 @@ final class NotificationController
         private ?StreamFactoryInterface $streamFactory = null,
     ) {
         if (!$client instanceof ClientInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.13', 'Using a service that does not implement "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in 2.0.', ClientInterface::class, self::class);
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.13',
+                'Using a service that does not implement "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                ClientInterface::class,
+                self::class,
+            );
         }
 
         if (!$requestFactory instanceof RequestFactoryInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.13', 'Using a service that does not implement "%s" as a 2nd argument of "%s" constructor is deprecated and will be prohibited in 2.0.', RequestFactoryInterface::class, self::class);
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.13',
+                'Using a service that does not implement "%s" as a 2nd argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                RequestFactoryInterface::class,
+                self::class,
+            );
         }
 
         if (null === $streamFactory) {
-            trigger_deprecation('sylius/admin-bundle', '1.13', 'Not passing a service that implements "%s" as a 5th argument of "%s" constructor is deprecated and will be prohibited in 2.0.', StreamFactoryInterface::class, self::class);
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.13',
+                'Not passing a service that implements "%s" as a 5th argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                StreamFactoryInterface::class,
+                self::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -35,7 +35,7 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
             trigger_deprecation(
                 'sylius/admin-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 SessionInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -32,7 +32,7 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -32,7 +32,14 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
@@ -143,9 +143,10 @@ final class MergingXmlExtractor extends AbstractResourceExtractor implements Pro
     {
         $graphql = 'operation' === $operationType;
         if (!$graphql && $legacyOperations = $this->extractAttributes($resource, $operationType)) {
-            @trigger_error(
+            trigger_deprecation(
+                'api-platform/core',
+                '2.1',
                 sprintf('Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', $operationType),
-                \E_USER_DEPRECATED,
             );
 
             return $legacyOperations;

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
@@ -146,7 +146,8 @@ final class MergingXmlExtractor extends AbstractResourceExtractor implements Pro
             trigger_deprecation(
                 'api-platform/core',
                 '2.1',
-                sprintf('Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3', $operationType),
+                'Configuring "%1$s" tags without using a parent "%1$ss" tag is deprecated since API Platform 2.1 and will not be possible anymore in API Platform 3',
+                $operationType,
             );
 
             return $legacyOperations;

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -31,11 +31,9 @@ class SelectAttributeChoicesCollectionType extends AbstractType
             trigger_deprecation(
                 'sylius/attribute-bundle',
                 '1.13',
-                sprintf(
-                    'Passing an instance of %s as a constructor argument for %s is deprecated and will not be possible in 2.0.',
-                    TranslationLocaleProviderInterface::class,
-                    self::class,
-                ),
+                'Passing an instance of %s as a constructor argument for %s is deprecated and will not be possible in Sylius 2.0.',
+                TranslationLocaleProviderInterface::class,
+                self::class,
             );
 
             $this->defaultLocaleCode = $localeProvider->getDefaultLocaleCode();

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -28,11 +28,15 @@ class SelectAttributeChoicesCollectionType extends AbstractType
     public function __construct(?TranslationLocaleProviderInterface $localeProvider = null)
     {
         if (null !== $localeProvider) {
-            @trigger_error(sprintf(
-                'Passing an instance of %s as a constructor argument for %s is deprecated as of Sylius 1.13 and will not be possible in 2.0.',
-                TranslationLocaleProviderInterface::class,
-                self::class,
-            ), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/attribute-bundle',
+                '1.13',
+                sprintf(
+                    'Passing an instance of %s as a constructor argument for %s is deprecated as of Sylius 1.13 and will not be possible in 2.0.',
+                    TranslationLocaleProviderInterface::class,
+                    self::class,
+                ),
+            );
 
             $this->defaultLocaleCode = $localeProvider->getDefaultLocaleCode();
         }

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -32,7 +32,7 @@ class SelectAttributeChoicesCollectionType extends AbstractType
                 'sylius/attribute-bundle',
                 '1.13',
                 sprintf(
-                    'Passing an instance of %s as a constructor argument for %s is deprecated as of Sylius 1.13 and will not be possible in 2.0.',
+                    'Passing an instance of %s as a constructor argument for %s is deprecated and will not be possible in 2.0.',
                     TranslationLocaleProviderInterface::class,
                     self::class,
                 ),

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -48,7 +48,11 @@ class Kernel extends HttpKernel
 
     public function __construct(string $environment, bool $debug)
     {
-        @trigger_error(sprintf('Using "%s" as Symfony kernel is deprecated since Sylius 1.3. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change', self::class), \E_USER_DEPRECATED);
+        trigger_deprecation(
+            'sylius/core-bundle',
+            '1.3',
+            sprintf('Using "%s" as Symfony kernel is deprecated since Sylius 1.3. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change', self::class),
+        );
 
         parent::__construct($environment, $debug);
     }

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -51,7 +51,8 @@ class Kernel extends HttpKernel
         trigger_deprecation(
             'sylius/core-bundle',
             '1.3',
-            sprintf('Using "%s" as Symfony kernel is deprecated. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change', self::class),
+            'Using "%s" as Symfony kernel is deprecated. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change',
+            self::class,
         );
 
         parent::__construct($environment, $debug);

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -51,7 +51,7 @@ class Kernel extends HttpKernel
         trigger_deprecation(
             'sylius/core-bundle',
             '1.3',
-            sprintf('Using "%s" as Symfony kernel is deprecated since Sylius 1.3. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change', self::class),
+            sprintf('Using "%s" as Symfony kernel is deprecated. Please migrate to Symfony 4 directory structure. Upgrade guide: https://github.com/Sylius/Sylius/blob/1.3/UPGRADE-1.3.md#directory-structure-change', self::class),
         );
 
         parent::__construct($environment, $debug);

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\CatalogPromotion\Command;
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see RemoveCatalogPromotion} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see RemoveCatalogPromotion} instead. */
 final class RemoveInactiveCatalogPromotion
 {
     public function __construct(public string $code)

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
@@ -22,7 +22,7 @@ final class RemoveInactiveCatalogPromotion
             'sylius/core-bundle',
             '1.13',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 RemoveCatalogPromotion::class,
             ),

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/RemoveInactiveCatalogPromotion.php
@@ -21,11 +21,9 @@ final class RemoveInactiveCatalogPromotion
         trigger_deprecation(
             'sylius/core-bundle',
             '1.13',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                RemoveCatalogPromotion::class,
-            ),
+            'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+            self::class,
+            RemoveCatalogPromotion::class,
         );
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
@@ -30,11 +30,9 @@ final class RemoveInactiveCatalogPromotionHandler
         trigger_deprecation(
             'sylius/core-bundle',
             '1.13',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                RemoveCatalogPromotionHandler::class,
-            ),
+            'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+            self::class,
+            RemoveCatalogPromotionHandler::class,
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
@@ -20,7 +20,7 @@ use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
 use Sylius\Component\Promotion\Model\CatalogPromotionStates;
 use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see RemoveCatalogPromotionHandler} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see RemoveCatalogPromotionHandler} instead. */
 final class RemoveInactiveCatalogPromotionHandler
 {
     public function __construct(

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandHandler/RemoveInactiveCatalogPromotionHandler.php
@@ -31,7 +31,7 @@ final class RemoveInactiveCatalogPromotionHandler
             'sylius/core-bundle',
             '1.13',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 RemoveCatalogPromotionHandler::class,
             ),

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
@@ -31,13 +31,13 @@ final class CatalogPromotionRemovalProcessor implements CatalogPromotionRemovalP
         private ?MessageBusInterface $eventBus = null, /** @phpstan-ignore-line */
     ) {
         if ($catalogPromotionRemovalAnnouncer instanceof MessageBusInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing an instance of %s as second constructor argument for %s is deprecated as of Sylius 1.13 and will be removed in 2.0. Pass an instance of %s instead.', MessageBusInterface::class, self::class, CatalogPromotionRemovalAnnouncerInterface::class));
+            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing an instance of %s as second constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', MessageBusInterface::class, self::class, CatalogPromotionRemovalAnnouncerInterface::class));
 
             $this->catalogPromotionRemovalAnnouncer = new CatalogPromotionRemovalAnnouncer($catalogPromotionRemovalAnnouncer);
         }
 
         if (null !== $eventBus) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing third constructor argument for %s is deprecated as of Sylius 1.13 and will be removed in 2.0.', self::class));
+            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing third constructor argument for %s is deprecated and will be removed in 2.0.', self::class));
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
@@ -31,13 +31,25 @@ final class CatalogPromotionRemovalProcessor implements CatalogPromotionRemovalP
         private ?MessageBusInterface $eventBus = null, /** @phpstan-ignore-line */
     ) {
         if ($catalogPromotionRemovalAnnouncer instanceof MessageBusInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing an instance of %s as second constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', MessageBusInterface::class, self::class, CatalogPromotionRemovalAnnouncerInterface::class));
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.13',
+                'Passing an instance of %s as second constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
+                MessageBusInterface::class,
+                self::class,
+                CatalogPromotionRemovalAnnouncerInterface::class,
+            );
 
             $this->catalogPromotionRemovalAnnouncer = new CatalogPromotionRemovalAnnouncer($catalogPromotionRemovalAnnouncer);
         }
 
         if (null !== $eventBus) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Passing third constructor argument for %s is deprecated and will be removed in 2.0.', self::class));
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.13',
+                'Passing third constructor argument for %s is deprecated and will be removed in Sylius 2.0.',
+                self::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
@@ -28,13 +28,14 @@ final class CancelOrderStateMachineCallbackPass implements CompilerPassInterface
         $smConfigs = $container->getParameter('sm.configs');
 
         if (isset($smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'])) {
-            trigger_error(
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.11',
                 sprintf(
                     'Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
                     'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
                     'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order',
                 ),
-                \E_USER_DEPRECATED,
             );
 
             $smConfigs['sylius_order']['callbacks']['after']['sylius_cancel_order'] = $smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'];

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPass.php
@@ -31,11 +31,9 @@ final class CancelOrderStateMachineCallbackPass implements CompilerPassInterface
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.11',
-                sprintf(
-                    'Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
-                    'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
-                    'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order',
-                ),
+                'Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
+                'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
+                'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order',
             );
 
             $smConfigs['sylius_order']['callbacks']['after']['sylius_cancel_order'] = $smConfigs['sylius_order']['callbacks']['after']['sylis_cancel_order'];

--- a/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
@@ -39,7 +39,14 @@ final class TaxonDeletionListener
         $this->ruleUpdaters = $ruleUpdaters;
 
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/user-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
@@ -39,7 +39,7 @@ final class TaxonDeletionListener
         $this->ruleUpdaters = $ruleUpdaters;
 
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-@trigger_error('The "BookProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.5',
+    'The "BookProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+);
 
 use Faker\Factory;
 use Faker\Generator;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 trigger_deprecation(
     'sylius/core-bundle',
     '1.5',
-    'The "BookProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+    'The "BookProductFixture" class is deprecated. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
 );
 
 use Faker\Factory;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -46,7 +46,7 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                sprintf('Not passing a $fileLocator or/and $imageUploader to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $fileLocator or/and $imageUploader to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
 
@@ -54,7 +54,7 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.10',
-                sprintf('Not passing a $avatarImageFactory to %s constructor is deprecated since Sylius 1.10 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $avatarImageFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -43,11 +43,19 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
         $this->configureOptions($this->optionsResolver);
 
         if ($this->fileLocator === null || $this->imageUploader === null) {
-            @trigger_error(sprintf('Not passing a $fileLocator or/and $imageUploader to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.6',
+                sprintf('Not passing a $fileLocator or/and $imageUploader to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class),
+            );
         }
 
         if ($this->avatarImageFactory === null) {
-            @trigger_error(sprintf('Not passing a $avatarImageFactory to %s constructor is deprecated since Sylius 1.10 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.10',
+                sprintf('Not passing a $avatarImageFactory to %s constructor is deprecated since Sylius 1.10 and will be removed in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -46,7 +46,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                sprintf('Not passing a $fileLocator or/and an $imageUploader to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing a $fileLocator or/and an $imageUploader to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
 
@@ -54,7 +55,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.10',
-                sprintf('Not passing an $avatarImageFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing an $avatarImageFactory to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -46,7 +46,7 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                sprintf('Not passing a $fileLocator or/and $imageUploader to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $fileLocator or/and an $imageUploader to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
 
@@ -54,7 +54,7 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.10',
-                sprintf('Not passing a $avatarImageFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing an $avatarImageFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -54,7 +54,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.8',
-                'Passing RouterInterface as the fifth argument is deprecated since 1.8 and will be prohibited in 2.0',
+                'Passing a $taxonRepository as the fifth argument is deprecated and will be prohibited in Sylius 2.0',
             );
         }
 
@@ -62,7 +62,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.8',
-                'Passing RouterInterface as the sixth argument is deprecated since 1.8 and will be prohibited in 2.0',
+                'Passing a $shopBillingDataFactory as the sixth argument is deprecated and will be prohibited in Sylius 2.0',
             );
         }
         $this->taxonRepository = $taxonRepository;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -51,11 +51,19 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
         ?FactoryInterface $shopBillingDataFactory = null,
     ) {
         if (null === $taxonRepository) {
-            @trigger_error('Passing RouterInterface as the fifth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.8',
+                'Passing RouterInterface as the fifth argument is deprecated since 1.8 and will be prohibited in 2.0',
+            );
         }
 
         if (null === $shopBillingDataFactory) {
-            @trigger_error('Passing RouterInterface as the sixth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.8',
+                'Passing RouterInterface as the sixth argument is deprecated since 1.8 and will be prohibited in 2.0',
+            );
         }
         $this->taxonRepository = $taxonRepository;
         $this->shopBillingDataFactory = $shopBillingDataFactory;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -66,7 +66,11 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
         private ?FileLocatorInterface $fileLocator = null,
     ) {
         if ($this->taxCategoryRepository === null) {
-            @trigger_error(sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.6',
+                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class),
+            );
         }
 
         $this->faker = Factory::create();
@@ -237,10 +241,11 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
     {
         foreach ($options['images'] as $image) {
             if (!array_key_exists('path', $image)) {
-                @trigger_error(
+                trigger_deprecation(
+                    'sylius/core-bundle',
+                    '1.3',
                     'It is deprecated since Sylius 1.3 to pass indexed array as an image definition. ' .
                     'Please use associative array with "path" and "type" keys instead.',
-                    \E_USER_DEPRECATED,
                 );
 
                 $imagePath = array_shift($image);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -69,7 +69,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -69,7 +69,8 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
 
@@ -244,8 +245,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
                 trigger_deprecation(
                     'sylius/core-bundle',
                     '1.3',
-                    'It is deprecated to pass indexed array as an image definition. ' .
-                    'Please use associative array with "path" and "type" keys instead.',
+                    'It is deprecated to pass indexed array as an image definition. Please use associative array with "path" and "type" keys instead.',
                 );
 
                 $imagePath = array_shift($image);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -244,7 +244,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
                 trigger_deprecation(
                     'sylius/core-bundle',
                     '1.3',
-                    'It is deprecated since Sylius 1.3 to pass indexed array as an image definition. ' .
+                    'It is deprecated to pass indexed array as an image definition. ' .
                     'Please use associative array with "path" and "type" keys instead.',
                 );
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -46,7 +46,11 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
         $this->configureOptions($this->optionsResolver);
 
         if ($this->couponFactory === null) {
-            @trigger_error(sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.8',
+                sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -49,7 +49,7 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.8',
-                sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $couponFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -49,7 +49,8 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.8',
-                sprintf('Not passing a $couponFactory to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing a $couponFactory to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -48,7 +48,7 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.4',
-                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.4 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -45,7 +45,11 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
         private ?RepositoryInterface $taxCategoryRepository = null,
     ) {
         if ($this->taxCategoryRepository === null) {
-            @trigger_error(sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.4 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.4',
+                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated since Sylius 1.4 and will be removed in Sylius 2.0.', self::class),
+            );
         }
 
         $this->faker = Factory::create();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -48,7 +48,8 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.4',
-                sprintf('Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing a $taxCategoryRepository to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -16,7 +16,11 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Faker\Factory;
 use Faker\Generator;
 
-@trigger_error('The "MugProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.5',
+    'The "MugProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+);
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -19,7 +19,7 @@ use Faker\Generator;
 trigger_deprecation(
     'sylius/core-bundle',
     '1.5',
-    'The "MugProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+    'The "MugProductFixture" class is deprecated and will be removed in Sylius 2.0. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
 );
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
@@ -27,6 +27,9 @@ use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @deprecated since Sylius 1.5 and will be removed in Sylius 2.0. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.
+ */
 class MugProductFixture extends AbstractFixture
 {
     private Generator $faker;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -80,7 +80,7 @@ class OrderFixture extends AbstractFixture
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.6',
-                'Use orderExampleFactory. OrderFixture is deprecated since 1.6 and will be prohibited since 2.0.',
+                'Use OrderExampleFactory. OrderFixture is deprecated and will be prohibited since Sylius 2.0.',
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -77,7 +77,11 @@ class OrderFixture extends AbstractFixture
                 $orderPaymentMethodSelectionRequirementChecker,
             );
 
-            @trigger_error('Use orderExampleFactory. OrderFixture is deprecated since 1.6 and will be prohibited since 2.0.', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.6',
+                'Use orderExampleFactory. OrderFixture is deprecated since 1.6 and will be prohibited since 2.0.',
+            );
         }
 
         $this->orderManager = $orderManager;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-@trigger_error('The "StickerProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.5',
+    'The "StickerProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+);
 
 use Faker\Factory;
 use Faker\Generator;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 trigger_deprecation(
     'sylius/core-bundle',
     '1.5',
-    'The "StickerProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+    'The "StickerProductFixture" class is deprecated. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
 );
 
 use Faker\Factory;
@@ -27,6 +27,9 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @deprecated since Sylius 1.5 and will be removed in Sylius 2.0. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.
+ */
 class StickerProductFixture extends AbstractFixture
 {
     private Generator $faker;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -19,7 +19,7 @@ use Faker\Generator;
 trigger_deprecation(
     'sylius/core-bundle',
     '1.5',
-    'The "TshirtProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+    'The "TshirtProductFixture" class is deprecated. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
 );
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
@@ -27,6 +27,9 @@ use Sylius\Component\Attribute\AttributeType\TextAttributeType;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @deprecated since Sylius 1.5 and will be removed in Sylius 2.0. Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.
+ */
 class TshirtProductFixture extends AbstractFixture
 {
     private Generator $faker;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -16,7 +16,11 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Faker\Factory;
 use Faker\Generator;
 
-@trigger_error('The "TshirtProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.5',
+    'The "TshirtProductFixture" class is deprecated since Sylius 1.5 Use new product fixtures class located at "src/Sylius/Bundle/CoreBundle/Fixture/" instead.',
+);
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Attribute\AttributeType\TextAttributeType;

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -40,12 +40,13 @@ final class AddressType extends AbstractResourceType
         parent::__construct($dataClass, $validationGroups);
 
         if (null === $addressComparator) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.8',
                 sprintf(
                     'Not passing an $addressComparator to "%s" constructor is deprecated since Sylius 1.8 and will be impossible in Sylius 2.0.',
                     __CLASS__,
                 ),
-                \E_USER_DEPRECATED,
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -43,10 +43,8 @@ final class AddressType extends AbstractResourceType
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.8',
-                sprintf(
-                    'Not passing an $addressComparator to "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
-                    __CLASS__,
-                ),
+                'Not passing an $addressComparator to "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -44,7 +44,7 @@ final class AddressType extends AbstractResourceType
                 'sylius/core-bundle',
                 '1.8',
                 sprintf(
-                    'Not passing an $addressComparator to "%s" constructor is deprecated since Sylius 1.8 and will be impossible in Sylius 2.0.',
+                    'Not passing an $addressComparator to "%s" constructor is deprecated and will be prohibited in Sylius 2.0.',
                     __CLASS__,
                 ),
             );

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -28,10 +28,8 @@ final class FilesystemRequirements extends RequirementCollection
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.2',
-                sprintf(
-                    'Passing root directory to "%s" constructor as the second argument is deprecated and this argument will be removed in Sylius 2.0.',
-                    self::class,
-                ),
+                'Passing root directory to "%s" constructor as the second argument is deprecated and this argument will be removed in Sylius 2.0.',
+                self::class,
             );
 
             [$rootDir, $cacheDir, $logsDir] = [$cacheDir, $logsDir, $rootDir];

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -25,11 +25,15 @@ final class FilesystemRequirements extends RequirementCollection
         parent::__construct($translator->trans('sylius.installer.filesystem.header', []));
 
         if (func_num_args() >= 4) {
-            @trigger_error(sprintf(
-                'Passing root directory to "%s" constructor as the second argument is deprecated since 1.2 ' .
-                'and this argument will be removed in 2.0.',
-                self::class,
-            ), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.2',
+                sprintf(
+                    'Passing root directory to "%s" constructor as the second argument is deprecated since 1.2 ' .
+                        'and this argument will be removed in 2.0.',
+                    self::class,
+                ),
+            );
 
             [$rootDir, $cacheDir, $logsDir] = [$cacheDir, $logsDir, $rootDir];
         }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -29,8 +29,7 @@ final class FilesystemRequirements extends RequirementCollection
                 'sylius/core-bundle',
                 '1.2',
                 sprintf(
-                    'Passing root directory to "%s" constructor as the second argument is deprecated since 1.2 ' .
-                        'and this argument will be removed in 2.0.',
+                    'Passing root directory to "%s" constructor as the second argument is deprecated and this argument will be removed in Sylius 2.0.',
                     self::class,
                 ),
             );

--- a/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
@@ -39,7 +39,14 @@ final class UserImpersonator implements UserImpersonatorInterface
         $this->firewallContextName = $firewallContextName;
 
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
@@ -39,7 +39,7 @@ final class UserImpersonator implements UserImpersonatorInterface
         $this->firewallContextName = $firewallContextName;
 
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
+++ b/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
@@ -30,7 +30,7 @@ final class CartSessionStorage implements CartStorageInterface
         private OrderRepositoryInterface $orderRepository,
     ) {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
+++ b/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
@@ -30,7 +30,15 @@ final class CartSessionStorage implements CartStorageInterface
         private OrderRepositoryInterface $orderRepository,
     ) {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/core-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            )
+            ;
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
+++ b/src/Sylius/Bundle/CoreBundle/Storage/CartSessionStorage.php
@@ -33,7 +33,7 @@ final class CartSessionStorage implements CartStorageInterface
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.12',
-                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
                 SessionInterface::class,
                 self::class,
                 RequestStack::class,

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantsMapProvider;
 use Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProvider} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProvider} instead. */
 class ProductVariantsPricesHelper extends Helper
 {
     public function __construct(private ProductVariantsPricesProviderInterface $productVariantsPricesProvider)

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
@@ -27,11 +27,9 @@ class ProductVariantsPricesHelper extends Helper
         trigger_deprecation(
             'sylius/core-bundle',
             '1.13',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                ProductVariantsMapProvider::class,
-            ),
+            'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+            self::class,
+            ProductVariantsMapProvider::class,
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/ProductVariantsPricesHelper.php
@@ -28,7 +28,7 @@ class ProductVariantsPricesHelper extends Helper
             'sylius/core-bundle',
             '1.13',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 ProductVariantsMapProvider::class,
             ),

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/Compiler/BackwardsCompatibility/CancelOrderStateMachineCallbackPassTest.php
@@ -75,25 +75,9 @@ class CancelOrderStateMachineCallbackPassTest extends AbstractCompilerPassTestCa
     ];
 
     /** @test */
-    public function it_triggers_deprecation_error_when_old_callback_name_is_used(): void
-    {
-        $this->setParameter('sm.configs', $this->smConfigs);
-
-        $this->expectDeprecation();
-        $this->expectDeprecationMessage(sprintf(
-            'Callback "%s" was renamed to "%s". The old name will be removed in Sylius 2.0, use the new name to override it.',
-            'winzou_state_machine.sylius_order.callbacks.after.sylis_cancel_order',
-            'winzou_state_machine.sylius_order.callbacks.after.sylius_cancel_order',
-        ));
-
-        $this->compile();
-    }
-
-    /** @test */
     public function it_converts_from_old_name_to_new_name(): void
     {
         $this->setParameter('sm.configs', $this->smConfigs);
-        $this->expectDeprecation();
         $this->compile();
 
         $smConfigs = $this->container->getParameter('sm.configs');

--- a/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
@@ -25,11 +25,9 @@ final class ProductVariantsPricesExtension extends AbstractExtension
         trigger_deprecation(
             'sylius/core-bundle',
             '1.13',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                ProductVariantsMapExtension::class,
-            ),
+            'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+            self::class,
+            ProductVariantsMapExtension::class,
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
@@ -17,7 +17,7 @@ use Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapExtension} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapExtension} instead. */
 final class ProductVariantsPricesExtension extends AbstractExtension
 {
     public function __construct(private ProductVariantsPricesHelper $productVariantsPricesHelper)

--- a/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
@@ -26,7 +26,7 @@ final class ProductVariantsPricesExtension extends AbstractExtension
             'sylius/core-bundle',
             '1.13',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 ProductVariantsMapExtension::class,
             ),

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
@@ -29,7 +29,7 @@ final class HasEnabledEntityValidator extends ConstraintValidator
         private ?PropertyAccessorInterface $accessor = null,
     ) {
         if (null === $this->accessor) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Not passing a PropertyAccessorInterface as the second constructor argument for %s is deprecated as of Sylius 1.13 and will be required in 2.0.', self::class));
+            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Not passing a PropertyAccessorInterface as the second constructor argument for %s is deprecated and will be required in 2.0.', self::class));
 
             $this->accessor = PropertyAccess::createPropertyAccessor();
         }

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
@@ -29,7 +29,12 @@ final class HasEnabledEntityValidator extends ConstraintValidator
         private ?PropertyAccessorInterface $accessor = null,
     ) {
         if (null === $this->accessor) {
-            trigger_deprecation('sylius/core-bundle', '1.13', sprintf('Not passing a PropertyAccessorInterface as the second constructor argument for %s is deprecated and will be required in 2.0.', self::class));
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.13',
+                'Not passing a PropertyAccessorInterface as the second constructor argument for %s is deprecated and will be required in Sylius 2.0.',
+                self::class,
+            );
 
             $this->accessor = PropertyAccess::createPropertyAccessor();
         }

--- a/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/CatalogPromotion/Processor/CatalogPromotionRemovalProcessorSpec.php
@@ -16,14 +16,12 @@ namespace spec\Sylius\Bundle\CoreBundle\CatalogPromotion\Processor;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Announcer\CatalogPromotionRemovalAnnouncerInterface;
-use Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessor;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Processor\CatalogPromotionRemovalProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Promotion\Exception\CatalogPromotionNotFoundException;
 use Sylius\Component\Promotion\Exception\InvalidCatalogPromotionStateException;
 use Sylius\Component\Promotion\Model\CatalogPromotionStates;
 use Sylius\Component\Promotion\Repository\CatalogPromotionRepositoryInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 final class CatalogPromotionRemovalProcessorSpec extends ObjectBehavior
 {
@@ -110,24 +108,6 @@ final class CatalogPromotionRemovalProcessorSpec extends ObjectBehavior
         $this
             ->shouldThrow(\DomainException::class)
             ->during('removeCatalogPromotion', ['CATALOG_PROMOTION_CODE'])
-        ;
-    }
-
-    public function it_deprecates_passing_message_busses(
-        CatalogPromotionRepositoryInterface $catalogPromotionRepository,
-        MessageBusInterface $eventBus,
-        MessageBusInterface $commandBus,
-    ): void {
-        $this->beConstructedWith($catalogPromotionRepository, $eventBus, $commandBus);
-
-        $this
-            ->shouldTrigger(\E_USER_DEPRECATED, sprintf('Passing an instance of %s as second constructor argument for %s is deprecated as of Sylius 1.13 and will be removed in 2.0. Pass an instance of %s instead.', MessageBusInterface::class, CatalogPromotionRemovalProcessor::class, CatalogPromotionRemovalAnnouncerInterface::class))
-            ->duringInstantiation()
-        ;
-
-        $this
-            ->shouldTrigger(\E_USER_DEPRECATED, sprintf('Passing third constructor argument for %s is deprecated as of Sylius 1.13 and will be removed in 2.0.', CatalogPromotionRemovalProcessor::class))
-            ->duringInstantiation()
         ;
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -25,7 +25,11 @@ final class LocaleHelper extends Helper implements LocaleHelperInterface
         private ?LocaleContextInterface $localeContext = null,
     ) {
         if (null === $localeContext) {
-            @trigger_error('Not passing LocaleContextInterface explicitly as the second argument is deprecated since 1.4 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/locale-bundle',
+                '1.4',
+                'Not passing LocaleContextInterface explicitly as the second argument is deprecated since 1.4 and will be prohibited in 2.0',
+            );
         }
     }
 

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -28,7 +28,7 @@ final class LocaleHelper extends Helper implements LocaleHelperInterface
             trigger_deprecation(
                 'sylius/locale-bundle',
                 '1.4',
-                'Not passing LocaleContextInterface explicitly as the second argument is deprecated since 1.4 and will be prohibited in 2.0',
+                'Not passing a $localeContext explicitly as the second argument is deprecated and will be prohibited in Sylius 2.0',
             );
         }
     }

--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -45,7 +45,8 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
             trigger_deprecation(
                 'sylius/order-bundle',
                 '1.12',
-                sprintf('Not injecting the expiration time into %s is deprecated and will be mandatory from 2.0', self::class),
+                'Not injecting the expiration time into %s is deprecated and will be mandatory from Sylius 2.0',
+                self::class,
             );
             $expirationTime = $this->getContainer()->getParameter('sylius_order.cart_expiration_period');
         } else {
@@ -61,7 +62,9 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
             trigger_deprecation(
                 'sylius/order-bundle',
                 '1.12',
-                sprintf('Not injecting the %s into the %s is deprecated and will be mandatory from 2.0', ExpiredCartsRemoverInterface::class, self::class),
+                'Not injecting the %s into the %s is deprecated and will be mandatory from Sylius 2.0',
+                ExpiredCartsRemoverInterface::class,
+                self::class,
             );
             $this->getContainer()->get('sylius.expired_carts_remover')->remove();
         } else {

--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -96,7 +96,7 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
         ;
     }
 
-    /** @deprecated since 1.9 and  will be removed in Sylius 2.0, use src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepositoryInterface instead */
+    /** @deprecated since Sylius 1.9 and  will be removed in Sylius 2.0, use src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepositoryInterface instead */
     public function findCartByTokenValue(string $tokenValue): ?OrderInterface
     {
         return $this->createQueryBuilder('o')

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
@@ -27,7 +27,7 @@ class ProductSlugController extends AbstractController
             trigger_deprecation(
                 'sylius/product-bundle',
                 '1.11',
-                sprintf('Not passing a $slugGenerator to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing a $slugGenerator to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
@@ -27,7 +27,8 @@ class ProductSlugController extends AbstractController
             trigger_deprecation(
                 'sylius/product-bundle',
                 '1.11',
-                sprintf('Not passing a $slugGenerator to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing a $slugGenerator to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductSlugController.php
@@ -24,7 +24,11 @@ class ProductSlugController extends AbstractController
     public function __construct(private ?SlugGeneratorInterface $slugGenerator = null)
     {
         if ($this->slugGenerator === null) {
-            @trigger_error(sprintf('Not passing a $slugGenerator to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '1.11',
+                sprintf('Not passing a $slugGenerator to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
@@ -31,7 +31,11 @@ final class GenerateProductVariantsSubscriber implements EventSubscriberInterfac
         private SessionInterface|RequestStack $requestStackOrSession,
     ) {
         if ($requestStackOrSession instanceof SessionInterface) {
-            @trigger_error(sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '1.12',
+                sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class),
+            );
         }
     }
 

--- a/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
@@ -34,7 +34,10 @@ final class GenerateProductVariantsSubscriber implements EventSubscriberInterfac
             trigger_deprecation(
                 'sylius/product-bundle',
                 '1.12',
-                sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class),
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
             );
         }
     }

--- a/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/EventSubscriber/GenerateProductVariantsSubscriber.php
@@ -34,7 +34,7 @@ final class GenerateProductVariantsSubscriber implements EventSubscriberInterfac
             trigger_deprecation(
                 'sylius/product-bundle',
                 '1.12',
-                sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class),
+                sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class),
             );
         }
     }

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
@@ -28,7 +28,7 @@ final class ProductOptionChoiceType extends AbstractType
         @trigger_deprecation(
             'sylius/product-bundle',
             '1.13',
-            'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
@@ -21,14 +21,17 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0.
+ */
 final class ProductOptionChoiceType extends AbstractType
 {
     public function __construct(private RepositoryInterface $productOptionRepository)
     {
-        @trigger_deprecation(
+        trigger_deprecation(
             'sylius/product-bundle',
             '1.13',
-            'The "%s" class is deprecated and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in Sylius 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
@@ -31,8 +31,7 @@ final class ProductOptionValueChoiceType extends AbstractType
             trigger_deprecation(
                 'sylius/product-bundle',
                 '1.8',
-                'Not passing availableProductOptionValuesResolver thru constructor is deprecated in Sylius 1.8 and ' .
-                'it will be removed in Sylius 2.0',
+                'Not passing an $availableProductOptionValuesResolver through constructor is deprecated and will be removed in Sylius 2.0',
             );
         }
 

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
@@ -28,7 +28,9 @@ final class ProductOptionValueChoiceType extends AbstractType
     public function __construct(?AvailableProductOptionValuesResolverInterface $availableProductOptionValuesResolver = null)
     {
         if (null === $availableProductOptionValuesResolver) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/product-bundle',
+                '1.8',
                 'Not passing availableProductOptionValuesResolver thru constructor is deprecated in Sylius 1.8 and ' .
                 'it will be removed in Sylius 2.0',
             );

--- a/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
+++ b/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
@@ -25,7 +25,7 @@ final class ShippingDateAssigner implements ShippingDateAssignerInterface
             trigger_deprecation(
                 'sylius/shipping-bundle',
                 '1.11',
-                sprintf('Passing a "Sylius\Bundle\ShippingBundle\Provider\DateTimeProvider" to "%s" constructor is deprecated since Sylius 1.11 and will be prohibited in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.', self::class),
+                sprintf('Passing a "Sylius\Bundle\ShippingBundle\Provider\DateTimeProvider" to "%s" constructor is deprecated and will be prohibited in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
+++ b/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
@@ -25,7 +25,10 @@ final class ShippingDateAssigner implements ShippingDateAssignerInterface
             trigger_deprecation(
                 'sylius/shipping-bundle',
                 '1.11',
-                sprintf('Passing a "Sylius\Bundle\ShippingBundle\Provider\DateTimeProvider" to "%s" constructor is deprecated and will be prohibited in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.', self::class),
+                'Passing a "%s" to "%s" constructor is deprecated and will be prohibited in Sylius 2.0. Use "%s" instead.',
+                DateTimeProvider::class,
+                self::class,
+                DateTimeProviderInterface::class,
             );
         }
     }

--- a/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
+++ b/src/Sylius/Bundle/ShippingBundle/Assigner/ShippingDateAssigner.php
@@ -22,9 +22,10 @@ final class ShippingDateAssigner implements ShippingDateAssignerInterface
     public function __construct(private DateTimeProvider|DateTimeProviderInterface $calendar)
     {
         if ($calendar instanceof DateTimeProvider) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/shipping-bundle',
+                '1.11',
                 sprintf('Passing a "Sylius\Bundle\ShippingBundle\Provider\DateTimeProvider" to "%s" constructor is deprecated since Sylius 1.11 and will be prohibited in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.', self::class),
-                \E_USER_DEPRECATED,
             );
         }
     }

--- a/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
+++ b/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
@@ -16,9 +16,14 @@ namespace Sylius\Bundle\ShippingBundle\Provider;
 trigger_deprecation(
     'sylius/shipping-bundle',
     '1.11',
-    'The "Sylius\Bundle\ShippingBundle\Provider\Calendar" class is deprecated and will be removed in 2.0. Use "Sylius\Calendar\Provider\Calendar" instead.',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+    Calendar::class,
+    \Sylius\Calendar\Provider\Calendar::class,
 );
 
+/**
+ * @deprecated since Sylius 1.11 and will be removed in Sylius 2.0. Use {@see \Sylius\Calendar\Provider\Calendar} instead.
+ */
 final class Calendar implements DateTimeProvider
 {
     public function today(): \DateTimeInterface

--- a/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
+++ b/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\ShippingBundle\Provider;
 trigger_deprecation(
     'sylius/shipping-bundle',
     '1.11',
-    'The "Sylius\Bundle\ShippingBundle\Provider\Calendar" class is deprecated since Sylius 1.11 and will be removed in 2.0. Use "Sylius\Calendar\Provider\Calendar" instead.',
+    'The "Sylius\Bundle\ShippingBundle\Provider\Calendar" class is deprecated and will be removed in 2.0. Use "Sylius\Calendar\Provider\Calendar" instead.',
 );
 
 final class Calendar implements DateTimeProvider

--- a/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
+++ b/src/Sylius/Bundle/ShippingBundle/Provider/Calendar.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShippingBundle\Provider;
 
-@trigger_error(
+trigger_deprecation(
+    'sylius/shipping-bundle',
+    '1.11',
     'The "Sylius\Bundle\ShippingBundle\Provider\Calendar" class is deprecated since Sylius 1.11 and will be removed in 2.0. Use "Sylius\Calendar\Provider\Calendar" instead.',
-    \E_USER_DEPRECATED,
 );
 
 final class Calendar implements DateTimeProvider

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -73,9 +73,7 @@
                  label="sylius.form.shipping_calculator.per_unit_rate_configuration.label"/>
         </service>
 
-        <service id="sylius.calendar" class="Sylius\Bundle\ShippingBundle\Provider\Calendar">
-            <deprecated package="sylius/sylius" version="1.11">The "%service_id%" is deprecated and will be removed in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.</deprecated>
-        </service>
+        <service id="sylius.calendar" class="Sylius\Bundle\ShippingBundle\Provider\Calendar"/>
 
         <service id="sylius.shipping_date_assigner" class="Sylius\Bundle\ShippingBundle\Assigner\ShippingDateAssigner">
             <argument type="service" id="Sylius\Calendar\Provider\DateTimeProviderInterface"/>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -74,7 +74,7 @@
         </service>
 
         <service id="sylius.calendar" class="Sylius\Bundle\ShippingBundle\Provider\Calendar">
-            <deprecated package="sylius/sylius" version="1.11">The "%service_id%" is deprecated since Sylius 1.11 and will be removed in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.</deprecated>
+            <deprecated package="sylius/sylius" version="1.11">The "%service_id%" is deprecated and will be removed in 2.0. Use "Sylius\Calendar\Provider\DateTimeProviderInterface" instead.</deprecated>
         </service>
 
         <service id="sylius.shipping_date_assigner" class="Sylius\Bundle\ShippingBundle\Assigner\ShippingDateAssigner">

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
@@ -19,23 +19,14 @@ use Sylius\Component\Core\Model\OrderInterface;
 trigger_deprecation(
     'sylius/sylius',
     '1.13',
-    sprintf(
-        'Class "%s" is deprecated and will be removed in Sylius 2.0. Items subtotal calculations is now available by using %s::getSubtotalItems method.',
-        OrderItemsSubtotalCalculator::class,
-        Order::class,
-    ),
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Items subtotal calculations is now available by using %s::getSubtotalItems method.',
+    OrderItemsSubtotalCalculator::class,
+    Order::class,
 );
 
-trigger_deprecation(
-    'sylius/sylius',
-    '1.13',
-    sprintf(
-        'Class "%s" is deprecated and will be removed in Sylius 2.0. Items subtotal calculations is now available by using %s::getSubtotalItems method.',
-        OrderItemsSubtotalCalculator::class,
-        Order::class,
-    ),
-);
-
+/**
+ * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Items subtotal calculations is now available by using {@see Order::getSubtotalItems} method.
+ */
 final class OrderItemsSubtotalCalculator implements OrderItemsSubtotalCalculatorInterface
 {
     public function getSubtotal(OrderInterface $order): int

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
@@ -30,15 +30,17 @@ final class ContactEmailManager implements ContactEmailManagerInterface
         ?string $localeCode = null,
     ): void {
         if ($channel === null) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '1.7',
                 sprintf('Not passing channel into %s::%s is deprecated since Sylius 1.7', __CLASS__, __METHOD__),
-                \E_USER_DEPRECATED,
             );
         }
         if ($localeCode === null) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '1.7',
                 sprintf('Not passing locale code into %s::%s is deprecated since Sylius 1.7', __CLASS__, __METHOD__),
-                \E_USER_DEPRECATED,
             );
         }
 

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
@@ -33,14 +33,18 @@ final class ContactEmailManager implements ContactEmailManagerInterface
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.7',
-                sprintf('Not passing a $channel into %s::%s is deprecated.', __CLASS__, __METHOD__),
+                'Not passing a $channel into %s::%s is deprecated.',
+                __CLASS__,
+                __METHOD__,
             );
         }
         if ($localeCode === null) {
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.7',
-                sprintf('Not passing a $localeCode into %s::%s is deprecated.', __CLASS__, __METHOD__),
+                'Not passing a $localeCode into %s::%s is deprecated.',
+                __CLASS__,
+                __METHOD__,
             );
         }
 

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/ContactEmailManager.php
@@ -33,14 +33,14 @@ final class ContactEmailManager implements ContactEmailManagerInterface
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.7',
-                sprintf('Not passing channel into %s::%s is deprecated since Sylius 1.7', __CLASS__, __METHOD__),
+                sprintf('Not passing a $channel into %s::%s is deprecated.', __CLASS__, __METHOD__),
             );
         }
         if ($localeCode === null) {
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.7',
-                sprintf('Not passing locale code into %s::%s is deprecated since Sylius 1.7', __CLASS__, __METHOD__),
+                sprintf('Not passing a $localeCode into %s::%s is deprecated.', __CLASS__, __METHOD__),
             );
         }
 

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
@@ -26,13 +26,14 @@ final class OrderEmailManager implements OrderEmailManagerInterface
         private ?DecoratedOrderEmailManagerInterface $decoratedEmailManager,
     ) {
         if ($decoratedEmailManager === null) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '1.8',
                 sprintf(
                     'Not passing an instance of %s to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.',
                     DecoratedOrderEmailManagerInterface::class,
                     self::class,
                 ),
-                \E_USER_DEPRECATED,
             );
         }
     }

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
@@ -30,7 +30,7 @@ final class OrderEmailManager implements OrderEmailManagerInterface
                 'sylius/shop-bundle',
                 '1.8',
                 sprintf(
-                    'Not passing an instance of %s to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.',
+                    'Not passing an instance of %s to %s constructor is deprecated and will be removed in Sylius 2.0.',
                     DecoratedOrderEmailManagerInterface::class,
                     self::class,
                 ),

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
@@ -29,11 +29,9 @@ final class OrderEmailManager implements OrderEmailManagerInterface
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.8',
-                sprintf(
-                    'Not passing an instance of %s to %s constructor is deprecated and will be removed in Sylius 2.0.',
-                    DecoratedOrderEmailManagerInterface::class,
-                    self::class,
-                ),
+                'Not passing an instance of %s to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                DecoratedOrderEmailManagerInterface::class,
+                self::class,
             );
         }
     }

--- a/src/Sylius/Bundle/ShopBundle/EventListener/CustomerEmailUpdaterListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/CustomerEmailUpdaterListener.php
@@ -40,7 +40,14 @@ final class CustomerEmailUpdaterListener
         private TokenStorageInterface $tokenStorage,
     ) {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/shop-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in Sylius 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/ShopBundle/EventListener/CustomerEmailUpdaterListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/CustomerEmailUpdaterListener.php
@@ -40,7 +40,7 @@ final class CustomerEmailUpdaterListener
         private TokenStorageInterface $tokenStorage,
     ) {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/shop-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/shop-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
@@ -17,7 +17,6 @@
 
         <service id="sylius.twig.extension.taxes" class="Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" public="false">
             <tag name="twig.extension" />
-            <deprecated package="sylius/shop-bundle" version="1.12">The "%service_id%" is deprecated and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.subtotal" class="Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension" public="false">

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
@@ -17,7 +17,7 @@
 
         <service id="sylius.twig.extension.taxes" class="Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" public="false">
             <tag name="twig.extension" />
-            <deprecated package="sylius/shop-bundle" version="1.12">The "%service_id%" is deprecated since Sylius 1.12 and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.</deprecated>
+            <deprecated package="sylius/shop-bundle" version="1.12">The "%service_id%" is deprecated and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.subtotal" class="Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension" public="false">

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -29,9 +29,10 @@ class OrderItemsSubtotalExtension extends AbstractExtension
         if (null === $calculator) {
             $calculator = new OrderItemsSubtotalCalculator();
 
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '1.6',
                 'Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0.',
-                \E_USER_DEPRECATED,
             );
         }
 

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -32,7 +32,7 @@ class OrderItemsSubtotalExtension extends AbstractExtension
             trigger_deprecation(
                 'sylius/shop-bundle',
                 '1.6',
-                'Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0.',
+                'Not passing a $calculator is deprecated. Argument will no longer be optional from Sylius 2.0.',
             );
         }
 

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\Twig;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Twig\Extension\AbstractExtension;
@@ -22,9 +23,16 @@ use Twig\TwigFunction;
 trigger_deprecation(
     'sylius/shop-bundle',
     '1.12',
-    'The "Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" class is deprecated and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "%s" instead.',
+    OrderTaxesTotalExtension::class,
+    Order::class,
 );
 
+/**
+ * @deprecated since Sylius 1.12 and will be removed in Sylius 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from {@see Order} instead.
+ *
+ * @psalm-suppress DeprecatedClass
+ */
 class OrderTaxesTotalExtension extends AbstractExtension
 {
     public function getFunctions(): array

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
@@ -19,9 +19,10 @@ use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-@trigger_error(
+trigger_deprecation(
+    'sylius/shop-bundle',
+    '1.12',
     'The "Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" class is deprecated since Sylius 1.12 and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.',
-    \E_USER_DEPRECATED,
 );
 
 class OrderTaxesTotalExtension extends AbstractExtension

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
@@ -22,7 +22,7 @@ use Twig\TwigFunction;
 trigger_deprecation(
     'sylius/shop-bundle',
     '1.12',
-    'The "Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" class is deprecated since Sylius 1.12 and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.',
+    'The "Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension" class is deprecated and will be removed in 2.0. Use methods "getTaxExcludedTotal" and "getTaxIncludedTotal" from "Sylius\Component\Core\Model\Order" instead.',
 );
 
 class OrderTaxesTotalExtension extends AbstractExtension

--- a/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
+++ b/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
@@ -23,9 +23,10 @@ final class BlockEventListener
 {
     public function __construct(private string $template)
     {
-        @trigger_error(
+        trigger_deprecation(
+            'sylius/ui-bundle',
+            '1.7',
             sprintf('Using "%s" to add blocks to the templates is deprecated since Sylius 1.7 and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.', self::class),
-            \E_USER_DEPRECATED,
         );
     }
 

--- a/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
+++ b/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
@@ -26,7 +26,7 @@ final class BlockEventListener
         trigger_deprecation(
             'sylius/ui-bundle',
             '1.7',
-            sprintf('Using "%s" to add blocks to the templates is deprecated since Sylius 1.7 and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.', self::class),
+            sprintf('Using "%s" to add blocks to the templates is deprecated and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.', self::class),
         );
     }
 

--- a/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
+++ b/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
@@ -17,7 +17,7 @@ use Sonata\BlockBundle\Event\BlockEvent;
 use Sonata\BlockBundle\Model\Block;
 
 /**
- * @deprecated
+ * @deprecated since Sylius 1.7 and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.
  */
 final class BlockEventListener
 {
@@ -26,7 +26,8 @@ final class BlockEventListener
         trigger_deprecation(
             'sylius/ui-bundle',
             '1.7',
-            sprintf('Using "%s" to add blocks to the templates is deprecated and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.', self::class),
+            'Using "%s" to add blocks to the templates is deprecated and will be removed in Sylius 2.0. Use "sylius_ui" configuration instead.',
+            self::class,
         );
     }
 

--- a/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
+++ b/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
@@ -21,7 +21,14 @@ final class FilterStorage implements FilterStorageInterface
     public function __construct(private SessionInterface|RequestStack $requestStackOrSession)
     {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
+++ b/src/Sylius/Bundle/UiBundle/Storage/FilterStorage.php
@@ -21,7 +21,7 @@ final class FilterStorage implements FilterStorageInterface
     public function __construct(private SessionInterface|RequestStack $requestStackOrSession)
     {
         if ($this->requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/admin-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
@@ -31,7 +31,8 @@ class SecurityController extends AbstractController
             trigger_deprecation(
                 'sylius/user-bundle',
                 '1.11',
-                sprintf('Not passing a $authenticationUtils to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing a $authenticationUtils to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
 
@@ -39,7 +40,8 @@ class SecurityController extends AbstractController
             trigger_deprecation(
                 'sylius/user-bundle',
                 '1.11',
-                sprintf('Not passing a $formFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing a $formFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
@@ -28,11 +28,19 @@ class SecurityController extends AbstractController
         private ?FormFactoryInterface $formFactory = null,
     ) {
         if ($this->authenticationUtils === null) {
-            @trigger_error(sprintf('Not passing a $authenticationUtils to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/user-bundle',
+                '1.11',
+                sprintf('Not passing a $authenticationUtils to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
 
         if ($this->formFactory === null) {
-            @trigger_error(sprintf('Not passing a $formFactory to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/user-bundle',
+                '1.11',
+                sprintf('Not passing a $formFactory to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
@@ -31,7 +31,7 @@ class SecurityController extends AbstractController
             trigger_deprecation(
                 'sylius/user-bundle',
                 '1.11',
-                sprintf('Not passing a $authenticationUtils to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing a $authenticationUtils to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
 
@@ -39,7 +39,7 @@ class SecurityController extends AbstractController
             trigger_deprecation(
                 'sylius/user-bundle',
                 '1.11',
-                sprintf('Not passing a $formFactory to %s constructor is deprecated since Sylius 1.11 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing a $formFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Bundle/UserBundle/EventListener/UserDeleteListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserDeleteListener.php
@@ -29,7 +29,7 @@ final class UserDeleteListener
     public function __construct(private TokenStorageInterface $tokenStorage, private SessionInterface|RequestStack $requestStackOrSession)
     {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated as of Sylius 1.12 and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
         }
     }
 

--- a/src/Sylius/Bundle/UserBundle/EventListener/UserDeleteListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserDeleteListener.php
@@ -29,7 +29,14 @@ final class UserDeleteListener
     public function __construct(private TokenStorageInterface $tokenStorage, private SessionInterface|RequestStack $requestStackOrSession)
     {
         if ($requestStackOrSession instanceof SessionInterface) {
-            trigger_deprecation('sylius/user-bundle', '1.12', sprintf('Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.', SessionInterface::class, self::class, RequestStack::class));
+            trigger_deprecation(
+                'sylius/user-bundle',
+                '1.12',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be removed in 2.0. Pass an instance of %s instead.',
+                SessionInterface::class,
+                self::class,
+                RequestStack::class,
+            );
         }
     }
 

--- a/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterfac
 trigger_deprecation('sylius/user-bundle', '1.12', 'The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoder::class, UserPasswordHasher::class);
 
 /**
- * @deprecated, use {@link UserPasswordHasher} instead
+ * @deprecated, use {@link UserPasswordHasher} instead.
  */
 class UserPasswordEncoder implements UserPasswordEncoderInterface
 {

--- a/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterfac
 trigger_deprecation('sylius/user-bundle', '1.12', 'The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoder::class, UserPasswordHasher::class);
 
 /**
- * @deprecated since Sylius 1.12, use {@link UserPasswordHasher} instead
+ * @deprecated, use {@link UserPasswordHasher} instead
  */
 class UserPasswordEncoder implements UserPasswordEncoderInterface
 {
@@ -34,7 +34,7 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
 
         throw new \InvalidArgumentException(
             sprintf(
-                'Using the "%s" class with "%s" argument is prohibited since Sylius 1.12, use "%s" service instead.',
+                'Using the "%s" class with "%s" argument is prohibited, use "%s" service instead.',
                 self::class,
                 PasswordHasherFactoryInterface::class,
                 UserPasswordHasher::class,

--- a/src/Sylius/Component/Channel/Context/ChannelNotFoundException.php
+++ b/src/Sylius/Component/Channel/Context/ChannelNotFoundException.php
@@ -20,7 +20,11 @@ class ChannelNotFoundException extends \RuntimeException
         $message = 'Channel could not be found! Tip: You can use the Web Debug Toolbar to switch between channels in development.';
 
         if ($messageOrPreviousException instanceof \Throwable) {
-            @trigger_error('Passing previous exception as the first argument is deprecated since 1.2 and will be prohibited since 2.0.', \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/channel',
+                '1.2',
+                'Passing previous exception as the first argument is deprecated since 1.2 and will be prohibited since 2.0.',
+            );
             $previousException = $messageOrPreviousException;
         }
 

--- a/src/Sylius/Component/Channel/Context/ChannelNotFoundException.php
+++ b/src/Sylius/Component/Channel/Context/ChannelNotFoundException.php
@@ -23,7 +23,7 @@ class ChannelNotFoundException extends \RuntimeException
             trigger_deprecation(
                 'sylius/channel',
                 '1.2',
-                'Passing previous exception as the first argument is deprecated since 1.2 and will be prohibited since 2.0.',
+                'Passing previous exception as the first argument is deprecated and will be prohibited since Sylius 2.0.',
             );
             $previousException = $messageOrPreviousException;
         }

--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -29,7 +29,7 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -29,7 +29,8 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -26,7 +26,11 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
         private ?ProductVariantLowestPriceDisplayCheckerInterface $productVariantLowestPriceDisplayChecker = null,
     ) {
         if ($this->productVariantLowestPriceDisplayChecker === null) {
-            @trigger_error(sprintf('Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing a $productVariantLowestPriceDisplayChecker to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
+++ b/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
@@ -47,7 +47,11 @@ final class ShopBasedCartContext implements CartContextInterface, ResetInterface
         $this->createdByGuestFlagResolver = $createdByGuestFlagResolver;
 
         if ($createdByGuestFlagResolver === null) {
-            @trigger_error('Not passing createdByGuestFlagResolver through constructor is deprecated in Sylius 1.10.9 and it will be prohibited in Sylius 2.0');
+            trigger_deprecation(
+                'sylius/core',
+                '1.10.9',
+                'Not passing createdByGuestFlagResolver through constructor is deprecated in Sylius 1.10.9 and it will be prohibited in Sylius 2.0',
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
+++ b/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
@@ -50,7 +50,7 @@ final class ShopBasedCartContext implements CartContextInterface, ResetInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.10.9',
-                'Not passing createdByGuestFlagResolver through constructor is deprecated in Sylius 1.10.9 and it will be prohibited in Sylius 2.0',
+                'Not passing a $createdByGuestFlagResolver through constructor is deprecated and will be prohibited in Sylius 2.0',
             );
         }
     }

--- a/src/Sylius/Component/Core/Factory/ChannelFactory.php
+++ b/src/Sylius/Component/Core/Factory/ChannelFactory.php
@@ -36,7 +36,11 @@ final class ChannelFactory implements ChannelFactoryInterface
         private ?FactoryInterface $channelPriceHistoryConfigFactory = null,
     ) {
         if (null === $this->channelPriceHistoryConfigFactory) {
-            @trigger_error(sprintf('Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/Factory/ChannelFactory.php
+++ b/src/Sylius/Component/Core/Factory/ChannelFactory.php
@@ -39,7 +39,8 @@ final class ChannelFactory implements ChannelFactoryInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/Factory/ChannelFactory.php
+++ b/src/Sylius/Component/Core/Factory/ChannelFactory.php
@@ -39,7 +39,7 @@ final class ChannelFactory implements ChannelFactoryInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing a $channelPriceHistoryConfigFactory to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
+++ b/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
@@ -27,7 +27,7 @@ final class GaufretteFilesystemAdapter implements FilesystemAdapterInterface
             'sylius/core',
             '1.12',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.12 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 FlysystemFilesystemAdapter::class,
             ),

--- a/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
+++ b/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
@@ -26,11 +26,9 @@ final class GaufretteFilesystemAdapter implements FilesystemAdapterInterface
         trigger_deprecation(
             'sylius/core',
             '1.12',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                FlysystemFilesystemAdapter::class,
-            ),
+            'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
+            self::class,
+            FlysystemFilesystemAdapter::class,
         );
     }
 

--- a/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
+++ b/src/Sylius/Component/Core/Filesystem/Adapter/GaufretteFilesystemAdapter.php
@@ -23,11 +23,15 @@ final class GaufretteFilesystemAdapter implements FilesystemAdapterInterface
 {
     public function __construct(private FilesystemInterface $filesystem)
     {
-        @trigger_error(sprintf(
-            'The "%s" class is deprecated since Sylius 1.12 and will be removed in 2.0. Use "%s" instead.',
-            self::class,
-            FlysystemFilesystemAdapter::class,
-        ), \E_USER_DEPRECATED);
+        trigger_deprecation(
+            'sylius/core',
+            '1.12',
+            sprintf(
+                'The "%s" class is deprecated since Sylius 1.12 and will be removed in 2.0. Use "%s" instead.',
+                self::class,
+                FlysystemFilesystemAdapter::class,
+            ),
+        );
     }
 
     public function has(string $location): bool

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -510,14 +510,22 @@ class Order extends BaseOrder implements OrderInterface
 
     public function getCreatedByGuest(): bool
     {
-        @trigger_error('This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. Please use `isCreatedByGuest` instead.');
+        trigger_deprecation(
+            'sylius/core',
+            '1.12',
+            'This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. Please use `isCreatedByGuest` instead.',
+        );
 
         return $this->isCreatedByGuest();
     }
 
     public function setCreatedByGuest(bool $createdByGuest): void
     {
-        @trigger_error('This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. This flag should be changed only through `setCustomerWithAuthorization` method.');
+        trigger_deprecation(
+            'sylius/core',
+            '1.12',
+            'This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. This flag should be changed only through `setCustomerWithAuthorization` method.',
+        );
 
         $this->createdByGuest = $createdByGuest;
     }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -513,7 +513,7 @@ class Order extends BaseOrder implements OrderInterface
         trigger_deprecation(
             'sylius/core',
             '1.12',
-            'This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. Please use `isCreatedByGuest` instead.',
+            'This method is deprecated and it will be removed in Sylius 2.0. Please use `isCreatedByGuest` instead.',
         );
 
         return $this->isCreatedByGuest();
@@ -524,7 +524,7 @@ class Order extends BaseOrder implements OrderInterface
         trigger_deprecation(
             'sylius/core',
             '1.12',
-            'This method is deprecated since Sylius 1.12 and it will be removed in Sylius 2.0. This flag should be changed only through `setCustomerWithAuthorization` method.',
+            'This method is deprecated and it will be removed in Sylius 2.0. This flag should be changed only through `setCustomerWithAuthorization` method.',
         );
 
         $this->createdByGuest = $createdByGuest;

--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -27,7 +27,7 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.2',
-                'Not passing adjustments types explicitly is deprecated since 1.2 and will be prohibited in 2.0',
+                'Not passing $adjustmentsToRemove explicitly is deprecated and will be prohibited in Sylius 2.0',
             );
 
             $adjustmentsToRemove = [

--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -24,9 +24,10 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
     public function __construct(array $adjustmentsToRemove = [])
     {
         if (0 === func_num_args()) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.2',
                 'Not passing adjustments types explicitly is deprecated since 1.2 and will be prohibited in 2.0',
-                \E_USER_DEPRECATED,
             );
 
             $adjustmentsToRemove = [

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -35,14 +35,14 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
         if ([] === $this->unprocessableOrderStates) {
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -32,10 +32,18 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
         private array $unprocessableOrderStates = [],
     ) {
         if ($this->orderPaymentsRemover === null) {
-            @trigger_error(sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
         if ([] === $this->unprocessableOrderStates) {
-            @trigger_error(sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -35,14 +35,16 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $orderPaymentsRemover to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing an $orderPaymentsRemover to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
         if ([] === $this->unprocessableOrderStates) {
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $unprocessableOrderStates to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing an $unprocessableOrderStates to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -25,9 +25,10 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
     public function __construct(private ProductVariantPriceCalculatorInterface|ProductVariantPricesCalculatorInterface $productVariantPriceCalculator)
     {
         if ($this->productVariantPriceCalculator instanceof ProductVariantPriceCalculatorInterface) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.11',
                 sprintf('Passing a "Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" to "%s" constructor is deprecated since Sylius 1.11 and will be prohibited in 2.0. Use "Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface" instead.', self::class),
-                \E_USER_DEPRECATED,
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -28,7 +28,7 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.11',
-                sprintf('Passing a "Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" to "%s" constructor is deprecated since Sylius 1.11 and will be prohibited in 2.0. Use "Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface" instead.', self::class),
+                sprintf('Passing a "Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" to "%s" constructor is deprecated and will be prohibited in 2.0. Use "Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface" instead.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -28,7 +28,10 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.11',
-                sprintf('Passing a "Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" to "%s" constructor is deprecated and will be prohibited in 2.0. Use "Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface" instead.', self::class),
+                'Passing a "%s" to "%s" constructor is deprecated and will be prohibited in 2.0. Use "%s" instead.',
+                ProductVariantPriceCalculatorInterface::class,
+                self::class,
+                ProductVariantPricesCalculatorInterface::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -31,9 +31,10 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         private ?ShippingMethodsResolverInterface $shippingMethodsResolver = null,
     ) {
         if (2 === func_num_args() || null === $shippingMethodsResolver) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.2',
                 'Not passing ShippingMethodsResolverInterface explicitly is deprecated since 1.2 and will be prohibited in 2.0',
-                \E_USER_DEPRECATED,
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -34,7 +34,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.2',
-                'Not passing ShippingMethodsResolverInterface explicitly is deprecated since 1.2 and will be prohibited in 2.0',
+                'Not passing a $shippingMethodsResolver explicitly is deprecated and will be prohibited in Sylius 2.0',
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -37,7 +37,11 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
         private ?TaxationAddressResolverInterface $taxationAddressResolver = null,
     ) {
         if ($this->taxationAddressResolver === null) {
-            @trigger_error(sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated since Sylius 1.11 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.11',
+                sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated since Sylius 1.11 and will be removed in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -40,7 +40,8 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.11',
-                sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
+                'Not passing a $taxationAddressResolver to %s constructor is deprecated and will be removed in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -40,7 +40,7 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.11',
-                sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated since Sylius 1.11 and will be removed in Sylius 2.0.', self::class),
+                sprintf('Not passing a $taxationAddressResolver to %s constructor is deprecated and will be removed in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
@@ -25,7 +25,7 @@ final class ContainsProductRuleUpdater implements ProductAwareRuleUpdaterInterfa
         @trigger_deprecation(
             'sylius/core',
             '1.13',
-            'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/ContainsProductRuleUpdater.php
@@ -18,14 +18,17 @@ use Sylius\Component\Core\Promotion\Checker\Rule\ContainsProductRuleChecker;
 use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
+/**
+ * @deprecated since Sylius 1.13 ane will be removed in Sylius 2.0
+ */
 final class ContainsProductRuleUpdater implements ProductAwareRuleUpdaterInterface
 {
     public function __construct(private RepositoryInterface $promotionRuleRepository)
     {
-        @trigger_deprecation(
+        trigger_deprecation(
             'sylius/core',
             '1.13',
-            'The "%s" class is deprecated and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in Sylius 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
@@ -18,14 +18,17 @@ use Sylius\Component\Core\Promotion\Checker\Rule\TotalOfItemsFromTaxonRuleChecke
 use Sylius\Component\Promotion\Model\PromotionRuleInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
+/**
+ * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0.
+ */
 final class TotalOfItemsFromTaxonRuleUpdater implements TaxonAwareRuleUpdaterInterface
 {
     public function __construct(private RepositoryInterface $promotionRuleRepository)
     {
-        @trigger_deprecation(
+        trigger_deprecation(
             'sylius/core',
             '1.13',
-            'The "%s" class is deprecated and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in Sylius 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
+++ b/src/Sylius/Component/Core/Promotion/Updater/Rule/TotalOfItemsFromTaxonRuleUpdater.php
@@ -25,7 +25,7 @@ final class TotalOfItemsFromTaxonRuleUpdater implements TaxonAwareRuleUpdaterInt
         @trigger_deprecation(
             'sylius/core',
             '1.13',
-            'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0.',
+            'The "%s" class is deprecated and will be removed in 2.0.',
             self::class,
         );
     }

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
@@ -31,7 +31,7 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
             'sylius/core-bundle',
             '1.13',
             sprintf(
-                'The "%s" class is deprecated since Sylius 1.13 and will be removed in 2.0. Use "%s" instead.',
+                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
                 self::class,
                 ProductVariantsMapProvider::class,
             ),

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
@@ -22,7 +22,7 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantsMapProvider;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProvider} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProvider} instead. */
 final class ProductVariantsPricesProvider implements ProductVariantsPricesProviderInterface
 {
     public function __construct(private ProductVariantPriceCalculatorInterface $productVariantPriceCalculator)

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
@@ -30,11 +30,9 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
         trigger_deprecation(
             'sylius/core-bundle',
             '1.13',
-            sprintf(
-                'The "%s" class is deprecated and will be removed in 2.0. Use "%s" instead.',
-                self::class,
-                ProductVariantsMapProvider::class,
-            ),
+            'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+            self::class,
+            ProductVariantsMapProvider::class,
         );
     }
 

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProviderInterface.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProviderInterface.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantsMapProviderI
 
 trigger_deprecation('sylius/core', '1.13', 'The "%s" class is deprecated, use "%s" instead.', ProductVariantsPricesProviderInterface::class, ProductVariantsMapProviderInterface::class);
 
-/** @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProviderInterface} instead. */
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProviderInterface} instead. */
 interface ProductVariantsPricesProviderInterface
 {
     public function provideVariantsPrices(ProductInterface $product, ChannelInterface $channel): array;

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProviderInterface.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProviderInterface.php
@@ -17,7 +17,13 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantsMapProviderInterface;
 
-trigger_deprecation('sylius/core', '1.13', 'The "%s" class is deprecated, use "%s" instead.', ProductVariantsPricesProviderInterface::class, ProductVariantsMapProviderInterface::class);
+trigger_deprecation(
+    'sylius/core',
+    '1.13',
+    'The "%s" class is deprecated, use "%s" instead.',
+    ProductVariantsPricesProviderInterface::class,
+    ProductVariantsMapProviderInterface::class,
+);
 
 /** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see ProductVariantsMapProviderInterface} instead. */
 interface ProductVariantsPricesProviderInterface

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -31,7 +31,7 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
     public function createListQueryBuilder(): QueryBuilder;
 
     /**
-     * @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see createCriteriaAwareSearchListQueryBuilder()} instead.
+     * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see createCriteriaAwareSearchListQueryBuilder()} instead.
      */
     public function createSearchListQueryBuilder(): QueryBuilder;
 
@@ -41,7 +41,7 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
     public function createCriteriaAwareSearchListQueryBuilder(?array $criteria): QueryBuilder;
 
     /**
-     * @deprecated since 1.13 and will be removed in Sylius 2.0. Use {@see createByCustomerIdCriteriaAwareQueryBuilder()} instead.
+     * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Use {@see createByCustomerIdCriteriaAwareQueryBuilder()} instead.
      */
     public function createByCustomerIdQueryBuilder($customerId): QueryBuilder;
 

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -25,7 +25,8 @@ use Webmozart\Assert\Assert;
 trigger_deprecation(
     'sylius/core',
     '1.2',
-    sprintf('This class is deprecated and will be removed in 2.0. "%s" should be used instead.', EligibleDefaultShippingMethodResolver::class),
+    'This class is deprecated and will be removed in 2.0. "%s" should be used instead.',
+    EligibleDefaultShippingMethodResolver::class,
 );
 
 /**

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -22,7 +22,11 @@ use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface;
 use Webmozart\Assert\Assert;
 
-@trigger_error(sprintf('This class is deprecated since Sylius 1.2 and will be removed in 2.0. "%s" should be used instead.', EligibleDefaultShippingMethodResolver::class), \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/core',
+    '1.2',
+    sprintf('This class is deprecated since Sylius 1.2 and will be removed in 2.0. "%s" should be used instead.', EligibleDefaultShippingMethodResolver::class),
+);
 
 class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInterface
 {

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -25,9 +25,12 @@ use Webmozart\Assert\Assert;
 trigger_deprecation(
     'sylius/core',
     '1.2',
-    sprintf('This class is deprecated since Sylius 1.2 and will be removed in 2.0. "%s" should be used instead.', EligibleDefaultShippingMethodResolver::class),
+    sprintf('This class is deprecated and will be removed in 2.0. "%s" should be used instead.', EligibleDefaultShippingMethodResolver::class),
 );
 
+/**
+ * @deprecated since Sylius 1.2, will be removed in Sylius 2.0. Use {@link EligibleDefaultShippingMethodResolver} instead.
+ */
 class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInterface
 {
     public function __construct(private ShippingMethodRepositoryInterface $shippingMethodRepository)

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -35,7 +35,8 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -32,7 +32,11 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
         private ?ProportionalIntegerDistributorInterface $proportionalIntegerDistributor = null,
     ) {
         if ($this->proportionalIntegerDistributor === null) {
-            @trigger_error(sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -35,7 +35,7 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -39,7 +39,7 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
             );
         }
     }

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -36,7 +36,11 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
         private ?ProportionalIntegerDistributorInterface $proportionalIntegerDistributor = null,
     ) {
         if ($this->proportionalIntegerDistributor === null) {
-            @trigger_error(sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated since Sylius 1.13 and will be prohibited in Sylius 2.0.', self::class),
+            );
         }
     }
 

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -39,7 +39,8 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                sprintf('Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.', self::class),
+                'Not passing an $proportionalIntegerDistributor to %s constructor is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
             );
         }
     }

--- a/src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php
+++ b/src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php
@@ -31,7 +31,7 @@ final class TranslatableEntityLocaleAssigner implements TranslatableEntityLocale
             trigger_deprecation(
                 'sylius/core',
                 '1.11',
-                'Not passing CommandBasedContextCheckedInterface explicitly as the third argument is deprecated since 1.11 and will be prohibited in 2.0.',
+                'Not passing a $commandBasedChecker explicitly as the third argument is deprecated and will be prohibited in Sylius 2.0.',
             );
         }
     }

--- a/src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php
+++ b/src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php
@@ -28,9 +28,10 @@ final class TranslatableEntityLocaleAssigner implements TranslatableEntityLocale
         private ?CLIContextCheckerInterface $commandBasedChecker = null,
     ) {
         if ($this->commandBasedChecker === null) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.11',
                 'Not passing CommandBasedContextCheckedInterface explicitly as the third argument is deprecated since 1.11 and will be prohibited in 2.0.',
-                \E_USER_DEPRECATED,
             );
         }
     }

--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -23,13 +23,11 @@ use Sylius\Component\Order\OrderTransitions;
 
 final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterface
 {
-    private ?LoggerInterface $logger;
-
     public function __construct(
         private OrderRepositoryInterface $orderRepository,
         private Factory $stateMachineFactory,
         private string $expirationPeriod,
-        LoggerInterface $logger = null,
+        private ?LoggerInterface $logger = null,
         private ?ObjectManager $orderManager = null,
         private int $batchSize = 100,
     ) {
@@ -37,7 +35,7 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
             trigger_deprecation(
                 'sylius/core',
                 '1.7',
-                'Not passing a logger is deprecated since 1.7',
+                'Not passing a $logger is deprecated and will be prohibited in Sylius 2.0.',
             );
         }
 
@@ -45,7 +43,7 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
             trigger_deprecation(
                 'sylius/core',
                 '1.13',
-                'Not passing an $orderManager is deprecated since 1.13 as it makes $batchSize useless.',
+                'Not passing the $orderManager is deprecated as it makes $batchSize useless.',
             );
         }
 

--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -34,16 +34,18 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
         private int $batchSize = 100,
     ) {
         if (null === $logger) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.7',
                 'Not passing a logger is deprecated since 1.7',
-                \E_USER_DEPRECATED,
             );
         }
 
         if (null === $orderManager) {
-            @trigger_error(
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
                 'Not passing an $orderManager is deprecated since 1.13 as it makes $batchSize useless.',
-                \E_USER_DEPRECATED,
             );
         }
 

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -42,10 +42,8 @@ class ImageUploader implements ImageUploaderInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.12',
-                sprintf(
-                    'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated and will be not possible in Sylius 2.0.',
-                    self::class,
-                ),
+                'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated and will be not possible in Sylius 2.0.',
+                self::class,
             );
 
             /** @psalm-suppress DeprecatedClass */
@@ -56,10 +54,8 @@ class ImageUploader implements ImageUploaderInterface
             trigger_deprecation(
                 'sylius/core',
                 '1.6',
-                sprintf(
-                    'Not passing an $imagePathGenerator to %s constructor is deprecated and will be not possible in Sylius 2.0.',
-                    self::class,
-                ),
+                'Not passing an $imagePathGenerator to %s constructor is deprecated and will be not possible in Sylius 2.0.',
+                self::class,
             );
         }
 

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -43,7 +43,7 @@ class ImageUploader implements ImageUploaderInterface
                 'sylius/core',
                 '1.12',
                 sprintf(
-                    'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated since Sylius 1.12 and will be not possible in Sylius 2.0.',
+                    'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated and will be not possible in Sylius 2.0.',
                     self::class,
                 ),
             );
@@ -57,7 +57,7 @@ class ImageUploader implements ImageUploaderInterface
                 'sylius/core',
                 '1.6',
                 sprintf(
-                    'Not passing an $imagePathGenerator to %s constructor is deprecated since Sylius 1.6 and will be not possible in Sylius 2.0.',
+                    'Not passing an $imagePathGenerator to %s constructor is deprecated and will be not possible in Sylius 2.0.',
                     self::class,
                 ),
             );

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -39,20 +39,28 @@ class ImageUploader implements ImageUploaderInterface
         protected ?ImagePathGeneratorInterface $imagePathGenerator = null,
     ) {
         if ($this->filesystem instanceof FilesystemInterface) {
-            @trigger_error(sprintf(
-                'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated since Sylius 1.12 and will be not possible in Sylius 2.0.',
-                self::class,
-            ), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.12',
+                sprintf(
+                    'Passing Gaufrette\FilesystemInterface as a first argument in %s constructor is deprecated since Sylius 1.12 and will be not possible in Sylius 2.0.',
+                    self::class,
+                ),
+            );
 
             /** @psalm-suppress DeprecatedClass */
             $this->filesystem = new GaufretteFilesystemAdapter($this->filesystem);
         }
 
         if ($imagePathGenerator === null) {
-            @trigger_error(sprintf(
-                'Not passing an $imagePathGenerator to %s constructor is deprecated since Sylius 1.6 and will be not possible in Sylius 2.0.',
-                self::class,
-            ), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/core',
+                '1.6',
+                sprintf(
+                    'Not passing an $imagePathGenerator to %s constructor is deprecated since Sylius 1.6 and will be not possible in Sylius 2.0.',
+                    self::class,
+                ),
+            );
         }
 
         $this->imagePathGenerator = $imagePathGenerator ?? new UploadedImagePathGenerator();

--- a/src/Sylius/Component/Core/spec/Filesystem/Adapter/GaufretteFilesystemAdapterSpec.php
+++ b/src/Sylius/Component/Core/spec/Filesystem/Adapter/GaufretteFilesystemAdapterSpec.php
@@ -30,11 +30,6 @@ final class GaufretteFilesystemAdapterSpec extends ObjectBehavior
         $this->shouldImplement(FilesystemAdapterInterface::class);
     }
 
-    function it_triggers_deprecated_warning_during_instantiation(): void
-    {
-        $this->shouldTrigger(\E_USER_DEPRECATED)->duringInstantiation();
-    }
-
     function it_returns_true_if_the_file_exists(FilesystemInterface $filesystem): void
     {
         $filesystem->has('/path/to/some-file')->willReturn(true);

--- a/src/Sylius/Component/Core/spec/Uploader/ImageUploaderSpec.php
+++ b/src/Sylius/Component/Core/spec/Uploader/ImageUploaderSpec.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Core\Uploader;
 
-use Gaufrette\FilesystemInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Filesystem\Adapter\FilesystemAdapterInterface;
@@ -38,30 +37,6 @@ final class ImageUploaderSpec extends ObjectBehavior
         $this->beConstructedWith($filesystem, $imagePathGenerator);
 
         $this->shouldImplement(ImageUploaderInterface::class);
-    }
-
-    function it_triggers_a_deprecation_exception_if_no_image_path_generator_is_passed(
-        FilesystemAdapterInterface $filesystem,
-        ImagePathGeneratorInterface $imagePathGenerator,
-    ): void {
-        $this->beConstructedWith($filesystem, $imagePathGenerator);
-
-        $this
-            ->shouldTrigger(\E_USER_DEPRECATED)
-            ->during('__construct', [$filesystem])
-        ;
-    }
-
-    function it_triggers_a_deprecation_exception_if_gaufrette_filesystem_is_passed(
-        FilesystemInterface $filesystem,
-        ImagePathGeneratorInterface $imagePathGenerator,
-    ): void {
-        $this->beConstructedWith($filesystem, $imagePathGenerator);
-
-        $this
-            ->shouldTrigger(\E_USER_DEPRECATED)
-            ->duringInstantiation()
-        ;
     }
 
     function it_uploads_an_image(

--- a/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
@@ -37,7 +37,7 @@ interface OrderRepositoryInterface extends RepositoryInterface
 
     public function findOneByTokenValue(string $tokenValue): ?OrderInterface;
 
-    /** @deprecated since 1.9 and  will be removed in Sylius 2.0, use src/Sylius/Component/Core/Repository/OrderRepositoryInterface instead */
+    /** @deprecated since Sylius 1.9 and  will be removed in Sylius 2.0, use src/Sylius/Component/Core/Repository/OrderRepositoryInterface instead */
     public function findCartByTokenValue(string $tokenValue): ?OrderInterface;
 
     public function findCartById($id): ?OrderInterface;

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Checker;
 
-use const E_USER_DEPRECATED;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.8, use "%s" instead.', 'Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker', 'Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker'), E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/shipping',
+    '1.8',
+    sprintf('The "%s" class is deprecated since Sylius 1.8, use "%s" instead.', 'Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker', 'Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker'),
+);
 
 /**
  * @deprecated since Sylius 1.8. Use Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker instead

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
@@ -19,7 +19,7 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 trigger_deprecation(
     'sylius/shipping',
     '1.8',
-    sprintf('The "%s" class is deprecated since Sylius 1.8, use "%s" instead.', 'Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker', 'Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker'),
+    sprintf('The "%s" class is deprecated, use "%s" instead.', 'Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker', 'Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker'),
 );
 
 /**

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.php
@@ -13,17 +13,20 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Checker;
 
+use Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
 trigger_deprecation(
     'sylius/shipping',
     '1.8',
-    sprintf('The "%s" class is deprecated, use "%s" instead.', 'Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker', 'Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker'),
+    'The "%s" class is deprecated, use "%s" instead.',
+    ShippingMethodEligibilityChecker::class,
+    CompositeShippingMethodEligibilityChecker::class,
 );
 
 /**
- * @deprecated since Sylius 1.8. Use Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker instead
+ * @deprecated since Sylius 1.8. Use {@see CompositeShippingMethodEligibilityChecker} instead.
  *
  * @psalm-suppress DeprecatedInterface
  */

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Checker;
 
-use const E_USER_DEPRECATED;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface as NewShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
-@trigger_error(sprintf('The "%s" interface is deprecated since Sylius 1.8, use "%s" instead.', ShippingMethodEligibilityCheckerInterface::class, NewShippingMethodEligibilityCheckerInterface::class), E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/shipping',
+    '1.8',
+    sprintf('The "%s" interface is deprecated since Sylius 1.8, use "%s" instead.', ShippingMethodEligibilityCheckerInterface::class, NewShippingMethodEligibilityCheckerInterface::class),
+);
 
 /**
  * @deprecated since Sylius 1.8. Use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface instead

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
@@ -20,7 +20,9 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 trigger_deprecation(
     'sylius/shipping',
     '1.8',
-    sprintf('The "%s" interface is deprecated since Sylius 1.8, use "%s" instead.', ShippingMethodEligibilityCheckerInterface::class, NewShippingMethodEligibilityCheckerInterface::class),
+    'The "%s" interface is deprecated, use "%s" instead.',
+    ShippingMethodEligibilityCheckerInterface::class,
+    NewShippingMethodEligibilityCheckerInterface::class,
 );
 
 /**

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -26,11 +26,15 @@ final class ShippingMethodsResolver implements ShippingMethodsResolverInterface
         private ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
     ) {
         if (!$this->shippingMethodRepository instanceof ShippingMethodRepositoryInterface) {
-            @trigger_error(sprintf(
-                'Not implementing "%s" in "%s" is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
-                ShippingMethodRepositoryInterface::class,
-                get_debug_type($this->shippingMethodRepository),
-            ), \E_USER_DEPRECATED);
+            trigger_deprecation(
+                'sylius/shipping',
+                '1.13',
+                sprintf(
+                    'Not implementing "%s" in "%s" is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                    ShippingMethodRepositoryInterface::class,
+                    get_debug_type($this->shippingMethodRepository),
+                ),
+            );
         }
     }
 

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -29,11 +29,9 @@ final class ShippingMethodsResolver implements ShippingMethodsResolverInterface
             trigger_deprecation(
                 'sylius/shipping',
                 '1.13',
-                sprintf(
-                    'Not implementing "%s" in "%s" is deprecated and will be required in Sylius 2.0.',
-                    ShippingMethodRepositoryInterface::class,
-                    get_debug_type($this->shippingMethodRepository),
-                ),
+                'Not implementing "%s" in "%s" is deprecated and will be required in Sylius 2.0.',
+                ShippingMethodRepositoryInterface::class,
+                get_debug_type($this->shippingMethodRepository),
             );
         }
     }

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -30,7 +30,7 @@ final class ShippingMethodsResolver implements ShippingMethodsResolverInterface
                 'sylius/shipping',
                 '1.13',
                 sprintf(
-                    'Not implementing "%s" in "%s" is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                    'Not implementing "%s" in "%s" is deprecated and will be required in Sylius 2.0.',
                     ShippingMethodRepositoryInterface::class,
                     get_debug_type($this->shippingMethodRepository),
                 ),

--- a/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping;
 
-@trigger_error('This class is deprecated since Sylius 1.12 and will be removed in 2.0. Copy these constants if you use them.', \E_USER_DEPRECATED);
+trigger_deprecation(
+    'sylius/shipping',
+    '1.12',
+    'This class is deprecated since Sylius 1.12 and will be removed in 2.0. Copy these constants if you use them.',
+);
 
 class ShipmentUnitTransitions
 {

--- a/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
@@ -16,9 +16,12 @@ namespace Sylius\Component\Shipping;
 trigger_deprecation(
     'sylius/shipping',
     '1.12',
-    'This class is deprecated since Sylius 1.12 and will be removed in 2.0. Copy these constants if you use them.',
+    'This class is deprecated and will be removed in 2.0. Copy these constants if you use them.',
 );
 
+/**
+ * @deprecated, copy these constants if you use them.
+ */
 class ShipmentUnitTransitions
 {
     public const GRAPH = 'sylius_shipment_unit';

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
@@ -28,7 +28,7 @@ class TaxRateResolver implements TaxRateResolverInterface
             trigger_deprecation(
                 'sylius/taxation',
                 '1.12',
-                'Not passing TaxRateDateEligibilityCheckerInterface through constructor is deprecated in Sylius 1.12 and it will be prohibited in Sylius 2.0',
+                'Not passing a $taxRateDateChecker through constructor is deprecated and it will be prohibited in Sylius 2.0',
             );
         }
     }

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
@@ -25,7 +25,11 @@ class TaxRateResolver implements TaxRateResolverInterface
         protected ?TaxRateDateEligibilityCheckerInterface $taxRateDateChecker = null,
     ) {
         if ($this->taxRateDateChecker === null) {
-            @trigger_error('Not passing TaxRateDateEligibilityCheckerInterface through constructor is deprecated in Sylius 1.12 and it will be prohibited in Sylius 2.0');
+            trigger_deprecation(
+                'sylius/taxation',
+                '1.12',
+                'Not passing TaxRateDateEligibilityCheckerInterface through constructor is deprecated in Sylius 1.12 and it will be prohibited in Sylius 2.0',
+            );
         }
     }
 

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -403,7 +403,7 @@ class User implements UserInterface, \Stringable
     /**
      * @internal
      *
-     * @deprecated will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__serialize() or \serialize($user) in PHP 8.1 instead
+     * @deprecated since Sylius 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__serialize() or \serialize($user) in PHP 8.1 instead
      */
     public function serialize(): string
     {

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -403,7 +403,7 @@ class User implements UserInterface, \Stringable
     /**
      * @internal
      *
-     * @deprecated since 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__serialize() or \serialize($user) in PHP 8.1 instead
+     * @deprecated will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__serialize() or \serialize($user) in PHP 8.1 instead
      */
     public function serialize(): string
     {
@@ -433,7 +433,7 @@ class User implements UserInterface, \Stringable
      *
      * @internal
      *
-     * @deprecated since 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__unserialize() or \unserialize($serialized) in PHP 8.1 instead
+     * @deprecated since Sylius 1.11 and will be removed in Sylius 2.0, use \Sylius\Component\User\Model\User::__unserialize() or \unserialize($serialized) in PHP 8.1 instead
      */
     public function unserialize($serialized): void
     {

--- a/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
+++ b/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\User\Model\CredentialsHolderInterface;
 trigger_deprecation('sylius/user', '1.12', 'The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoderInterface::class, UserPasswordHasherInterface::class);
 
 /**
- * @deprecated, use {@link UserPasswordHasherInterface} instead
+ * @deprecated since Sylius 1.12, use {@link UserPasswordHasherInterface} instead.
  */
 interface UserPasswordEncoderInterface
 {

--- a/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
+++ b/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\User\Model\CredentialsHolderInterface;
 trigger_deprecation('sylius/user', '1.12', 'The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoderInterface::class, UserPasswordHasherInterface::class);
 
 /**
- * @deprecated since Sylius 1.12, use {@link UserPasswordHasherInterface} instead
+ * @deprecated, use {@link UserPasswordHasherInterface} instead
  */
 interface UserPasswordEncoderInterface
 {


### PR DESCRIPTION
Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We need to sort out the deprecations as only one way is currently supported