### PR TITLE
Use SyliusShop macros instead of SyliusUi in shop templates

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/_defaultAddress.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/_defaultAddress.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% import '@SyliusShop/Macro/buttons.html.twig' as buttons %}
 
 <div class="address-card address-card--default" id="sylius-default-address" {{ sylius_test_html_attribute('default-address') }}>
     <div class="address-card-content default" {{ sylius_test_html_attribute('address', "%s %s"|format(address.firstName, address.lastName)) }}>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/_item.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/_item.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% import '@SyliusShop/Macro/buttons.html.twig' as buttons %}
 
 <div class="address-card">
     <div class="address-card-content" {{ sylius_test_html_attribute('address', "%s %s"|format(address.firstName, address.lastName)) }}>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/index.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/index.html.twig
@@ -1,6 +1,6 @@
 {% extends '@SyliusShop/Account/AddressBook/layout.html.twig' %}
 
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 
 {% block title %}{{ 'sylius.ui.address_book'|trans }} | {{ parent() }}{% endblock %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Grid/Action/pay.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Grid/Action/pay.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% import '@SyliusShop/Macro/buttons.html.twig' as buttons %}
 
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('show')), options.link.parameters|default({'id': data.id}))) %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusShop/Macro/buttons.html.twig' as buttons %}
-{% import '@SyliusUi/Macro/flags.html.twig' as flags %}
+{% import '@SyliusShop/Macro/flags.html.twig' as flags %}
 
 <h1 class="ui header">
     <i class="circular cart icon"></i>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% import '@SyliusShop/Macro/buttons.html.twig' as buttons %}
 {% import '@SyliusUi/Macro/flags.html.twig' as flags %}
 
 <h1 class="ui header">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_header.html.twig
@@ -11,7 +11,7 @@
                     {{ order.checkoutCompletedAt|format_date }}
                 </div>
                 <div class="item">
-                    {% include [('@SyliusShop/Account/Order/Label/State' ~ '/' ~ order.state ~ '.html.twig'), '@SyliusUi/Label/_default.html.twig'] with {'value': ('sylius.ui.' ~ order.state)|trans} %}
+                    {% include [('@SyliusShop/Account/Order/Label/State' ~ '/' ~ order.state ~ '.html.twig'), '@SyliusShop/Label/_default.html.twig'] with {'value': ('sylius.ui.' ~ order.state)|trans} %}
                 </div>
                 <div class="item">
                     {{ order.currencyCode }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_header.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
+{% import '@SyliusShop/Macro/headers.html.twig' as headers %}
 
 <div class="ui hidden divider"></div>
 <div class="ui two column stackable grid">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
@@ -2,7 +2,7 @@
 
 {% form_theme form '@SyliusShop/Form/theme.html.twig' %}
 
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 
 {% set header = 'sylius.ui.your_shopping_cart' %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Complete/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Complete/_header.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/flags.html.twig' as flags %}
+{% import '@SyliusShop/Macro/flags.html.twig' as flags %}
 
 <h1 class="ui header">
     <i class="circular cart icon"></i>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/_address.html.twig
@@ -1,4 +1,4 @@
-{% import "@SyliusUi/Macro/flags.html.twig" as flags %}
+{% import "@SyliusShop/Macro/flags.html.twig" as flags %}
 
 <address {{ sylius_test_html_attribute('address-context', "%s %s"|format(address.firstName, address.lastName)) }}>
     {% if address.company is not null %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Label/_default.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Label/_default.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Label/_default.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Login/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Login/_form.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 
 {% if last_error %}
     {{ messages.error(last_error.messageKey|trans(last_error.messageData, 'security')) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/buttons.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Macro/buttons.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/flags.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/flags.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Macro/flags.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/headers.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/headers.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Macro/headers.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/messages.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/messages.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Macro/messages.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/pagination.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Macro/pagination.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Macro/pagination.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Modal/_confirmation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Modal/_confirmation.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Modal/_confirmation.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
@@ -1,6 +1,6 @@
 {% extends '@SyliusShop/layout.html.twig' %}
 
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 
 {% form_theme form '@SyliusShop/Form/theme.html.twig' %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusShop/Macro/messages.html.twig' as messages %}
-{% import '@SyliusUi/Macro/pagination.html.twig' as pagination %}
+{% import '@SyliusShop/Macro/pagination.html.twig' as pagination %}
 
 {{ sylius_template_event('sylius.shop.product.index.search', _context) }}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 {% import '@SyliusUi/Macro/pagination.html.twig' as pagination %}
 
 {{ sylius_template_event('sylius.shop.product.index.search', _context) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_list.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_list.html.twig
@@ -1,4 +1,4 @@
-{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusShop/Macro/messages.html.twig' as messages %}
 
 {% if product_reviews|length > 0 %}
     <div class="ui large comments">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/_flashes.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/_flashes.html.twig
@@ -1,1 +1,1 @@
-{% include '@SyliusUi/_flashes.html.twig' %}
+{% extends '@SyliusUi/_flashes.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -58,7 +58,7 @@
     {{ sylius_template_event('sylius.shop.layout.javascripts') }}
 {% endblock %}
 
-{% include '@SyliusUi/Modal/_confirmation.html.twig' %}
+{% include '@SyliusShop/Modal/_confirmation.html.twig' %}
 {{ sylius_template_event('sylius.shop.layout.after_body') }}
 </body>
 </html>


### PR DESCRIPTION
- Use Shop buttons macro in templates
- Use Shop headers macro in templates
- Use Shop flags macro in templates
- Use Shop messages macro in templates
- Use Shop pagination macro in templates

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets |                  |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
