### PR TITLE
Fix failing phpspec scenario on Symfony 6.3.5 and above

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/spec/DataPersister/MessengerDataPersisterSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataPersister/MessengerDataPersisterSpec.php
@@ -17,6 +17,7 @@ use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
@@ -42,7 +43,13 @@ final class MessengerDataPersisterSpec extends ObjectBehavior
         $completeOrder->setOrderTokenValue('ORDERTOKEN');
         $envelope = new Envelope($completeOrder);
 
-        $decoratedDataPersister->persist($envelope, [])->willThrow(new DelayedMessageHandlingException([new \RuntimeException('Delayed message exception')]));
+        if (version_compare(Kernel::VERSION, '6.3.5', '>=')) {
+            $exception = new DelayedMessageHandlingException([new \RuntimeException('Delayed message exception')], $envelope);
+        } else {
+            $exception = new DelayedMessageHandlingException([new \RuntimeException('Delayed message exception')]);
+        }
+
+        $decoratedDataPersister->persist($envelope, [])->willThrow($exception);
 
         $this->shouldThrow(new \RuntimeException('Delayed message exception'))->during('persist', [$envelope, []]);
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no|
| Related tickets | #15395 and #15397|
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
