### PR TITLE
[DOC] Fix display link in authorize page

### DIFF
--- a/docs/cookbook/payments/authorize.rst
+++ b/docs/cookbook/payments/authorize.rst
@@ -6,7 +6,7 @@ Sometimes, due to legal constraint in some countries, you'll want to only author
 Authorizing payments
 --------------------
 
-Sylius supports the use of `Payums payment authorization <https://github.com/Payum/Payum/blob/master/docs/symfony/authorize.md>_`
+Sylius supports the use of `Payums payment authorization <https://github.com/Payum/Payum/blob/master/docs/symfony/authorize.md>`_.
 Not all payment gateways support this and it is up to the payment plugin to make use of this functionality.
 
 To use authorize status for your payments, your plugin must set a flag in it's GatewayConfig called `use_authorize`. This is easily done with a hidden input field.


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12 |
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets | N/A |
| License         | MIT |

The actual link is not well rendered on documentation website : 
![image](https://github.com/Sylius/Sylius/assets/3168281/fb24056b-9c98-43b1-bb9b-3bc17fb9ed03)

