### PR TITLE
Improve error handling while sending malformed amount value in the tax rate api resource update operation

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -77,6 +77,7 @@ api_platform:
         Symfony\Component\Serializer\Exception\UnexpectedValueException: 400
         Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 400
         Sylius\Bundle\ApiBundle\CommandHandler\Checkout\Exception\OrderTotalHasChangedException: 409
+        Sylius\Bundle\ApiBundle\Serializer\Exception\InvalidAmountTypeException: 400
     collection:
         pagination:
             client_items_per_page: true

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Exception/InvalidAmountTypeException.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Exception/InvalidAmountTypeException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Serializer\Exception;
+
+class InvalidAmountTypeException extends \RuntimeException
+{
+    public function __construct (
+        string $message = 'Amount must be a numeric value.',
+        int $code = 0,
+        \Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Serializer/TaxRateDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/TaxRateDenormalizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Serializer;
 
+use Sylius\Bundle\ApiBundle\Serializer\Exception\InvalidAmountTypeException;
 use Sylius\Component\Taxation\Model\TaxRateInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
@@ -40,9 +41,12 @@ final class TaxRateDenormalizer implements ContextAwareDenormalizerInterface, De
         $context[self::ALREADY_CALLED] = true;
 
         $data = (array) $data;
-        if (is_numeric($data['amount'])) {
-            $data['amount'] = (string) $data['amount'];
+
+        if (!is_numeric($data['amount'])) {
+            throw new InvalidAmountTypeException();
         }
+
+        $data['amount'] = (string) $data['amount'];
 
         return $this->denormalizer->denormalize($data, $type, $format, $context);
     }

--- a/tests/Api/Admin/TaxRatesTest.php
+++ b/tests/Api/Admin/TaxRatesTest.php
@@ -147,4 +147,34 @@ final class TaxRatesTest extends JsonApiTestCase
             Response::HTTP_OK,
         );
     }
+
+    /** @test */
+    public function it_returns_an_error_when_trying_to_update_with_a_malformed_amount(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['authentication/api_administrator.yaml', 'tax_rates.yaml']);
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        /** @var TaxRateInterface $taxRate */
+        $taxRate = $fixtures['regular_tax'];
+
+        $this->client->request(
+            method: 'PUT',
+            uri: '/api/v2/admin/tax-rates/' . $taxRate->getCode(),
+            server: $header,
+            content: json_encode([
+                'zone' => '/api/v2/admin/zones/EU',
+                'category' => '/api/v2/admin/tax-categories/TC2',
+                'name' => 'Regular Tax 30%',
+                'amount' => '0.3_test',
+                'includedInPrice' => true,
+                'calculator' => 'default',
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/tax_rate/put_tax_rate_with_malformed_amount_response',
+            Response::HTTP_BAD_REQUEST,
+        );
+    }
 }

--- a/tests/Api/Responses/Expected/admin/tax_rate/put_tax_rate_with_malformed_amount_response.json
+++ b/tests/Api/Responses/Expected/admin/tax_rate/put_tax_rate_with_malformed_amount_response.json
@@ -1,0 +1,6 @@
+{
+    "@context": "\/api\/v2\/contexts\/Error",
+    "@type": "hydra:Error",
+    "hydra:title": "An error occurred",
+    "hydra:description": "Amount must be a numeric value."
+}


### PR DESCRIPTION

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

![CleanShot 2023-12-18 at 10 54 51](https://github.com/Sylius/Sylius/assets/80641364/8878df1a-5028-4273-8edf-2810e06a8222)