### PR TITLE
[CoreBundle] Move the PaymentFixture class in a proper namespace and deprecate other code

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -153,3 +153,5 @@
 1. The `Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture` has been deprecated. Use `Sylius\Bundle\CoreBundle\Fixture\PaymentFixture` instead.
 
 1. Not passing a `$router` to `Sylius\Bundle\AdminBundle\Controller\ImpersonateUserController` as the fourth argument is deprecated and will be prohibited in Sylius 2.0.
+
+1. The `Sylius\Bundle\CoreBundle\Provider\SessionProvider` has been deprecated and will be removed in Sylius 2.0.

--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -149,3 +149,7 @@
 
 1. Interface `Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface` and class `Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension` responsible for the `sylius_order_items_subtotal` twig function have been deprecated and will be removed in Sylius 2.0.
    Use the `::getItemsSubtotal()` method from the `Order` class instead.
+
+1. The `Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture` has been deprecated. Use `Sylius\Bundle\CoreBundle\Fixture\PaymentFixture` instead.
+
+1. Not passing a `$router` to `Sylius\Bundle\AdminBundle\Controller\ImpersonateUserController` as the fourth argument is deprecated and will be prohibited in Sylius 2.0.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -40,3 +40,4 @@ parameters:
         - '/Method Symfony\\Component\\Serializer\\Normalizer\\NormalizerInterface\:\:supportsNormalization\(\) invoked with 3 parameters\, 1\-2 required\./'
         - '/(Interface|Class) [a-zA-Z\\]+ specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior, we are basing on Psalm for generics checks
         - '/Symfony\\Component\\Serializer\\NameConverter\\NameConverterInterface::normalize\(\) invoked with 2 parameters, 1 required./'
+        - '/Class "Sylius\\Bundle\\CoreBundle\\Fixture\\PaymentFixture" not found/'

--- a/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/ImpersonateUserController.php
@@ -37,11 +37,11 @@ final class ImpersonateUserController
         ?RouterInterface $router,
         private string $authorizationRole,
     ) {
-        if (null !== $router) {
+        if (null === $router) {
             trigger_deprecation(
                 'sylius/admin-bundle',
-                '1.4',
-                'Passing a $router as the fourth argument is deprecated and will be prohibited in Sylius 2.0',
+                '1.13',
+                'Not passing a $router as the fourth argument is deprecated and will be prohibited in Sylius 2.0',
             );
         }
         $this->router = $router;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/PaymentFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/PaymentFixture.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
+namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
@@ -24,20 +24,34 @@ use Sylius\Component\Payment\PaymentTransitions;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+class_alias(PaymentFixture::class, '\Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture');
+
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.13',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use "%s" instead.',
+    '\Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture',
+    PaymentFixture::class,
+);
+
 class PaymentFixture extends AbstractFixture
 {
     private Generator $faker;
 
     private OptionsResolver $optionsResolver;
 
+    /**
+     * @param PaymentRepositoryInterface<PaymentInterface> $paymentRepository
+     */
     public function __construct(
         private PaymentRepositoryInterface $paymentRepository,
         private StateMachineFactoryInterface $stateMachineFactory,
         private ObjectManager $paymentManager,
     ) {
+        $this->faker = Factory::create();
+
         $this->optionsResolver = new OptionsResolver();
         $this->configureOptions($this->optionsResolver);
-        $this->faker = Factory::create();
     }
 
     public function getName(): string
@@ -45,6 +59,9 @@ class PaymentFixture extends AbstractFixture
         return 'payments';
     }
 
+    /**
+     * @param string[] $options
+     */
     public function load(array $options): void
     {
         $options = $this->optionsResolver->resolve($options);

--- a/src/Sylius/Bundle/CoreBundle/Provider/SessionProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/SessionProvider.php
@@ -16,6 +16,13 @@ namespace Sylius\Bundle\CoreBundle\Provider;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.13',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0',
+    SessionProvider::class,
+);
+
 final class SessionProvider
 {
     public static function getSession(RequestStack|SessionInterface $requestStackOrSession): SessionInterface

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -182,11 +182,13 @@
             <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
         </service>
 
-        <service id="Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture">
+        <service id="Sylius\Bundle\CoreBundle\Fixture\PaymentFixture">
             <argument type="service" id="sylius.repository.payment" />
             <argument type="service" id="sm.factory" />
             <argument type="service" id="sylius.manager.payment" />
             <tag name="sylius_fixtures.fixture" />
         </service>
+
+        <service id="Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture" alias="Sylius\Bundle\CoreBundle\Fixture\PaymentFixture" />
     </services>
 </container>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                       |
| Deprecations?   |yes <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We are resolving any inconsistencies we encounter before moving to Sylius 2.0.