### PR TITLE
Add upmerging from 1.13 to 2.0

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -19,6 +19,9 @@ jobs:
                     -
                         base_branch: "1.12"
                         target_branch: "1.13"
+                    -
+                        base_branch: "1.13"
+                        target_branch: "2.0"
 
         steps:
             -


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

It's targeted against `1.13` as its the default branch. All scheduled workflows are run only from the default branch.