### PR TITLE
Accept nodejs 20 for @sylius-ui/frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,12 @@
     "lint:js": "eslint gulpfile.babel.js src/Sylius/Bundle/AdminBundle/gulpfile.babel.js src/Sylius/Bundle/ShopBundle/gulpfile.babel.js src/Sylius/Bundle/UiBundle/Resources/private/js src/Sylius/Bundle/AdminBundle/Resources/private/js src/Sylius/Bundle/ShopBundle/Resources/private/js",
     "postinstall": "semantic-ui-css-patch"
   },
+  "homepage": "https://sylius.com/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Sylius/Sylius.git"
   },
-  "author": "Sylius Sp. z o.o.",
-  "license": "MIT"
+  "bugs": {
+    "url": "https://github.com/Sylius/Sylius/issues"
+  }
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | reported via Slack                      |
| License         | MIT                                                          |

# Motivation
- NodeJS 20 has been released 2023-11-22
- Alpine Linux (heavily used for Docker images) adopted that (probably) on 2024-01-04 as a default nodejs 
- Changing nodejs version in Alpine is not so easy https://stackoverflow.com/questions/76109982/installing-specific-version-of-nodejs-and-npm-on-alpine-docker-image (see _Compile the official versions_ section)
- All that makes some automated tests complicated

# Tests

As it seems that you do not have nodejs versions in your test matrix `.github/workflows/matrix.json` I have tested it manually in Sylius Docker
```bash
docker compose up -d
docker compose exec app bash
apt-get purge nodejs && rm -fr /etc/apt/sources.list.d/nodesource.list && rm -fr /etc/apt/keyrings/nodesource.gpg
curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
node -v # v20.10.0
yarn install # ... Done in 8.84s.
yarn build # ... Done in 3.83s.
```