### PR TITLE
[FIX] Restrict NonChannelLocaleListener to the routes having _locale attribut

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
@@ -57,7 +57,7 @@ final class NonChannelLocaleListener
         }
 
         $request = $event->getRequest();
-        if (in_array($request->attributes->get('_route'), ['_wdt', '_profiler', '_profiler_search', '_profiler_search_results'])) {
+        if (!$request->attributes->has('_locale')) {
             return;
         }
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/NonChannelLocaleListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/NonChannelLocaleListenerSpec.php
@@ -176,11 +176,6 @@ final class NonChannelLocaleListenerSpec extends ObjectBehavior
 
         $localeProvider->getAvailableLocalesCodes()->willReturn(['ga', 'ga_IE']);
 
-        $this
-            ->shouldNotThrow(NotFoundHttpException::class)
-            ->during('restrictRequestLocale', [$event])
-        ;
-
         $request->attributes = new ParameterBag(['_route' => '_profiler']);
         $this
             ->shouldNotThrow(NotFoundHttpException::class)
@@ -206,7 +201,7 @@ final class NonChannelLocaleListenerSpec extends ObjectBehavior
         );
 
         $request->getLocale()->willReturn('en');
-        $request->attributes = new ParameterBag();
+        $request->attributes = new ParameterBag(['_locale' => 'en']);
 
         $localeProvider->getAvailableLocalesCodes()->willReturn(['ga', 'ga_IE']);
         $localeProvider->getDefaultLocaleCode()->willReturn('ga');
@@ -215,5 +210,25 @@ final class NonChannelLocaleListenerSpec extends ObjectBehavior
 
         $this->restrictRequestLocale($event);
         $event->setResponse(new RedirectResponse('/ga/'))->shouldHaveBeenCalledOnce();
+    }
+
+    function it_does_nothing_if_request_attributes_does_not_have_locale(
+        Request $request,
+        RequestEvent $event,
+    ): void {
+        if (\method_exists(RequestEvent::class, 'isMainRequest')) {
+            $event->isMainRequest()->willReturn(true);
+        } else {
+            $event->isMasterRequest()->willReturn(true);
+        }
+        $event->getRequest()->willReturn($request);
+
+        $request->getLocale()->willReturn('en');
+        $request->attributes = new ParameterBag();
+
+        $this
+            ->shouldNotThrow(NotFoundHttpException::class)
+            ->during('restrictRequestLocale', [$event])
+        ;
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #13198 and maybe #15282                      |
| License         | MIT                                                          |

Before this PR behaviour:
Given the `%locale%` parameter is set to `en` for example and the available channel locales are different from this locale. When I reach a Payum route like `payum_capture_do` or any other route not beginning with `/{_locale}` and being part of the `shop` firewall.
Then I'm redirected to the homepage.

This PR will avoid redirecting to the homepage if no attribut locale is found in the route.

