### PR TITLE
[FIX][EMAIL] Use raw filter to avoid html encoded chars

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/Blocks/ContactRequest/_subject.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/Blocks/ContactRequest/_subject.html.twig
@@ -1,1 +1,1 @@
-{{ 'sylius.email.contact_request.subject'|trans({}, null, localeCode) }}
+{{ 'sylius.email.contact_request.subject'|trans({}, null, localeCode)|raw }}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/Blocks/OrderConfirmation/_subject.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/Blocks/OrderConfirmation/_subject.html.twig
@@ -1,1 +1,1 @@
-{{ 'sylius.email.order_confirmation.subject'|trans({}, null, localeCode) }}
+{{ 'sylius.email.order_confirmation.subject'|trans({}, null, localeCode)|raw }}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/accountVerification.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/accountVerification.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusCore/Email/layout.html.twig' %}
 
 {% block subject %}
-    {{ 'sylius.email.verification_token.subject'|trans({}, null, localeCode) }}
+    {{ 'sylius.email.verification_token.subject'|trans({}, null, localeCode)|raw }}
 {% endblock %}
 
 {% block content %}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/adminPasswordReset.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusCore/Email/layout.html.twig' %}
 
 {% block subject %}
-    {{ 'sylius.email.admin_password_reset.subject'|trans({}, null, localeCode) }}
+    {{ 'sylius.email.admin_password_reset.subject'|trans({}, null, localeCode)|raw }}
 {% endblock %}
 
 {% block body %}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/passwordReset.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/passwordReset.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusCore/Email/layout.html.twig' %}
 
 {% block subject %}
-    {{ 'sylius.email.password_reset.subject'|trans({}, null, localeCode) }}
+    {{ 'sylius.email.password_reset.subject'|trans({}, null, localeCode)|raw }}
 {% endblock %}
 
 {% block content %}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/shipmentConfirmation.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/shipmentConfirmation.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusCore/Email/layout.html.twig' %}
 
 {% block subject %}
-    {{ 'sylius.email.shipment_confirmation.subject'|trans({}, null, localeCode) }}
+    {{ 'sylius.email.shipment_confirmation.subject'|trans({}, null, localeCode)|raw }}
 {% endblock %}
 
 {% block content %}

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/userRegistration.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/userRegistration.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusCore/Email/layout.html.twig' %}
 
 {% block subject %}
-    {{ 'sylius.email.user_registration.subject'|trans({}, null, localeCode) }}
+    {{ 'sylius.email.user_registration.subject'|trans({}, null, localeCode)|raw }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                   |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #12670                      |
| License         | MIT                                                          |

Following what @NoResponseMate suggeste here : https://github.com/Sylius/Sylius/issues/12670#issuecomment-1195216609
This PR applies a `raw` filter to each subject block available in Sylius (CoreBundle).

We can also decode html entities right after the block is rendered, but I don't know if it will break something if someone is using an API to send the email instead of a classic SMTP.
