### PR TITLE
Fix CI

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/spec/Storage/CartSessionStorageSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Storage/CartSessionStorageSpec.php
@@ -97,7 +97,7 @@ final class CartSessionStorageSpec extends ObjectBehavior
         $channel->getCode()->willReturn('channel_code');
 
         $requestStack->getSession()->willReturn($session);
-        $session->remove('session_key_name.channel_code')->shouldBeCalled();
+        $session->remove('session_key_name.channel_code')->willReturn(null)->shouldBeCalled();
 
         $this->removeForChannel($channel);
     }

--- a/src/Sylius/Bundle/OrderBundle/spec/Context/SessionBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Context/SessionBasedCartContextSpec.php
@@ -59,7 +59,7 @@ final class SessionBasedCartContextSpec extends ObjectBehavior
         $session->get('session_key_name')->willReturn(12345);
         $orderRepository->findCartById(12345)->willReturn(null);
 
-        $session->remove('session_key_name')->shouldBeCalled();
+        $session->remove('session_key_name')->willReturn(null)->shouldBeCalled();
 
         $this->shouldThrow(CartNotFoundException::class)->during('getCart');
     }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

In some patch version, Symfony updated the return type for one of the methods to `mixed`. PHPSpec doesn't support this return type, so I had to return `anything` manually.