### PR TITLE
[Api] Mark bulk delete scenarios as @no-api

### DIFF
--- a/features/addressing/managing_zones/deleting_multiple_zones.feature
+++ b/features/addressing/managing_zones/deleting_multiple_zones.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple zones
         Given the store has zones "North America", "South America" and "Europe"
         And I am logged in as an administrator
 
-    @ui @api @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple zones at once
         When I browse zones
         And I check the "North America" zone

--- a/features/channel/managing_channels/deleting_multiple_channels.feature
+++ b/features/channel/managing_channels/deleting_multiple_channels.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple channels
         And the store operates on another channel named "DE Store"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple channels at once
         When I browse channels
         And I check the "PL Store" channel

--- a/features/currency/managing_exchange_rates/deleting_multiple_exchange_rates.feature
+++ b/features/currency/managing_exchange_rates/deleting_multiple_exchange_rates.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple exchange rates
         And the exchange rate of "Polish Zloty" to "Euro" is 0.22
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple exchange rates at once
         When I browse exchange rates
         And I check the exchange rate between "Euro" and "British Pound"

--- a/features/payment/managing_payment_methods/deleting_multiple_payment_methods.feature
+++ b/features/payment/managing_payment_methods/deleting_multiple_payment_methods.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple payment methods
         And the store has also a payment method "PayPal Express Checkout" with a code "paypal" and Paypal Express Checkout gateway
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple payment methods at once
         When I browse payment methods
         And I check the "Offline" payment method

--- a/features/product/managing_product_association_types/deleting_multiple_product_association_types.feature
+++ b/features/product/managing_product_association_types/deleting_multiple_product_association_types.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product association types
         And the store has also a product association type "Accessories"
         And I am logged in as an administrator
 
-    @ui @api @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple product association types at once
         When I browse product association types
         And I check the "Cross sell" product association type

--- a/features/product/managing_product_options/deleting_multiple_product_options.feature
+++ b/features/product/managing_product_options/deleting_multiple_product_options.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product options
         And the store has also a product option "T-Shirt brand"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple product options at once
         When I browse product options
         And I check the "T-Shirt size" product option

--- a/features/product/managing_product_reviews/deleting_multiple_product_reviews.feature
+++ b/features/product/managing_product_reviews/deleting_multiple_product_reviews.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple product reviews
         And this product has also a review titled "Cool" and rated 4 with a comment "Quite cool" added by customer "aquaman@dc.com"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple product reviews at once
         When I browse product reviews
         And I check the "Awesome" product review

--- a/features/product/managing_product_variants/deleting_multiple_product_variants.feature
+++ b/features/product/managing_product_variants/deleting_multiple_product_variants.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product variants
         And this product has "Small PHP Mug", "Medium PHP Mug" and "Big PHP Mug" variants
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple product variants at once
         When I browse variants of this product
         And I check the "Small PHP Mug" product variant

--- a/features/product/managing_products/deleting_multiple_products.feature
+++ b/features/product/managing_products/deleting_multiple_products.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple products
         Given the store has "Audi RS5 model", "Audi RS6 model" and "Audi RS7 model" products
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple products at once
         When I browse products
         And I check the "Audi RS5 model" product

--- a/features/promotion/managing_coupons/deleting_multiple_coupons.feature
+++ b/features/promotion/managing_coupons/deleting_multiple_coupons.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple coupons
         And this promotion has "SANTA1", "SANTA2" and "SANTA3" coupons
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple coupons at once
         When I browse coupons of this promotion
         And I check the "SANTA1" coupon

--- a/features/promotion/managing_promotions/deleting_multiple_promotions.feature
+++ b/features/promotion/managing_promotions/deleting_multiple_promotions.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple promotions
         And there is also a promotion "Easter sale"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple promotions at once
         When I browse promotions
         And I check the "Christmas sale" promotion

--- a/features/shipping/managing_shipping_categories/deleting_multiple_shipping_categories.feature
+++ b/features/shipping/managing_shipping_categories/deleting_multiple_shipping_categories.feature
@@ -9,7 +9,7 @@ Feature: Deleting multiple shipping categories
         And the store has "Big" and "Small" shipping category
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple shipping categories at once
         When I browse shipping categories
         And I check the "Big" shipping category

--- a/features/shipping/managing_shipping_methods/deleting_multiple_shipping_methods.feature
+++ b/features/shipping/managing_shipping_methods/deleting_multiple_shipping_methods.feature
@@ -9,7 +9,7 @@ Feature: Deleting multiple shipping methods
         And the store allows shipping with "UPS", "FedEx" and "DHL"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple shipping methods at once
         When I browse shipping methods
         And I check the "UPS" shipping method

--- a/features/taxation/managing_tax_categories/deleting_multiple_tax_categories.feature
+++ b/features/taxation/managing_tax_categories/deleting_multiple_tax_categories.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple tax categories
         Given the store has tax categories "Alcohol", "Food" and "Books"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple tax categories at once
         When I browse tax categories
         And I check the "Alcohol" tax category

--- a/features/taxation/managing_tax_rates/deleting_multiple_tax_rates.feature
+++ b/features/taxation/managing_tax_rates/deleting_multiple_tax_rates.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple tax rates
         And the store has "High VAT" tax rate of 40% for "Food" for the rest of the world
         And I am logged in as an administrator
 
-    @ui @javascript @api
+    @ui @javascript @no-api
     Scenario: Deleting multiple tax rates at once
         When I browse tax rates
         And I check the "Low VAT" tax rate

--- a/features/user/managing_administrators/deleting_multiple_administrators.feature
+++ b/features/user/managing_administrators/deleting_multiple_administrators.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple administrators
         And there is also an administrator "watermelon@example.com"
         And I am logged in as "watermelon@example.com" administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple administrators at once
         Given I browse administrators
         And I check the "banana@example.com" administrator

--- a/features/user/managing_customer_groups/deleting_multiple_customer_groups.feature
+++ b/features/user/managing_customer_groups/deleting_multiple_customer_groups.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple customer groups
         Given the store has customer groups "Retail", "Wholesale" and "General"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui @javascript @no-api
     Scenario: Deleting multiple customer groups at once
         When I browse customer groups
         And I check the "Retail" customer group

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
@@ -131,7 +131,7 @@ final class ManagingProductAssociationTypesContext implements Context
     }
 
     /**
-     * @Then /^I should be notified that (?:it has|they have) been successfully deleted$/
+     * @Then /^I should be notified that it has been successfully deleted$/
      */
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
@@ -192,29 +192,6 @@ final class ManagingProductAssociationTypesContext implements Context
             $this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'),
             'The shipping category code should not be changed to "NEW_CODE", but it is',
         );
-    }
-
-    /**
-     * @When I check (also) the :productAssociationType product association type
-     */
-    public function iCheckTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
-    {
-        $productAssociationTypeToDelete = [];
-        if ($this->sharedStorage->has('product_association_type_to_delete')) {
-            $productAssociationTypeToDelete = $this->sharedStorage->get('product_association_type_to_delete');
-        }
-        $productAssociationTypeToDelete[] = $productAssociationType->getCode();
-        $this->sharedStorage->set('product_association_type_to_delete', $productAssociationTypeToDelete);
-    }
-
-    /**
-     * @When I delete them
-     */
-    public function iDeleteThem(): void
-    {
-        foreach ($this->sharedStorage->get('product_association_type_to_delete') as $code) {
-            $this->client->delete(Resources::PRODUCT_ASSOCIATION_TYPES, $code);
-        }
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxRatesContext.php
@@ -179,30 +179,6 @@ class ManagingTaxRatesContext implements Context
     }
 
     /**
-     * @When I check the :taxRate tax rate
-     * @When I check also the :taxRate tax rate
-     */
-    public function iCheckTheTaxRate(TaxRateInterface $taxRate): void
-    {
-        $taxRatesToDelete = [];
-        if ($this->sharedStorage->has('tax_rates_to_delete')) {
-            $taxRatesToDelete = $this->sharedStorage->get('tax_rates_to_delete');
-        }
-        $taxRatesToDelete[] = $taxRate->getCode();
-        $this->sharedStorage->set('tax_rates_to_delete', $taxRatesToDelete);
-    }
-
-    /**
-     * @When I delete them
-     */
-    public function iDeleteThem(): void
-    {
-        foreach ($this->sharedStorage->get('tax_rates_to_delete') as $id) {
-            $this->client->delete(Resources::TAX_RATES, (string) $id)->getContent();
-        }
-    }
-
-    /**
      * @When I remove its name
      */
     public function iRemoveItsName(): void
@@ -331,17 +307,6 @@ class ManagingTaxRatesContext implements Context
         Assert::false(
             $this->responseChecker->hasItemWithValue($this->client->index(Resources::TAX_RATES), 'name', $name),
             sprintf('Tax rate with name %s exists', $name),
-        );
-    }
-
-    /**
-     * @Then I should be notified that they have been successfully deleted
-     */
-    public function iShouldBeNotifiedThatTheyHaveBeenSuccessfullyDeleted(): void
-    {
-        Assert::true(
-            $this->responseChecker->isDeletionSuccessful($this->client->getLastResponse()),
-            'Tax rate could not be deleted',
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
@@ -135,29 +135,6 @@ final class ManagingZonesContext implements Context
     }
 
     /**
-     * @When I check (also) the :zone zone
-     */
-    public function iCheckTheZone(ZoneInterface $zone): void
-    {
-        $ZoneToDelete = [];
-        if ($this->sharedStorage->has('zone_to_delete')) {
-            $ZoneToDelete = $this->sharedStorage->get('zone_to_delete');
-        }
-        $ZoneToDelete[] = $zone->getCode();
-        $this->sharedStorage->set('zone_to_delete', $ZoneToDelete);
-    }
-
-    /**
-     * @When I delete them
-     */
-    public function iDeleteThem(): void
-    {
-        foreach ($this->sharedStorage->get('zone_to_delete') as $code) {
-            $this->client->delete(Resources::ZONES, $code);
-        }
-    }
-
-    /**
      * @When I want to modify the zone named :zone
      */
     public function iWantToModifyTheZoneNamed(ZoneInterface $zone): void
@@ -376,7 +353,6 @@ final class ManagingZonesContext implements Context
 
     /**
      * @Then I should be notified that it has been successfully deleted
-     * @Then I should be notified that they have been successfully deleted
      */
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | kinda                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

There is no such thing as **bulk delete** in the API context, the scenarios were seemingly covered, but what was actually happening under the hood was a series of calls on the delete endpoint.