### PR TITLE
[Maintenance] Remove obsolete extended type method from form extensions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
@@ -66,11 +66,6 @@ final class CartItemTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return CartItemType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [CartItemType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
@@ -48,11 +48,6 @@ final class CartTypeExtension extends AbstractTypeExtension
         });
     }
 
-    public function getExtendedType(): string
-    {
-        return CartType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [CartType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionTypeExtension.php
@@ -32,11 +32,6 @@ final class CatalogPromotionTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return CatalogPromotionType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [CatalogPromotionType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -112,11 +112,6 @@ final class ChannelTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return ChannelType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ChannelType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CountryTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CountryTypeExtension.php
@@ -65,11 +65,6 @@ final class CountryTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return CountryType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [CountryType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
@@ -26,11 +26,6 @@ final class CustomerTypeExtension extends AbstractTypeExtension
         $builder->addEventSubscriber(new AddUserFormSubscriber(ShopUserType::class));
     }
 
-    public function getExtendedType(): string
-    {
-        return CustomerType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [CustomerType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
@@ -50,11 +50,6 @@ final class LocaleTypeExtension extends AbstractTypeExtension
         });
     }
 
-    public function getExtendedType(): string
-    {
-        return LocaleType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [LocaleType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
@@ -28,11 +28,6 @@ final class OrderTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return OrderType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [OrderType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
@@ -70,11 +70,6 @@ final class PaymentMethodTypeExtension extends AbstractTypeExtension
         ]);
     }
 
-    public function getExtendedType(): string
-    {
-        return PaymentMethodType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [PaymentMethodType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
@@ -30,11 +30,6 @@ final class ProductTranslationTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return ProductTranslationType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ProductTranslationType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
@@ -65,11 +65,6 @@ final class ProductTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return ProductType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ProductType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
@@ -40,11 +40,6 @@ final class ProductVariantGenerationTypeExtension extends AbstractTypeExtension
         });
     }
 
-    public function getExtendedType(): string
-    {
-        return ProductVariantGenerationType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ProductVariantGenerationType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
@@ -91,11 +91,6 @@ final class ProductVariantTypeExtension extends AbstractTypeExtension
         });
     }
 
-    public function getExtendedType(): string
-    {
-        return ProductVariantType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ProductVariantType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
@@ -35,11 +35,6 @@ final class PromotionCouponTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return PromotionCouponType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [PromotionCouponType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
@@ -33,11 +33,6 @@ final class PromotionFilterCollectionTypeExtension extends AbstractTypeExtension
         ]);
     }
 
-    public function getExtendedType(): string
-    {
-        return PromotionFilterCollectionType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [PromotionFilterCollectionType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
@@ -31,11 +31,6 @@ final class PromotionTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return PromotionType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [PromotionType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
@@ -56,11 +56,6 @@ final class ShippingMethodTypeExtension extends AbstractTypeExtension
         ]);
     }
 
-    public function getExtendedType(): string
-    {
-        return ShippingMethodType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [ShippingMethodType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
@@ -26,11 +26,6 @@ final class TaxRateTypeExtension extends AbstractTypeExtension
         $builder->add('zone', ZoneChoiceType::class, ['zone_scope' => Scope::TAX]);
     }
 
-    public function getExtendedType(): string
-    {
-        return TaxRateType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [TaxRateType::class];

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxonTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxonTypeExtension.php
@@ -34,11 +34,6 @@ final class TaxonTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return TaxonType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [TaxonType::class];

--- a/src/Sylius/Bundle/PayumBundle/Form/Extension/CryptedGatewayConfigTypeExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Form/Extension/CryptedGatewayConfigTypeExtension.php
@@ -58,11 +58,6 @@ final class CryptedGatewayConfigTypeExtension extends AbstractTypeExtension
         ;
     }
 
-    public function getExtendedType(): string
-    {
-        return GatewayConfigType::class;
-    }
-
     public static function getExtendedTypes(): iterable
     {
         return [GatewayConfigType::class];


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

The `getExtendedType` method has been deprecated in Symfony 4.2 and has not been in use for a while.