### PR TITLE
[Checkout] Prevent extra fields when login in on addressing page

### DIFF
--- a/features/checkout/addressing_order/sign_in_during_addressing_step.feature
+++ b/features/checkout/addressing_order/sign_in_during_addressing_step.feature
@@ -33,3 +33,16 @@ Feature: Sign in to the store during checkout
         And I specify the password as "francis"
         And I sign in
         Then I should be notified about bad credentials
+
+    @ui @no-api @javascript
+    Scenario: Successful sign in after omitting fill the email field
+        Given I have product "PHP T-Shirt" in the cart
+        And I am at the checkout addressing step
+        When I specify the billing address for "Jon Snow" from "Ankh Morpork", "Frost Alley", "90210", "United States", "Texas"
+        And I try to complete the addressing step
+        And I specify the email as "francis@underwood.com"
+        And I specify the password as "whitehouse"
+        And I sign in
+        Then I should be notified to resubmit the addressing form
+        And I should not be notified that the form contains extra fields
+        And address "Jon Snow", "Ankh Morpork", "Frost Alley", "90210", "United States", "Texas" should be filled as billing address

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -356,6 +356,22 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
+     * @Then I should be notified to resubmit the addressing form
+     */
+    public function iShouldBeNotifiedToResubmitTheAddressingForm()
+    {
+        Assert::true($this->addressPage->checkFormValidationMessage('Please resubmit complete form.'), 'Unable to find "Please resubmit complete form." validation message');
+    }
+
+    /**
+     * @Then I should not be notified that the form contains extra fields
+     */
+    public function iShouldNotBeNotifiedTheFormContainsExtraFields()
+    {
+        Assert::false($this->addressPage->checkFormValidationMessage('This form should not contain extra fields.'), 'Found "This form should not contains extra fields." validation message');
+    }
+
+    /**
      * @Then I should be redirected to the addressing step
      * @Then I should be on the checkout addressing step
      */

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -101,6 +101,23 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         return $message === $validationMessage->getText();
     }
 
+    public function checkFormValidationMessage(string $message): bool
+    {
+        $formElement = $this->getElement('form');
+        if (null === $formElement) {
+            throw new ElementNotFoundException($this->getSession(), 'Form');
+        }
+
+        $validationMessage = $formElement->findAll('css', '[data-test-validation-error]');
+        foreach ($validationMessage as $validationMessage) {
+            if ($validationMessage->getText() === $message) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function specifyShippingAddress(AddressInterface $shippingAddress): void
     {
         $this->specifyAddress($shippingAddress, self::TYPE_SHIPPING);
@@ -296,6 +313,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
             'shipping_postcode' => '[data-test-shipping-postcode]',
             'shipping_province' => '[data-test-shipping-address] [data-test-province-name]',
             'shipping_street' => '[data-test-shipping-street]',
+            'form' => 'form[name="sylius_checkout_address"]',
         ]);
     }
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
@@ -26,6 +26,8 @@ interface AddressPageInterface extends SymfonyPageInterface
 
     public function checkValidationMessageFor(string $element, string $message): bool;
 
+    public function checkFormValidationMessage(string $message): bool;
+
     public function specifyShippingAddress(AddressInterface $shippingAddress): void;
 
     public function selectShippingAddressProvince(string $province): void;

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -144,16 +144,15 @@ final class AddressType extends AbstractResourceType
 
                 $event->setData($orderData);
             })
-            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($options): void {
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event): void {
                 $orderData = $event->getData();
+                $form = $event->getForm();
 
-                if ($options['customer'] instanceof CustomerInterface && array_key_exists('customer', $orderData)) {
+                if (array_key_exists('customer', $orderData) && !$form->has('customer')) {
                     // Logged-in user try to submit customer while reloading page after login
                     unset($orderData['customer']);
-                    $event->getForm()->remove('customer');
+                    $event->setData($orderData);
                 }
-
-                $event->setData($orderData);
             })
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -144,6 +144,17 @@ final class AddressType extends AbstractResourceType
 
                 $event->setData($orderData);
             })
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($options): void {
+                $orderData = $event->getData();
+
+                if ($options['customer'] instanceof CustomerInterface && array_key_exists('customer', $orderData)) {
+                    // Logged-in user try to submit customer while reloading page after login
+                    unset($orderData['customer']);
+                    $event->getForm()->remove('customer');
+                }
+
+                $event->setData($orderData);
+            })
         ;
     }
 
@@ -154,6 +165,7 @@ final class AddressType extends AbstractResourceType
         $resolver
             ->setDefaults([
                 'customer' => null,
+                'csrf_message' => 'sylius.checkout.addressing.csrf_error',
             ])
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
@@ -47,6 +47,8 @@ sylius:
             min: Price cannot be lower than 0.
             not_blank: Please enter the price.
     checkout:
+        addressing:
+            csrf_error: Please resubmit complete form.
         shipping_method:
             not_blank: Please select shipping method.
         email:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
@@ -29,8 +29,6 @@ sylius:
             min: Le prix ne peut pas être inférieur à 0.
             not_blank: Veuillez saisir un prix.
     checkout:
-        addressing:
-            csrf_error: Merci de soumettre à nouveau le formulaire complet.
         shipping_method:
             not_blank: Veuillez sélectionner un mode de livraison.
     contact:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
@@ -29,6 +29,8 @@ sylius:
             min: Le prix ne peut pas être inférieur à 0.
             not_blank: Veuillez saisir un prix.
     checkout:
+        addressing:
+            csrf_error: Merci de soumettre à nouveau le formulaire complet.
         shipping_method:
             not_blank: Veuillez sélectionner un mode de livraison.
     contact:


### PR DESCRIPTION
| Q               | A   |
|-----------------|-----|
| Branch?         | 1.12 |
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets | fixes #15183 |
| License         | MIT |

Refs video in #15183

When we login in addressing page after submit once the page, the reload process after login resubmit data, and keep sending `form[customer][email]`, that it doesn't be added in form. 

So I unset these data on pre-submit. 
I also change the csrf_error message for something more "understandable".

By this way, we can still have previous submitted data for address fields.

![image](https://github.com/Sylius/Sylius/assets/3168281/e53f0c5a-8fe7-4bd7-81b9-021eb8d819b7)

The other way, suggested by @Wojdylak, is to change this line https://github.com/Sylius/Sylius/blob/1.12/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-api-login.js#L50 
by 
```
window.location = window.location.href;
``` 

But using it, all already filled data are lost.

WDYT ? Would it be acceptable to lose such data, or should we keep them ? 