### PR TITLE
Improve Product's show page performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         "symfony/asset": "^5.4.21 || ^6.4",
         "symfony/config": "^5.4.21 || ^6.4",
         "symfony/console": "^5.4.21 || ^6.4",
+        "symfony/cache-contracts": "^2.5 || ^3.0",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/deprecation-contracts": "^2.5",
         "symfony/doctrine-bridge": "^5.4.21 || ^6.4",

--- a/src/Sylius/Behat/Context/Hook/CacheContext.php
+++ b/src/Sylius/Behat/Context/Hook/CacheContext.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Hook;
+
+use Behat\Behat\Context\Context;
+use Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CacheContext implements Context
+{
+    public function __construct(private readonly CacheInterface $cache)
+    {
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function purgeCache(): void
+    {
+        $this->cache->delete(CachedLocaleCollectionProvider::LOCALES_CACHE_KEY);
+    }
+}

--- a/src/Sylius/Behat/Context/Hook/CacheContext.php
+++ b/src/Sylius/Behat/Context/Hook/CacheContext.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Hook;
 
 use Behat\Behat\Context\Context;
-use Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class CacheContext implements Context
@@ -28,6 +27,6 @@ final class CacheContext implements Context
      */
     public function purgeCache(): void
     {
-        $this->cache->delete(CachedLocaleCollectionProvider::LOCALES_CACHE_KEY);
+        $this->cache->clear();
     }
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/hook.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/hook.xml
@@ -31,5 +31,9 @@
         <service id="sylius.behat.context.hook.mailer" class="Sylius\Behat\Context\Hook\MailerContext">
             <argument type="service" id="test.mailer_pool"/>
         </service>
+
+        <service id="sylius.behat.context.hook.cache" class="Sylius\Behat\Context\Hook\CacheContext">
+            <argument type="service" id="cache.app" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_products:
             contexts:
+                - sylius.behat.context.hook.cache
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_customers:
             contexts:
+                - sylius.behat.context.hook.cache
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
@@ -39,6 +39,9 @@ sylius_admin_product_update:
             section: admin
             permission: true
             redirect: referer
+            repository:
+                method: findOneByIdHydrated
+                arguments: $id
             template: "@SyliusAdmin/Crud/update.html.twig"
             vars:
                 subheader: sylius.ui.manage_your_product_catalog

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -42,7 +42,7 @@ abstract class AttributeValueType extends AbstractResourceType
         if (null === $this->localeToCodeTransformer) {
             trigger_deprecation(
                 'sylius/attribute-bundle',
-                '1.12',
+                '1.13',
                 'Not passing a "%s" instance as argument 7 to "%s" is deprecated. It will not be possible in Sylius 2.0.',
                 LocaleToCodeTransformer::class,
                 self::class,

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AttributeBundle\Form\Type;
 
+use Sylius\Bundle\LocaleBundle\Form\DataTransformer\LocaleToCodeTransformer;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ResourceToIdentifierTransformer;
 use Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
@@ -20,6 +21,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -35,7 +37,18 @@ abstract class AttributeValueType extends AbstractResourceType
         protected RepositoryInterface $attributeRepository,
         protected RepositoryInterface $localeRepository,
         protected FormTypeRegistryInterface $formTypeRegistry,
+        protected ?DataTransformerInterface $localeToCodeTransformer = null,
     ) {
+        if (null === $this->localeToCodeTransformer) {
+            trigger_deprecation(
+                'sylius/attribute-bundle',
+                '1.12',
+                'Not passing a "%s" instance as argument 7 to "%s" is deprecated. It will not be possible in Sylius 2.0.',
+                LocaleToCodeTransformer::class,
+                self::class,
+            );
+        }
+
         parent::__construct($dataClass, $validationGroups);
     }
 
@@ -78,7 +91,7 @@ abstract class AttributeValueType extends AbstractResourceType
         ;
 
         $builder->get('localeCode')->addModelTransformer(
-            new ReversedTransformer(new ResourceToIdentifierTransformer($this->localeRepository, 'code')),
+            new ReversedTransformer($this->localeToCodeTransformer ?? new ResourceToIdentifierTransformer($this->localeRepository, 'code')),
         );
     }
 

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\ReversedTransformer;
 abstract class AttributeValueType extends AbstractResourceType
 {
     /**
-     * @param DataTransformerInterface<LocaleInterface, string>|null $localeToCodeTransformer
+     * @param DataTransformerInterface<LocaleInterface, string|null>|null $localeToCodeTransformer
      */
     public function __construct(
         string $dataClass,

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -30,6 +31,9 @@ use Symfony\Component\Form\ReversedTransformer;
 
 abstract class AttributeValueType extends AbstractResourceType
 {
+    /**
+     * @param DataTransformerInterface<LocaleInterface, string>|null $localeToCodeTransformer
+     */
     public function __construct(
         string $dataClass,
         array $validationGroups,

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -219,6 +219,31 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         ;
     }
 
+    public function findOneByIdHydrated(mixed $id): ?ProductInterface
+    {
+        $product = $this->createQueryBuilder('o')
+            ->where('o.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+
+        $this->associationHydrator->hydrateAssociations($product, [
+            'images',
+            'options',
+            'options.translations',
+            'variants',
+            'variants.channelPricings',
+            'variants.optionValues',
+            'variants.optionValues.translations',
+            'attributes',
+            'attributes.attribute',
+            'attributes.attribute.translations',
+        ]);
+
+        return $product;
+    }
+
     public function findByTaxon(TaxonInterface $taxon): array
     {
         return $this

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/providers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/providers.xml
@@ -32,7 +32,7 @@
         <service id="Sylius\Component\Core\Provider\ProductVariantsPricesProviderInterface" alias="sylius.provider.product_variants_prices" />
 
         <service id="sylius.translation_locale_provider.admin" class="Sylius\Component\Core\Provider\TranslationLocaleProvider">
-            <argument type="service" id="sylius.repository.locale" />
+            <argument type="service" id="sylius.locale_collection_provider" />
             <argument type="string">%locale%</argument>
         </service>
 

--- a/src/Sylius/Bundle/LocaleBundle/Doctrine/EventListener/LocaleModificationListener.php
+++ b/src/Sylius/Bundle/LocaleBundle/Doctrine/EventListener/LocaleModificationListener.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\LocaleBundle\Doctrine\EventListener;
+
+use Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class LocaleModificationListener
+{
+    public function __construct(private CacheInterface $cache)
+    {
+    }
+
+    public function invalidateCachedLocales(): void
+    {
+        $this->cache->delete(CachedLocaleCollectionProvider::LOCALES_CACHE_KEY);
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/** @phpstan-ignore-next-line */
+final class LocaleToCodeTransformer implements DataTransformerInterface
+{
+    public function __construct(private LocaleCollectionProviderInterface $localesProvider)
+    {
+    }
+
+    public function transform(mixed $value): string
+    {
+        if (!$value instanceof LocaleInterface) {
+            throw new \InvalidArgumentException(
+                sprintf('Value must be instance of %s. Got "%s"',
+                    LocaleInterface::class,
+                    is_object($value) ? get_class($value) : gettype($value)
+                ),
+            );
+        }
+
+        return $value->getCode();
+    }
+
+    public function reverseTransform(mixed $value): ?LocaleInterface
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return $this->getLocaleByCode($value);
+    }
+
+    private function getLocaleByCode(string $localeCode): LocaleInterface
+    {
+        $locales = $this->localesProvider->getAll();
+
+        if (!isset($locales[$localeCode])) {
+            throw new \InvalidArgumentException(sprintf('Locale with code "%s" does not exist.', $localeCode));
+        }
+
+        return $locales[$localeCode];
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
@@ -17,7 +17,6 @@ use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /** @phpstan-ignore-next-line */
 final class LocaleToCodeTransformer implements DataTransformerInterface
@@ -26,10 +25,10 @@ final class LocaleToCodeTransformer implements DataTransformerInterface
     {
     }
 
-    public function transform(mixed $value): string
+    public function transform(mixed $value): ?string
     {
         if (!$value instanceof LocaleInterface) {
-            throw new UnexpectedTypeException($value, LocaleInterface::class);
+            return null;
         }
 
         return $value->getCode();

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/LocaleToCodeTransformer.php
@@ -16,6 +16,8 @@ namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /** @phpstan-ignore-next-line */
 final class LocaleToCodeTransformer implements DataTransformerInterface
@@ -27,12 +29,7 @@ final class LocaleToCodeTransformer implements DataTransformerInterface
     public function transform(mixed $value): string
     {
         if (!$value instanceof LocaleInterface) {
-            throw new \InvalidArgumentException(
-                sprintf('Value must be instance of %s. Got "%s"',
-                    LocaleInterface::class,
-                    is_object($value) ? get_class($value) : gettype($value)
-                ),
-            );
+            throw new UnexpectedTypeException($value, LocaleInterface::class);
         }
 
         return $value->getCode();
@@ -52,7 +49,7 @@ final class LocaleToCodeTransformer implements DataTransformerInterface
         $locales = $this->localesProvider->getAll();
 
         if (!isset($locales[$localeCode])) {
-            throw new \InvalidArgumentException(sprintf('Locale with code "%s" does not exist.', $localeCode));
+            throw new TransformationFailedException(sprintf('Locale with code "%s" does not exist.', $localeCode));
         }
 
         return $locales[$localeCode];

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -89,5 +89,12 @@
             <argument type="service" id="sylius.resource_registry" />
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
+
+        <service id="Sylius\Bundle\LocaleBundle\Doctrine\EventListener\LocaleModificationListener">
+            <argument type="service" id="cache.app" />
+            <tag name="doctrine.orm.entity_listener" event="postPersist" entity="Sylius\Component\Locale\Model\Locale" method="invalidateCachedLocales" />
+            <tag name="doctrine.orm.entity_listener" event="postUpdate" entity="Sylius\Component\Locale\Model\Locale" method="invalidateCachedLocales" />
+            <tag name="doctrine.orm.entity_listener" event="postRemove" entity="Sylius\Component\Locale\Model\Locale" method="invalidateCachedLocales" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -27,6 +27,10 @@
             <tag name="form.type" />
         </service>
 
+        <service id="sylius.form.data_transformer.locale_to_code" class="Sylius\Bundle\LocaleBundle\Form\DataTransformer\LocaleToCodeTransformer">
+            <argument type="service" id="sylius.locale_collection_provider" />
+        </service>
+
         <service id="sylius.form.type.locale_choice" class="Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType">
             <argument type="service" id="sylius.repository.locale" />
             <tag name="form.type" />
@@ -45,8 +49,17 @@
             <tag name="sylius.context.locale" priority="32" />
         </service>
 
-        <service id="sylius.locale_provider" class="Sylius\Component\Locale\Provider\LocaleProvider">
+        <service id="sylius.locale_collection_provider" class="Sylius\Component\Locale\Provider\LocaleCollectionProvider">
             <argument type="service" id="sylius.repository.locale" />
+        </service>
+
+        <service id="sylius.locale_collection_provider.cached" class="Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider" decorates="sylius.locale_collection_provider">
+            <argument type="service" id=".inner" />
+            <argument type="service" id="cache.app" />
+        </service>
+
+        <service id="sylius.locale_provider" class="Sylius\Component\Locale\Provider\LocaleProvider">
+            <argument type="service" id="sylius.locale_collection_provider" />
             <argument>%sylius_locale.locale%</argument>
         </service>
         <service id="Sylius\Component\Locale\Provider\LocaleProviderInterface" alias="sylius.locale_provider" />

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -29,6 +29,7 @@
         "php": "^8.1",
         "sylius/locale": "^1.13",
         "sylius/resource-bundle": "^1.9",
+        "symfony/cache-contracts": "^2.5 || ^3.0",
         "symfony/framework-bundle": "^5.4.21 || ^6.4",
         "symfony/templating": "^5.4.21 || ^6.4"
     },

--- a/src/Sylius/Bundle/LocaleBundle/spec/Doctrine/EventListener/LocaleModificationListenerSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Doctrine/EventListener/LocaleModificationListenerSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\LocaleBundle\Doctrine\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class LocaleModificationListenerSpec extends ObjectBehavior
+{
+    function let(CacheInterface $cache): void
+    {
+        $this->beConstructedWith($cache);
+    }
+
+    function it_invalidates_cache(CacheInterface $cache): void
+    {
+        $cache->delete('sylius_locales')->shouldBeCalled();
+
+        $this->invalidateCachedLocales();
+    }
+}

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services/form.xml
@@ -121,6 +121,7 @@
             <argument type="service" id="sylius.repository.product_attribute" />
             <argument type="service" id="sylius.repository.locale" />
             <argument type="service" id="sylius.form_registry.attribute_type" />
+            <argument type="service" id="sylius.form.data_transformer.locale_to_code" />
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
+++ b/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
@@ -14,18 +14,22 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Provider;
 
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 
 final class TranslationLocaleProvider implements TranslationLocaleProviderInterface
 {
-    public function __construct(private RepositoryInterface $localeRepository, private string $defaultLocaleCode)
+    /**
+     * @param RepositoryInterface<LocaleInterface>|LocaleCollectionProviderInterface $localeRepository
+     */
+    public function __construct(private RepositoryInterface|LocaleCollectionProviderInterface $localeRepository, private string $defaultLocaleCode)
     {
     }
 
     public function getDefinedLocalesCodes(): array
     {
-        $locales = $this->localeRepository->findAll();
+        $locales = $this->getLocales();
 
         return array_map(
             function (LocaleInterface $locale) {
@@ -33,6 +37,18 @@ final class TranslationLocaleProvider implements TranslationLocaleProviderInterf
             },
             $locales,
         );
+    }
+
+    /**
+     * @return array<LocaleInterface>
+     */
+    private function getLocales(): array
+    {
+        if ($this->localeRepository instanceof LocaleCollectionProviderInterface) {
+            return $this->localeRepository->getAll();
+        }
+
+        return $this->localeRepository->findAll();
     }
 
     public function getDefaultLocaleCode(): string

--- a/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
+++ b/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
@@ -25,6 +25,17 @@ final class TranslationLocaleProvider implements TranslationLocaleProviderInterf
      */
     public function __construct(private RepositoryInterface|LocaleCollectionProviderInterface $localeRepository, private string $defaultLocaleCode)
     {
+        if ($this->localeRepository instanceof RepositoryInterface) {
+            trigger_deprecation(
+                'sylius/core',
+                '1.13',
+                sprintf(
+                    'Passing an instance of "%s" as first argument of "%s" is deprecated. Use an instance of "%s" instead.',
+                    RepositoryInterface::class, self::class,
+                    LocaleCollectionProviderInterface::class,
+                ),
+            );
+        }
     }
 
     public function getDefinedLocalesCodes(): array

--- a/src/Sylius/Component/Locale/Provider/CachedLocaleCollectionProvider.php
+++ b/src/Sylius/Component/Locale/Provider/CachedLocaleCollectionProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Locale\Provider;
+
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedLocaleCollectionProvider implements LocaleCollectionProviderInterface
+{
+    public function __construct(private LocaleCollectionProviderInterface $decorated, private CacheInterface $cache)
+    {
+    }
+
+    public function getAll(): array
+    {
+        return $this->cache->get('sylius_locales', function () {
+            return $this->decorated->getAll();
+        });
+    }
+}

--- a/src/Sylius/Component/Locale/Provider/CachedLocaleCollectionProvider.php
+++ b/src/Sylius/Component/Locale/Provider/CachedLocaleCollectionProvider.php
@@ -17,13 +17,15 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedLocaleCollectionProvider implements LocaleCollectionProviderInterface
 {
+    public const LOCALES_CACHE_KEY = 'sylius_locales';
+
     public function __construct(private LocaleCollectionProviderInterface $decorated, private CacheInterface $cache)
     {
     }
 
     public function getAll(): array
     {
-        return $this->cache->get('sylius_locales', function () {
+        return $this->cache->get(self::LOCALES_CACHE_KEY, function () {
             return $this->decorated->getAll();
         });
     }

--- a/src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Locale\Provider;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class LocaleCollectionProvider implements LocaleCollectionProviderInterface
+{
+    /**
+     * @param RepositoryInterface<LocaleInterface> $localeRepository
+     */
+    public function __construct(private RepositoryInterface $localeRepository)
+    {
+    }
+
+    public function getAll(): array
+    {
+        return $this->localeRepository->findAll();
+    }
+}

--- a/src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php
@@ -27,6 +27,12 @@ final class LocaleCollectionProvider implements LocaleCollectionProviderInterfac
 
     public function getAll(): array
     {
-        return $this->localeRepository->findAll();
+        $locales = [];
+
+        foreach ($this->localeRepository->findAll() as $locale) {
+            $locales[$locale->getCode()] = $locale;
+        }
+
+        return $locales;
     }
 }

--- a/src/Sylius/Component/Locale/Provider/LocaleCollectionProviderInterface.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleCollectionProviderInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\Locale\Model\LocaleInterface;
 interface LocaleCollectionProviderInterface
 {
     /**
-     * @return array<string, LocaleInterface>
+     * @return array<array-key, LocaleInterface>
      */
     public function getAll(): array;
 }

--- a/src/Sylius/Component/Locale/Provider/LocaleCollectionProviderInterface.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleCollectionProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Locale\Provider;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+
+interface LocaleCollectionProviderInterface
+{
+    /**
+     * @return array<string, LocaleInterface>
+     */
+    public function getAll(): array;
+}

--- a/src/Sylius/Component/Locale/Provider/LocaleProvider.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleProvider.php
@@ -23,6 +23,17 @@ final class LocaleProvider implements LocaleProviderInterface
      */
     public function __construct(private RepositoryInterface|LocaleCollectionProviderInterface $localeRepository, private string $defaultLocaleCode)
     {
+        if ($this->localeRepository instanceof RepositoryInterface) {
+            trigger_deprecation(
+                'sylius/locale',
+                '1.13',
+                sprintf(
+                    'Passing an instance of "%s" as first argument of "%s" is deprecated. Use an instance of "%s" instead.',
+                    RepositoryInterface::class, self::class,
+                    LocaleCollectionProviderInterface::class,
+                ),
+            );
+        }
     }
 
     public function getAvailableLocalesCodes(): array

--- a/src/Sylius/Component/Locale/Provider/LocaleProvider.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleProvider.php
@@ -18,13 +18,16 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 final class LocaleProvider implements LocaleProviderInterface
 {
-    public function __construct(private RepositoryInterface $localeRepository, private string $defaultLocaleCode)
+    /**
+     * @param RepositoryInterface<LocaleInterface>|LocaleCollectionProviderInterface $localeRepository
+     */
+    public function __construct(private RepositoryInterface|LocaleCollectionProviderInterface $localeRepository, private string $defaultLocaleCode)
     {
     }
 
     public function getAvailableLocalesCodes(): array
     {
-        $locales = $this->localeRepository->findAll();
+        $locales = $this->getLocales();
 
         return array_map(
             function (LocaleInterface $locale) {
@@ -32,6 +35,18 @@ final class LocaleProvider implements LocaleProviderInterface
             },
             $locales,
         );
+    }
+
+    /**
+     * @return array<string, LocaleInterface>
+     */
+    private function getLocales(): array
+    {
+        if ($this->localeRepository instanceof LocaleCollectionProviderInterface) {
+            return $this->localeRepository->getAll();
+        }
+
+        return $this->localeRepository->findAll();
     }
 
     public function getDefaultLocaleCode(): string

--- a/src/Sylius/Component/Locale/Provider/LocaleProvider.php
+++ b/src/Sylius/Component/Locale/Provider/LocaleProvider.php
@@ -49,7 +49,7 @@ final class LocaleProvider implements LocaleProviderInterface
     }
 
     /**
-     * @return array<string, LocaleInterface>
+     * @return array<array-key, LocaleInterface>
      */
     private function getLocales(): array
     {

--- a/src/Sylius/Component/Locale/spec/Provider/CachedLocaleCollectionProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/CachedLocaleCollectionProviderSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Locale\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+final class CachedLocaleCollectionProviderSpec extends ObjectBehavior
+{
+    function let(LocaleCollectionProviderInterface $decorated, CacheInterface $cache): void
+    {
+        $this->beConstructedWith($decorated, $cache);
+    }
+
+    function it_implements_locale_collection_provider_interface(): void
+    {
+        $this->shouldImplement(LocaleCollectionProviderInterface::class);
+    }
+
+    function it_returns_all_locales_via_cache(
+        LocaleCollectionProviderInterface $decorated,
+        CacheInterface $cache,
+        LocaleInterface $someLocale,
+        LocaleInterface $anotherLocale
+    ): void {
+        $cache->get('sylius_locales', Argument::type('callable'))->will(function ($args) {
+            return $args[1]();
+        });
+        $decorated->getAll()->willReturn([$someLocale, $anotherLocale]);
+
+        $this->getAll()->shouldReturn([$someLocale, $anotherLocale]);
+    }
+}

--- a/src/Sylius/Component/Locale/spec/Provider/CachedLocaleCollectionProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/CachedLocaleCollectionProviderSpec.php
@@ -37,11 +37,14 @@ final class CachedLocaleCollectionProviderSpec extends ObjectBehavior
         LocaleInterface $someLocale,
         LocaleInterface $anotherLocale
     ): void {
+        $someLocale->getCode()->willReturn('en_US');
+        $anotherLocale->getCode()->willReturn('en_GB');
+
         $cache->get('sylius_locales', Argument::type('callable'))->will(function ($args) {
             return $args[1]();
         });
-        $decorated->getAll()->willReturn([$someLocale, $anotherLocale]);
+        $decorated->getAll()->willReturn(['en_US' => $someLocale, 'en_GB' => $anotherLocale]);
 
-        $this->getAll()->shouldReturn([$someLocale, $anotherLocale]);
+        $this->getAll()->shouldReturn(['en_US' => $someLocale, 'en_GB' => $anotherLocale]);
     }
 }

--- a/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
@@ -35,8 +35,10 @@ final class LocaleCollectionProviderSpec extends ObjectBehavior
         LocaleInterface $someLocale,
         LocaleInterface $anotherLocale
     ): void {
+        $someLocale->getCode()->willReturn('en_US');
+        $anotherLocale->getCode()->willReturn('en_GB');
         $localeRepository->findAll()->willReturn([$someLocale, $anotherLocale]);
 
-        $this->getAll()->shouldReturn([$someLocale, $anotherLocale]);
+        $this->getAll()->shouldReturn(['en_US' => $someLocale, 'en_GB' => $anotherLocale]);
     }
 }

--- a/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Locale\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class LocaleCollectionProviderSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $localeRepository): void
+    {
+        $this->beConstructedWith($localeRepository);
+    }
+
+    function it_implements_locale_collection_provider_interface(): void
+    {
+        $this->shouldImplement(LocaleCollectionProviderInterface::class);
+    }
+
+    function it_returns_all_locales(
+        RepositoryInterface $localeRepository,
+        LocaleInterface $someLocale,
+        LocaleInterface $anotherLocale
+    ): void {
+        $localeRepository->findAll()->willReturn([$someLocale, $anotherLocale]);
+
+        $this->getAll()->shouldReturn([$someLocale, $anotherLocale]);
+    }
+}

--- a/src/Sylius/Component/Locale/spec/Provider/LocaleProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/LocaleProviderSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Locale\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
@@ -41,5 +42,16 @@ final class LocaleProviderSpec extends ObjectBehavior
     function it_returns_the_default_locale(): void
     {
         $this->getDefaultLocaleCode()->shouldReturn('pl_PL');
+    }
+
+    function it_returns_all_enabled_locales_via_collection_provider(
+        LocaleCollectionProviderInterface $localeCollectionProvider,
+        LocaleInterface $locale
+    ): void {
+        $this->beConstructedWith($localeCollectionProvider, 'pl_PL');
+        $localeCollectionProvider->getAll()->willReturn([$locale]);
+        $locale->getCode()->willReturn('en_US');
+
+        $this->getAvailableLocalesCodes()->shouldReturn(['en_US']);
     }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | improved #15493
| License         | MIT

`~250` attributes, higher numbers were hanging edit page when the execution limit is set to `30s`.

![CleanShot 2023-12-25 at 12 13 06@2x](https://github.com/Sylius/Sylius/assets/80641364/770ab125-49e6-41a5-9bf3-0924d2403936)

I was wondering against which version this PR should be opened, but I decided it better fits for the `1.13`, as it isn't a bug fix, it's a performance improvement. With so broad definition of bug, we could define almost anything as a bug.

Comparing to the original PR:
- Already present hydration mechanism has been used.
- No need to open anything against Sylius Resource repository, the custom `LocaleToCodeTransformer` has been created (thanks @NoResponseMate for the suggestion).
- Symonfy's cache mechanism has been leveraged.