### PR TITLE
[DX] Dispatch ui event to allow customize every choice in payment method selection

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -1036,6 +1036,11 @@ sylius_ui:
                     context:
                         event: sylius.shop.checkout.select_shipping.before_navigation
 
+        sylius.shop.checkout.select_payment.choice_item_content:
+            blocks:
+                description:
+                    template: "@SyliusShop/Checkout/SelectPayment/_description.html.twig"
+
         sylius.shop.product.show.left_sidebar:
             blocks:
                 before_legacy:

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_choice.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_choice.html.twig
@@ -11,5 +11,6 @@
                 <p>{{ method.description }}</p>
             </div>
         {% endif %}
+        {{ sylius_template_event('sylius.shop.checkout.select_payment.choice_item_content', {'method': method}) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_choice.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_choice.html.twig
@@ -6,11 +6,6 @@
     </div>
     <div class="content">
         <a class="header">{{ form_label(form, null, {'label_attr': {'data-test-payment-method-label': ''}}) }}</a>
-        {% if method.description is not null %}
-            <div class="description">
-                <p>{{ method.description }}</p>
-            </div>
-        {% endif %}
         {{ sylius_template_event('sylius.shop.checkout.select_payment.choice_item_content', {'method': method}) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_description.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_description.html.twig
@@ -1,0 +1,5 @@
+{% if method.description is not null %}
+    <div class="description">
+        <p>{{ method.description }}</p>
+    </div>
+{% endif %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

To help PaymentPlugin providers, let's dispatch an ui event inside choice of each payment method. This will allow paymentPlugins to add additionnal field easily without the pain while installing paymentPlugins to copy/paste template that override `SyliusShopBundle/Checkout/SelectPayment/_payment.html.twig` (for example in [Mollie](https://github.com/mollie/Sylius/blob/master/doc/installation.md#13-copy-sylius-templates-overridden-in-plugin-to-your-templates-directory-eg-templatesbundles)) or  `SyliusShopBundle/Checkout/SelectPayment/_choice.html.twig` (like in [Payplug](https://github.com/payplug/SyliusPayPlugPlugin/blob/master/src/Resources/views/SyliusShopBundle/Checkout/SelectPayment/_choice.html.twig)) 

I targetted 1.13 as it could be considered as a new feature, and paymentPlugins will can start to use it configuring a sylius_ui event block, and still provide template to copy/paste for previous version. 

WDYT ? 

I'm also wondering if we should merge the GatewayFactory name inside the event name to avoid lot of check on method when creating a new block. 