### PR TITLE
Update catalog_promotions.rst, fix links to BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher and ApplyCatalogPromotionsOnVariants

### DIFF
--- a/docs/book/products/catalog_promotions.rst
+++ b/docs/book/products/catalog_promotions.rst
@@ -349,7 +349,7 @@ one is edited, then the ``CatalogPromotionUpdated`` event is dispatched to event
 This event is handled by `CatalogPromotionUpdateListener <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionUpdateListener.php>`_ which resolves the appropriate ``CatalogPromotion``.
 With the needed data and configuration from ``CatalogPromotion`` we can now process the Product Catalog.
 
-Any changes in Catalog Promotion cause recalculations of entire Product Catalog (`BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher.php>`_ is called, which dispatch events `ApplyCatalogPromotionsOnVariants <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Command/ApplyCatalogPromotionsOnVariants.php>`_)
+Any changes in Catalog Promotion cause recalculations of entire Product Catalog (`BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher.php>`_ is called, which dispatch events `ApplyCatalogPromotionsOnVariants <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/ApplyCatalogPromotionsOnVariants.php>`_)
 
 .. note::
 


### PR DESCRIPTION
Fix links to classes: 

src/Sylius/Bundle/CoreBundle/CatalogPromotion/Command/ApplyCatalogPromotionsOnVariants.php src/Sylius/Bundle/CoreBundle/CatalogPromotion/CommandDispatcher/BatchedApplyCatalogPromotionsOnVariantsCommandDispatcher.php

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 or 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no/yes                                                       |
| New feature?    | no/yes                                                       |
| BC breaks?      | no/yes                                                       |
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
