### PR TITLE
[PostgreSQL] Misleading error message when invalid IRI is provided

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/EventListener/PostgreSQLDriverExceptionListener.php
+++ b/src/Sylius/Bundle/ApiBundle/EventListener/PostgreSQLDriverExceptionListener.php
@@ -29,8 +29,8 @@ final class PostgreSQLDriverExceptionListener
             $event
                 ->setResponse(
                     new JSONResponse(
-                        ['message' => 'Invalid URL parameter for type integer'],
-                        $event->getRequest()->getMethod() === Request::METHOD_GET ? Response::HTTP_NOT_FOUND : Response::HTTP_UNPROCESSABLE_ENTITY,
+                        ['message' => 'No route matches the given filter IRI'],
+                        $event->getRequest()->getMethod() === Request::METHOD_GET ? Response::HTTP_BAD_REQUEST : Response::HTTP_UNPROCESSABLE_ENTITY,
                     ),
                 )
             ;

--- a/src/Sylius/Bundle/ApiBundle/Tests/Listener/PostgreSQLDriverExceptionListenerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Listener/PostgreSQLDriverExceptionListenerTest.php
@@ -44,7 +44,7 @@ final class PostgreSQLDriverExceptionListenerTest extends TestCase
     }
 
     /** @test */
-    public function it_responses_with_not_found_status_if_exception_is_a_driver_exception_with_sql_state_22P02_and_request_method_is_get(): void
+    public function it_responses_with_bad_request_status_if_exception_is_a_driver_exception_with_sql_state_22P02_and_request_method_is_get(): void
     {
         $event = $this->createDriverExceptionEvent('22P02', Request::METHOD_GET);
 
@@ -54,8 +54,8 @@ final class PostgreSQLDriverExceptionListenerTest extends TestCase
 
         $this->assertNotNull($response);
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        $this->assertEquals(json_encode(['message' => 'Invalid URL parameter for type integer']), $response->getContent());
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertEquals(json_encode(['message' => 'No route matches the given filter IRI']), $response->getContent());
     }
 
     /** @test */
@@ -70,7 +70,7 @@ final class PostgreSQLDriverExceptionListenerTest extends TestCase
         $this->assertNotNull($response);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        $this->assertEquals(json_encode(['message' => 'Invalid URL parameter for type integer']), $response->getContent());
+        $this->assertEquals(json_encode(['message' => 'No route matches the given filter IRI']), $response->getContent());
     }
 
     private function createExceptionEvent(): ExceptionEvent

--- a/tests/Api/Admin/ProductVariantsTest.php
+++ b/tests/Api/Admin/ProductVariantsTest.php
@@ -62,6 +62,32 @@ final class ProductVariantsTest extends JsonApiTestCase
     }
 
     /** @test */
+    public function it_returns_bad_request_http_status_code_if_invalid_filter_parameter_is_passed(): void
+    {
+        $this->loadFixturesFromFiles([
+            'authentication/api_administrator.yaml',
+            'channel.yaml',
+            'tax_category.yaml',
+            'shipping_category.yaml',
+            'product/product_variant.yaml',
+        ]);
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/admin/product-variants',
+            parameters: ['product' => 'WRONG-IRI'],
+            server: $header,
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/product_variant/invalid_filter_parameter_response',
+            Response::HTTP_BAD_REQUEST
+        );
+    }
+
+    /** @test */
     public function it_gets_a_product_variant(): void
     {
         $fixtures = $this->loadFixturesFromFiles([

--- a/tests/Api/Responses/admin/product_variant/invalid_filter_parameter_response.json
+++ b/tests/Api/Responses/admin/product_variant/invalid_filter_parameter_response.json
@@ -1,0 +1,3 @@
+{
+    "message": "No route matches the given filter IRI"
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

The misleading message was introduced here:
https://github.com/Sylius/Sylius/pull/15064
<!--

 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
