### PR TITLE
[Fix] Early return in CartCollector on stateless requests

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
@@ -78,6 +78,10 @@ final class CartCollector extends DataCollector
 
     public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
+        if ($request->attributes->getBoolean('_stateless')) {
+            return;
+        }
+
         try {
             /** @var OrderInterface $cart */
             $cart = $this->cartContext->getCart();

--- a/tests/Functional/CartCollectorTest.php
+++ b/tests/Functional/CartCollectorTest.php
@@ -69,6 +69,34 @@ final class CartCollectorTest extends KernelTestCase
     }
 
     /** @test */
+    public function it_returns_no_cart_data_when_request_is_stateless(): void
+    {
+        $sessionFactory = self::getContainer()->get('session.factory');
+        $session = $sessionFactory->createSession();
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->attributes->set('_stateless', true);
+
+        $requestStack = self::getContainer()->get('request_stack');
+        $requestStack->push($request);
+
+        $fixtures = $this->loadFixtures([__DIR__ . '/../DataFixtures/ORM/resources/cart.yml']);
+        /** @var ChannelInterface $channel */
+        $channel = $fixtures['channel_web'];
+        /** @var OrderInterface $cart */
+        $cart = $fixtures['order_001'];
+
+        $sessionCartStorage = self::getContainer()->get(CartStorageInterface::class);
+        $sessionCartStorage->setForChannel($channel, $cart);
+
+        $collector = self::getContainer()->get(CartCollector::class);
+        $collector->collect($request, new Response());
+
+        $this->assertFalse($collector->hasCart());
+    }
+
+    /** @test */
     public function it_collects_cart_data(): void
     {
         $sessionFactory = self::getContainer()->get('session.factory');


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #15388 |
| License         | MIT                                                          |