### PR TITLE
[Maintenance] Deprecate `OrderItemsSubtotalCalculatorInterface`

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -146,3 +146,6 @@
     `sylius_admin_ajax_taxon_move_up` and `sylius_admin_ajax_taxon_move_down` routes.
 
 1. Not passing a `$fileLocator` to `Sylius\Bundle\CoreBundle\Fixture\Factory\ProductExampleFactory` constructor is deprecated and will be prohibited in Sylius 2.0.
+
+1. Interface `Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface` and class `Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension` responsible for the `sylius_order_items_subtotal` twig function have been deprecated and will be removed in Sylius 2.0.
+   Use the `::getItemsSubtotal()` method from the `Order` class instead.

--- a/psalm.xml
+++ b/psalm.xml
@@ -46,6 +46,7 @@
                 <referencedClass name="Sylius\Bundle\ShippingBundle\Provider\Calendar"/>
                 <referencedClass name="Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator"/>
                 <referencedClass name="Sylius\Bundle\ShopBundle\Twig\OrderTaxesTotalExtension"/>
+                <referencedClass name="Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension" />
                 <referencedClass name="Sylius\Bundle\UserBundle\Security\UserPasswordEncoder"/>
                 <referencedClass name="Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" />
                 <referencedClass name="Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface" />
@@ -66,6 +67,7 @@
         <DeprecatedInterface>
             <errorLevel type="info">
                 <referencedClass name="ApiPlatform\Core\Api\IriConverterInterface" /> <!-- deprecated in ApiPlatform 2.7 -->
+                <referencedClass name="Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface" />
                 <referencedClass name="Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" />
                 <referencedClass name="Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface" />
                 <referencedClass name="Sylius\Component\User\Security\UserPasswordEncoderInterface" />

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculatorInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculatorInterface.php
@@ -15,6 +15,17 @@ namespace Sylius\Bundle\ShopBundle\Calculator;
 
 use Sylius\Component\Core\Model\OrderInterface;
 
+trigger_deprecation(
+    'sylius/shop-bundle',
+    '1.13',
+    'The "%s" interface is deprecated and will be removed in Sylius 2.0, use method "getItemsSubtotal" from "%s" instead.',
+    OrderItemsSubtotalCalculatorInterface::class,
+    OrderInterface::class,
+);
+
+/**
+ * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Items subtotal calculations is now available by using {@see Order::getSubtotalItems} method.
+ */
 interface OrderItemsSubtotalCalculatorInterface
 {
     public function getSubtotal(OrderInterface $order): int;

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_totals.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_totals.html.twig
@@ -1,6 +1,6 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
-{% set itemsSubtotal = sylius_order_items_subtotal(cart) %}
+{% set itemsSubtotal = cart.getItemsSubtotal() %}
 {% set taxIncluded = cart.getTaxIncludedTotal() %}
 {% set taxExcluded = cart.getTaxExcludedTotal() %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_summary.html.twig
@@ -1,6 +1,6 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
-{% set itemsSubtotal = sylius_order_items_subtotal(order) %}
+{% set itemsSubtotal = order.getItemsSubtotal() %}
 {% set taxIncluded = order.getTaxIncludedTotal() %}
 {% set taxExcluded = order.getTaxExcludedTotal() %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_totals.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_totals.html.twig
@@ -1,6 +1,6 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
-{% set itemsSubtotal = sylius_order_items_subtotal(order) %}
+{% set itemsSubtotal = order.getItemsSubtotal() %}
 {% set taxIncluded = order.getTaxIncludedTotal() %}
 {% set taxExcluded = order.getTaxExcludedTotal() %}
 

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -13,41 +13,44 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig;
 
-use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator;
 use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface;
+use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\OrderInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+trigger_deprecation(
+    'sylius/shop-bundle',
+    '1.13',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use method "getItemsSubtotal" from "%s" instead.',
+    OrderItemsSubtotalExtension::class,
+    Order::class,
+);
+
+/**
+ * @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. Items subtotal calculations is now available by using {@see Order::getSubtotalItems} method.
+ *
+ * @psalm-suppress DeprecatedClass
+ */
 class OrderItemsSubtotalExtension extends AbstractExtension
 {
-    /** @var OrderItemsSubtotalCalculatorInterface */
-    private $calculator;
-
-    public function __construct(?OrderItemsSubtotalCalculatorInterface $calculator = null)
+    public function __construct(private ?OrderItemsSubtotalCalculatorInterface $calculator = null)
     {
-        if (null === $calculator) {
-            $calculator = new OrderItemsSubtotalCalculator();
-
-            trigger_deprecation(
-                'sylius/shop-bundle',
-                '1.6',
-                'Not passing a $calculator is deprecated. Argument will no longer be optional from Sylius 2.0.',
-            );
-        }
-
-        $this->calculator = $calculator;
     }
 
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sylius_order_items_subtotal', [$this, 'getSubtotal']),
+            new TwigFunction('sylius_order_items_subtotal', [$this, 'getSubtotal'], ['deprecated' => true]),
         ];
     }
 
     public function getSubtotal(OrderInterface $order): int
     {
+        if (null === $this->calculator) {
+            return $order->getItemsSubtotal();
+        }
+
         return $this->calculator->getSubtotal($order);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | kinda                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes |
| Related tickets | -                      |
| License         | MIT                                                          |
