### PR TITLE
Remove redundant denormalization check

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
@@ -23,8 +23,6 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 /** @experimental */
 final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 {
-    private const OBJECT_TO_POPULATE = 'object_to_populate';
-
     public function __construct(private DenormalizerInterface $itemNormalizer)
     {
     }
@@ -36,10 +34,6 @@ final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 
     public function denormalize($data, $type, $format = null, array $context = [])
     {
-        if (isset($context[self::OBJECT_TO_POPULATE])) {
-            return $this->itemNormalizer->denormalize($data, $type, $format, $context);
-        }
-
         try {
             return $this->itemNormalizer->denormalize($data, $type, $format, $context);
         } catch (UnexpectedValueException $exception) {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fix #15568
| License         | MIT

This PR fixes a bug found by @GSadee while the QA check. Subresource-like endpoints have had populated the `object to populate` key, so they've been processed as usual. This PR applies our custom validation rules always when the `input` class is defined.
![CleanShot 2023-12-04 at 16 57 32](https://github.com/Sylius/Sylius/assets/80641364/a3cc7e11-c629-4344-bdbd-da7f41f818f5)
 