### PR TITLE
[FIX] Default variant

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -2,6 +2,13 @@
 
 1. The `Sylius\Component\User\Model\UserInterface` extends the `Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface`
    interface to fix the compatibility with Symfony 6.
+2. The constructor of `Sylius\Component\Product\Resolver\DefaultProductVariantResolver` has been modified, a new argument has been added :
+   
+   ```php
+    public function __construct(
+        private ?ProductVariantRepositoryInterface $productVariantRepository = null,
+    )
+    ```
 
 # UPGRADE FROM `v1.12.10` TO `v1.12.11`
 

--- a/features/product/viewing_products/viewing_product_price_on_products_list.feature
+++ b/features/product/viewing_products/viewing_product_price_on_products_list.feature
@@ -8,7 +8,7 @@ Feature: Viewing a product price on products list
         Given the store operates on a single channel in "United States"
 
     @ui @api
-    Scenario: Viewing a products with price on list
+    Scenario: Viewing a product with price on list
         Given the store has a product "T-Shirt watermelon" priced at "$19.00"
         And the store classifies its products as "T-Shirts"
         And this product belongs to "T-Shirts"
@@ -16,7 +16,7 @@ Feature: Viewing a product price on products list
         Then I should see the product "T-Shirt watermelon" with price "$19.00"
 
     @ui @api
-    Scenario: Viewing a products with discount on list
+    Scenario: Viewing a product with discount on list
         Given the store has a product "T-Shirt watermelon" priced at "$19.00"
         And the product "T-Shirt watermelon" has original price "$20.00"
         And the store classifies its products as "T-Shirts"
@@ -33,3 +33,13 @@ Feature: Viewing a product price on products list
         When I browse products from taxon "T-Shirts"
         Then I should see the product "T-Shirt watermelon" with price "$19.00"
         And I should see "T-Shirt watermelon" product not discounted on the list
+
+    @ui @api
+    Scenario: Viewing a product with a positioned default variant
+        Given the store has a product "T-Shirt watermelon" priced at "$19.00"
+        And the product "T-Shirt watermelon" has also an "Extra Large" variant at position 0
+        And this variant is also priced at "$10.00" in "United States" channel
+        And the store classifies its products as "T-Shirts"
+        And this product belongs to "T-Shirts"
+        When I browse products from taxon "T-Shirts"
+        Then I should see the product "T-Shirt watermelon" with price "$10.00"

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -442,12 +442,18 @@ final class ProductContext implements Context
     /**
      * @Given /^(this variant) is also priced at ("[^"]+") in ("([^"]+)" channel)$/
      */
-    public function thisVariantIsAlsoPricedAtInChannel(ProductVariantInterface $productVariant, string $price, ChannelInterface $channel)
+    public function thisVariantIsAlsoPricedAtInChannel(ProductVariantInterface $productVariant, int $price, ChannelInterface $channel)
     {
-        $productVariant->addChannelPricing($this->createChannelPricingForChannel(
-            $this->getPriceFromString(str_replace(['$', '€', '£'], '', $price)),
-            $channel,
-        ));
+        $channelPricing = $productVariant->getChannelPricingForChannel($channel);
+
+        if (null === $channelPricing) {
+            $productVariant->addChannelPricing($this->createChannelPricingForChannel(
+                $price,
+                $channel,
+            ));
+        } else {
+            $channelPricing->setPrice($price);
+        }
 
         $this->objectManager->flush();
     }

--- a/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
+++ b/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
@@ -21,6 +21,13 @@ final class DefaultProductVariantResolver implements ProductVariantResolverInter
 {
     public function __construct(private ?ProductVariantRepositoryInterface $productVariantRepository = null)
     {
+        if (null === $productVariantRepository) {
+            trigger_deprecation('sylius/product', '1.12',
+                'Not passing a service that implements "%s" as a 1st argument of "%s" constructor is deprecated and will be prohibited in 2.0.',
+                ProductVariantRepositoryInterface::class,
+                self::class
+            );
+        }
     }
 
     public function getVariant(ProductInterface $subject): ?ProductVariantInterface

--- a/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
+++ b/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
@@ -34,13 +34,17 @@ final class DefaultProductVariantResolver implements ProductVariantResolverInter
     {
         if ($this->productVariantRepository && $subject->getId()) {
             /** @var ProductVariantInterface|null $productVariant */
-            $productVariant = $this->productVariantRepository->findOneBy([
-                'product' => $subject,
-                'enabled' => true,
-            ], [
-                'position' => 'ASC',
-                'id' => 'ASC',
-            ]);
+            $productVariant = $this->productVariantRepository->findBy(
+                [
+                    'product' => $subject,
+                    'enabled' => true,
+                ],
+                [
+                    'position' => 'ASC',
+                    'id' => 'ASC',
+                ],
+                1
+            );
 
             return $productVariant;
         }

--- a/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
+++ b/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
@@ -33,8 +33,8 @@ final class DefaultProductVariantResolver implements ProductVariantResolverInter
     public function getVariant(ProductInterface $subject): ?ProductVariantInterface
     {
         if ($this->productVariantRepository && $subject->getId()) {
-            /** @var ProductVariantInterface|null $productVariant */
-            $productVariant = $this->productVariantRepository->findBy(
+            /** @var ProductVariantInterface[] $productVariants */
+            $productVariants = $this->productVariantRepository->findBy(
                 [
                     'product' => $subject,
                     'enabled' => true,
@@ -46,7 +46,7 @@ final class DefaultProductVariantResolver implements ProductVariantResolverInter
                 1
             );
 
-            return $productVariant;
+            return $productVariants[0] ?? null;
         }
 
         if ($subject->getEnabledVariants()->isEmpty()) {

--- a/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
+++ b/src/Sylius/Component/Product/Resolver/DefaultProductVariantResolver.php
@@ -35,8 +35,11 @@ final class DefaultProductVariantResolver implements ProductVariantResolverInter
         if ($this->productVariantRepository && $subject->getId()) {
             /** @var ProductVariantInterface|null $productVariant */
             $productVariant = $this->productVariantRepository->findOneBy([
-                'product' => $subject->getId(),
+                'product' => $subject,
                 'enabled' => true,
+            ], [
+                'position' => 'ASC',
+                'id' => 'ASC',
             ]);
 
             return $productVariant;

--- a/src/Sylius/Component/Product/spec/Resolver/DefaultProductVariantResolverSpec.php
+++ b/src/Sylius/Component/Product/spec/Resolver/DefaultProductVariantResolverSpec.php
@@ -55,13 +55,17 @@ final class DefaultProductVariantResolverSpec extends ObjectBehavior
         $this->beConstructedWith($productVariantRepository);
 
         $product->getId()->willReturn(1);
-        $productVariantRepository->findOneBy([
-            'product' => 1,
-            'enabled' => true,
-        ], [
-            'position' => 'ASC',
-            'id' => 'ASC',
-        ])->willReturn($variant);
+        $productVariantRepository->findBy(
+            [
+                'product' => $product,
+                'enabled' => true,
+            ],
+            [
+                'position' => 'ASC',
+                'id' => 'ASC',
+            ],
+            1
+        )->willReturn([$variant]);
 
         $this->getVariant($product)->shouldReturn($variant);
     }
@@ -73,13 +77,17 @@ final class DefaultProductVariantResolverSpec extends ObjectBehavior
         $this->beConstructedWith($productVariantRepository);
 
         $product->getId()->willReturn(1);
-        $productVariantRepository->findOneBy([
-            'product' => 1,
-            'enabled' => true,
-        ], [
-            'position' => 'ASC',
-            'id' => 'ASC',
-        ])->willReturn(null);
+        $productVariantRepository->findBy(
+            [
+                'product' => $product,
+                'enabled' => true,
+            ],
+            [
+                'position' => 'ASC',
+                'id' => 'ASC',
+            ],
+            1
+        )->willReturn([]);
 
         $this->getVariant($product)->shouldReturn(null);
     }

--- a/src/Sylius/Component/Product/spec/Resolver/DefaultProductVariantResolverSpec.php
+++ b/src/Sylius/Component/Product/spec/Resolver/DefaultProductVariantResolverSpec.php
@@ -58,6 +58,9 @@ final class DefaultProductVariantResolverSpec extends ObjectBehavior
         $productVariantRepository->findOneBy([
             'product' => 1,
             'enabled' => true,
+        ], [
+            'position' => 'ASC',
+            'id' => 'ASC',
         ])->willReturn($variant);
 
         $this->getVariant($product)->shouldReturn($variant);
@@ -73,6 +76,9 @@ final class DefaultProductVariantResolverSpec extends ObjectBehavior
         $productVariantRepository->findOneBy([
             'product' => 1,
             'enabled' => true,
+        ], [
+            'position' => 'ASC',
+            'id' => 'ASC',
         ])->willReturn(null);
 
         $this->getVariant($product)->shouldReturn(null);


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                  |
| Bug fix?        | yes                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes |
| Related tickets | fixes #15547                      |
| License         | MIT                                                          |

This PR fix an issue introduced by #15273.
Variants are by default ordered by position via a specific Doctrine resource configuration :
https://github.com/Sylius/Sylius/blob/1.12/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml#L37-L38
This behaviour has to be cloned to retrieve the right variant.