### PR TITLE
[DX] Unify API and admin panel user passwords

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -276,7 +276,7 @@ final class ManagingProductsContext implements Context
     public function iSetItsNonTranslatableAttributeTo(ProductAttributeInterface $attribute, string $value): void
     {
         $this->client->addSubResourceData(
-        'attributes',
+            'attributes',
             [
                 'attribute' => $this->iriConverter->getIriFromResource($attribute),
                 'value' => $this->getAttributeValueInProperType($attribute, $value),
@@ -290,7 +290,7 @@ final class ManagingProductsContext implements Context
     public function iSetTheInvalidIntegerValueOfTheNonTranslatableAttributeTo(ProductAttributeInterface $attribute, int $value): void
     {
         $this->client->addSubResourceData(
-        'attributes',
+            'attributes',
             [
                 'attribute' => $this->iriConverter->getIriFromResource($attribute),
                 'value' => $value,
@@ -304,7 +304,7 @@ final class ManagingProductsContext implements Context
     public function iSetTheInvalidStringValueOfTheNonTranslatableAttributeTo(ProductAttributeInterface $attribute, string $value): void
     {
         $this->client->addSubResourceData(
-        'attributes',
+            'attributes',
             [
                 'attribute' => $this->iriConverter->getIriFromResource($attribute),
                 'value' => $value,
@@ -320,7 +320,7 @@ final class ManagingProductsContext implements Context
     public function iSetItsAttributeTo(
         ProductAttributeInterface $attribute,
         ?string $value = null,
-        string $localeCode = 'en_US'
+        string $localeCode = 'en_US',
     ): void {
         $this->client->addSubResourceData(
             'attributes',
@@ -363,7 +363,7 @@ final class ManagingProductsContext implements Context
     public function iSelectValueInForTheAttribute(
         string $value,
         string $localeCode,
-        ProductAttributeInterface $attribute
+        ProductAttributeInterface $attribute,
     ): void {
         $this->client->addSubResourceData(
             'attributes',
@@ -380,7 +380,7 @@ final class ManagingProductsContext implements Context
      */
     public function iSelectValueForTheAttribute(
         string $value,
-        ProductAttributeInterface $attribute
+        ProductAttributeInterface $attribute,
     ): void {
         $this->client->addSubResourceData(
             'attributes',
@@ -678,7 +678,7 @@ final class ManagingProductsContext implements Context
     public function nonTranslatableAttributeOfProductShouldBe(
         ProductAttributeInterface $attribute,
         ProductInterface $product,
-        string $value
+        string $value,
     ): void {
         $this->client->show(Resources::PRODUCTS, $product->getCode());
 
@@ -702,7 +702,7 @@ final class ManagingProductsContext implements Context
         ProductAttributeInterface $attribute,
         ProductInterface $product,
         string $value,
-        string $localeCode = 'en_US'
+        string $localeCode = 'en_US',
     ): void {
         $this->client->show(Resources::PRODUCTS, $product->getCode());
 
@@ -718,7 +718,7 @@ final class ManagingProductsContext implements Context
         foreach ($attributes as $attributeValue) {
             if ($attributeValue['attribute'] === $this->sectionAwareIriConverter->getIriFromResourceInSection($attribute, 'admin')) {
                 throw new \InvalidArgumentException(
-                    sprintf('Product %s have attribute %s', $product->getName(), $attribute->getName())
+                    sprintf('Product %s have attribute %s', $product->getName(), $attribute->getName()),
                 );
             }
         }
@@ -780,7 +780,7 @@ final class ManagingProductsContext implements Context
     public function iShouldBeNotifiedThatTheAttributeInShouldBeLongerThan(
         string $attributeName,
         string $localeCode,
-        int $number
+        int $number,
     ): void {
         Assert::contains(
             $this->responseChecker->getError($this->client->getLastResponse()),
@@ -861,7 +861,7 @@ final class ManagingProductsContext implements Context
 
     private function getAttributeValueInProperType(
         ProductAttributeInterface $productAttribute,
-        string $value
+        string $value,
     ): string|bool|float|int {
         switch ($productAttribute->getStorageType()) {
             case AttributeValueInterface::STORAGE_BOOLEAN:
@@ -887,7 +887,7 @@ final class ManagingProductsContext implements Context
         }
 
         throw new \InvalidArgumentException(
-            sprintf('Value "%s" not found in attribute "%s"', $value, $attribute->getName())
+            sprintf('Value "%s" not found in attribute "%s"', $value, $attribute->getName()),
         );
     }
 
@@ -908,7 +908,7 @@ final class ManagingProductsContext implements Context
         }
 
         throw new \InvalidArgumentException(
-            sprintf('The given product does not have attribute %s', $attribute->getName())
+            sprintf('The given product does not have attribute %s', $attribute->getName()),
         );
     }
 

--- a/src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AdminAuthenticationTokenDocumentationModifier.php
+++ b/src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AdminAuthenticationTokenDocumentationModifier.php
@@ -54,7 +54,7 @@ final class AdminAuthenticationTokenDocumentationModifier implements Documentati
                 ],
                 'password' => [
                     'type' => 'string',
-                    'example' => 'sylius-api',
+                    'example' => 'sylius',
                 ],
             ],
         ];

--- a/src/Sylius/Bundle/ApiBundle/docs/authorization.md
+++ b/src/Sylius/Bundle/ApiBundle/docs/authorization.md
@@ -20,15 +20,15 @@ but all responses will be prepared as for Shop User.
 
     As an Admin User:
     ```bash
-    curl -X POST http://127.0.0.1:8000/api/v2/admin-authentication-token -H "Content-Type: application/json" -H "Accept: application/json" -d '{"email": "api@example.com", "password": "sylius-api"}'
+    curl -X POST http://127.0.0.1:8000/api/v2/admin-authentication-token -H "Content-Type: application/json" -H "Accept: application/json" -d '{"email": "api@example.com", "password": "sylius"}'
     ```
    
-    > Email "api@example.com" and password "sylius-api" are default credentials for API administrator provided in the default
+    > Email "api@example.com" and password "sylius" are default credentials for API administrator provided in the default
     [fixtures suite](https://github.com/Sylius/Sylius/blob/0e4ed2e34e7f255aacef02a43cc2e7bf006d03fd/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml#L158)
     
     As a Shop User:
     ```bash
-    curl -X POST http://127.0.0.1:8000/api/v2/shop-authentication-token -H "Content-Type: application/json" -H "Accept: application/json" -d '{"email": "api@example.com", "password": "sylius-api"}'
+    curl -X POST http://127.0.0.1:8000/api/v2/shop-authentication-token -H "Content-Type: application/json" -H "Accept: application/json" -d '{"email": "api@example.com", "password": "sylius"}'
     ```
 
     > Email "shop@example.com" and password "sylius" are default credentials for API client provided in the default

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductAttributeValueDenormalizerSpec.php
@@ -88,7 +88,7 @@ final class ProductAttributeValueDenormalizerSpec extends ObjectBehavior
                 ['attribute' => '/attributes/material', 'value' => 'ceramic'],
                 ProductAttributeValueInterface::class,
                 null,
-                [self::ALREADY_CALLED => true]
+                [self::ALREADY_CALLED => true],
             )
             ->shouldBeCalled()
         ;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -176,7 +176,7 @@ sylius_fixtures:
 
                             -   email: 'api@example.com'
                                 username: 'api'
-                                password: 'sylius-api'
+                                password: 'sylius'
                                 enabled: true
                                 locale_code: '%locale%'
                                 first_name: 'Luke'


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no|
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

Once I have the API client environment ready to work with the API, it is annoying to have to adjust user credentials when switching from `dev` to `test` in the Sylius application.

This can be solved the other way around - match all test data password entries to `sylius-api`.