### PR TITLE
[PoC 🦔] Make it possible to create readonly commands when using API

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Attribute/ChannelCodeAware.php
+++ b/src/Sylius/Bundle/ApiBundle/Attribute/ChannelCodeAware.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ChannelCodeAware
+{
+    public function __construct (
+        public string $constructorArgumentName = 'channelCode',
+    ) {
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Command/SendContactRequest.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SendContactRequest.php
@@ -13,16 +13,18 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command;
 
+use Sylius\Bundle\ApiBundle\Attribute\ChannelCodeAware;
+
 /** experimental */
+#[ChannelCodeAware()]
 class SendContactRequest implements ChannelCodeAwareInterface, LocaleCodeAwareInterface, LoggedInCustomerEmailIfNotSetAwareInterface
 {
     public ?string $localeCode = null;
 
-    public ?string $channelCode = null;
-
     public function __construct(
         private ?string $email = null,
         private ?string $message = null,
+        private string $channelCode,
     ) {
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -26,6 +26,7 @@
         <import resource="services/event_subscribers.xml" />
         <import resource="services/extensions.xml" />
         <import resource="services/filters.xml" />
+        <import resource="services/serializers.xml" />
         <import resource="services/payments.xml" />
         <import resource="services/providers.xml" />
         <import resource="services/state_processors.xml" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -18,102 +18,107 @@
     <services>
         <defaults public="true" />
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\AddressDenormalizer">
-            <argument type="service" id="serializer.normalizer.object" />
-            <argument type="string">%sylius.model.address.class%</argument>
-            <argument type="string">%sylius.model.address.interface%</argument>
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\AddressDenormalizer">-->
+<!--            <argument type="service" id="serializer.normalizer.object" />-->
+<!--            <argument type="string">%sylius.model.address.class%</argument>-->
+<!--            <argument type="string">%sylius.model.address.interface%</argument>-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandArgumentsDenormalizer">
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer" />
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface" />
-            <argument type="service" id="sylius.api.data_transformer.command_aware_input_data_transformer" />
-            <tag name="serializer.normalizer" priority="128" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandArgumentsDenormalizer">-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer" />-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface" />-->
+<!--            <argument type="service" id="sylius.api.data_transformer.command_aware_input_data_transformer" />-->
+<!--            <tag name="serializer.normalizer" priority="128" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer">
-            <argument type="service" id="api_platform.serializer.normalizer.item" />
-            <argument type="service" id="api_platform.name_converter" />
-            <tag name="serializer.normalizer" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer">-->
+<!--            <argument type="service" id="api_platform.serializer.normalizer.item" />-->
+<!--            <argument type="service" id="api_platform.name_converter" />-->
+<!--            <tag name="serializer.normalizer" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\HydraErrorNormalizer" decorates="api_platform.hydra.normalizer.error">
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\HydraErrorNormalizer.inner" />
-            <argument type="service" id="request_stack" />
-            <argument>%sylius.security.new_api_route%</argument>
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\HydraErrorNormalizer" decorates="api_platform.hydra.normalizer.error">-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\HydraErrorNormalizer.inner" />-->
+<!--            <argument type="service" id="request_stack" />-->
+<!--            <argument>%sylius.security.new_api_route%</argument>-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductNormalizer">
-            <argument type="service" id="Sylius\Component\Product\Resolver\ProductVariantResolverInterface" />
-            <argument type="service" id="api_platform.symfony.iri_converter" />
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductNormalizer">-->
+<!--            <argument type="service" id="Sylius\Component\Product\Resolver\ProductVariantResolverInterface" />-->
+<!--            <argument type="service" id="api_platform.symfony.iri_converter" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductAttributeValueNormalizer">
-            <argument type="service" id="sylius.locale_provider.channel_based" />
-            <argument>%locale%</argument>
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductAttributeValueNormalizer">-->
+<!--            <argument type="service" id="sylius.locale_provider.channel_based" />-->
+<!--            <argument>%locale%</argument>-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductImageNormalizer">
-            <argument type="service" id="liip_imagine.cache.manager" />
-            <argument type="service" id="request_stack" />
-            <argument type="string">%sylius_api.product_image_prefix%</argument>
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductImageNormalizer">-->
+<!--            <argument type="service" id="liip_imagine.cache.manager" />-->
+<!--            <argument type="service" id="request_stack" />-->
+<!--            <argument type="string">%sylius_api.product_image_prefix%</argument>-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandNormalizer">
-            <argument type="service" id="serializer.normalizer.object" />
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\CommandNormalizer">-->
+<!--            <argument type="service" id="serializer.normalizer.object" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductVariantNormalizer">
-            <argument type="service" id="sylius.calculator.product_variant_price" />
-            <argument type="service" id="sylius.availability_checker" />
-            <argument type="service" id="sylius.section_resolver.uri_based_section_resolver" />
-            <argument type="service" id="api_platform.symfony.iri_converter" />
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ProductVariantNormalizer">-->
+<!--            <argument type="service" id="sylius.calculator.product_variant_price" />-->
+<!--            <argument type="service" id="sylius.availability_checker" />-->
+<!--            <argument type="service" id="sylius.section_resolver.uri_based_section_resolver" />-->
+<!--            <argument type="service" id="api_platform.symfony.iri_converter" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\FlattenExceptionNormalizer" decorates="fos_rest.serializer.flatten_exception_normalizer">
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\FlattenExceptionNormalizer.inner" />
-            <argument type="service" id="request_stack" />
-            <argument>%sylius.security.new_api_route%</argument>
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\FlattenExceptionNormalizer" decorates="fos_rest.serializer.flatten_exception_normalizer">-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Serializer\FlattenExceptionNormalizer.inner" />-->
+<!--            <argument type="service" id="request_stack" />-->
+<!--            <argument>%sylius.security.new_api_route%</argument>-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ShippingMethodNormalizer">
-            <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="sylius.repository.shipment" />
-            <argument type="service" id="sylius.registry.shipping_calculator" />
-            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
-            <argument type="service" id="Sylius\Component\Channel\Context\ChannelContextInterface" />
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ShippingMethodNormalizer">-->
+<!--            <argument type="service" id="sylius.repository.order" />-->
+<!--            <argument type="service" id="sylius.repository.shipment" />-->
+<!--            <argument type="service" id="sylius.registry.shipping_calculator" />-->
+<!--            <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />-->
+<!--            <argument type="service" id="Sylius\Component\Channel\Context\ChannelContextInterface" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ZoneDenormalizer">
-            <argument type="service" id="api_platform.symfony.iri_converter" />
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ZoneDenormalizer">-->
+<!--            <argument type="service" id="api_platform.symfony.iri_converter" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="date_time_normalizer" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer">
-            <argument type="collection">
-                <argument key="datetime_format">Y-m-d H:i:s</argument>
-            </argument>
-            <tag name="serializer.normalizer"/>
-        </service>
+<!--        <service id="date_time_normalizer" class="Symfony\Component\Serializer\Normalizer\DateTimeNormalizer">-->
+<!--            <argument type="collection">-->
+<!--                <argument key="datetime_format">Y-m-d H:i:s</argument>-->
+<!--            </argument>-->
+<!--            <tag name="serializer.normalizer"/>-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ChannelPriceHistoryConfigDenormalizer">
-            <argument type="service" id="api_platform.symfony.iri_converter" />
-            <argument type="service" id="sylius.factory.channel_price_history_config" />
-            <argument type="service" id="Sylius\Bundle\ApiBundle\Validator\ResourceInputDataPropertiesValidatorInterface" />
-            <argument>%sylius.form.type.channel_price_history_config.validation_groups%</argument>
-            <tag name="serializer.normalizer" priority="64" />
-        </service>
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ChannelPriceHistoryConfigDenormalizer">-->
+<!--            <argument type="service" id="api_platform.symfony.iri_converter" />-->
+<!--            <argument type="service" id="sylius.factory.channel_price_history_config" />-->
+<!--            <argument type="service" id="Sylius\Bundle\ApiBundle\Validator\ResourceInputDataPropertiesValidatorInterface" />-->
+<!--            <argument>%sylius.form.type.channel_price_history_config.validation_groups%</argument>-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
 
-        <service id="Sylius\Bundle\ApiBundle\Serializer\ChannelDenormalizer">
-            <argument type="service" id="sylius.factory.channel_price_history_config" />
-            <tag name="serializer.normalizer" priority="64" />
+<!--        <service id="Sylius\Bundle\ApiBundle\Serializer\ChannelDenormalizer">-->
+<!--            <argument type="service" id="sylius.factory.channel_price_history_config" />-->
+<!--            <tag name="serializer.normalizer" priority="64" />-->
+<!--        </service>-->
+
+        <service id="Sylius\Bundle\ApiBundle\Serializer\ChannelAwareContextBuilder" decorates="api_platform.serializer.context_builder">
+            <argument type="service" id=".inner" />
+            <argument type="service" id="sylius.context.channel" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ChannelAwareContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ChannelAwareContextBuilder.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Serializer;
+
+use ApiPlatform\Serializer\SerializerContextBuilderInterface;
+use Sylius\Bundle\ApiBundle\Attribute\ChannelCodeAware;
+use Sylius\Bundle\ApiBundle\Command\ChannelCodeAwareInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+final readonly class ChannelAwareContextBuilder implements SerializerContextBuilderInterface
+{
+    public function __construct (
+        private SerializerContextBuilderInterface $decorated,
+        private ChannelContextInterface $channelContext,
+    ) {
+    }
+
+    /**
+     * @param array<string>|null $extractedAttributes
+     * @return array<string, mixed>
+     */
+    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array
+    {
+        $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
+        $inputClass = $this->getInputClassFromContext($context);
+
+        if ($inputClass === null || !$this->isChannelAware($inputClass)) {
+            return $context;
+        }
+
+        $constructorArgumentName = $this->getConstructorArgumentName($inputClass) ?? 'channelCode';
+
+        $context[AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS][$inputClass] = [
+            $constructorArgumentName => $this->channelContext->getChannel()->getCode(),
+        ];
+
+        return $context;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function getInputClassFromContext(array $context): ?string
+    {
+        return $context['input']['class'] ?? null;
+    }
+
+    private function isChannelAware(string $inputClass): bool
+    {
+        return is_a($inputClass, ChannelCodeAwareInterface::class, true);
+    }
+
+    private function getConstructorArgumentName(string $class): ?string
+    {
+        $classReflection = new \ReflectionClass($class);
+        $attributes = $classReflection->getAttributes(ChannelCodeAware::class);
+
+        if (count($attributes) === 0) {
+            return null;
+        }
+
+        /** @var ChannelCodeAware $channelCodeAwareAttribute */
+        $channelCodeAwareAttribute = $attributes[0]->newInstance();
+
+        return $channelCodeAwareAttribute->constructorArgumentName;
+    }
+}


### PR DESCRIPTION
This PR is only a PoC how we can solve a problem of only partially valid commands.

If we need a channel code in the command, we need to implement the interface, and inside the processor we invoke `->setChannelCode()` method.

This PR shows we're able to create a complete command instance with minimal effort.