### PR TITLE
[PostgreSQL] Sylius installation fix

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -127,6 +127,8 @@
 1. PostgreSQL migration support has been introduced. If you are using PostgreSQL, we assume that you have already created a database schema in some way.
    All you need to do is run migrations, which will mark all migrations created before Sylius 1.13 as executed.
 
+1. Not passing an `$entityManager` and passing a `$doctrineRegistry` to `Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider` constructor is deprecated and will be prohibited in Sylius 2.0.
+
 1. Product variants resolving has been refactored for better extendability.
    The tag `sylius.product_variant_resolver.default` has been removed as it was never used.
 

--- a/src/Sylius/Behat/Service/Converter/IriConverter.php
+++ b/src/Sylius/Behat/Service/Converter/IriConverter.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\Operation;
 
 /**
  * Wrapper between the legacy iri converter and the new one
+ *
  * @experimental
  */
 final class IriConverter implements LegacyIriConverterInterface, IriConverterInterface

--- a/src/Sylius/Bundle/CoreBundle/EventListener/PostgreSQLDefaultSchemaListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PostgreSQLDefaultSchemaListener.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 
@@ -22,9 +20,7 @@ final class PostgreSQLDefaultSchemaListener
 {
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
     {
-        $connection = $args->getEntityManager()->getConnection();
-
-        $schemaManager = $this->createSchemaManager($connection);
+        $schemaManager = $args->getEntityManager()->getConnection()->createSchemaManager();
 
         if (!is_a($schemaManager, PostgreSQLSchemaManager::class)) {
             return;
@@ -37,19 +33,5 @@ final class PostgreSQLDefaultSchemaListener
                 $schema->createNamespace($namespace);
             }
         }
-    }
-
-    private function createSchemaManager(Connection $connection): AbstractSchemaManager
-    {
-        if (method_exists($connection, 'createSchemaManager')) {
-            return $connection->createSchemaManager();
-        }
-
-        if (method_exists($connection, 'getSchemaManager')) {
-            /** @psalm-suppress DeprecatedMethod */
-            return $connection->getSchemaManager();
-        }
-
-        throw new \RuntimeException('Cannot create schema manager');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Installer\Provider;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,6 +28,9 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
     {
     }
 
+    /**
+     * @return array<string, array>
+     */
     public function getCommands(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): array
     {
         $outputStyle = new SymfonyStyle($input, $output);
@@ -66,7 +68,7 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
     private function isEmptyDatabasePresent(): bool
     {
         try {
-            return 0 === count($this->getSchemaManager()->listTableNames());
+            return 0 === count($this->getEntityManager()->getConnection()->createSchemaManager()->listTableNames());
         } catch (\Exception) {
             return false;
         }
@@ -75,7 +77,7 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
     private function isSchemaHasAnyTable(): bool
     {
         try {
-            return 0 !== count($this->getSchemaManager()->listTableNames());
+            return 0 !== count($this->getEntityManager()->getConnection()->createSchemaManager()->listTableNames());
         } catch (\Exception) {
             return false;
         }
@@ -84,22 +86,6 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
     private function getDatabaseName(): string
     {
         return $this->getEntityManager()->getConnection()->getDatabase();
-    }
-
-    private function getSchemaManager(): AbstractSchemaManager
-    {
-        $connection = $this->getEntityManager()->getConnection();
-
-        if (method_exists($connection, 'createSchemaManager')) {
-            return $connection->createSchemaManager();
-        }
-
-        if (method_exists($connection, 'getSchemaManager')) {
-            /** @psalm-suppress DeprecatedMethod */
-            return $connection->getSchemaManager();
-        }
-
-        throw new \RuntimeException('Unable to get schema manager.');
     }
 
     private function getEntityManager(): EntityManagerInterface

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20220407131547.php
@@ -51,12 +51,8 @@ final class Version20220407131547 extends AbstractMigration
 
     private function getExistingIndexesNames(string $tableName): array
     {
-        if (method_exists($this->connection, 'createSchemaManager')) {
-            $indexes = $this->connection->createSchemaManager()->listTableIndexes($tableName);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $indexes = $this->connection->getSchemaManager()->listTableIndexes($tableName);
-        }
+        $indexes = $this->connection->createSchemaManager()->listTableIndexes($tableName);
+
         $indexesNames = [];
 
         foreach ($indexes as $index) {

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -27,6 +27,7 @@
 
         <service id="sylius.commands_provider.database_setup" class="Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider">
             <argument type="service" id="doctrine" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
         <service id="Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProviderInterface" alias="sylius.commands_provider.database_setup" />
 

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/PostgreSQLDefaultSchemaListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/PostgreSQLDefaultSchemaListenerSpec.php
@@ -61,18 +61,4 @@ final class PostgreSQLDefaultSchemaListenerSpec extends ObjectBehavior
 
         $this->postGenerateSchema($args);
     }
-
-    function it_throws_an_exception_if_schema_manager_cannot_be_created(
-        Connection $connection,
-        EntityManagerInterface $entityManager,
-        GenerateSchemaEventArgs $args,
-    ): void {
-        $connection->createSchemaManager()->willThrow(\RuntimeException::class);
-        $entityManager->getConnection()->willReturn($connection);
-        $args->getEntityManager()->willReturn($entityManager);
-
-        $args->getSchema()->shouldNotBeCalled();
-
-        $this->shouldThrow(\RuntimeException::class)->during('postGenerateSchema', [$args]);
-    }
 }


### PR DESCRIPTION
Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | https://github.com/Sylius/Sylius/pull/15050 https://github.com/Sylius/Sylius/pull/15043 https://github.com/Sylius/Sylius/pull/14950            |
| License         | MIT                                                          |

The installation of Sylius 1.13 with PostgreSQL on board ended with the following error:
<img width="1665" alt="image" src="https://github.com/Sylius/Sylius/assets/40125720/87b8e16c-a281-4bb3-9b99-b158ab67c9d1">
This PR resolves this issue

Second, we removed checking:
```php
if (method_exists($connection, 'createSchemaManager')) {
    return $connection->createSchemaManager();
}

if (method_exists($connection, 'getSchemaManager')) {
    /** @psalm-suppress DeprecatedMethod */
    return $connection->getSchemaManager();
}
```
as we no longer support `doctrine/dbal: 2.x` in `Sylius 1.13`