### PR TITLE
[PoC] Add BC layer for transition from :read to :index and :show serialization groups

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,7 +31,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:read</attribute>
+                    <attribute name="groups">shop:country:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -42,7 +42,7 @@
                     <attribute name="groups">admin:country:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -52,14 +52,14 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:read</attribute>
+                    <attribute name="groups">shop:country:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -70,7 +70,7 @@
                     <attribute name="groups">admin:country:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
@@ -17,13 +17,17 @@
 >
     <class name="Sylius\Component\Currency\Model\Currency">
        <attribute name="code">
-           <group>admin:currency:read</group>
+           <group>admin:currency:index</group>
+           <group>admin:currency:show</group>
            <group>admin:currency:create</group>
-           <group>shop:currency:read</group>
+           <group>shop:currency:index</group>
+           <group>shop:currency:show</group>
        </attribute>
         <attribute name="name">
-            <group>admin:currency:read</group>
-            <group>shop:currency:read</group>
+            <group>admin:currency:index</group>
+            <group>admin:currency:show</group>
+            <group>shop:currency:index</group>
+            <group>shop:currency:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
@@ -28,6 +28,14 @@
         </service>
 
         <service
+            id="Sylius\Bundle\ApiBundle\SerializerContextBuilder\ReadOperationContextBuilder"
+            decorates="api_platform.serializer.context_builder"
+            decoration-priority="64"
+        >
+            <argument type="service" id=".inner" />
+        </service>
+
+        <service
             id="Sylius\Bundle\ApiBundle\SerializerContextBuilder\LocaleContextBuilder"
             decorates="api_platform.serializer.context_builder"
             decoration-priority="64"

--- a/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/ReadOperationContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/ReadOperationContextBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\SerializerContextBuilder;
+
+use ApiPlatform\Serializer\SerializerContextBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReadOperationContextBuilder implements SerializerContextBuilderInterface
+{
+    public function __construct (
+        private SerializerContextBuilderInterface $decorated,
+//        We can allow configuring these two options to allow smoother transition from :read to :index and :show
+//        private bool $skipAddingReadGroup,
+//        private bool $skipAddingIndexAndShowGroups,
+    ) {
+    }
+
+    public function createFromRequest(Request $request, bool $normalization, array $extractedAttributes = null): array
+    {
+        $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
+
+        $groups = $context['groups'] ?? [];
+        $groups = is_string($groups) ? [$groups] : $groups;
+
+        foreach ($groups as $group) {
+            if ($this->shouldReadGroupBeAdded($group)) {
+                $readGroup = str_replace([':show', ':index'], ':read', $group);
+
+                if (in_array($readGroup, $groups, true)) {
+                    continue;
+                }
+
+                $groups[] = $readGroup;
+            }
+
+            if ($this->shouldIndexAndShowGroupsBeAdded($group)) {
+                $indexGroup = str_replace(':read', ':index', $group);
+                $showGroup = str_replace(':read', ':show', $group);
+
+                if (!in_array($indexGroup, $groups, true)) {
+                    $groups[] = $indexGroup;
+                }
+
+                if (!in_array($showGroup, $groups, true)) {
+                    $groups[] = $showGroup;
+                }
+            }
+        }
+
+        $context['groups'] = $groups;
+
+        return $context;
+    }
+
+    private function shouldReadGroupBeAdded(string $group): bool
+    {
+        return str_ends_with($group, ':show') || str_ends_with($group, ':index');
+    }
+
+    private function shouldIndexAndShowGroupsBeAdded(string $group): bool
+    {
+        return str_ends_with($group, ':read');
+    }
+}


### PR DESCRIPTION
> **Important!** This PR is just a proof of concept, so there are no "extra" tests for every piece of added code. I've changed the `Country` and `Currency` API resource definition to make sure my changes work, covering the cases below.

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

So, basically we want to split the `:read` serialization group into two parts -> `:index` and `:read`.

My idea to make everyone's life easier is to provide a `ContextBuilder` adding missing serialization groups to the context.

**Benefit for Sylius**: We use only new serialization groups internally, without bothering about adding/keeping the old `:read`.
**Benefit for end-devs**: You can disable the BC layer, so you know earlier whether your app is compatible with this new change :).

The idea is to provide two configuration keys:
1. When I pass (use) the `:read` serialization group, add `:index` and `:show` groups automatically.
2. When I pass (use) `:index` **or** `:show` group, add the `:read` automatically.

Both of these keys can be configured independently.

## Use cases

1. Sylius already changed their serialization groups to `:index` and `:show`. I still use the `:read` group in API Resource declaration. Sylius will automatically add `:index` and `:show` groups (keeping the `:read` group).
2. Sylius already changed their serialization groups. In my app, I still use the `:read` group. It doesn't break, as Sylius does its best to always have all `:read`, `:index` and `:show` groups.
3.  Sylius already changed their serialization group. I don't know whether my app is compatible with this change. I disable adding groups automatically, so I know if something breaks.

## Known limitations

1. There's no (easy) way to check whether a given group is Sylius' one or no. So in my PoC, I "translate" every group ending with `:read`, `:index` or `:show`.
2. Non-Sylius (in terms of living inside the Sylius repo) groups with "weird" names like `admin:customer:some_other_word_with_read:read` will end up with additional `admin:customer:some_other_word_with_index:index` and `admin:customer:some_other_word_with_show:show` groups.

These limitations can be (probably) easily fixed in the final PR.