### PR TITLE
Use serialized name when displaying an error about a wrong request field type

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -34,6 +34,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\Serializer\CommandDenormalizer">
             <argument type="service" id="api_platform.serializer.normalizer.item" />
+            <argument type="service" id="api_platform.name_converter" />
             <tag name="serializer.normalizer" />
         </service>
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
@@ -19,14 +19,15 @@ use Sylius\Bundle\ApiBundle\Exception\InvalidRequestArgumentException;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class CommandDenormalizerSpec extends ObjectBehavior
 {
-    function let(DenormalizerInterface $baseNormalizer): void
+    function let(DenormalizerInterface $baseNormalizer, AdvancedNameConverterInterface $nameConverter): void
     {
-        $this->beConstructedWith($baseNormalizer);
+        $this->beConstructedWith($baseNormalizer, $nameConverter);
     }
 
     function it_throws_exception_if_not_all_required_parameters_are_present_in_the_context(
@@ -46,7 +47,9 @@ final class CommandDenormalizerSpec extends ObjectBehavior
 
     function it_throws_exception_for_mismatched_argument_type(
         DenormalizerInterface $baseNormalizer,
+        AdvancedNameConverterInterface $nameConverter,
     ): void {
+        $nameConverter->normalize('firstName', class: RegisterShopUser::class)->willReturn('first_name');
         $previousException = NotNormalizableValueException::createForUnexpectedDataType('Not normalizable value', 1, ['string'], 'firstName');
         $exception = new UnexpectedValueException('Unexpected value', 400, $previousException);
         $context = ['input' => ['class' => RegisterShopUser::class]];
@@ -55,7 +58,7 @@ final class CommandDenormalizerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(new InvalidRequestArgumentException(
-                'Request field "firstName" should be of type "string".',
+                'Request field "first_name" should be of type "string".',
             ))
             ->during('denormalize', [$data, '', null, $context]);
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | improvement after #15568
| License         | MIT
