### PR TITLE
Add newline to align with other public method

### DIFF
--- a/src/Sylius/Component/Order/Modifier/OrderModifier.php
+++ b/src/Sylius/Component/Order/Modifier/OrderModifier.php
@@ -35,6 +35,7 @@ final class OrderModifier implements OrderModifierInterface
     public function removeFromOrder(OrderInterface $cart, OrderItemInterface $item): void
     {
         $cart->removeItem($item);
+
         $this->orderProcessor->process($cart);
     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13    |
| Bug fix?        | no                                              |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| License         | MIT                                                          |

Not really a bug, but I noticed there was a newline between the method calls in the first public method, but not in the second. So it looks more tidy now :)
