### PR TITLE
🚧 New autocomplete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,6 +132,7 @@
         "symfony/translation": "^6.3.3",
         "symfony/translation-contracts": "^2.5.2",
         "symfony/twig-bundle": "^6.3.0",
+        "symfony/ux-autocomplete": "^2.13",
         "symfony/ux-live-component": "^2.12",
         "symfony/ux-twig-component": "^2.11.2",
         "symfony/validator": "^6.3.4",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -62,4 +62,5 @@ return [
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
+    Symfony\UX\Autocomplete\AutocompleteBundle::class => ['all' => true],
 ];

--- a/config/routes/ux_autocomplete.yaml
+++ b/config/routes/ux_autocomplete.yaml
@@ -1,0 +1,3 @@
+ux_autocomplete:
+    resource: '@AutocompleteBundle/config/routes.php'
+    prefix: '/autocomplete'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@hotwired/stimulus": "^3.0.0",
     "@semantic-ui-react/css-patch": "^1.1.2",
     "@symfony/stimulus-bridge": "^3.2.0",
+    "@symfony/ux-autocomplete": "file:vendor/symfony/ux-autocomplete/assets",
     "@symfony/webpack-encore": "^3.1.0",
     "eslint": "^8.23.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -29,6 +30,7 @@
     "eslint-plugin-import": "^2.26.0",
     "sass": "^1.54.8",
     "sass-loader": "^13.0.0",
+    "tom-select": "^2.2.2",
     "yargs": "^17.5.1"
   },
   "engines": {

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/ChannelPricingHistoryConfigTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/ChannelPricingHistoryConfigTypeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Extension;
+
+use Sylius\Bundle\AdminBundle\Form\Type\TaxonAutocompleteChoiceType;
+use Sylius\Bundle\CoreBundle\Form\Type\ChannelPriceHistoryConfigType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ChannelPricingHistoryConfigTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('taxonsExcludedFromShowingLowestPrice', TaxonAutocompleteChoiceType::class, [
+                'label' => 'sylius.ui.taxons_for_which_the_lowest_price_is_not_displayed',
+                'required' => false,
+                'multiple' => true,
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ChannelPriceHistoryConfigType::class];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/ChannelTypeExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Extension;
+
+use Sylius\Bundle\AdminBundle\Form\Type\TaxonAutocompleteChoiceType;
+use Sylius\Bundle\ChannelBundle\Form\Type\ChannelType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ChannelTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('menuTaxon', TaxonAutocompleteChoiceType::class, [
+                'label' => 'sylius.form.channel.menu_taxon',
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ChannelType::class];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/ProductTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/ProductTypeExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Extension;
+
+use Sylius\Bundle\AdminBundle\Form\Type\TaxonAutocompleteChoiceType;
+use Sylius\Bundle\ProductBundle\Form\Type\ProductType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ProductTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('mainTaxon', TaxonAutocompleteChoiceType::class, [
+                'label' => 'sylius.form.product.main_taxon',
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductType::class];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/TaxonTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/TaxonTypeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Extension;
+
+use Sylius\Bundle\AdminBundle\Form\Type\TaxonAutocompleteChoiceType;
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class TaxonTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $taxonId = $builder->getData()->getId();
+
+        $builder
+            ->add('parent', TaxonAutocompleteChoiceType::class, [
+                'label' => 'sylius.form.taxon.parent',
+                'extra_options' => [
+                    'excluded_taxons' => null !== $taxonId ? [$taxonId] : [],
+                ],
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [TaxonType::class];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteChoiceType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteChoiceType.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Doctrine\ORM\EntityRepository;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
+use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
+
+#[AsEntityAutocompleteField]
+final class TaxonAutocompleteChoiceType extends AbstractType
+{
+    public function __construct (
+        private readonly string $entityClass,
+    ) {
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'class' => $this->entityClass,
+            'searchable_fields' => ['translations.name'],
+            'choice_label' => 'fullname',
+            'query_builder' => function (Options $options) {
+                return function (EntityRepository $er) use ($options) {
+                    $qb = $er->createQueryBuilder('o');
+                    $qb->andWhere('o.enabled = true');
+
+                    $taxonsToBeExcluded = $options['extra_options']['excluded_taxons'] ?? [];
+                    if ([] !== $taxonsToBeExcluded) {
+                        $qb->andWhere($qb->expr()->notIn('o.id', $taxonsToBeExcluded));
+                    }
+
+                    return $qb;
+                };
+            }
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return BaseEntityAutocompleteType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
@@ -1,4 +1,17 @@
 {
-  "controllers": [],
+  "controllers": {
+    "@symfony/ux-autocomplete": {
+      "autocomplete": {
+        "main": "dist/controller.js",
+        "webpackMode": "eager",
+        "fetch": "eager",
+        "enabled": true,
+        "autoimport": {
+          "tom-select/dist/css/tom-select.default.css": false,
+          "tom-select/dist/css/tom-select.bootstrap5.css": true
+        }
+      }
+    }
+  },
   "entrypoints": []
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/main.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/main.scss
@@ -19,6 +19,10 @@ $primary: #1ABB9C;
 @import "_flags.scss";
 
 body {
+    --bs-body-bg: #{$body-bg};
+    --bs-tertiary-bg: #{$body-bg};
+    --bs-body-color: #{$body-color};
+
     font-family: "Inter", sans-serif;
     font-feature-settings: "cv03", "cv04", "cv11";
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
@@ -45,5 +45,33 @@
             <argument>%sylius.form.type.admin.reset_password.validation_groups%</argument>
             <tag name="form.type" />
         </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Extension\ChannelPricingHistoryConfigTypeExtension">
+            <tag name="form.type_extension" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Extension\ChannelTypeExtension">
+            <tag name="form.type_extension" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Extension\ProductTypeExtension">
+            <tag name="form.type_extension" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Type\TaxonAutocompleteChoiceType">
+            <argument>%sylius.model.taxon.class%</argument>
+            <tag name="form.type" />
+            <tag name="ux.entity_autocomplete_field" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Extension\TaxonTypeExtension">
+            <tag name="form.type_extension" />
+        </service>
+
+        <service id="Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotion\ForTaxonsScopeConfigurationType">
+            <argument type="service" id="sylius.form.type.data_transformer.taxons_to_codes" />
+            <tag name="sylius.catalog_promotion.scope_configuration_type" key="%sylius.catalog_promotion.scope.for_taxons%" />
+            <tag name="form.type" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -37,6 +37,7 @@
         "sylius/ui-bundle": "^2.0",
         "symfony/framework-bundle": "^6.3.4",
         "symfony/stimulus-bundle": "^2.12",
+        "symfony/ux-autocomplete": "^2.13",
         "symfony/ux-live-component": "^2.12",
         "symfony/webpack-encore-bundle": "^1.17.1",
         "twig/intl-extra": "^2.12 || ^3.4",

--- a/src/Sylius/Bundle/AdminBundle/test/config/bundles.php
+++ b/src/Sylius/Bundle/AdminBundle/test/config/bundles.php
@@ -62,4 +62,5 @@ return [
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
+    Symfony\UX\Autocomplete\AutocompleteBundle::class => ['all' => true],
 ];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -23,7 +23,6 @@ use Sylius\Bundle\CoreBundle\Form\Type\ShopBillingDataType;
 use Sylius\Bundle\CoreBundle\Form\Type\TaxCalculationStrategyChoiceType;
 use Sylius\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
-use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonAutocompleteChoiceType;
 use Sylius\Bundle\ThemeBundle\Form\Type\ThemeNameChoiceType;
 use Sylius\Component\Core\Model\Scope;
 use Symfony\Component\Form\AbstractTypeExtension;
@@ -99,9 +98,6 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ])
             ->add('shopBillingData', ShopBillingDataType::class, [
                 'label' => 'sylius.form.channel.shop_billing_data',
-            ])
-            ->add('menuTaxon', TaxonAutocompleteChoiceType::class, [
-                'label' => 'sylius.form.channel.menu_taxon',
             ])
             ->add('channelPriceHistoryConfig', ChannelPriceHistoryConfigType::class, [
                 'label' => false,

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
 use Sylius\Bundle\CoreBundle\Form\Type\Product\ProductImageType;
 use Sylius\Bundle\CoreBundle\Form\Type\Taxon\ProductTaxonAutocompleteChoiceType;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductType;
-use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonAutocompleteChoiceType;
 use Sylius\Component\Core\Model\Product;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -35,9 +34,6 @@ final class ProductTypeExtension extends AbstractTypeExtension
                 'multiple' => true,
                 'expanded' => true,
                 'label' => 'sylius.form.product.channels',
-            ])
-            ->add('mainTaxon', TaxonAutocompleteChoiceType::class, [
-                'label' => 'sylius.form.product.main_taxon',
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
                 $product = $event->getData();

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionScope/ForTaxonsScopeConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionScope/ForTaxonsScopeConfigurationType.php
@@ -27,6 +27,7 @@ final class ForTaxonsScopeConfigurationType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** TODO: Extract to AdminBundle and replace with new TaxonAutocompleteChoiceType once the CRUD implemented */
         $builder->add('taxons', TaxonAutocompleteChoiceType::class, [
             'label' => 'sylius.ui.taxons',
             'multiple' => true,

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ChannelPriceHistoryConfigType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ChannelPriceHistoryConfigType.php
@@ -16,7 +16,6 @@ namespace Sylius\Bundle\CoreBundle\Form\Type;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
-use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonAutocompleteChoiceType;
 use Sylius\Component\Core\Model\ChannelPriceHistoryConfigInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Symfony\Component\Form\DataMapperInterface;
@@ -44,11 +43,6 @@ final class ChannelPriceHistoryConfigType extends AbstractResourceType implement
             ])
             ->add('lowestPriceForDiscountedProductsCheckingPeriod', IntegerType::class, [
                 'label' => 'sylius.form.admin.channel.period_for_which_the_lowest_price_is_calculated',
-            ])
-            ->add('taxonsExcludedFromShowingLowestPrice', TaxonAutocompleteChoiceType::class, [
-                'label' => 'sylius.ui.taxons_for_which_the_lowest_price_is_not_displayed',
-                'required' => false,
-                'multiple' => true,
             ])
         ;
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
@@ -27,6 +27,7 @@ final class TaxonFilterConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            /** TODO: Extract to AdminBundle and replace with new TaxonAutocompleteChoiceType once the CRUD implemented */
             ->add('taxons', TaxonAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_filter.taxons',
                 'multiple' => true,

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
@@ -27,6 +27,7 @@ final class HasTaxonConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            /** TODO: Extract to AdminBundle and replace with new TaxonAutocompleteChoiceType once the CRUD implemented */
             ->add('taxons', TaxonAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_rule.has_taxon.taxons',
                 'multiple' => true,

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/TotalOfItemsFromTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/TotalOfItemsFromTaxonConfigurationType.php
@@ -31,6 +31,7 @@ final class TotalOfItemsFromTaxonConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            /** TODO: Extract to AdminBundle and replace with new TaxonAutocompleteChoiceType once the CRUD implemented */
             ->add('taxon', TaxonAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_rule.total_of_items_from_taxon.taxon',
             ])

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
@@ -33,10 +33,6 @@ final class TaxonType extends AbstractResourceType
                 'label' => 'sylius.form.taxon.enabled',
             ])
             ->addEventSubscriber(new AddCodeFormSubscriber())
-            ->add('parent', TaxonAutocompleteChoiceType::class, [
-                'label' => 'sylius.form.taxon.parent',
-                'required' => false,
-            ])
         ;
     }
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -888,6 +888,18 @@
             "templates/base.html.twig"
         ]
     },
+    "symfony/ux-autocomplete": {
+        "version": "2.13",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.6",
+            "ref": "07d9602b7231ba355f484305d6cea58310c01741"
+        },
+        "files": [
+            "config/routes/ux_autocomplete.yaml"
+        ]
+    },
     "symfony/ux-live-component": {
         "version": "2.12",
         "recipe": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | waiting for https://github.com/symfony/ux/pull/1322
| License         | MIT

Easier to create autocomplete fields without a line of custom JS powered by Symfony UX 🤟🏻.
