### PR TITLE
Refresh payments when skipped payment step and the payment method is already disabled

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -225,6 +225,12 @@
 
         <service id="Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface" class="Sylius\Component\Core\Payment\Remover\OrderPaymentsRemover" />
 
+        <service id="sylius.order_payment_refresher" class="Sylius\Component\Core\Payment\Refresher\OrderPaymentRefresher">
+            <argument type="service" id="Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface" />
+            <argument type="service" id="Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface" />
+        </service>
+        <service id="Sylius\Component\Core\Payment\Refresher\OrderPaymentRefresherInterface" alias="sylius.order_payment_refresher" />
+
         <service id="sylius.customer_statistics_provider" class="Sylius\Component\Core\Customer\Statistics\CustomerStatisticsProvider">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.repository.channel" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
@@ -70,6 +70,7 @@
 
         <service id="sylius.order_processing.order_payment_processor.checkout" class="Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor">
             <argument type="service" id="sylius.order_payment_provider" />
+            <argument type="service" id="sylius.order_payment_refresher" />
             <argument>cart</argument>
             <argument type="service" id="Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface" />
             <argument>%sylius.order_payment_processor.checkout.unsupported_states%</argument>
@@ -77,6 +78,7 @@
         </service>
         <service id="sylius.order_processing.order_payment_processor.after_checkout" class="Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor">
             <argument type="service" id="sylius.order_payment_provider" />
+            <argument type="service" id="sylius.order_payment_refresher" />
             <argument>new</argument>
             <argument type="service" id="Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface" />
             <argument>%sylius.order_payment_processor.after_checkout.unsupported_states%</argument>

--- a/src/Sylius/Component/Core/Payment/Refresher/OrderPaymentRefresher.php
+++ b/src/Sylius/Component/Core/Payment/Refresher/OrderPaymentRefresher.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Payment\Refresher;
+
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
+use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
+use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
+use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
+use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
+use Sylius\Component\Resource\StateMachine\StateMachineInterface;
+use Webmozart\Assert\Assert;
+
+final class OrderPaymentRefresher implements OrderPaymentRefresherInterface
+{
+    public function __construct(
+        private OrderPaymentProviderInterface $orderPaymentProvider,
+        private OrderPaymentsRemoverInterface $orderPaymentsRemover,
+    ) {
+    }
+
+    public function isPaymentRefreshingNeeded(OrderInterface $order): bool
+    {
+        $channel = $order->getChannel();
+        $isAnyPaymentMethodDisabled = false;
+        foreach ($order->getPayments() as $payment) {
+            if ($payment->getMethod() !== null && $payment->getMethod()->isEnabled() === false) {
+                $isAnyPaymentMethodDisabled = true;
+
+                break;
+            }
+        }
+
+        return $channel->isSkippingPaymentStepAllowed() && $isAnyPaymentMethodDisabled;
+    }
+
+    public function refreshPayments(OrderInterface $order, string $targetState): void
+    {
+        $this->orderPaymentsRemover->removePayments($order);
+
+        try {
+            $newPayment = $this->orderPaymentProvider->provideOrderPayment($order, $targetState);
+            $order->addPayment($newPayment);
+        } catch (NotProvidedOrderPaymentException) {
+            return;
+        }
+    }
+}

--- a/src/Sylius/Component/Core/Payment/Refresher/OrderPaymentRefresherInterface.php
+++ b/src/Sylius/Component/Core/Payment/Refresher/OrderPaymentRefresherInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Payment\Refresher;
+
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
+use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
+use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
+use Sylius\Component\Resource\StateMachine\StateMachineInterface;
+use Webmozart\Assert\Assert;
+
+interface OrderPaymentRefresherInterface
+{
+    public function isPaymentRefreshingNeeded(OrderInterface $order): bool;
+
+    public function refreshPayments(OrderInterface $order, string $targetState): void;
+}

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
@@ -13,23 +13,33 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Core\OrderProcessing;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
 use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
+use Sylius\Component\Core\Payment\Refresher\OrderPaymentRefresherInterface;
 use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 final class OrderPaymentProcessorSpec extends ObjectBehavior
 {
-    function let(OrderPaymentProviderInterface $orderPaymentProvider): void
-    {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART);
+    function let(
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
+    ): void {
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART
+        );
     }
 
     function it_is_an_order_processor(): void
@@ -56,11 +66,17 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
 
     function it_does_nothing_if_the_order_state_is_in_unsupported_states(
         OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderInterface $order,
     ): void {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, null, [
-            OrderInterface::STATE_FULFILLED,
-        ]);
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART,
+            null, [OrderInterface::STATE_FULFILLED],
+        );
+
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
 
         $order->getState()->willReturn(OrderInterface::STATE_FULFILLED);
         $order->getLastPayment(Argument::any())->shouldNotBeCalled();
@@ -92,9 +108,12 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_sets_last_order_currency_with_target_state_currency_code_and_amount(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderInterface $order,
         PaymentInterface $payment,
     ): void {
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
+
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn($payment);
 
@@ -108,10 +127,13 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_sets_provided_order_payment_if_it_is_not_null(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderInterface $order,
         OrderPaymentProviderInterface $orderPaymentProvider,
         PaymentInterface $payment,
     ): void {
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
+
         $order->getTotal()->willReturn(10);
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn(null);
@@ -123,9 +145,12 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_does_not_set_order_payment_if_it_cannot_be_provided(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderInterface $order,
         OrderPaymentProviderInterface $orderPaymentProvider,
     ): void {
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
+
         $order->getTotal()->willReturn(10);
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn(null);
@@ -140,33 +165,48 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_removes_cart_payments_from_order_when_using_payments_remover(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderPaymentProviderInterface $orderPaymentProvider,
         OrderPaymentsRemoverInterface $orderPaymentsRemover,
         OrderInterface $order,
     ): void {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, $orderPaymentsRemover);
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART,
+            $orderPaymentsRemover
+        );
+
 
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getTotal()->shouldNotBeCalled();
 
         $orderPaymentsRemover->canRemovePayments($order)->willReturn(true);
         $orderPaymentsRemover->removePayments($order)->shouldBeCalled();
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
 
         $this->process($order);
     }
 
     function it_sets_last_order_currency_with_target_state_currency_code_and_amount_when_using_payments_remover(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderPaymentProviderInterface $orderPaymentProvider,
         OrderPaymentsRemoverInterface $orderPaymentsRemover,
         OrderInterface $order,
         PaymentInterface $payment,
     ): void {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, $orderPaymentsRemover);
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART,
+            $orderPaymentsRemover
+        );
 
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn($payment);
 
         $orderPaymentsRemover->canRemovePayments($order)->willReturn(false);
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
 
         $order->getCurrencyCode()->willReturn('PLN');
         $order->getTotal()->willReturn(1000);
@@ -178,18 +218,25 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_sets_provided_order_payment_if_it_is_not_null_when_using_payments_remover(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderPaymentProviderInterface $orderPaymentProvider,
         OrderPaymentsRemoverInterface $orderPaymentsRemover,
         OrderInterface $order,
         PaymentInterface $payment,
     ): void {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, $orderPaymentsRemover);
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART,
+            $orderPaymentsRemover
+        );
 
         $order->getTotal()->willReturn(10);
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn(null);
 
         $orderPaymentsRemover->canRemovePayments($order)->willReturn(false);
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
 
         $orderPaymentProvider->provideOrderPayment($order, PaymentInterface::STATE_CART)->willReturn($payment);
         $order->addPayment($payment)->shouldBeCalled();
@@ -198,23 +245,62 @@ final class OrderPaymentProcessorSpec extends ObjectBehavior
     }
 
     function it_does_not_set_order_payment_if_it_cannot_be_provided_when_using_payments_remover(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
         OrderPaymentProviderInterface $orderPaymentProvider,
         OrderPaymentsRemoverInterface $orderPaymentsRemover,
         OrderInterface $order,
     ): void {
-        $this->beConstructedWith($orderPaymentProvider, PaymentInterface::STATE_CART, $orderPaymentsRemover);
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentRefresher,
+            PaymentInterface::STATE_CART,
+            $orderPaymentsRemover
+        );
 
         $order->getTotal()->willReturn(10);
         $order->getState()->willReturn(OrderInterface::STATE_CART);
         $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn(null);
 
         $orderPaymentsRemover->canRemovePayments($order)->willReturn(false);
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
 
         $orderPaymentProvider
             ->provideOrderPayment($order, PaymentInterface::STATE_CART)
             ->willThrow(NotProvidedOrderPaymentException::class)
         ;
         $order->addPayment(Argument::any())->shouldNotBeCalled();
+
+        $this->process($order);
+    }
+
+    function it_refreshes_payment_when_needed(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
+        OrderInterface $order,
+    ): void {
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->getTotal()->willReturn(100);
+
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(true);
+        $orderPaymentRefresher->refreshPayments($order, OrderInterface::STATE_CART)->shouldBeCalledOnce();
+
+        $this->process($order);
+    }
+
+    function it_doesnt_refreshe_payment_if_not_needed(
+        OrderPaymentRefresherInterface $orderPaymentRefresher,
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderInterface $order,
+        PaymentInterface $payment,
+    ): void {
+        $orderPaymentRefresher->isPaymentRefreshingNeeded($order)->willReturn(false);
+        $orderPaymentRefresher->refreshPayments($order)->shouldNotBeCalled();
+
+        $order->getState()->willReturn(OrderInterface::STATE_CART);
+        $order->getTotal()->willReturn(100);
+        $order->getLastPayment(PaymentInterface::STATE_CART)->willReturn(null);
+
+        $orderPaymentProvider->provideOrderPayment($order, PaymentInterface::STATE_CART)->willReturn($payment);
+        $order->addPayment($payment)->shouldBeCalledOnce();
 
         $this->process($order);
     }

--- a/src/Sylius/Component/Core/spec/Payment/Refresher/OrderPaymentRefresherSpec.php
+++ b/src/Sylius/Component/Core/spec/Payment/Refresher/OrderPaymentRefresherSpec.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Core\Payment\Refresher;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
+use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
+use Sylius\Component\Core\Payment\Remover\OrderPaymentsRemoverInterface;
+use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
+use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
+use Sylius\Component\Resource\StateMachine\StateMachineInterface;
+
+final class OrderPaymentRefresherSpec extends ObjectBehavior
+{
+    function let(
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderPaymentsRemoverInterface $orderPaymentsRemover,
+    ): void {
+        $this->beConstructedWith(
+            $orderPaymentProvider,
+            $orderPaymentsRemover,
+        );
+    }
+
+    function it_should_be_refreshed_when_one_payment_has_disabled_method(
+        OrderInterface $order,
+        ChannelInterface $channel,
+        PaymentInterface $payment1,
+        PaymentInterface $payment2,
+        PaymentMethodInterface $paymentMethod1,
+        PaymentMethodInterface $paymentMethod2,
+    ): void {
+        $order->getChannel()->willReturn($channel);
+        $channel->isSkippingPaymentStepAllowed()->willReturn(true);
+
+        $order->getPayments()->willReturn(new ArrayCollection([
+            $payment1->getWrappedObject(),
+            $payment2->getWrappedObject(),
+        ]));
+
+        $payment1->getMethod()->willReturn($paymentMethod1);
+        $payment2->getMethod()->willReturn($paymentMethod2);
+        $paymentMethod1->isEnabled()->willReturn(true);
+        $paymentMethod1->isEnabled()->willReturn(false);
+
+        $this->isPaymentRefreshingNeeded($order)->shouldReturn(true);
+    }
+
+    function it_should_not_be_refreshed_when_no_payment_has_disabled_method(
+        OrderInterface $order,
+        ChannelInterface $channel,
+        PaymentInterface $payment1,
+        PaymentInterface $payment2,
+        PaymentMethodInterface $paymentMethod1,
+        PaymentMethodInterface $paymentMethod2,
+    ): void {
+        $order->getChannel()->willReturn($channel);
+        $channel->isSkippingPaymentStepAllowed()->willReturn(true);
+
+        $order->getPayments()->willReturn(new ArrayCollection([
+            $payment1->getWrappedObject(),
+            $payment2->getWrappedObject(),
+        ]));
+
+        $payment1->getMethod()->willReturn($paymentMethod1);
+        $payment2->getMethod()->willReturn($paymentMethod2);
+        $paymentMethod1->isEnabled()->willReturn(true);
+        $paymentMethod1->isEnabled()->willReturn(true);
+
+        $this->isPaymentRefreshingNeeded($order)->shouldReturn(false);
+    }
+
+    function it_should_not_be_refreshed_when_channel_has_no_skipping_payment_step_allowed(
+        OrderInterface $order,
+        ChannelInterface $channel,
+        PaymentInterface $payment1,
+        PaymentInterface $payment2,
+        PaymentMethodInterface $paymentMethod1,
+        PaymentMethodInterface $paymentMethod2,
+    ): void {
+        $order->getChannel()->willReturn($channel);
+        $channel->isSkippingPaymentStepAllowed()->willReturn(false);
+
+        $order->getPayments()->willReturn(new ArrayCollection([
+            $payment1->getWrappedObject(),
+            $payment2->getWrappedObject(),
+        ]));
+
+        $payment1->getMethod()->willReturn($paymentMethod1);
+        $payment2->getMethod()->willReturn($paymentMethod2);
+        $paymentMethod1->isEnabled()->willReturn(true);
+        $paymentMethod1->isEnabled()->willReturn(false);
+
+        $this->isPaymentRefreshingNeeded($order)->shouldReturn(false);
+    }
+
+    function it_removes_previous_and_creates_new_payment_method(
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderPaymentsRemoverInterface $orderPaymentsRemover,
+        OrderInterface $order,
+    ): void {
+        $orderPaymentsRemover->removePayments($order)->shouldBeCalledOnce();
+        $orderPaymentProvider->provideOrderPayment($order, "cart")->shouldBeCalledOnce();
+
+        $this->refreshPayments($order, "cart");
+    }
+
+    function it_ignores_no_payment_exception_when_remove_previous_and_creates_new_payment_method(
+        OrderPaymentProviderInterface $orderPaymentProvider,
+        OrderPaymentsRemoverInterface $orderPaymentsRemover,
+        OrderInterface $order,
+    ): void {
+        $orderPaymentsRemover->removePayments($order)->shouldBeCalledOnce();
+        $orderPaymentProvider->provideOrderPayment($order, "cart")->willThrow(NotProvidedOrderPaymentException::class);
+
+        $this->refreshPayments($order, "cart");
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #11678                      |
| License         | MIT                                                          |
