### PR TITLE
[Behat] Unify the Currency Handling in Behat Scenarios

### DIFF
--- a/features/account/customer_account/viewing_orders_history/viewing_order_only_from_current_channel.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_only_from_current_channel.feature
@@ -12,7 +12,7 @@ Feature: Viewing orders only from current channel
         And the store has a zone "United States + United Kingdom" with code "US + UK"
         And this zone has the "United States" country member
         And this zone has the "United Kingdom" country member
-        And the store has a product "Angel T-Shirt" priced at "$100" in "Web-US" channel
+        And the store has a product "Angel T-Shirt" priced at "$100.00" in "Web-US" channel
         And this product is also priced at "£200" in "Web-UK" channel
         And the store ships everywhere for free for all channels
         And the store allows paying Offline for all channels

--- a/features/account/customer_account/viewing_orders_history/viewing_order_only_from_current_channel.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_only_from_current_channel.feature
@@ -13,7 +13,7 @@ Feature: Viewing orders only from current channel
         And this zone has the "United States" country member
         And this zone has the "United Kingdom" country member
         And the store has a product "Angel T-Shirt" priced at "$100.00" in "Web-US" channel
-        And this product is also priced at "£200" in "Web-UK" channel
+        And this product is also priced at "£200.00" in "Web-UK" channel
         And the store ships everywhere for free for all channels
         And the store allows paying Offline for all channels
         And there is a customer "John Hancock" identified by an email "hancock@superheronope.com" and a password "superPower"

--- a/features/admin/dashboard.feature
+++ b/features/admin/dashboard.feature
@@ -9,7 +9,7 @@ Feature: Statistics dashboard in a single channel
         And the store ships everywhere for Free
         And the store allows paying Offline
         And the store has a product "Sylius T-Shirt"
-        And this product has "Red XL" variant priced at "$40"
+        And this product has "Red XL" variant priced at "$40.00"
         And I am logged in as an administrator
 
     @ui

--- a/features/admin/dashboard.feature
+++ b/features/admin/dashboard.feature
@@ -14,7 +14,7 @@ Feature: Statistics dashboard in a single channel
 
     @ui
     Scenario: Seeing basic statistics for entire store
-        Given 3 customers have fulfilled 4 orders placed for total of "$8566.00"
+        Given 3 customers have fulfilled 4 orders placed for total of "$8,566.00"
         And then 2 more customers have paid 2 orders placed for total of "$459.00"
         When I open administration dashboard
         Then I should see 6 new orders
@@ -24,10 +24,10 @@ Feature: Statistics dashboard in a single channel
 
     @ui
     Scenario: Statistics include only fulfilled orders that were not cancelled
-        Given 4 customers have fulfilled 4 orders placed for total of "$5241.00"
+        Given 4 customers have fulfilled 4 orders placed for total of "$5,241.00"
         And then 2 more customers have placed 2 orders for total of "$459.00"
-        And 2 customers have added products to the cart for total of "$3450.00"
-        And a single customer has placed an order for total of "$1000.00"
+        And 2 customers have added products to the cart for total of "$3,450.00"
+        And a single customer has placed an order for total of "$1,000.00"
         But the customer cancelled this order
         When I open administration dashboard
         Then I should see 4 new orders

--- a/features/admin/dashboard.feature
+++ b/features/admin/dashboard.feature
@@ -15,7 +15,7 @@ Feature: Statistics dashboard in a single channel
     @ui
     Scenario: Seeing basic statistics for entire store
         Given 3 customers have fulfilled 4 orders placed for total of "$8,566.00"
-        And then 2 more customers have paid 2 orders placed for total of "$459.00"
+        And 2 more customers have paid 2 orders placed for total of "$459.00"
         When I open administration dashboard
         Then I should see 6 new orders
         And I should see 5 new customers
@@ -25,7 +25,7 @@ Feature: Statistics dashboard in a single channel
     @ui
     Scenario: Statistics include only fulfilled orders that were not cancelled
         Given 4 customers have fulfilled 4 orders placed for total of "$5,241.00"
-        And then 2 more customers have placed 2 orders for total of "$459.00"
+        And 2 more customers have placed 2 orders for total of "$459.00"
         And 2 customers have added products to the cart for total of "$3,450.00"
         And a single customer has placed an order for total of "$1,000.00"
         But the customer cancelled this order

--- a/features/admin/dashboard_per_channel.feature
+++ b/features/admin/dashboard_per_channel.feature
@@ -15,7 +15,7 @@ Feature: Statistics dashboard per channel
 
     @ui
     Scenario: Seeing basic statistics for the first channel by default
-        Given 3 customers have fulfilled 4 orders placed for total of "$8566.00" mostly "Onion" product
+        Given 3 customers have fulfilled 4 orders placed for total of "$8,566.00" mostly "Onion" product
         And then 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
         When I open administration dashboard
         Then I should see 4 new orders
@@ -25,9 +25,9 @@ Feature: Statistics dashboard per channel
 
     @ui
     Scenario: Changing channel in administration dashboard
-        Given 4 customers have fulfilled 4 orders placed for total of "$5241.00" mostly "Onion" product
+        Given 4 customers have fulfilled 4 orders placed for total of "$5,241.00" mostly "Onion" product
         And then 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
-        And then 2 more customers have placed 3 orders for total of "$1259.00" mostly "Banana" product
+        And then 2 more customers have placed 3 orders for total of "$1,259.00" mostly "Banana" product
         When I open administration dashboard
         And I choose "United States" channel
         Then I should see 2 new orders
@@ -37,14 +37,14 @@ Feature: Statistics dashboard per channel
 
     @ui
     Scenario: Seeing recent orders in a specific channel
-        Given 3 customers have placed 4 orders for total of "$8566.00" mostly "Onion" product
+        Given 3 customers have placed 4 orders for total of "$8,566.00" mostly "Onion" product
         And then 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
         When I open administration dashboard for "Poland" channel
         Then I should see 4 new orders in the list
 
     @ui
     Scenario: Seeing recent orders in a specific channel
-        Given 3 customers have placed 4 orders for total of "$8566.00" mostly "Onion" product
+        Given 3 customers have placed 4 orders for total of "$8,566.00" mostly "Onion" product
         And then 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
         When I open administration dashboard for "United States" channel
         Then I should see 2 new orders in the list

--- a/features/admin/dashboard_per_channel.feature
+++ b/features/admin/dashboard_per_channel.feature
@@ -16,7 +16,7 @@ Feature: Statistics dashboard per channel
     @ui
     Scenario: Seeing basic statistics for the first channel by default
         Given 3 customers have fulfilled 4 orders placed for total of "$8,566.00" mostly "Onion" product
-        And then 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
+        And 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
         When I open administration dashboard
         Then I should see 4 new orders
         And I should see 5 new customers
@@ -26,8 +26,8 @@ Feature: Statistics dashboard per channel
     @ui
     Scenario: Changing channel in administration dashboard
         Given 4 customers have fulfilled 4 orders placed for total of "$5,241.00" mostly "Onion" product
-        And then 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
-        And then 2 more customers have placed 3 orders for total of "$1,259.00" mostly "Banana" product
+        And 2 more customers have fulfilled 2 orders placed for total of "$459.00" mostly "Banana" product
+        And 2 more customers have placed 3 orders for total of "$1,259.00" mostly "Banana" product
         When I open administration dashboard
         And I choose "United States" channel
         Then I should see 2 new orders
@@ -38,13 +38,13 @@ Feature: Statistics dashboard per channel
     @ui
     Scenario: Seeing recent orders in a specific channel
         Given 3 customers have placed 4 orders for total of "$8,566.00" mostly "Onion" product
-        And then 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
+        And 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
         When I open administration dashboard for "Poland" channel
         Then I should see 4 new orders in the list
 
     @ui
     Scenario: Seeing recent orders in a specific channel
         Given 3 customers have placed 4 orders for total of "$8,566.00" mostly "Onion" product
-        And then 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
+        And 2 more customers have placed 2 orders for total of "$459.00" mostly "Banana" product
         When I open administration dashboard for "United States" channel
         Then I should see 2 new orders in the list

--- a/features/cart/shopping_cart/adding_product_with_discounted_catalog_price_to_cart.feature
+++ b/features/cart/shopping_cart/adding_product_with_discounted_catalog_price_to_cart.feature
@@ -6,8 +6,8 @@ Feature: Adding a simple product with discounted catalog price to the cart
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mug" priced at "$40"
-        And the store has a product "T-Shirt" priced at "$20"
+        And the store has a product "Mug" priced at "$40.00"
+        And the store has a product "T-Shirt" priced at "$20.00"
         And there is a catalog promotion "Winter sale" that reduces price by "25%" and applies on "T-Shirt" variant
 
     @ui @api
@@ -23,7 +23,7 @@ Feature: Adding a simple product with discounted catalog price to the cart
     @ui @api
     Scenario: Adding a simple product with catalog and cart promotion to the cart
         Given there is a promotion "Cheap Stuff"
-        And this promotion gives "50%" off on every product when the item total is at least "$5"
+        And this promotion gives "50%" off on every product when the item total is at least "$5.00"
         When I add product "T-Shirt" to the cart
         And I add product "Mug" to the cart
         Then I should be on my cart summary page

--- a/features/cart/shopping_cart/adding_product_with_variants_with_discounted_catalog_price_to_cart.feature
+++ b/features/cart/shopping_cart/adding_product_with_variants_with_discounted_catalog_price_to_cart.feature
@@ -7,11 +7,11 @@ Feature: Adding a product with selected variant with discounted catalog price to
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a "T-Shirt" configurable product
-        And the product "T-Shirt" has a "PHP T-Shirt" variant priced at "$20"
-        And the product "T-Shirt" has a "Kotlin T-Shirt" variant priced at "$400"
+        And the product "T-Shirt" has a "PHP T-Shirt" variant priced at "$20.00"
+        And the product "T-Shirt" has a "Kotlin T-Shirt" variant priced at "$400.00"
         And the store has a "Keyboard" configurable product
-        And the product "Keyboard" has a "RGB Keyboard" variant priced at "$40"
-        And the product "Keyboard" has a "Pink Keyboard" variant priced at "$40"
+        And the product "Keyboard" has a "RGB Keyboard" variant priced at "$40.00"
+        And the product "Keyboard" has a "Pink Keyboard" variant priced at "$40.00"
         And there is a catalog promotion "Winter sale" that reduces price by "25%" and applies on "PHP T-Shirt" variant
 
     @ui @api

--- a/features/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_based_on_method_position.feature
+++ b/features/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_based_on_method_position.feature
@@ -8,7 +8,7 @@ Feature: Viewing a cart summary with the correct default shipping method
         Given the store operates on a single channel in "United States"
         And the store allows shipping with "Method 1" at position 2 with "$5.00" fee
         And the store also allows shipping with "Method 2" at position 0 with "$6.00" fee
-        And the store has a product "T-Shirt banana" priced at "$10"
+        And the store has a product "T-Shirt banana" priced at "$10.00"
 
     @ui @api
     Scenario:

--- a/features/checkout/ability_to_change_email_during_checkout.feature
+++ b/features/checkout/ability_to_change_email_during_checkout.feature
@@ -6,7 +6,7 @@ Feature: Changing email during checkout with registered email
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mantis blade" priced at "$1200.00"
+        And the store has a product "Mantis blade" priced at "$1,200.00"
         And the store ships everywhere for Free
         And the store allows paying Offline
         And there is a customer "John Doe" identified by an email "john@example.com" and a password "secret"

--- a/features/checkout/ability_to_change_email_during_checkout.feature
+++ b/features/checkout/ability_to_change_email_during_checkout.feature
@@ -6,7 +6,7 @@ Feature: Changing email during checkout with registered email
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Mantis blade" priced at "$1200"
+        And the store has a product "Mantis blade" priced at "$1200.00"
         And the store ships everywhere for Free
         And the store allows paying Offline
         And there is a customer "John Doe" identified by an email "john@example.com" and a password "secret"

--- a/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
+++ b/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
@@ -8,7 +8,7 @@ Feature: Placing an order with different scopes for shipping and taxes
         Given the store operates on a single channel in "USD" currency
         And the store operates in "United States"
         And the store operates in "Germany"
-        And the store has a product "Jane's Vest" priced at "$20"
+        And the store has a product "Jane's Vest" priced at "$20.00"
         And the store allows paying Offline
         And I am a logged in customer
 
@@ -58,4 +58,4 @@ Feature: Placing an order with different scopes for shipping and taxes
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
-        And my order total should be "$20"
+        And my order total should be "$20.00"

--- a/features/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
@@ -19,5 +19,5 @@ Feature: Seeing a order item discount
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
-        And the "Lannister Coat" product should have unit price discounted by "$10"
-        And my order total should be "$90"
+        And the "Lannister Coat" product should have unit price discounted by "$10.00"
+        And my order total should be "$90.00"

--- a/features/checkout/seeing_purchaser_identifier_in_checkout_page.feature
+++ b/features/checkout/seeing_purchaser_identifier_in_checkout_page.feature
@@ -6,7 +6,7 @@ Feature: Seeing purchaser identifier in checkout page
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Gaming chair" priced at "$399"
+        And the store has a product "Gaming chair" priced at "$399.00"
         And the store ships everywhere for Free
         And the store allows paying Offline
         And there is a customer "John Doe" identified by an email "john@example.com" and a password "secret"

--- a/features/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
+++ b/features/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
@@ -80,7 +80,7 @@ Feature: Preventing not available shipping method selection
     Scenario: Not being able to select shipping method not available due to shipping rules
         Given the store has "Raven Post" shipping method with "$10.00" fee
         And the store has "Dragon Post" shipping method with "$30.00" fee
-        And this shipping method is only available for orders over or equal to "$100"
+        And this shipping method is only available for orders over or equal to "$100.00"
         And I have product "Targaryen T-Shirt" in the cart
         And I am at the checkout addressing step
         When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/order/managing_orders/cancelling_order_with_promotion.feature
+++ b/features/order/managing_orders/cancelling_order_with_promotion.feature
@@ -10,7 +10,7 @@ Feature: Cancelling order with promotion applied
         And the store allows paying with "Cash on Delivery"
         And the store has a product "Suit" priced at "$400.00"
         And there is a promotion "Holiday promotion"
-        And the promotion gives "$50" discount to every order
+        And the promotion gives "$50.00" discount to every order
         And there is a customer "mike@ross.com" that placed an order "#00000001"
         And the customer bought a single "Suit"
         And the customer "Mike Ross" addressed it to "350 5th Ave", "10118" "New York" in the "United States" with identical billing address

--- a/features/order/managing_orders/order_filtration/filtering_orders_by_total_in_different_currencies.feature
+++ b/features/order/managing_orders/order_filtration/filtering_orders_by_total_in_different_currencies.feature
@@ -12,9 +12,9 @@ Feature: Filtering orders by total in different currencies
         And this customer has placed an order "#00000001" buying a single "Apple T-Shirt" product for "$100.00" on the "Web-US" channel
         And this customer has also placed an order "#00000002" buying a single "Pineapple T-Shirt" product for "$200.00" on the "Web-US" channel
         And this customer has also placed an order "#00000003" buying a single "Pen T-Shirt" product for "$150.50" on the "Web-US" channel
-        And this customer has also placed an order "#00000004" buying a single "Apple T-Shirt" product for "£200" on the "Web-UK" channel
+        And this customer has also placed an order "#00000004" buying a single "Apple T-Shirt" product for "£200.00" on the "Web-UK" channel
         And this customer has also placed an order "#00000005" buying a single "Pineapple T-Shirt" product for "£150.50" on the "Web-UK" channel
-        And this customer has also placed an order "#00000006" buying a single "Pen T-Shirt" product for "£100" on the "Web-UK" channel
+        And this customer has also placed an order "#00000006" buying a single "Pen T-Shirt" product for "£100.00" on the "Web-UK" channel
         And I am logged in as an administrator
         And I am browsing orders
 

--- a/features/order/managing_orders/order_filtration/filtering_orders_by_total_in_different_currencies.feature
+++ b/features/order/managing_orders/order_filtration/filtering_orders_by_total_in_different_currencies.feature
@@ -9,8 +9,8 @@ Feature: Filtering orders by total in different currencies
         And the store operates on a channel named "Web-UK" in "GBP" currency
         And the store has "Apple T-Shirt", "Pineapple T-Shirt" and "Pen T-Shirt" products
         And the store has customer "John Hancock" with email "hancock@superheronope.com"
-        And this customer has placed an order "#00000001" buying a single "Apple T-Shirt" product for "$100" on the "Web-US" channel
-        And this customer has also placed an order "#00000002" buying a single "Pineapple T-Shirt" product for "$200" on the "Web-US" channel
+        And this customer has placed an order "#00000001" buying a single "Apple T-Shirt" product for "$100.00" on the "Web-US" channel
+        And this customer has also placed an order "#00000002" buying a single "Pineapple T-Shirt" product for "$200.00" on the "Web-US" channel
         And this customer has also placed an order "#00000003" buying a single "Pen T-Shirt" product for "$150.50" on the "Web-US" channel
         And this customer has also placed an order "#00000004" buying a single "Apple T-Shirt" product for "£200" on the "Web-UK" channel
         And this customer has also placed an order "#00000005" buying a single "Pineapple T-Shirt" product for "£150.50" on the "Web-UK" channel

--- a/features/order/managing_orders/order_filtration/filtering_orders_by_variants.feature
+++ b/features/order/managing_orders/order_filtration/filtering_orders_by_variants.feature
@@ -9,10 +9,10 @@ Feature: Filtering orders by variants
         And the store ships everywhere for Free
         And the store allows paying Offline
         And the store has a product "Galaxy Shirt" with code "cosmic-tee"
-        And this product has "Nebula Top" variant priced at "$25"
-        And this product also has "Neutron Sleeveless" variant priced at "$20"
+        And this product has "Nebula Top" variant priced at "$25.00"
+        And this product also has "Neutron Sleeveless" variant priced at "$20.00"
         And the store has a product "Space Dress" with code "cosmic-dress"
-        And this product has "Sundress" variant priced at "$40"
+        And this product has "Sundress" variant priced at "$40.00"
         And there is a customer "tanith@low.com" that placed an order "#0000001"
         And the customer bought a single "Nebula Top" variant of product "Galaxy Shirt"
         And the customer also bought a "Neutron Sleeveless" variant of product "Galaxy Shirt"

--- a/features/order/managing_orders/order_history/tracking_changes_on_order_addresses.feature
+++ b/features/order/managing_orders/order_history/tracking_changes_on_order_addresses.feature
@@ -8,7 +8,7 @@ Feature: Tracking changes on order addresses
         Given the store operates on a single channel in "United States"
         And the store ships everywhere for Free
         And the store allows paying with "Cash on Delivery"
-        And the store has a product "Italian suit" priced at "$4000.00"
+        And the store has a product "Italian suit" priced at "$4,000.00"
         And there is a customer "barney@stinson.com" that placed an order "#00000001"
         And the customer bought a single "Italian suit"
         When I am logged in as an administrator

--- a/features/product/managing_product_variants/checking_products_in_the_shop_while_editing_their_product_variants.feature
+++ b/features/product/managing_product_variants/checking_products_in_the_shop_while_editing_their_product_variants.feature
@@ -13,14 +13,14 @@ In order to check a product in shop in all channels it is available in
     @ui @no-api
     Scenario: Accessing product show page in shop from the product variant edit page where product is available in more than one channel
         Given this product is also available in the "Europe" channel
-        And this product has "Red" variant priced at "$220000.00" in "Europe" channel
+        And this product has "Red" variant priced at "$220,000.00" in "Europe" channel
         When I want to modify the "Bugatti" product variant
         And I choose to show this product in the "Europe" channel
         Then I should see this product in the "Europe" channel in the shop
 
     @ui @no-api
     Scenario: Accessing product show page in shop from the product variant edit page where product is available in one channel
-        Given this product has "Red" variant priced at "$220000.00" in "United States" channel
+        Given this product has "Red" variant priced at "$220,000.00" in "United States" channel
         When I want to modify the "Bugatti" product variant
         And I choose to show this product in this channel
         Then I should see this product in the "United States" channel in the shop

--- a/features/product/managing_product_variants/generating_product_variant.feature
+++ b/features/product/managing_product_variants/generating_product_variant.feature
@@ -13,8 +13,8 @@ Feature: Generating product variants
     @ui @no-api
     Scenario: Generating a product variant for product without variants
         When I want to generate new variants for this product
-        And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90" in "United States" channel
-        And I specify that the 2nd variant is identified by "WYBOROWA_MELON" code and costs "$95" in "United States" channel
+        And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90.00" in "United States" channel
+        And I specify that the 2nd variant is identified by "WYBOROWA_MELON" code and costs "$95.00" in "United States" channel
         And I generate it
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
@@ -23,7 +23,7 @@ Feature: Generating product variants
     Scenario: Generating the rest of product variants for product with at least one
         Given this product is available in "Melon" taste priced at "$95.00"
         When I want to generate new variants for this product
-        And I specify that the 2nd variant is identified by "WYBOROWA_ORANGE" code and costs "$90" in "United States" channel
+        And I specify that the 2nd variant is identified by "WYBOROWA_ORANGE" code and costs "$90.00" in "United States" channel
         And I generate it
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
@@ -32,7 +32,7 @@ Feature: Generating product variants
     Scenario: Generating the rest of product variants for product with at least one
         Given this product is available in "Orange" taste priced at "$90.00"
         When I want to generate new variants for this product
-        And I specify that the 2nd variant is identified by "WYBOROWA_MELON" code and costs "$95" in "United States" channel
+        And I specify that the 2nd variant is identified by "WYBOROWA_MELON" code and costs "$95.00" in "United States" channel
         And I generate it
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
@@ -40,7 +40,7 @@ Feature: Generating product variants
     @ui @javascript @no-api
     Scenario: Generating only a part of product variants
         When I want to generate new variants for this product
-        And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90" in "United States" channel
+        And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90.00" in "United States" channel
         And I remove 2nd variant from the list
         And I generate it
         Then I should be notified that it has been successfully generated

--- a/features/product/managing_product_variants/generating_product_variant_validation.feature
+++ b/features/product/managing_product_variants/generating_product_variant_validation.feature
@@ -21,7 +21,7 @@ Feature: Generating product variant generation
     @ui @no-api
     Scenario: Generating a product's variant without code
         When I want to generate new variants for this product
-        And I specify that the 1st variant costs "$90" in "United States" channel
+        And I specify that the 1st variant costs "$90.00" in "United States" channel
         And I try to generate it
         Then I should be notified that code is required for the 1st variant
         And I should not see any variants in the list
@@ -30,7 +30,7 @@ Feature: Generating product variant generation
     Scenario: Generating product's variants without specific required fields for second variant
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code
-        And I specify that the 1st variant costs "$90" in "United States" channel
+        And I specify that the 1st variant costs "$90.00" in "United States" channel
         And I try to generate it
         Then I should be notified that code is required for the 2nd variant
         Then I should be notified that prices in all channels must be defined for the 2nd variant
@@ -40,9 +40,9 @@ Feature: Generating product variant generation
     Scenario: Generating product's variants with the same code
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_TASTE" code
-        And I specify that the 1st variant costs "$90" in "United States" channel
+        And I specify that the 1st variant costs "$90.00" in "United States" channel
         And I specify that the 2nd variant is identified by "WYBOROWA_TASTE" code
-        And I specify that the 2nd variant costs "$90" in "United States" channel
+        And I specify that the 2nd variant costs "$90.00" in "United States" channel
         And I try to generate it
         Then I should be notified that variant code must be unique within this product for the 1st variant
         And I should be notified that variant code must be unique within this product for the 2nd variant

--- a/features/product/managing_product_variants/product_variant_validation.feature
+++ b/features/product/managing_product_variants/product_variant_validation.feature
@@ -38,7 +38,7 @@ Feature: Product variant validation
 
     @api @ui
     Scenario: Adding a new product variant with duplicated code
-        Given this product has "Wyborowa Exquisite" variant priced at "$90" identified by "VODKA_WYBOROWA_PREMIUM"
+        Given this product has "Wyborowa Exquisite" variant priced at "$90.00" identified by "VODKA_WYBOROWA_PREMIUM"
         When I want to create a new variant of this product
         And I set its price to "$80.00" for "United States" channel
         And I specify its code as "VODKA_WYBOROWA_PREMIUM"

--- a/features/product/managing_product_variants/removing_product_variant_price_from_obsolete_channel.feature
+++ b/features/product/managing_product_variants/removing_product_variant_price_from_obsolete_channel.feature
@@ -8,7 +8,7 @@ Feature: Removing a product variant's price from obsolete channel
         Given the store operates on a channel named "Web-US" in "USD" currency
         And the store operates on another channel named "Web-GB" in "USD" currency
         And the store has a "PHP Mug" configurable product
-        And this product has "Medium PHP Mug" variant priced at "$20" in "Web-US" channel
+        And this product has "Medium PHP Mug" variant priced at "$20.00" in "Web-US" channel
         And "Medium PHP Mug" variant priced at "£25" in "Web-GB" channel
         And "Medium PHP Mug" variant is originally priced at "£50.00" in "Web-GB" channel
         And this product is disabled in "Web-GB" channel

--- a/features/product/managing_product_variants/removing_product_variant_price_from_obsolete_channel.feature
+++ b/features/product/managing_product_variants/removing_product_variant_price_from_obsolete_channel.feature
@@ -9,7 +9,7 @@ Feature: Removing a product variant's price from obsolete channel
         And the store operates on another channel named "Web-GB" in "USD" currency
         And the store has a "PHP Mug" configurable product
         And this product has "Medium PHP Mug" variant priced at "$20.00" in "Web-US" channel
-        And "Medium PHP Mug" variant priced at "£25" in "Web-GB" channel
+        And "Medium PHP Mug" variant priced at "£25.00" in "Web-GB" channel
         And "Medium PHP Mug" variant is originally priced at "£50.00" in "Web-GB" channel
         And this product is disabled in "Web-GB" channel
         And I am logged in as an administrator

--- a/features/product/managing_products/editing_product.feature
+++ b/features/product/managing_products/editing_product.feature
@@ -95,10 +95,10 @@ Feature: Editing a product
     Scenario: Enabling product in channel when all its variants already have specified price in this channel
         Given the store operates on another channel named "Mobile"
         And the store has a "7 Wonders" configurable product
-        And this product has "7 Wonders: Cities" variant priced at "$30" in "United States" channel
-        And this variant is also priced at "$25" in "Mobile" channel
-        And this product has "7 Wonders: Leaders" variant priced at "$20" in "United States" channel
-        And this variant is also priced at "$20" in "Mobile" channel
+        And this product has "7 Wonders: Cities" variant priced at "$30.00" in "United States" channel
+        And this variant is also priced at "$25.00" in "Mobile" channel
+        And this product has "7 Wonders: Leaders" variant priced at "$20.00" in "United States" channel
+        And this variant is also priced at "$20.00" in "Mobile" channel
         When I want to modify the "7 Wonders" product
         And I assign it to channel "Mobile"
         And I save my changes

--- a/features/product/managing_products/product_validation.feature
+++ b/features/product/managing_products/product_validation.feature
@@ -36,7 +36,7 @@ Feature: Products validation
     @ui @no-api
     Scenario: Adding a new simple product with duplicated code among product variants
         Given the store has a product "7 Wonders"
-        And this product has "7 Wonders: Cities" variant priced at "$30" identified by "AWESOME_GAME"
+        And this product has "7 Wonders: Cities" variant priced at "$30.00" identified by "AWESOME_GAME"
         When I want to create a new simple product
         And I specify its code as "AWESOME_GAME"
         And I name it "Dice Brewing" in "English (United States)"
@@ -133,8 +133,8 @@ Feature: Products validation
     @ui @api
     Scenario: Trying to assign new channel to an existing configurable product without specifying its all variant prices for this channel
         Given the store has a "7 Wonders" configurable product
-        And this product has "7 Wonders: Cities" variant priced at "$30"
-        And this product has "7 Wonders: Leaders" variant priced at "$20"
+        And this product has "7 Wonders: Cities" variant priced at "$30.00"
+        And this product has "7 Wonders: Leaders" variant priced at "$20.00"
         And the store operates on another channel named "Mobile Channel"
         When I want to modify the "7 Wonders" product
         And I assign it to channel "Mobile Channel"

--- a/features/product/viewing_price_history/accessing_price_history_from_simple_product.feature
+++ b/features/product/viewing_price_history/accessing_price_history_from_simple_product.feature
@@ -6,7 +6,7 @@ Feature: Accessing the price history from the simple product show page
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Ursus C-355" priced at "$1000.00" in "United States" channel
+        And the store has a product "Ursus C-355" priced at "$1,000.00" in "United States" channel
         And there is a catalog promotion with "company_bankruptcy_sale" code and "Company bankruptcy sale" name
         And the catalog promotion "Company bankruptcy sale" is available in "United States"
         And it applies on "Ursus C-355" product

--- a/features/product/viewing_product_in_admin_panel/viewing_applied_catalog_promotions_details_for_a_simple_product.feature
+++ b/features/product/viewing_product_in_admin_panel/viewing_applied_catalog_promotions_details_for_a_simple_product.feature
@@ -6,7 +6,7 @@ Feature: Seeing applied catalog promotions details for a simple product
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Ursus C-355" priced at "$1000.00" in "United States" channel
+        And the store has a product "Ursus C-355" priced at "$1,000.00" in "United States" channel
         And there is a catalog promotion with "company_bankruptcy_sale" code and "Company bankruptcy sale" name
         And the catalog promotion "Company bankruptcy sale" is available in "United States"
         And it applies on "Ursus C-355" product

--- a/features/promotion/applying_catalog_promotions/applying_catalog_promotions_price_calculation.feature
+++ b/features/promotion/applying_catalog_promotions/applying_catalog_promotions_price_calculation.feature
@@ -7,7 +7,7 @@ Feature: Applying percentage catalog promotions
     Background:
         Given the store operates on a single channel in "United States"
         And the store classifies its products as "Soft Drinks"
-        And the store has a product "Orange Juice" priced at "$20"
+        And the store has a product "Orange Juice" priced at "$20.00"
         And this product belongs to "Soft Drinks"
         And the store has a product "Apple Juice" priced at "$20.25"
         And this product belongs to "Soft Drinks"

--- a/features/promotion/managing_promotions/adding_promotion_with_action_in_different_channels.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action_in_different_channels.feature
@@ -14,7 +14,7 @@ Feature: Adding a new promotion with action configured in different channels
         When I want to create a new promotion
         And I specify its code as "20_for_all_products"
         And I name it "Item fixed discount for all products!"
-        And I add the "Item fixed discount" action configured with amount of "$10" for "United States" channel
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "United States" channel
         And it is also configured with amount of "£16.00" for "Web-GB" channel
         And I add it
         Then I should be notified that it has been successfully created

--- a/features/promotion/managing_promotions/adding_promotion_with_filter.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_filter.feature
@@ -13,8 +13,8 @@ Feature: Adding promotion with filter
         When I want to create a new promotion
         And I specify its code as "10_for_all_products_over_10"
         And I name it "$10 discount for all products over $10!"
-        And I add the "Item fixed discount" action configured with amount of "$10" for "United States" channel
-        And I specify that on "United States" channel this action should be applied to items with price greater than "$10"
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "United States" channel
+        And I specify that on "United States" channel this action should be applied to items with price greater than "$10.00"
         And I add it
         Then I should be notified that it has been successfully created
         And the "$10 discount for all products over $10!" promotion should appear in the registry
@@ -24,8 +24,8 @@ Feature: Adding promotion with filter
         When I want to create a new promotion
         And I specify its code as "10_for_all_products_over_10"
         And I name it "$10 discount for (almost) all products!"
-        And I add the "Item fixed discount" action configured with amount of "$10" for "United States" channel
-        And I specify that on "United States" channel this action should be applied to items with price between "$10" and "$100"
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "United States" channel
+        And I specify that on "United States" channel this action should be applied to items with price between "$10.00" and "$100.00"
         And I add it
         Then I should be notified that it has been successfully created
         And the "$10 discount for (almost) all products!" promotion should appear in the registry
@@ -36,7 +36,7 @@ Feature: Adding promotion with filter
         When I want to create a new promotion
         And I specify its code as "10_for_all_t_shirts"
         And I name it "$10 discount for all T-Shirts!"
-        And I add the "Item fixed discount" action configured with amount of "$10" for "United States" channel
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "United States" channel
         And I specify that this action should be applied to items from "T-Shirts" category
         And I add it
         Then I should be notified that it has been successfully created
@@ -48,7 +48,7 @@ Feature: Adding promotion with filter
         When I want to create a new promotion
         And I specify its code as "10_for_php_t_shirt"
         And I name it "$10 discount for PHP T-Shirts!"
-        And I add the "Item fixed discount" action configured with amount of "$10" for "United States" channel
+        And I add the "Item fixed discount" action configured with amount of "$10.00" for "United States" channel
         And I specify that this action should be applied to the "PHP T-Shirt" product
         And I add it
         Then I should be notified that it has been successfully created
@@ -60,7 +60,7 @@ Feature: Adding promotion with filter
         And I specify its code as "10_for_all_products_over_10"
         And I name it "$10 discount for all products over $10!"
         And I add the "Item percentage discount" action configured with a percentage value of "10%" for "United States" channel
-        And I specify that on "United States" channel this action should be applied to items with price greater than "$10"
+        And I specify that on "United States" channel this action should be applied to items with price greater than "$10.00"
         And I add it
         Then I should be notified that it has been successfully created
         And the "$10 discount for all products over $10!" promotion should appear in the registry
@@ -71,7 +71,7 @@ Feature: Adding promotion with filter
         And I specify its code as "10_for_all_products_over_10"
         And I name it "$10 discount for (almost) all products!"
         And I add the "Item percentage discount" action configured with a percentage value of "10%" for "United States" channel
-        And I specify that on "United States" channel this action should be applied to items with price between "$10" and "$100"
+        And I specify that on "United States" channel this action should be applied to items with price between "$10.00" and "$100.00"
         And I add it
         Then I should be notified that it has been successfully created
         And the "$10 discount for (almost) all products!" promotion should appear in the registry

--- a/features/promotion/managing_promotions/adding_promotion_with_rule.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_rule.feature
@@ -24,7 +24,7 @@ Feature: Adding a new promotion with rule
         When I want to create a new promotion
         And I specify its code as "100_MUGS_PROMOTION"
         And I name it "100 Mugs promotion"
-        And I add the "Total price of items from taxon" rule configured with "Mugs" taxon and "$100" amount for "United States" channel
+        And I add the "Total price of items from taxon" rule configured with "Mugs" taxon and "$100.00" amount for "United States" channel
         And I add it
         Then I should be notified that it has been successfully created
         And the "100 Mugs promotion" promotion should appear in the registry

--- a/features/promotion/managing_promotions/adding_promotion_with_rule_in_different_channels.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_rule_in_different_channels.feature
@@ -14,7 +14,7 @@ Feature: Adding a new promotion with rule configured in different channels
         When I want to create a new promotion
         And I specify its code as "100_IN_EVERY_CURRENCY"
         And I name it "100 in every currency"
-        And I add the "Item total" rule configured with "€100" amount for "United States" channel and "£100" amount for "Web-GB" channel
+        And I add the "Item total" rule configured with "€100.00" amount for "United States" channel and "£100.00" amount for "Web-GB" channel
         And I add it
         Then I should be notified that it has been successfully created
         And the "100 in every currency" promotion should appear in the registry

--- a/features/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
+++ b/features/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
@@ -115,7 +115,7 @@ Feature: Receiving discounts with product minimum price specified
         Then I should be on the checkout summary step
         And the "T-Shirt" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "PHP Mug" product should have unit prices discounted by "$4.25" and "$4.25"
-        And the "Symfony Mug" product should have unit price discounted by "$8.5"
+        And the "Symfony Mug" product should have unit price discounted by "$8.50"
 
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified

--- a/features/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
+++ b/features/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
@@ -84,7 +84,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount evenly between different products when one has minimum price specified
-        Given it gives "$25" discount to every order
+        Given it gives "$25.00" discount to every order
         And I add product "T-Shirt" to the cart
         And I add 3 products "PHP Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -95,7 +95,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount evenly between different products when one has minimum price specified
-        Given it gives "$20" discount to every order
+        Given it gives "$20.00" discount to every order
         And I add 2 products "T-Shirt" to the cart
         And I add 3 products "PHP Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -106,7 +106,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified
-        Given it gives "$27" discount to every order
+        Given it gives "$27.00" discount to every order
         And I add 2 products "T-Shirt" to the cart
         And I add 2 products "PHP Mug" to the cart
         And I add product "Symfony Mug" to the cart
@@ -119,7 +119,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified
-        Given it gives "$36" discount to every order
+        Given it gives "$36.00" discount to every order
         And the store has a "Keyboard" configurable product
         And this product has "RGB Keyboard" variant priced at "$20.00"
         And the "RGB Keyboard" variant has minimum price of "$15.00" in the "United States" channel
@@ -139,7 +139,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified
-        Given it gives "$12" discount to every order
+        Given it gives "$12.00" discount to every order
         And the store has a product "Cup" priced at "$10.00"
         And the store has a "Keyboard" configurable product
         And this product has "RGB Keyboard" variant priced at "$20.00"
@@ -164,7 +164,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified
-        Given it gives "$12" discount to every order
+        Given it gives "$12.00" discount to every order
         And the store has a product "Cup" priced at "$10.00"
         And the store has a "Keyboard" configurable product
         And this product has "RGB Keyboard" variant priced at "$20.00"
@@ -189,7 +189,7 @@ Feature: Receiving discounts with product minimum price specified
 
     @api
     Scenario: Distributing more than allowed discount proportionally between different products when one has minimum price specified
-        Given it gives "$20" discount to every order
+        Given it gives "$20.00" discount to every order
         And the store has a product "Cup" priced at "$10.00"
         And the store has a "Keyboard" configurable product
         And this product has "RGB Keyboard" variant priced at "$20.00"
@@ -215,7 +215,7 @@ Feature: Receiving discounts with product minimum price specified
     @api
     Scenario: Distributing discount proportionally between different products when one has minimum price specified and promotion does not apply on discounted products
         Given this promotion does not apply on discounted products
-        And it gives "$27" discount to every order
+        And it gives "$27.00" discount to every order
         And there is a catalog promotion "Fixed T-Shirt sale" that reduces price by fixed "$2.50" in the "United States" channel and applies on "PHP Mug" product
         And I add 2 products "T-Shirt" to the cart
         And I add 2 products "PHP Mug" to the cart

--- a/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
@@ -28,7 +28,7 @@ Feature: Receiving percentage discount promotion on order
 
     @ui @api
     Scenario: Receiving percentage discount is correct for two items with different price
-        Given the store has a product "Vintage Watch" priced at "$1000.00"
+        Given the store has a product "Vintage Watch" priced at "$1,000.00"
         When I add product "PHP T-Shirt" to the cart
         And I add product "Vintage Watch" to the cart
         Then my cart total should be "$880.00"

--- a/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
+++ b/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
@@ -11,7 +11,7 @@ Feature: Receiving stacked promotion with changing context
         And there is a promotion "Holiday promotion" with priority 1
         And it gives "50%" discount to every order
         And there is a promotion "Free shiping over" with priority 0
-        And it gives free shipping to every order over "$100"
+        And it gives free shipping to every order over "$100.00"
 
     @ui @api
     Scenario: Receiving only the "Holiday promotion"

--- a/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
+++ b/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
@@ -8,9 +8,9 @@ Feature: Seeing estimated shipping costs based on items total
         Given the store operates on a single channel in "United States"
         And the store has a product "Cheap Jacket" priced at "$20.00"
         And the store has a product "Expensive Jacket" priced at "$30.00"
-        And the store has "Above $30" shipping method with "$1" fee
-        And this shipping method is only available for orders over or equal to "$30"
-        And the store has "Below $29.99" shipping method with "$10" fee
+        And the store has "Above $30" shipping method with "$1.00" fee
+        And this shipping method is only available for orders over or equal to "$30.00"
+        And the store has "Below $29.99" shipping method with "$10.00" fee
         And this shipping method is only available for orders under or equal to "$29.99"
         And I am a logged in customer
 

--- a/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
+++ b/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
@@ -6,7 +6,7 @@ Feature: Seeing estimated shipping costs based on total weight
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Jacket for the Lochness Monster" priced at "$1337.00"
+        And the store has a product "Jacket for the Lochness Monster" priced at "$1,337.00"
         And this product's weight is 200
         And the store has a product "T-Shirt for Tinkerbell" priced at "$1.00"
         And this product's weight is 0.1

--- a/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
+++ b/features/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
@@ -10,9 +10,9 @@ Feature: Seeing estimated shipping costs based on total weight
         And this product's weight is 200
         And the store has a product "T-Shirt for Tinkerbell" priced at "$1.00"
         And this product's weight is 0.1
-        And the store has "Heavy Duty Courier" shipping method with "$200" fee
+        And the store has "Heavy Duty Courier" shipping method with "$200.00" fee
         And this shipping method is only available for orders with a total weight greater or equal to 100.0
-        And the store has "Fairytale Delivery Service" shipping method with "$2" fee
+        And the store has "Fairytale Delivery Service" shipping method with "$2.00" fee
         And this shipping method is only available for orders with a total weight less or equal to 1.0
         And I am a logged in customer
 

--- a/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total.feature
+++ b/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total.feature
@@ -8,11 +8,11 @@ Feature: Viewing available shipping methods based on items total
         Given the store operates on a single channel in "United States"
         And the store has a product "Cheap Jacket" priced at "$20.00"
         And the store has a product "Expensive Jacket" priced at "$50.00"
-        And the store has "Above $50" shipping method with "$1" fee
-        And this shipping method is only available for orders over or equal to "$50"
-        And the store has "Below $29.99" shipping method with "$10" fee
+        And the store has "Above $50" shipping method with "$1.00" fee
+        And this shipping method is only available for orders over or equal to "$50.00"
+        And the store has "Below $29.99" shipping method with "$10.00" fee
         And this shipping method is only available for orders under or equal to "$29.99"
-        And the store has "DHL" shipping method with "$20" fee
+        And the store has "DHL" shipping method with "$20.00" fee
         And I am a logged in customer
 
     @ui @api

--- a/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total_with_taxes_and_promotions.feature
+++ b/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total_with_taxes_and_promotions.feature
@@ -12,13 +12,13 @@ Feature: Viewing available shipping methods based on items total
         And it belongs to "Clothes" tax category
         And the store has a product "Expensive Jacket" priced at "$47.00"
         And it belongs to "Clothes" tax category
-        And the store has "Above $50" shipping method with "$1" fee within the "US" zone
+        And the store has "Above $50" shipping method with "$1.00" fee within the "US" zone
         And shipping method "Above $50" belongs to "Shipping Services" tax category
-        And this shipping method is only available for orders over or equal to "$50"
-        And the store has "Below $29.99" shipping method with "$20" fee within the "US" zone
+        And this shipping method is only available for orders over or equal to "$50.00"
+        And the store has "Below $29.99" shipping method with "$20.00" fee within the "US" zone
         And shipping method "Below $29.99" belongs to "Shipping Services" tax category
         And this shipping method is only available for orders under or equal to "$29.99"
-        And the store has "DHL" shipping method with "$20" fee
+        And the store has "DHL" shipping method with "$20.00" fee
         And there is a promotion "50% shipping discount"
         And it gives "50%" discount on shipping to every order
         And there is a promotion "Expensive promotion"

--- a/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
+++ b/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
@@ -6,7 +6,7 @@ Feature: Viewing available shipping methods based on total weight
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Jacket for the Lochness Monster" priced at "$1337.00"
+        And the store has a product "Jacket for the Lochness Monster" priced at "$1,337.00"
         And this product's weight is 200
         And the store has a product "T-Shirt for Tinkerbell" priced at "$1.00"
         And this product's weight is 0.1

--- a/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
+++ b/features/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
@@ -10,10 +10,10 @@ Feature: Viewing available shipping methods based on total weight
         And this product's weight is 200
         And the store has a product "T-Shirt for Tinkerbell" priced at "$1.00"
         And this product's weight is 0.1
-        And the store has "DHL" shipping method with "$20" fee
-        And the store has "Heavy Duty Courier" shipping method with "$150" fee
+        And the store has "DHL" shipping method with "$20.00" fee
+        And the store has "Heavy Duty Courier" shipping method with "$150.00" fee
         And this shipping method is only available for orders with a total weight greater or equal to 100.0
-        And the store has "Fairytale Delivery Service" shipping method with "$2" fee
+        And the store has "Fairytale Delivery Service" shipping method with "$2.00" fee
         And this shipping method is only available for orders with a total weight less or equal to 1.0
         And I am a logged in customer
 

--- a/features/shipping/managing_shipping_methods/seeing_errors_in_shipping_method_charges.feature
+++ b/features/shipping/managing_shipping_methods/seeing_errors_in_shipping_method_charges.feature
@@ -13,7 +13,7 @@ Feature: Seeing errors in shipping method charges
 
     @ui @no-api
     Scenario: Seeing the number of errors with per shipment charges
-        Given the store has "FedEx Carrier" shipping method with "$20" fee per shipment for "Web" channel and "$15" for "Mobile" channel
+        Given the store has "FedEx Carrier" shipping method with "$20.00" fee per shipment for "Web" channel and "$15.00" for "Mobile" channel
         When I want to modify this shipping method
         And I remove the shipping charges of "Mobile" channel
         And I try to save my changes
@@ -21,7 +21,7 @@ Feature: Seeing errors in shipping method charges
 
     @ui @no-api
     Scenario: Seeing the number of errors with per unit charges
-        Given the store has "FedEx Carrier" shipping method with "$20" fee per unit for "Web" channel and "$15" for "Mobile" channel
+        Given the store has "FedEx Carrier" shipping method with "$20.00" fee per unit for "Web" channel and "$15.00" for "Mobile" channel
         When I want to modify this shipping method
         And I remove the shipping charges of "Mobile" channel
         And I try to save my changes

--- a/features/user/managing_customers/seeing_orders_statistics_on_customer_details_page.feature
+++ b/features/user/managing_customers/seeing_orders_statistics_on_customer_details_page.feature
@@ -8,7 +8,7 @@ Feature: Seeing customer's orders' statistics
         Given the store operates on a channel named "Web-US" in "USD" currency
         And the store also operates on another channel named "Web-UK" in "GBP" currency
         And the store has a product "Onion" priced at "$200.00" in "Web-US" channel
-        And this product is also priced at "£100" in "Web-UK" channel
+        And this product is also priced at "£100.00" in "Web-UK" channel
         And the store has customer "lirael.clayr@abhorsen.ok"
         And I am logged in as an administrator
 

--- a/features/user/managing_customers/seeing_orders_statistics_on_customer_details_page.feature
+++ b/features/user/managing_customers/seeing_orders_statistics_on_customer_details_page.feature
@@ -7,7 +7,7 @@ Feature: Seeing customer's orders' statistics
     Background:
         Given the store operates on a channel named "Web-US" in "USD" currency
         And the store also operates on another channel named "Web-UK" in "GBP" currency
-        And the store has a product "Onion" priced at "$200" in "Web-US" channel
+        And the store has a product "Onion" priced at "$200.00" in "Web-US" channel
         And this product is also priced at "£100" in "Web-UK" channel
         And the store has customer "lirael.clayr@abhorsen.ok"
         And I am logged in as an administrator

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -106,7 +106,7 @@ final class OrderContext implements Context
         AddressInterface $address,
         ShippingMethodInterface $shippingMethod,
         PaymentMethodInterface $paymentMethod,
-    ) {
+    ): void {
         $this->placeOrder($product, $shippingMethod, $address, $paymentMethod, $customer, 1);
         $this->objectManager->flush();
     }
@@ -120,7 +120,7 @@ final class OrderContext implements Context
         AddressInterface $address,
         ShippingMethodInterface $shippingMethod,
         PaymentMethodInterface $paymentMethod,
-    ) {
+    ): void {
         $customer = $this->createCustomer($email);
 
         $this->customerRepository->add($customer);
@@ -138,7 +138,7 @@ final class OrderContext implements Context
         AddressInterface $address,
         ShippingMethodInterface $shippingMethod,
         PaymentMethodInterface $paymentMethod,
-    ) {
+    ): void {
         $customer = $this->createCustomer($email);
 
         $this->customerRepository->add($customer);
@@ -152,7 +152,7 @@ final class OrderContext implements Context
     /**
      * @Given a customer :customer added something to cart
      */
-    public function customerStartedCheckout(CustomerInterface $customer)
+    public function customerStartedCheckout(CustomerInterface $customer): void
     {
         $cart = $this->createCart($customer);
 
@@ -182,7 +182,7 @@ final class OrderContext implements Context
     /**
      * @Given /^(I) placed (an order "[^"]+")$/
      */
-    public function iPlacedAnOrder(ShopUserInterface $user, $orderNumber)
+    public function iPlacedAnOrder(ShopUserInterface $user, $orderNumber): void
     {
         $customer = $user->getCustomer();
         $order = $this->createOrder($customer, $orderNumber);
@@ -196,7 +196,7 @@ final class OrderContext implements Context
      * @Given /^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/
      * @Given /^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/
      */
-    public function theCustomerAddressedItTo(AddressInterface $address)
+    public function theCustomerAddressedItTo(AddressInterface $address): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -208,7 +208,7 @@ final class OrderContext implements Context
     /**
      * @Given the customer changed shipping address' street to :street
      */
-    public function theCustomerChangedShippingAddressStreetTo($street)
+    public function theCustomerChangedShippingAddressStreetTo(string $street): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -226,7 +226,7 @@ final class OrderContext implements Context
      * @Given /^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "[^"]+", "[^"]+")$/
      * @Given /^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "([^"]+)", "[^"]+", "[^"]+")$/
      */
-    public function forTheBillingAddressOf(AddressInterface $address)
+    public function forTheBillingAddressOf(AddressInterface $address): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -242,7 +242,7 @@ final class OrderContext implements Context
      * @Given /^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/
      * @Given /^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/
      */
-    public function theCustomerAddressedItToWithIdenticalBillingAddress(AddressInterface $address)
+    public function theCustomerAddressedItToWithIdenticalBillingAddress(AddressInterface $address): void
     {
         $this->theCustomerAddressedItTo($address);
         $this->forTheBillingAddressOf(clone $address);
@@ -306,7 +306,7 @@ final class OrderContext implements Context
     /**
      * @Given /^the customer chose ("[^"]+" shipping method)$/
      */
-    public function theCustomerChoseShippingMethod(ShippingMethodInterface $shippingMethod)
+    public function theCustomerChoseShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -327,7 +327,7 @@ final class OrderContext implements Context
     /**
      * @Given /^the customer chose ("[^"]+" payment)$/
      */
-    public function theCustomerChosePayment(PaymentMethodInterface $paymentMethod)
+    public function theCustomerChosePayment(PaymentMethodInterface $paymentMethod): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -346,7 +346,7 @@ final class OrderContext implements Context
      * @Given the customer bought a single :product
      * @Given I bought a single :product
      */
-    public function theCustomerBoughtSingleProduct(ProductInterface $product, ?ChannelInterface $channel = null)
+    public function theCustomerBoughtSingleProduct(ProductInterface $product, ?ChannelInterface $channel = null): void
     {
         $this->addProductVariantToOrder($this->variantResolver->getVariant($product), 1, $channel);
 
@@ -378,7 +378,7 @@ final class OrderContext implements Context
      * @Given /^the customer bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/
      * @Given /^I bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/
      */
-    public function theCustomerBoughtProductAndProduct(ProductInterface $product, ProductInterface $secondProduct)
+    public function theCustomerBoughtProductAndProduct(ProductInterface $product, ProductInterface $secondProduct): void
     {
         $this->theCustomerBoughtSingleProduct($product);
         $this->theCustomerBoughtSingleProduct($secondProduct);
@@ -387,7 +387,7 @@ final class OrderContext implements Context
     /**
      * @Given /^the customer bought (\d+) ("[^"]+" products)$/
      */
-    public function theCustomerBoughtSeveralProducts($quantity, ProductInterface $product)
+    public function theCustomerBoughtSeveralProducts(int $quantity, ProductInterface $product): void
     {
         $variant = $this->variantResolver->getVariant($product);
         $this->addProductVariantToOrder($variant, $quantity);
@@ -398,7 +398,7 @@ final class OrderContext implements Context
     /**
      * @Given /^the customer bought ([^"]+) units of ("[^"]+" variant of product "[^"]+")$/
      */
-    public function theCustomerBoughtSeveralVariantsOfProduct($quantity, ProductVariantInterface $variant)
+    public function theCustomerBoughtSeveralVariantsOfProduct(int $quantity, ProductVariantInterface $variant): void
     {
         $this->addProductVariantToOrder($variant, $quantity);
 
@@ -409,7 +409,7 @@ final class OrderContext implements Context
      * @Given /^the customer bought a single ("[^"]+" variant of product "[^"]+")$/
      * @Given /^the customer also bought a ("[^"]+" variant of product "[^"]+")$/
      */
-    public function theCustomerBoughtSingleProductVariant(ProductVariantInterface $productVariant)
+    public function theCustomerBoughtSingleProductVariant(ProductVariantInterface $productVariant): void
     {
         $this->addProductVariantToOrder($productVariant);
 
@@ -420,7 +420,7 @@ final class OrderContext implements Context
      * @Given the customer bought a single :product using :coupon coupon
      * @Given I bought a single :product using :coupon coupon
      */
-    public function theCustomerBoughtSingleUsing(ProductInterface $product, PromotionCouponInterface $coupon)
+    public function theCustomerBoughtSingleUsing(ProductInterface $product, PromotionCouponInterface $coupon): void
     {
         $order = $this->addProductVariantToOrder($this->variantResolver->getVariant($product));
         $order->setPromotionCoupon($coupon);
@@ -431,7 +431,7 @@ final class OrderContext implements Context
     /**
      * @Given I used :coupon coupon
      */
-    public function iUsedCoupon(PromotionCouponInterface $coupon)
+    public function iUsedCoupon(PromotionCouponInterface $coupon): void
     {
         $order = $this->sharedStorage->get('order');
         $order->setPromotionCoupon($coupon);
@@ -499,7 +499,7 @@ final class OrderContext implements Context
     /**
      * @Given /^(this customer) has(?:| also) placed (an order "[^"]+") at "([^"]+)"$/
      */
-    public function thisCustomerHasPlacedAnOrderAtDate(CustomerInterface $customer, $number, $checkoutCompletedAt)
+    public function thisCustomerHasPlacedAnOrderAtDate(CustomerInterface $customer, $number, $checkoutCompletedAt): void
     {
         $order = $this->createOrder($customer, $number);
         $order->setCheckoutCompletedAt(new \DateTime($checkoutCompletedAt));
@@ -511,7 +511,7 @@ final class OrderContext implements Context
     /**
      * @Given /^(this customer) has(?:| also) placed (an order "[^"]+") on a (channel "[^"]+")$/
      */
-    public function thisCustomerHasPlacedAnOrderOnAChannel(CustomerInterface $customer, $number, $channel)
+    public function thisCustomerHasPlacedAnOrderOnAChannel(CustomerInterface $customer, $number, $channel): void
     {
         $order = $this->createOrder($customer, $number, $channel);
         $order->setState(OrderInterface::STATE_NEW);
@@ -523,7 +523,7 @@ final class OrderContext implements Context
     /**
      * @Given /^(this customer) has(?:| also) started checkout on a (channel "[^"]+")$/
      */
-    public function thisCustomerHasStartedCheckoutOnAChannel(CustomerInterface $customer, $channel)
+    public function thisCustomerHasStartedCheckoutOnAChannel(CustomerInterface $customer, $channel): void
     {
         $order = $this->createOrder($customer, null, $channel);
 
@@ -558,14 +558,13 @@ final class OrderContext implements Context
     }
 
     /**
-     * @Given :numberOfCustomers customers have added products to the cart for total of :total
+     * @Given /^(\d+) customers have added products to the cart for total of ("[^"]+")$/
      */
-    public function customersHaveAddedProductsToTheCartForTotalOf($numberOfCustomers, $total)
+    public function customersHaveAddedProductsToTheCartForTotalOf(int $numberOfCustomers, int $total): void
     {
         $customers = $this->generateCustomers($numberOfCustomers);
 
         $sampleProductVariant = $this->sharedStorage->get('variant');
-        $total = $this->getPriceFromString($total);
 
         for ($i = 0; $i < $numberOfCustomers; ++$i) {
             $order = $this->createCart($customers[random_int(0, $numberOfCustomers - 1)]);
@@ -582,62 +581,63 @@ final class OrderContext implements Context
     }
 
     /**
-     * @Given a single customer has placed an order for total of :total
-     * @Given :numberOfCustomers customers have placed :numberOfOrders orders for total of :total
-     * @Given then :numberOfCustomers more customers have placed :numberOfOrders orders for total of :total
+     * @Given /^a single customer has placed an order for total of ("[^"]+")$/
      */
-    public function customersHavePlacedOrdersForTotalOf(
-        string $total,
-        int $numberOfCustomers = 1,
-        int $numberOfOrders = 1,
-    ): void {
+    public function aSingleCustomerHasPlacedAnOrderForTotalOf(int $total): void
+    {
+        $this->createOrders(numberOfCustomers: 1, numberOfOrders: 1, total: $total);
+    }
+
+    /**
+     * @Given /^(\d+) (?:|more )customers have placed (\d+) orders for total of ("[^"]+")$/
+     */
+    public function customersHavePlacedOrdersForTotalOf(int $numberOfCustomers, int $numberOfOrders, int $total): void
+    {
         $this->createOrders($numberOfCustomers, $numberOfOrders, $total);
     }
 
     /**
-     * @Given :numberOfCustomers customers have fulfilled :numberOfOrders orders placed for total of :total
-     * @Given then :numberOfCustomers more customers have fulfilled :numberOfOrders orders placed for total of :total
+     * @Given /^(\d+) customers have fulfilled (\d+) orders placed for total of ("[^"]+")$/
      */
     public function customersHaveFulfilledOrdersPlacedForTotalOf(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
     ): void {
         $this->createOrders($numberOfCustomers, $numberOfOrders, $total, true);
     }
 
     /**
-     * @Given :numberOfCustomers customers have placed :numberOfOrders orders for total of :total mostly :product product
-     * @Given then :numberOfCustomers more customers have placed :numberOfOrders orders for total of :total mostly :product product
+     * @Given /^(\d+) (?:|more )customers have placed (\d+) orders for total of ("[^"]+") mostly ("[^"]+" product)$/
      */
     public function customersHavePlacedOrdersForTotalOfMostlyProduct(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
         ProductInterface $product,
     ): void {
         $this->createOrdersWithProduct($numberOfCustomers, $numberOfOrders, $total, $product);
     }
 
     /**
-     * @Given (then) :numberOfCustomers (more) customers have fulfilled :numberOfOrders orders placed for total of :total mostly :product product
+     * @Given /^(\d+) (?:|more )customers have fulfilled (\d+) orders placed for total of ("[^"]+") mostly ("[^"]+" product)$/
      */
     public function customersHaveFulfilledOrdersPlacedForTotalOfMostlyProduct(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
         ProductInterface $product,
     ): void {
         $this->createOrdersWithProduct($numberOfCustomers, $numberOfOrders, $total, $product, true);
     }
 
     /**
-     * @Given (then) :numberOfCustomers (more) customers have paid :numberOfOrders orders placed for total of :total
+     * @Given /^(\d+) (?:|more )customers have paid (\d+) orders placed for total of ("[^"]+")$/
      */
-    public function thenMoreCustomersHavePaidOrdersPlacedForTotalOf(
+    public function moreCustomersHavePaidOrdersPlacedForTotalOf(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
     ): void {
         $this->createPaidOrders($numberOfCustomers, $numberOfOrders, $total);
     }
@@ -665,7 +665,7 @@ final class OrderContext implements Context
      * @Given /^(this order) is already paid$/
      * @Given the order :order is already paid
      */
-    public function thisOrderIsAlreadyPaid(OrderInterface $order)
+    public function thisOrderIsAlreadyPaid(OrderInterface $order): void
     {
         $this->applyPaymentTransitionOnOrder($order, PaymentTransitions::TRANSITION_COMPLETE);
 
@@ -676,7 +676,7 @@ final class OrderContext implements Context
      * @Given /^(this order) has been refunded$/
      * @Given the customer has refunded the order with number :order
      */
-    public function thisOrderHasBeenRefunded(OrderInterface $order)
+    public function thisOrderHasBeenRefunded(OrderInterface $order): void
     {
         $this->applyPaymentTransitionOnOrder($order, PaymentTransitions::TRANSITION_REFUND);
 
@@ -689,7 +689,7 @@ final class OrderContext implements Context
      * @Given the order :order was cancelled
      * @Given /^I cancelled (this order)$/
      */
-    public function theCustomerCancelledThisOrder(OrderInterface $order)
+    public function theCustomerCancelledThisOrder(OrderInterface $order): void
     {
         $this->stateMachineFactory->get($order, OrderTransitions::GRAPH)->apply(OrderTransitions::TRANSITION_CANCEL);
 
@@ -699,7 +699,7 @@ final class OrderContext implements Context
     /**
      * @Given /^I cancelled my last order$/
      */
-    public function theCustomerCancelledMyLastOrder()
+    public function theCustomerCancelledMyLastOrder(): void
     {
         $order = $this->sharedStorage->get('order');
         $this->stateMachineFactory->get($order, OrderTransitions::GRAPH)->apply(OrderTransitions::TRANSITION_CANCEL);
@@ -711,7 +711,7 @@ final class OrderContext implements Context
      * @Given /^(this order) has already been shipped$/
      * @Given the order :order is already shipped
      */
-    public function thisOrderHasAlreadyBeenShipped(OrderInterface $order)
+    public function thisOrderHasAlreadyBeenShipped(OrderInterface $order): void
     {
         $this->applyShipmentTransitionOnOrder($order, ShipmentTransitions::TRANSITION_SHIP);
 
@@ -721,7 +721,7 @@ final class OrderContext implements Context
     /**
      * @When the customer used coupon :coupon
      */
-    public function theCustomerUsedCoupon(PromotionCouponInterface $coupon)
+    public function theCustomerUsedCoupon(PromotionCouponInterface $coupon): void
     {
         /** @var OrderInterface $order */
         $order = $this->sharedStorage->get('order');
@@ -926,17 +926,12 @@ final class OrderContext implements Context
         return $customers;
     }
 
-    private function getPriceFromString(string $price): int
-    {
-        return (int) round((float) str_replace(['€', '£', '$'], '', $price) * 100, 2);
-    }
-
     private function checkoutUsing(
         OrderInterface $order,
         ShippingMethodInterface $shippingMethod,
         AddressInterface $address,
         PaymentMethodInterface $paymentMethod,
-    ) {
+    ): void {
         $order->setShippingAddress($address);
         $order->setBillingAddress(clone $address);
 
@@ -946,7 +941,7 @@ final class OrderContext implements Context
         $this->completeCheckout($order);
     }
 
-    private function completeCheckout(OrderInterface $order)
+    private function completeCheckout(OrderInterface $order): void
     {
         $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_COMPLETE);
     }
@@ -973,8 +968,11 @@ final class OrderContext implements Context
         $this->theCustomerChoseShippingWithPayment($shippingMethod, $paymentMethod);
     }
 
-    private function proceedSelectingShippingAndPaymentMethod(OrderInterface $order, ShippingMethodInterface $shippingMethod, PaymentMethodInterface $paymentMethod)
-    {
+    private function proceedSelectingShippingAndPaymentMethod(
+        OrderInterface $order,
+        ShippingMethodInterface $shippingMethod,
+        PaymentMethodInterface $paymentMethod,
+    ): void {
         foreach ($order->getShipments() as $shipment) {
             $shipment->setMethod($shippingMethod);
         }
@@ -986,10 +984,7 @@ final class OrderContext implements Context
         $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
     }
 
-    /**
-     * @param int $price
-     */
-    private function addVariantWithPriceToOrder(OrderInterface $order, ProductVariantInterface $variant, $price)
+    private function addVariantWithPriceToOrder(OrderInterface $order, ProductVariantInterface $variant, int $price): void
     {
         /** @var OrderItemInterface $item */
         $item = $this->orderItemFactory->createNew();
@@ -1004,12 +999,11 @@ final class OrderContext implements Context
     private function createOrders(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
         bool $isFulfilled = false,
     ): void {
         $customers = $this->generateCustomers($numberOfCustomers);
         $sampleProductVariant = $this->sharedStorage->get('variant');
-        $total = $this->getPriceFromString($total);
 
         for ($i = 0; $i < $numberOfOrders; ++$i) {
             $order = $this->createOrder($customers[random_int(0, $numberOfCustomers - 1)], '#' . uniqid());
@@ -1033,11 +1027,10 @@ final class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    private function createPaidOrders(int $numberOfCustomers, int $numberOfOrders, string $total): void
+    private function createPaidOrders(int $numberOfCustomers, int $numberOfOrders, int $total): void
     {
         $customers = $this->generateCustomers($numberOfCustomers);
         $sampleProductVariant = $this->sharedStorage->get('variant');
-        $total = $this->getPriceFromString($total);
 
         for ($i = 0; $i < $numberOfOrders; ++$i) {
             $order = $this->createOrder($customers[random_int(0, $numberOfCustomers - 1)], '#' . uniqid());
@@ -1061,13 +1054,12 @@ final class OrderContext implements Context
     private function createOrdersWithProduct(
         int $numberOfCustomers,
         int $numberOfOrders,
-        string $total,
+        int $total,
         ProductInterface $product,
         bool $isFulfilled = false,
     ): void {
         $customers = $this->generateCustomers($numberOfCustomers);
         $sampleProductVariant = $product->getVariants()->first();
-        $total = $this->getPriceFromString($total);
 
         for ($i = 0; $i < $numberOfOrders; ++$i) {
             $order = $this->createOrder($customers[random_int(0, $numberOfCustomers - 1)], '#' . uniqid(), $product->getChannels()->first());
@@ -1105,7 +1097,7 @@ final class OrderContext implements Context
                 $order,
                 $channel,
                 $this->variantResolver->getVariant($product),
-                (int) $productCount,
+                $productCount,
             );
 
             $order->setState($isFulfilled ? OrderInterface::STATE_FULFILLED : OrderInterface::STATE_NEW);
@@ -1116,6 +1108,7 @@ final class OrderContext implements Context
         $this->objectManager->flush();
     }
 
+    /** @return array<array-key, string> */
     private function getTargetPaymentTransitions(string $state): array
     {
         $state = strtolower($state);

--- a/src/Sylius/Behat/Context/Transform/LexicalContext.php
+++ b/src/Sylius/Behat/Context/Transform/LexicalContext.php
@@ -18,8 +18,7 @@ use Behat\Behat\Context\Context;
 final class LexicalContext implements Context
 {
     /**
-     * @Transform /^"(\-)?(?:€|£|￥|\$)([^"]+)"$/
-     * @Transform /^"(\-)?(?:€|£|￥|\$)([^"]+\.[^"]+)"$/
+     * @Transform /^"(\-)?(?:€|£|￥|\$)([0-9,]+(\.[0-9]*)?)"$/
      */
     public function getPriceFromString(string $sign, string $price): int
     {
@@ -52,7 +51,7 @@ final class LexicalContext implements Context
             throw new \InvalidArgumentException('The price string should have exactly 2 decimal digits.');
         }
 
-        if (preg_match('/^\d{4}+\.\d{2}$/', $price)) {
+        if (!preg_match('/^\d{1,3}(,\d{3})*\.\d{2}$/', $price)) {
             throw new \InvalidArgumentException('Thousands and larger numbers should be separated by commas.');
         }
     }

--- a/src/Sylius/Behat/Context/Transform/LexicalContext.php
+++ b/src/Sylius/Behat/Context/Transform/LexicalContext.php
@@ -18,12 +18,14 @@ use Behat\Behat\Context\Context;
 final class LexicalContext implements Context
 {
     /**
-     * @Transform /^"(\-)?(?:€|£|￥|\$)((?:\d+\.)?\d+)"$/
+     * @Transform /^"(\-)?(?:€|£|￥|\$)([^"]+)"$/
+     * @Transform /^"(\-)?(?:€|£|￥|\$)([^"]+\.[^"]+)"$/
      */
     public function getPriceFromString(string $sign, string $price): int
     {
         $this->validatePriceString($price);
 
+        $price = str_replace(',', '', $price);
         $price = (int) round((float) $price * 100, 2);
 
         if ('-' === $sign) {
@@ -46,8 +48,12 @@ final class LexicalContext implements Context
      */
     private function validatePriceString(string $price): void
     {
-        if (!(bool) preg_match('/^\d+(?:\.\d{1,2})?$/', $price)) {
-            throw new \InvalidArgumentException('Price string should not have more than 2 decimal digits.');
+        if (!preg_match('/^.*\.\d{2}$/', $price)) {
+            throw new \InvalidArgumentException('The price string should have exactly 2 decimal digits.');
+        }
+
+        if (preg_match('/^\d{4}+\.\d{2}$/', $price)) {
+            throw new \InvalidArgumentException('Thousands and larger numbers should be separated by commas.');
         }
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
@@ -147,7 +147,7 @@ final class CheckoutCompleteContext implements Context
     }
 
     /**
-     * @Then /^the ("[^"]+" product) should have unit price discounted by ("\$\d+")$/
+     * @Then /^the ("[^"]+" product) should have unit price discounted by ("[^"]+")$/
      */
     public function theShouldHaveUnitPriceDiscountedFor(ProductInterface $product, int $amount): void
     {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

Purpose:
There were inconsistencies in Behat scenarios regarding the way we described money values. For example, we mixed the use of commas in thousand values, some prices had two decimal values, some only had one, and some didn't have any.

In the OrderContext, we had a small utility function called `getPriceFromString` that was parsing the string value into money. This was quite redundant as we have `LexicalContext` responsible for parsing prices.

Goal:
This proposal introduces a unified way of describing currency values.
The output goals:
- Always use two decimal digits
- Use commas for thousands and larger numbers (this is US convention, but since we mostly use `$` in our scenarios I think we can agree on that)
- Type numeric values as `int` for the `setup` context
- Type numeric values as `int` for the API contexts and operate directly on correctly formatted integer values
- Type numeric values as `string` for the UI context for convenient comparison with string values from gherkin scenarios and UI elements.
