### PR TITLE
[API] Split read serialization group

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
@@ -19,7 +19,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/addresses</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:read</attribute>
+                    <attribute name="groups">shop:address:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -30,7 +30,7 @@
                     <attribute name="groups">shop:address:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:read</attribute>
+                    <attribute name="groups">shop:address:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -41,7 +41,7 @@
                 <attribute name="path">/admin/addresses/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:address:read</attribute>
+                        <attribute>admin:address:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -56,7 +56,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:address:read</attribute>
+                        <attribute>admin:address:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -66,7 +66,7 @@
                 <attribute name="path">/admin/addresses/{id}/log-entries</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetAddressLogEntryCollectionAction</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:address:log_entry:read</attribute>
+                    <attribute name="groups">admin:address:log_entry:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Retrieves the collection of AddressLogEntry resources.</attribute>
@@ -78,7 +78,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/addresses/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:read</attribute>
+                    <attribute name="groups">shop:address:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -94,7 +94,7 @@
                     <attribute name="groups">shop:address:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:read</attribute>
+                    <attribute name="groups">shop:address:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
@@ -24,7 +24,7 @@
                     <attribute>sylius.api.order_token_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:read</attribute>
+                    <attribute name="groups">admin:adjustment:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -34,7 +34,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/adjustments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:read</attribute>
+                    <attribute name="groups">admin:adjustment:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -42,7 +42,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/adjustments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:adjustment:read</attribute>
+                    <attribute name="groups">shop:adjustment:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
@@ -50,12 +50,12 @@
         <subresourceOperations>
             <subresourceOperation name="api_orders_adjustments_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
             </subresourceOperation>
             <subresourceOperation name="api_orders_items_adjustments_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminUser.xml
@@ -24,7 +24,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:read</attribute>
+                    <attribute name="groups">admin:admin_user:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -38,7 +38,7 @@
                     <attribute name="groups">admin:admin_user:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:read</attribute>
+                    <attribute name="groups">admin:admin_user:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -47,7 +47,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:read</attribute>
+                    <attribute name="groups">admin:admin_user:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -57,7 +57,7 @@
                     <attribute name="groups">admin:admin_user:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:read</attribute>
+                    <attribute name="groups">admin:admin_user:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AvatarImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AvatarImage.xml
@@ -45,7 +45,7 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:avatar_image:read</attribute>
+                    <attribute name="groups">admin:avatar_image:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -54,7 +54,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:avatar_image:read</attribute>
+                    <attribute name="groups">admin:avatar_image:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
@@ -36,7 +36,7 @@
                     <attribute>sylius.api.order_filter.priority</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:read</attribute>
+                    <attribute name="groups">admin:catalog_promotion:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -47,7 +47,7 @@
                     <attribute name="groups">admin:catalog_promotion:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:read</attribute>
+                    <attribute name="groups">admin:catalog_promotion:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -84,7 +84,7 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="path">/admin/catalog-promotions/{code}</attribute>
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:read</attribute>
+                    <attribute name="groups">admin:catalog_promotion:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -92,7 +92,7 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="path">/shop/catalog-promotions/{code}</attribute>
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:catalog_promotion:read</attribute>
+                    <attribute name="groups">shop:catalog_promotion:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -103,7 +103,7 @@ Example configuration for `percentage_discount` action type:
                     <attribute name="groups">admin:catalog_promotion:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:read</attribute>
+                    <attribute name="groups">admin:catalog_promotion:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionTranslation.xml
@@ -25,7 +25,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/catalog-promotion-translations/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:read</attribute>
+                    <attribute name="groups">admin:catalog_promotion:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
@@ -21,7 +21,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channels</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:read</attribute>
+                    <attribute name="groups">admin:channel:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -29,7 +29,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/channels</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:channel:read</attribute>
+                    <attribute name="groups">shop:channel:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -40,7 +40,7 @@
                     <attribute name="groups">admin:channel:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:read</attribute>
+                    <attribute name="groups">admin:channel:show</attribute>
                 </attribute>
                 <attribute name="validation_groups">sylius</attribute>
             </collectionOperation>
@@ -54,7 +54,7 @@
                     <attribute name="summary">Use $code to retrieve a channel resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:read</attribute>
+                    <attribute name="groups">admin:channel:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +62,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/channels/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:channel:read</attribute>
+                    <attribute name="groups">shop:channel:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Use $code to retrieve a channel resource.</attribute>
@@ -76,7 +76,7 @@
                     <attribute name="groups">admin:channel:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:read</attribute>
+                    <attribute name="groups">admin:channel:show</attribute>
                 </attribute>
                 <attribute name="validation_groups">sylius</attribute>
             </itemOperation>
@@ -92,7 +92,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channels/{code}/shop-billing-data</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shop_billing_data:read</attribute>
+                    <attribute name="groups">admin:shop_billing_data:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPriceHistoryConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPriceHistoryConfig.xml
@@ -25,7 +25,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_price_history_config:read</attribute>
+                    <attribute name="groups">admin:channel_price_history_config:show</attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="admin_put">
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:channel_price_history_config:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_price_history_config:read</attribute>
+                    <attribute name="groups">admin:channel_price_history_config:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricingLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricingLogEntry.xml
@@ -21,7 +21,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channel-pricing-log-entries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_pricing_log_entry:read</attribute>
+                    <attribute name="groups">admin:channel_pricing_log_entry:index</attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.channel_pricing_channel_filter</attribute>
@@ -38,7 +38,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channel-pricing-log-entries/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_pricing_log_entry:read</attribute>
+                    <attribute name="groups">admin:channel_pricing_log_entry:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,7 +31,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:read</attribute>
+                    <attribute name="groups">shop:country:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -42,7 +42,7 @@
                     <attribute name="groups">admin:country:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -52,14 +52,14 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:read</attribute>
+                    <attribute name="groups">shop:country:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -70,7 +70,7 @@
                     <attribute name="groups">admin:country:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:read</attribute>
+                    <attribute name="groups">admin:country:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Currency.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/currencies</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:read</attribute>
+                    <attribute name="groups">admin:currency:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:currency:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:read</attribute>
+                    <attribute name="groups">admin:currency:show</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -43,7 +43,7 @@
                 <attribute name="route_prefix">shop</attribute>
                 <attribute name="path">/shop/currencies</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:currency:read</attribute>
+                    <attribute name="groups">shop:currency:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -53,7 +53,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/currencies/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:read</attribute>
+                    <attribute name="groups">admin:currency:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +62,7 @@
                 <attribute name="route_prefix">shop</attribute>
                 <attribute name="path">/shop/currencies/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:currency:read</attribute>
+                    <attribute name="groups">shop:currency:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
@@ -24,7 +24,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/customers</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:read</attribute>
+                    <attribute name="groups">admin:customer:index</attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.customer_group_filter</attribute>
@@ -38,7 +38,7 @@
                     <attribute name="groups">admin:customer:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:read</attribute>
+                    <attribute name="groups">admin:customer:show</attribute>
                 </attribute>
                 <attribute name="validation_groups">
                     <attribute>sylius</attribute>
@@ -67,7 +67,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/customers/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:read</attribute>
+                    <attribute name="groups">admin:customer:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -76,7 +76,7 @@
                 <attribute name="path">/admin/customers/{id}/statistics</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetCustomerStatisticsAction</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:statistics:read</attribute>
+                    <attribute name="groups">admin:customer:statistics:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -87,7 +87,7 @@
                     <attribute name="groups">admin:customer:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:read</attribute>
+                    <attribute name="groups">admin:customer:show</attribute>
                 </attribute>
                 <attribute name="validation_groups">
                     <attribute>sylius</attribute>
@@ -106,7 +106,7 @@
                 <attribute name="path">/shop/customers/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:customer:read</attribute>
+                        <attribute>shop:customer:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -132,7 +132,7 @@
                     <attribute name="groups">shop:customer:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:customer:read</attribute>
+                    <attribute name="groups">shop:customer:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
@@ -23,7 +23,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:read</attribute>
+                    <attribute name="groups">admin:customer_group:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -33,7 +33,7 @@
                     <attribute name="groups">admin:customer_group:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:read</attribute>
+                    <attribute name="groups">admin:customer_group:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -42,7 +42,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:read</attribute>
+                    <attribute name="groups">admin:customer_group:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -52,7 +52,7 @@
                     <attribute name="groups">admin:customer_group:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:read</attribute>
+                    <attribute name="groups">admin:customer_group:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ExchangeRate.xml
@@ -26,7 +26,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ExchangeRateFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:read</attribute>
+                    <attribute name="groups">admin:exchange_rate:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +34,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/exchange-rates</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:exchange_rate:read</attribute>
+                    <attribute name="groups">shop:exchange_rate:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -45,7 +45,7 @@
                     <attribute name="groups">admin:exchange_rate:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:read</attribute>
+                    <attribute name="groups">admin:exchange_rate:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -55,7 +55,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/exchange-rates/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:read</attribute>
+                    <attribute name="groups">admin:exchange_rate:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -63,7 +63,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/exchange-rates/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:exchange_rate:read</attribute>
+                    <attribute name="groups">shop:exchange_rate:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -74,7 +74,7 @@
                     <attribute name="groups">admin:exchange_rate:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:read</attribute>
+                    <attribute name="groups">admin:exchange_rate:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/GatewayConfig.xml
@@ -28,7 +28,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:gateway_config:read</attribute>
+                    <attribute name="groups">admin:gateway_config:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Locale.xml
@@ -24,7 +24,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/locales</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:read</attribute>
+                    <attribute name="groups">admin:locale:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -35,7 +35,7 @@
                     <attribute name="groups">admin:locale:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:read</attribute>
+                    <attribute name="groups">admin:locale:show</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -43,7 +43,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/locales</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:locale:read</attribute>
+                    <attribute name="groups">shop:locale:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -53,7 +53,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/locales/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:read</attribute>
+                    <attribute name="groups">admin:locale:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -66,7 +66,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/locales/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:locale:read</attribute>
+                    <attribute name="groups">shop:locale:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -37,7 +37,7 @@
                     <attribute name="number">DESC</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:read</attribute>
+                    <attribute name="groups">admin:order:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -51,8 +51,8 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:order:read</attribute>
-                        <attribute>shop:cart:read</attribute>
+                        <attribute>shop:order:show</attribute>
+                        <attribute>shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -64,7 +64,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/orders</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:read</attribute>
+                    <attribute name="groups">shop:order:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -74,7 +74,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/orders/{tokenValue}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:read</attribute>
+                    <attribute name="groups">admin:order:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -92,7 +92,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/orders/{tokenValue}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -103,7 +103,7 @@
                     <attribute name="summary">Deletes cart</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:read</attribute>
+                    <attribute name="groups">shop:order:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -116,7 +116,7 @@
                     <attribute name="groups">admin:order:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:read</attribute>
+                    <attribute name="groups">admin:order:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Cancels Order</attribute>
@@ -129,7 +129,7 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:add_item</attribute>
@@ -152,8 +152,8 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:order:read</attribute>
-                        <attribute>shop:cart:read</attribute>
+                        <attribute>shop:order:show</attribute>
+                        <attribute>shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -189,8 +189,8 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:order:read</attribute>
-                        <attribute>shop:cart:read</attribute>
+                        <attribute>shop:order:show</attribute>
+                        <attribute>shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -225,7 +225,7 @@
                     <attribute name="groups">shop:order:account:change_payment_method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:account:read</attribute>
+                    <attribute name="groups">shop:order:account:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Change the payment method as logged shop user</attribute>
@@ -291,8 +291,8 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:order:read</attribute>
-                        <attribute>shop:cart:read</attribute>
+                        <attribute>shop:order:show</attribute>
+                        <attribute>shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -339,7 +339,7 @@
                     <attribute name="groups">shop:cart:change_quantity</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Changes quantity of order item</attribute>
@@ -374,8 +374,8 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:order:read</attribute>
-                        <attribute>shop:cart:read</attribute>
+                        <attribute>shop:order:show</attribute>
+                        <attribute>shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -84,7 +84,7 @@
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetOrderAdjustmentsAction</attribute>
                 <attribute name="write">false</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:read</attribute>
+                    <attribute name="groups">admin:adjustment:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItem.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-items/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item:read</attribute>
+                    <attribute name="groups">admin:order_item:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -31,8 +31,8 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/order-items/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order_item:read</attribute>
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:order_item:show</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -42,12 +42,12 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-items/{id}/adjustments</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item:read</attribute>
+                    <attribute name="groups">admin:order_item:show</attribute>
                 </attribute>
             </subresourceOperation>
             <subresourceOperation name="api_orders_items_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
+                    <attribute name="groups">shop:cart:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItemUnit.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-item-units/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item_unit:read</attribute>
+                    <attribute name="groups">admin:order_item_unit:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -31,7 +31,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/order-item-units/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order_item_unit:read</attribute>
+                    <attribute name="groups">shop:order_item_unit:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
@@ -30,7 +30,7 @@
                     <attribute>sylius.api.search_payment_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment:read</attribute>
+                    <attribute name="groups">admin:payment:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -40,7 +40,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment:read</attribute>
+                    <attribute name="groups">admin:payment:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -48,7 +48,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/payments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:payment:read</attribute>
+                    <attribute name="groups">shop:payment:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
@@ -33,7 +33,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:payment_method:read</attribute>
+                        <attribute>shop:payment_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -47,7 +47,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:payment_method:read</attribute>
+                        <attribute>admin:payment_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -59,7 +59,7 @@
                     <attribute name="groups">admin:payment_method:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:read</attribute>
+                    <attribute name="groups">admin:payment_method:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -69,7 +69,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payment-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:read</attribute>
+                    <attribute name="groups">admin:payment_method:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -80,7 +80,7 @@
                     <attribute name="groups">admin:payment_method:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:read</attribute>
+                    <attribute name="groups">admin:payment_method:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -93,7 +93,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/payment-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:payment_method:read</attribute>
+                    <attribute name="groups">shop:payment_method:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -103,7 +103,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payment-methods/{code}/gateway-config</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:gateway_config:read</attribute>
+                    <attribute name="groups">admin:gateway_config:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -34,7 +34,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TranslationOrderNameAndLocaleFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:read</attribute>
+                    <attribute name="groups">admin:product:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -50,7 +50,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TaxonFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:read</attribute>
+                    <attribute name="groups">shop:product:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -61,7 +61,7 @@
                     <attribute name="groups">admin:product:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:read</attribute>
+                    <attribute name="groups">admin:product:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -74,7 +74,7 @@
                     <attribute name="summary">Use code to retrieve a product resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:read</attribute>
+                    <attribute name="groups">admin:product:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -85,7 +85,7 @@
                     <attribute name="summary">Use code to retrieve a product resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:read</attribute>
+                    <attribute name="groups">shop:product:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -108,7 +108,7 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:read</attribute>
+                    <attribute name="groups">shop:product:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -119,7 +119,7 @@
                     <attribute name="groups">admin:product:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:read</attribute>
+                    <attribute name="groups">admin:product:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociation.xml
@@ -27,7 +27,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:product_association:read</attribute>
+                        <attribute>admin:product_association:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -42,7 +42,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:product_association:read</attribute>
+                        <attribute>admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -54,7 +54,7 @@
                 <attribute name="path">/admin/product-associations/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:product_association:read</attribute>
+                        <attribute>admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -69,7 +69,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:product_association:read</attribute>
+                        <attribute>admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -84,7 +84,7 @@
                 <attribute name="path">/shop/product-associations/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:product_association:read</attribute>
+                        <attribute>shop:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
@@ -26,7 +26,7 @@
                     <attribute>sylius.api.product_association_type_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:read</attribute>
+                    <attribute name="groups">admin:product_association_type:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -37,7 +37,7 @@
                     <attribute name="groups">admin:product_association_type:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:read</attribute>
+                    <attribute name="groups">admin:product_association_type:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -47,7 +47,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-association-types/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:read</attribute>
+                    <attribute name="groups">admin:product_association_type:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -55,7 +55,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-association-types/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_association_type:read</attribute>
+                    <attribute name="groups">shop:product_association_type:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -66,7 +66,7 @@
                     <attribute name="groups">admin:product_association_type:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:read</attribute>
+                    <attribute name="groups">admin:product_association_type:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
@@ -30,7 +30,7 @@
                     <attribute>sylius.api.order_filter.position</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:read</attribute>
+                    <attribute name="groups">admin:product_attribute:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -41,7 +41,7 @@
                     <attribute name="groups">admin:product_attribute:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:read</attribute>
+                    <attribute name="groups">admin:product_attribute:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -111,7 +111,7 @@ Example configuration for a `select` type attribute:
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-attributes/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:read</attribute>
+                    <attribute name="groups">admin:product_attribute:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -127,7 +127,7 @@ Example configuration for a `select` type attribute:
                     <attribute name="groups">admin:product_attribute:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:read</attribute>
+                    <attribute name="groups">admin:product_attribute:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -195,7 +195,7 @@ Example configuration for a `select` type attribute:
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-attributes/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute:read</attribute>
+                    <attribute name="groups">shop:product_attribute:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeTranslation.xml
@@ -26,8 +26,8 @@
                 <attribute name="path">/admin/product-attribute-translations/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:product_attribute:read</attribute>
-                        <attribute>admin:product_attribute_translation:read</attribute>
+                        <attribute>admin:product_attribute:show</attribute>
+                        <attribute>admin:product_attribute_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
@@ -29,7 +29,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-attribute-values/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute_value:read</attribute>
+                    <attribute name="groups">admin:product_attribute_value:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -37,7 +37,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-attribute-values/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute_value:read</attribute>
+                    <attribute name="groups">shop:product_attribute_value:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -45,7 +45,7 @@
         <subresourceOperations>
             <subresourceOperation name="api_products_attributes_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute_value:read</attribute>
+                    <attribute name="groups">shop:product_attribute_value:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -15,7 +15,7 @@
                     <attribute>sylius.api.product_image_product_variants_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
+                    <attribute name="groups">admin:product_image:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -68,7 +68,7 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
+                    <attribute name="groups">admin:product_image:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -78,7 +78,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
+                    <attribute name="groups">admin:product_image:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -86,7 +86,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_image:read</attribute>
+                    <attribute name="groups">shop:product_image:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="parameters">
@@ -109,7 +109,7 @@
                     <attribute name="groups">admin:product_image:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
+                    <attribute name="groups">admin:product_image:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -122,7 +122,7 @@
         <subresourceOperations>
             <subresourceOperation name="api_products_images_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
+                    <attribute name="groups">admin:product_image:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -27,7 +27,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:read</attribute>
+                    <attribute name="groups">admin:product_option:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -38,7 +38,7 @@
                     <attribute name="groups">admin:product_option:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:read</attribute>
+                    <attribute name="groups">admin:product_option:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -48,7 +48,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:read</attribute>
+                    <attribute name="groups">admin:product_option:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -56,7 +56,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-options/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_option:read</attribute>
+                    <attribute name="groups">shop:product_option:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -67,7 +67,7 @@
                     <attribute name="groups">admin:product_option:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:read</attribute>
+                    <attribute name="groups">admin:product_option:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -77,7 +77,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}/values</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:read</attribute>
+                    <attribute name="groups">admin:product_option:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -25,7 +25,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-option-values/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option_value:read</attribute>
+                    <attribute name="groups">admin:product_option_value:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -33,7 +33,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-option-values/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_option_value:read</attribute>
+                    <attribute name="groups">shop:product_option_value:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
@@ -27,7 +27,7 @@
                     <attribute>sylius.api.product_review_status_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:read</attribute>
+                    <attribute name="groups">admin:product_review:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -40,7 +40,7 @@
                     <attribute name="groups">shop:product_review:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:read</attribute>
+                    <attribute name="groups">shop:product_review:show</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -52,7 +52,7 @@
                     <attribute>sylius.api.product_review_date_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:read</attribute>
+                    <attribute name="groups">shop:product_review:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -62,7 +62,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-reviews/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:read</attribute>
+                    <attribute name="groups">admin:product_review:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -70,7 +70,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-reviews/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:read</attribute>
+                    <attribute name="groups">shop:product_review:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -89,7 +89,7 @@
                     <attribute name="groups">admin:product_review:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:read</attribute>
+                    <attribute name="groups">admin:product_review:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -102,7 +102,7 @@
                     <attribute name="summary">Accepts Product Review</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:read</attribute>
+                    <attribute name="groups">admin:product_review:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -115,7 +115,7 @@
                     <attribute name="summary">Rejects Product Review</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:read</attribute>
+                    <attribute name="groups">admin:product_review:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTaxon.xml
@@ -32,9 +32,10 @@
                     <attribute>sylius.api.order_filter.position</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_taxon:read</attribute>
+                    <attribute name="groups">admin:product_taxon:index</attribute>
                 </attribute>
             </collectionOperation>
+
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-taxons</attribute>
@@ -49,9 +50,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-taxons/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_taxon:read</attribute>
+                    <attribute name="groups">admin:product_taxon:show</attribute>
                 </attribute>
             </itemOperation>
+
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-taxons/{id}</attribute>
@@ -59,11 +61,12 @@
                     <attribute name="groups">admin:product_taxon:update</attribute>
                 </attribute>
             </itemOperation>
+
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-taxons/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_taxon:read</attribute>
+                    <attribute name="groups">shop:product_taxon:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -23,7 +23,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-variants/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:read</attribute>
+                    <attribute name="groups">admin:product_variant:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:product_variant:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:read</attribute>
+                    <attribute name="groups">admin:product_variant:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -42,7 +42,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-variants/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_variant:read</attribute>
+                    <attribute name="groups">shop:product_variant:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +62,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ProductVariantCatalogPromotionFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:read</attribute>
+                    <attribute name="groups">admin:product_variant:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -73,7 +73,7 @@
                     <attribute name="groups">admin:product_variant:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:read</attribute>
+                    <attribute name="groups">admin:product_variant:show</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -85,7 +85,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ProductVariantOptionValueFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_variant:read</attribute>
+                    <attribute name="groups">shop:product_variant:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:promotion:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -71,7 +71,7 @@ Example configuration for `order_fixed_discount` action type:
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:index</attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.promotion_coupon_search_filter</attribute>
@@ -84,7 +84,7 @@ Example configuration for `order_fixed_discount` action type:
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -94,7 +94,7 @@ Example configuration for `order_fixed_discount` action type:
                     <attribute name="groups">admin:promotion:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionCoupon.xml
@@ -28,7 +28,7 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\PromotionCouponPromotionFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:index</attribute>
                 </attribute>
                 <attribute name="order">
                     <attribute name="used">DESC</attribute>
@@ -38,7 +38,7 @@
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:show</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:promotion_coupon:create</attribute>
@@ -54,7 +54,7 @@
                     <attribute name="groups">admin:promotion_coupon:generate</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Generates promotion coupons</attribute>
@@ -67,14 +67,14 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:show</attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:show</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">admin:promotion_coupon:update</attribute>
@@ -89,7 +89,7 @@
         <subresourceOperations>
             <subresourceOperation name="api_promotions_coupons_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:read</attribute>
+                    <attribute name="groups">admin:promotion_coupon:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Province.xml
@@ -26,7 +26,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:province:read</attribute>
+                    <attribute name="groups">admin:province:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -36,7 +36,7 @@
                     <attribute name="groups">admin:province:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:province:read</attribute>
+                    <attribute name="groups">admin:province:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Shipment.xml
@@ -30,7 +30,7 @@
                     <attribute>sylius.api.search_shipment_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipment:read</attribute>
+                    <attribute name="groups">admin:shipment:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -40,7 +40,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/shipments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipment:read</attribute>
+                    <attribute name="groups">admin:shipment:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -48,7 +48,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/shipments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:shipment:read</attribute>
+                    <attribute name="groups">shop:shipment:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
@@ -24,7 +24,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:read</attribute>
+                    <attribute name="groups">admin:shipping_category:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:shipping_category:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:read</attribute>
+                    <attribute name="groups">admin:shipping_category:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -43,7 +43,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:read</attribute>
+                    <attribute name="groups">admin:shipping_category:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -53,7 +53,7 @@
                     <attribute name="groups">admin:shipping_category:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:read</attribute>
+                    <attribute name="groups">admin:shipping_category:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -27,7 +27,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/shipping-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -35,7 +35,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/shipping-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:shipping_method:read</attribute>
+                    <attribute name="groups">shop:shipping_method:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -46,7 +46,7 @@
                     <attribute name="groups">admin:shipping_method:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -91,7 +91,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute name="summary">Archives Shipping Method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -104,7 +104,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute name="summary">Restores archived Shipping Method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -119,7 +119,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TranslationOrderNameAndLocaleFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:index</attribute>
                 </attribute>
             </collectionOperation>
             <collectionOperation name="shop_get">
@@ -131,7 +131,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:shipping_method:read</attribute>
+                        <attribute>shop:shipping_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -143,7 +143,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute name="groups">admin:shipping_method:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:read</attribute>
+                    <attribute name="groups">admin:shipping_method:show</attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopBillingData.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopBillingData.xml
@@ -26,7 +26,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shop_billing_data:read</attribute>
+                    <attribute name="groups">admin:shop_billing_data:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxCategory.xml
@@ -24,7 +24,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:read</attribute>
+                    <attribute name="groups">admin:tax_category:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +34,7 @@
                     <attribute name="groups">admin:tax_category:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:read</attribute>
+                    <attribute name="groups">admin:tax_category:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -43,7 +43,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:read</attribute>
+                    <attribute name="groups">admin:tax_category:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -53,7 +53,7 @@
                     <attribute name="groups">admin:tax_category:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:read</attribute>
+                    <attribute name="groups">admin:tax_category:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
@@ -24,7 +24,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:tax_rate:read</attribute>
+                        <attribute>admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -38,7 +38,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:tax_rate:read</attribute>
+                        <attribute>admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -56,7 +56,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:tax_rate:read</attribute>
+                        <attribute>admin:tax_rate:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -70,7 +70,7 @@
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:tax_rate:read</attribute>
+                        <attribute>admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
@@ -12,7 +12,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -23,7 +23,7 @@
                     <attribute name="groups">admin:taxon:create</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:show</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,7 +31,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:read</attribute>
+                    <attribute name="groups">shop:taxon:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -41,7 +41,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -52,7 +52,7 @@
                     <attribute name="groups">admin:taxon:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -65,7 +65,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:read</attribute>
+                    <attribute name="groups">shop:taxon:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonImage.xml
@@ -12,7 +12,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxon-images</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:read</attribute>
+                    <attribute name="groups">admin:taxon_image:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -52,7 +52,7 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:read</attribute>
+                    <attribute name="groups">admin:taxon_image:show</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -62,7 +62,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxon-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:read</attribute>
+                    <attribute name="groups">admin:taxon_image:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -73,7 +73,7 @@
                     <attribute name="groups">admin:taxon_image:update</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:read</attribute>
+                    <attribute name="groups">admin:taxon_image:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -86,7 +86,7 @@
         <subresourceOperations>
             <subresourceOperation name="api_taxa_images_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:read</attribute>
+                    <attribute name="groups">admin:taxon_image:show</attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
@@ -15,8 +15,8 @@
                 <attribute name="path">/admin/taxon-translations/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>admin:taxon:read</attribute>
-                        <attribute>admin:taxon_translation:read</attribute>
+                        <attribute>admin:taxon:show</attribute>
+                        <attribute>admin:taxon_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -26,7 +26,7 @@
                 <attribute name="path">/shop/taxon-translations/{id}</attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
-                        <attribute>shop:taxon_translation:read</attribute>
+                        <attribute>shop:taxon_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Zone.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Zone.xml
@@ -24,7 +24,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone:read</attribute>
+                    <attribute name="groups">admin:zone:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -40,7 +40,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone:read</attribute>
+                    <attribute name="groups">admin:zone:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ZoneMember.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ZoneMember.xml
@@ -26,7 +26,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone_member:read</attribute>
+                    <attribute name="groups">admin:zone_member:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
@@ -30,105 +30,113 @@
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="lastName">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="phoneNumber">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="company">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="city">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="street">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="postcode">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="countryCode">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="provinceCode">
             <group>admin:address:index</group>
@@ -139,21 +147,22 @@
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="provinceName">
             <group>admin:address:index</group>
             <group>admin:address:show</group>
             <group>admin:address:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:address:create</group>
             <group>shop:address:index</group>
             <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
@@ -17,116 +17,139 @@
 >
     <class name="Sylius\Component\Core\Model\Address">
         <attribute name="id">
-            <group>admin:address:read</group>
-            <group>shop:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
         </attribute>
         <attribute name="customer">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
         </attribute>
         <attribute name="firstName">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="lastName">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="phoneNumber">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="company">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="city">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="street">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="postcode">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="countryCode">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="provinceCode">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
         </attribute>
         <attribute name="provinceName">
-            <group>admin:address:read</group>
+            <group>admin:address:index</group>
+            <group>admin:address:show</group>
             <group>admin:address:update</group>
             <group>admin:order:read</group>
             <group>shop:address:create</group>
-            <group>shop:address:read</group>
+            <group>shop:address:index</group>
+            <group>shop:address:show</group>
             <group>shop:address:update</group>
             <group>shop:cart:update</group>
             <group>shop:cart:read</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AddressLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AddressLogEntry.xml
@@ -17,16 +17,16 @@
 >
     <class name="Sylius\Component\Addressing\Model\AddressLogEntry">
         <attribute name="action">
-            <group>admin:address:log_entry:read</group>
+            <group>admin:address:log_entry:show</group>
         </attribute>
         <attribute name="logged_at">
-            <group>admin:address:log_entry:read</group>
+            <group>admin:address:log_entry:show</group>
         </attribute>
         <attribute name="version">
-            <group>admin:address:log_entry:read</group>
+            <group>admin:address:log_entry:show</group>
         </attribute>
         <attribute name="data">
-            <group>admin:address:log_entry:read</group>
+            <group>admin:address:log_entry:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
@@ -17,53 +17,71 @@
 >
     <class name="Sylius\Component\Order\Model\Adjustment">
         <attribute name="id">
-            <group>admin:adjustment:read</group>
-            <group>shop:adjustment:read</group>
+            <group>admin:adjustment:index</group>
+            <group>admin:adjustment:show</group>
+            <group>shop:adjustment:index</group>
+            <group>shop:adjustment:show</group>
             <group>shop:cart:read</group>
         </attribute>
 
         <attribute name="type">
-            <group>admin:adjustment:read</group>
-            <group>shop:adjustment:read</group>
+            <group>admin:adjustment:index</group>
+            <group>admin:adjustment:show</group>
+            <group>shop:adjustment:index</group>
+            <group>shop:adjustment:show</group>
             <group>shop:cart:read</group>
        </attribute>
 
         <attribute name="label">
-            <group>admin:adjustment:read</group>
-            <group>shop:adjustment:read</group>
+            <group>admin:adjustment:index</group>
+            <group>admin:adjustment:show</group>
+            <group>shop:adjustment:index</group>
+            <group>shop:adjustment:show</group>
             <group>shop:cart:read</group>
        </attribute>
 
        <attribute name="amount">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
            <group>shop:cart:read</group>
        </attribute>
 
        <attribute name="order">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
        </attribute>
 
        <attribute name="order_item">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
        </attribute>
 
        <attribute name="order_item_unit">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
        </attribute>
 
        <attribute name="neutral">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
            <group>shop:cart:read</group>
        </attribute>
 
        <attribute name="locked">
-           <group>admin:adjustment:read</group>
-           <group>shop:adjustment:read</group>
+           <group>admin:adjustment:index</group>
+           <group>admin:adjustment:show</group>
+           <group>shop:adjustment:index</group>
+           <group>shop:adjustment:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
@@ -21,7 +21,7 @@
             <group>admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
-            <group>shop:cart:read</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="type">
@@ -29,7 +29,7 @@
             <group>admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
-            <group>shop:cart:read</group>
+            <group>shop:cart:show</group>
        </attribute>
 
         <attribute name="label">
@@ -37,7 +37,7 @@
             <group>admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
-            <group>shop:cart:read</group>
+            <group>shop:cart:show</group>
        </attribute>
 
        <attribute name="amount">
@@ -45,7 +45,7 @@
            <group>admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
-           <group>shop:cart:read</group>
+           <group>shop:cart:show</group>
        </attribute>
 
        <attribute name="order">
@@ -74,7 +74,7 @@
            <group>admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
-           <group>shop:cart:read</group>
+           <group>shop:cart:show</group>
        </attribute>
 
        <attribute name="locked">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AdminUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AdminUser.xml
@@ -17,15 +17,18 @@
 >
     <class name="Sylius\Component\Core\Model\AdminUser">
         <attribute name="id">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
         <attribute name="email">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="username">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
@@ -34,39 +37,48 @@
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="enabled">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="firstName">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="lastName">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="localeCode">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
         </attribute>
         <attribute name="avatar">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
         <attribute name="verifiedAt">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
         <attribute name="lastLogin">
-            <group>admin:admin_user:read</group>
+            <group>admin:admin_user:index</group>
+            <group>admin:admin_user:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AvatarImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AvatarImage.xml
@@ -17,13 +17,13 @@
 >
     <class name="Sylius\Component\Core\Model\AvatarImage">
         <attribute name="id">
-            <group>admin:avatar_image:read</group>
+            <group>admin:avatar_image:show</group>
         </attribute>
         <attribute name="path">
-            <group>admin:avatar_image:read</group>
+            <group>admin:avatar_image:show</group>
         </attribute>
         <attribute name="owner">
-            <group>admin:avatar_image:read</group>
+            <group>admin:avatar_image:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
@@ -17,7 +17,8 @@
             <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>shop:catalog_promotion:show</group>
         </attribute>
 
@@ -25,7 +26,8 @@
             <group>admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
         </attribute>
 
         <attribute name="name">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
@@ -13,83 +13,96 @@
 >
     <class name="Sylius\Component\Promotion\Model\CatalogPromotion">
         <attribute name="id">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
             <group>admin:product_variant:read</group>
-            <group>shop:catalog_promotion:read</group>
+            <group>shop:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="code">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:product_variant:read</group>
         </attribute>
 
         <attribute name="name">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="channels">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="startDate">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="endDate">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="priority">
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
-            <group>admin:catalog_promotion:read</group>
         </attribute>
 
         <attribute name="state">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="label">
-            <group>shop:catalog_promotion:read</group>
+            <group>shop:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="translations">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="scopes">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="actions">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="enabled">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="exclusive">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionAction.xml
@@ -13,15 +13,18 @@
 >
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionAction">
         <attribute name="id">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionScope.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionScope.xml
@@ -17,15 +17,18 @@
 >
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionScope">
         <attribute name="id">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionTranslation.xml
@@ -17,17 +17,20 @@
 >
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionTranslation">
         <attribute name="id">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="label">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="description">
-            <group>admin:catalog_promotion:read</group>
+            <group>admin:catalog_promotion:index</group>
+            <group>admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Channel.xml
@@ -17,121 +17,150 @@
 >
     <class name="Sylius\Component\Core\Model\Channel">
         <attribute name="code">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="enabled">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="description">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="hostname">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="color">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="baseCurrency">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="defaultLocale">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="defaultTaxZone">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="taxCalculationStrategy">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="currencies">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="locales">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
-            <group>shop:channel:read</group>
+            <group>shop:channel:index</group>
+            <group>shop:channel:show</group>
         </attribute>
         <attribute name="countries">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="themeName">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="contactEmail">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="contactPhoneNumber">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="skippingShippingStepAllowed">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="skippingPaymentStepAllowed">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="accountVerificationRequired">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="shippingAddressInCheckoutRequired">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="shopBillingData">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="menuTaxon">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>
         <attribute name="channelPriceHistoryConfig">
-            <group>admin:channel:read</group>
+            <group>admin:channel:index</group>
+            <group>admin:channel:show</group>
             <group>admin:channel:create</group>
             <group>admin:channel:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPriceHistoryConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPriceHistoryConfig.xml
@@ -17,22 +17,22 @@
 >
     <class name="Sylius\Component\Core\Model\ChannelPriceHistoryConfig">
         <attribute name="id">
-            <group>admin:channel_price_history_config:read</group>
+            <group>admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="lowestPriceForDiscountedProductsVisible">
             <group>admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
-            <group>admin:channel_price_history_config:read</group>
+            <group>admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="lowestPriceForDiscountedProductsCheckingPeriod">
             <group>admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
-            <group>admin:channel_price_history_config:read</group>
+            <group>admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="taxonsExcludedFromShowingLowestPrice">
             <group>admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
-            <group>admin:channel_price_history_config:read</group>
+            <group>admin:channel_price_history_config:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
@@ -22,29 +22,34 @@
         </attribute>
 
         <attribute name="price">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
 
         <attribute name="originalPrice">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
 
         <attribute name="minimumPrice">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
 
         <attribute name="lowestPriceBeforeDiscount">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
         </attribute>
 
         <attribute name="appliedPromotions">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricingLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricingLogEntry.xml
@@ -17,16 +17,20 @@
 >
     <class name="Sylius\Component\Core\Model\ChannelPricingLogEntry">
         <attribute name="channelPricing">
-            <group>admin:channel_pricing_log_entry:read</group>
+            <group>admin:channel_pricing_log_entry:index</group>
+            <group>admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="price">
-            <group>admin:channel_pricing_log_entry:read</group>
+            <group>admin:channel_pricing_log_entry:index</group>
+            <group>admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="originalPrice">
-            <group>admin:channel_pricing_log_entry:read</group>
+            <group>admin:channel_pricing_log_entry:index</group>
+            <group>admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="loggedAt">
-            <group>admin:channel_pricing_log_entry:read</group>
+            <group>admin:channel_pricing_log_entry:index</group>
+            <group>admin:channel_pricing_log_entry:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/AddProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/AddProductReview.xml
@@ -18,23 +18,28 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview">
         <attribute name="title">
             <group>shop:product_review:create</group>
-            <group>shop:product_review:read</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
         <attribute name="rating">
             <group>shop:product_review:create</group>
-            <group>shop:product_review:read</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
         <attribute name="comment">
             <group>shop:product_review:create</group>
-            <group>shop:product_review:read</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
         <attribute name="productCode" serialized-name="product">
             <group>shop:product_review:create</group>
-            <group>shop:product_review:read</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
         <attribute name="email">
             <group>shop:product_review:create</group>
-            <group>shop:product_review:read</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
@@ -17,27 +17,35 @@
 >
     <class name="Sylius\Component\Addressing\Model\Country">
         <attribute name="id">
-            <group>admin:country:read</group>
+            <group>admin:country:index</group>
+            <group>admin:country:show</group>
         </attribute>
        <attribute name="code">
-           <group>admin:country:read</group>
+           <group>admin:country:index</group>
+           <group>admin:country:show</group>
            <group>admin:country:create</group>
-           <group>shop:country:read</group>
+           <group>shop:country:index</group>
+           <group>shop:country:show</group>
        </attribute>
        <attribute name="name">
-           <group>admin:country:read</group>
-           <group>shop:country:read</group>
+           <group>admin:country:index</group>
+           <group>admin:country:show</group>
+           <group>shop:country:index</group>
+           <group>shop:country:show</group>
        </attribute>
        <attribute name="enabled">
-           <group>admin:country:read</group>
+           <group>admin:country:index</group>
+           <group>admin:country:show</group>
            <group>admin:country:create</group>
            <group>admin:country:update</group>
        </attribute>
        <attribute name="provinces">
-           <group>admin:country:read</group>
+           <group>admin:country:index</group>
+           <group>admin:country:show</group>
            <group>admin:country:create</group>
            <group>admin:country:update</group>
-           <group>shop:country:read</group>
+           <group>shop:country:index</group>
+           <group>shop:country:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
@@ -17,13 +17,17 @@
 >
     <class name="Sylius\Component\Currency\Model\Currency">
        <attribute name="code">
-           <group>admin:currency:read</group>
+           <group>admin:currency:index</group>
+           <group>admin:currency:show</group>
            <group>admin:currency:create</group>
-           <group>shop:currency:read</group>
+           <group>shop:currency:index</group>
+           <group>shop:currency:show</group>
        </attribute>
         <attribute name="name">
-            <group>admin:currency:read</group>
-            <group>shop:currency:read</group>
+            <group>admin:currency:index</group>
+            <group>admin:currency:show</group>
+            <group>shop:currency:index</group>
+            <group>shop:currency:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Customer.xml
@@ -17,87 +17,100 @@
 >
     <class name="Sylius\Component\Core\Model\Customer">
         <attribute name="id">
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
         </attribute>
 
         <attribute name="email">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
-            <group>shop:customer:read</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="firstName">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
-            <group>shop:customer:read</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="lastName">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
-            <group>shop:customer:read</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="fullName">
-            <group>admin:customer:read</group>
-            <group>shop:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
+            <group>shop:customer:show</group>
         </attribute>
 
         <attribute name="defaultAddress">
-            <group>admin:customer:read</group>
-            <group>shop:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="user">
             <group>admin:customer:create</group>
             <group>admin:customer:update</group>
-            <group>admin:customer:read</group>
-            <group>shop:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
+            <group>shop:customer:show</group>
         </attribute>
 
         <attribute name="group">
             <group>admin:customer:create</group>
             <group>admin:customer:update</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
         </attribute>
 
         <attribute name="gender">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
-            <group>shop:customer:read</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="birthday">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
         </attribute>
 
         <attribute name="phoneNumber">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
         </attribute>
 
         <attribute name="subscribedToNewsletter">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
-            <group>shop:customer:read</group>
+            <group>shop:customer:show</group>
             <group>shop:customer:update</group>
         </attribute>
 
         <attribute name="createdAt">
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerGroup.xml
@@ -17,14 +17,17 @@
 >
     <class name="Sylius\Component\Customer\Model\CustomerGroup">
         <attribute name="id">
-            <group>admin:customer_group:read</group>
+            <group>admin:customer_group:index</group>
+            <group>admin:customer_group:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:customer_group:read</group>
+            <group>admin:customer_group:index</group>
+            <group>admin:customer_group:show</group>
             <group>admin:customer_group:create</group>
         </attribute>
         <attribute name="name">
-            <group>admin:customer_group:read</group>
+            <group>admin:customer_group:index</group>
+            <group>admin:customer_group:show</group>
             <group>admin:customer_group:create</group>
             <group>admin:customer_group:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerStatistics.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerStatistics.xml
@@ -17,10 +17,10 @@
 >
     <class name="Sylius\Component\Core\Customer\Statistics\CustomerStatistics">
         <attribute name="allOrdersCount">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
         <attribute name="perChannelsStatistics">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ExchangeRate.xml
@@ -17,24 +17,32 @@
 >
     <class name="Sylius\Component\Currency\Model\ExchangeRate">
         <attribute name="id">
-            <group>admin:exchange_rate:read</group>
-            <group>shop:exchange_rate:read</group>
+            <group>admin:exchange_rate:index</group>
+            <group>admin:exchange_rate:show</group>
+            <group>shop:exchange_rate:index</group>
+            <group>shop:exchange_rate:show</group>
         </attribute>
         <attribute name="ratio">
             <group>admin:exchange_rate:create</group>
-            <group>admin:exchange_rate:read</group>
+            <group>admin:exchange_rate:index</group>
+            <group>admin:exchange_rate:show</group>
             <group>admin:exchange_rate:update</group>
-            <group>shop:exchange_rate:read</group>
+            <group>shop:exchange_rate:index</group>
+            <group>shop:exchange_rate:show</group>
         </attribute>
         <attribute name="sourceCurrency">
             <group>admin:exchange_rate:create</group>
-            <group>admin:exchange_rate:read</group>
-            <group>shop:exchange_rate:read</group>
+            <group>admin:exchange_rate:index</group>
+            <group>admin:exchange_rate:show</group>
+            <group>shop:exchange_rate:index</group>
+            <group>shop:exchange_rate:show</group>
         </attribute>
         <attribute name="targetCurrency">
             <group>admin:exchange_rate:create</group>
-            <group>admin:exchange_rate:read</group>
-            <group>shop:exchange_rate:read</group>
+            <group>admin:exchange_rate:index</group>
+            <group>admin:exchange_rate:show</group>
+            <group>shop:exchange_rate:index</group>
+            <group>shop:exchange_rate:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
@@ -17,19 +17,19 @@
 >
     <class name="Sylius\Bundle\PayumBundle\Model\GatewayConfig">
         <attribute name="id">
-            <group>admin:gateway_config:read</group>
+            <group>admin:gateway_config:show</group>
         </attribute>
         <attribute name="config">
-            <group>admin:gateway_config:read</group>
+            <group>admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
         </attribute>
         <attribute name="gatewayName">
-            <group>admin:gateway_config:read</group>
+            <group>admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
         </attribute>
         <attribute name="factoryName">
-            <group>admin:gateway_config:read</group>
+            <group>admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Locale.xml
@@ -17,16 +17,21 @@
 >
     <class name="Sylius\Component\Locale\Model\Locale">
         <attribute name="id">
-            <group>admin:locale:read</group>
+            <group>admin:locale:index</group>
+            <group>admin:locale:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:locale:read</group>
+            <group>admin:locale:index</group>
+            <group>admin:locale:show</group>
             <group>admin:locale:create</group>
-            <group>shop:locale:read</group>
+            <group>shop:locale:index</group>
+            <group>shop:locale:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:locale:read</group>
-            <group>shop:locale:read</group>
+            <group>admin:locale:index</group>
+            <group>admin:locale:show</group>
+            <group>shop:locale:index</group>
+            <group>shop:locale:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
@@ -17,168 +17,203 @@
 >
     <class name="Sylius\Component\Core\Model\Order">
         <attribute name="id">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
         </attribute>
 
         <attribute name="number">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
         </attribute>
 
         <attribute name="currencyCode">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="channel">
-            <group>admin:order:read</group>
-            <group>shop:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
         </attribute>
 
         <attribute name="customer">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
         </attribute>
 
         <attribute name="payments">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="shipments">
-            <group>shop:order:account:read</group>
-            <group>shop:cart:read</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="checkoutState">
-            <group>shop:order:account:read</group>
-            <group>shop:cart:read</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="state">
-            <group>admin:order:read</group>
-            <group>shop:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
         </attribute>
 
         <attribute name="paymentState">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="shippingState">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
         </attribute>
 
         <attribute name="total">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="orderPromotionTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingPromotionTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="tokenValue">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
         </attribute>
 
         <attribute name="items">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="notes">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
         </attribute>
 
         <attribute name="itemsTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="itemsSubtotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:index</group>
+            <group>shop:order:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingTaxTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxExcludedTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxIncludedTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="itemsSubtotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="localeCode">
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>admin:cart:update</group>
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingTotal">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingAddress">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
 
         <attribute name="billingAddress">
-            <group>admin:order:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
@@ -17,93 +17,103 @@
 >
     <class name="Sylius\Component\Core\Model\OrderItem">
         <attribute name="id">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="order">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="variant">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="quantity">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="unitPrice">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
+            <group>shop:cart:show</group>
         </attribute>
         <attribute name="originalUnitPrice">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
+            <group>shop:cart:show</group>
         </attribute>
         <attribute name="discountedUnitPrice">
-            <group>shop:order_item:read</group>
-            <group>shop:cart:read</group>
+            <group>shop:order_item:show</group>
+            <group>shop:cart:show</group>
         </attribute>
         <attribute name="units">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="adjustments">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsRecursively">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsTotal">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsTotalRecursively">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="product">
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="productName">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="subtotal">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:cart:show</group>
+            <group>shop:order_item:show</group>
         </attribute>
         <attribute name="total">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
-            <group>shop:cart:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
+            <group>shop:order_item:show</group>
+            <group>shop:cart:show</group>
         </attribute>
         <attribute name="fullDiscountedUnitPrice">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
+            <group>admin:order_item:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItemUnit.xml
@@ -17,12 +17,12 @@
 >
     <class name="Sylius\Component\Core\Model\OrderItemUnit">
         <attribute name="id">
-            <group>admin:order_item_unit:read</group>
-            <group>shop:order_item_unit:read</group>
+            <group>admin:order_item_unit:show</group>
+            <group>shop:order_item_unit:show</group>
         </attribute>
         <attribute name="shippable">
-            <group>admin:order_item_unit:read</group>
-            <group>shop:order_item_unit:read</group>
+            <group>admin:order_item_unit:show</group>
+            <group>shop:order_item_unit:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
@@ -17,16 +17,18 @@
 >
     <class name="Sylius\Component\Core\Model\Payment">
         <attribute name="id">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>admin:payment:read</group>
-            <group>shop:cart:read</group>
+            <group>shop:cart:show</group>
             <group>shop:payment:read</group>
         </attribute>
         <attribute name="method">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>admin:payment:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
             <group>shop:payment:read</group>
         </attribute>
         <attribute name="currencyCode">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
@@ -19,45 +19,54 @@
         <attribute name="id">
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>admin:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
             <group>shop:cart:show</group>
-            <group>shop:payment:read</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="method">
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>admin:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
             <group>shop:cart:show</group>
             <group>shop:order:account:show</group>
-            <group>shop:payment:read</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="currencyCode">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="amount">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="state">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="details">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
         <attribute name="order">
-            <group>admin:payment:read</group>
-            <group>shop:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
+            <group>shop:payment:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -17,58 +17,72 @@
 >
     <class name="Sylius\Component\Core\Model\PaymentMethod">
         <attribute name="id">
-            <group>admin:payment_method:read</group>
-            <group>shop:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="translations">
-            <group>admin:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
             <group>shop:order:account:show</group>
-            <group>shop:payment:read</group>
+            <group>shop:payment:show</group>
         </attribute>
 
         <attribute name="name">
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
         </attribute>
 
         <attribute name="code">
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="description">
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="instructions">
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
         </attribute>
 
         <attribute name="position">
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="gatewayConfig">
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -26,7 +26,7 @@
             <group>admin:payment_method:create</group>
             <group>admin:payment_method:read</group>
             <group>admin:payment_method:update</group>
-            <group>shop:order:account:read</group>
+            <group>shop:order:account:show</group>
             <group>shop:payment:read</group>
         </attribute>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
@@ -25,7 +25,7 @@
             <group>admin:payment_method:create</group>
             <group>admin:payment_method:read</group>
             <group>admin:payment_method:update</group>
-            <group>shop:order:account:read</group>
+            <group>shop:order:account:show</group>
             <group>shop:payment:read</group>
             <group>shop:payment_method:read</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
@@ -17,31 +17,39 @@
 >
     <class name="Sylius\Component\Payment\Model\PaymentMethodTranslation">
         <attribute name="id">
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
         </attribute>
 
         <attribute name="name">
-            <group>admin:payment:read</group>
+            <group>admin:payment:index</group>
+            <group>admin:payment:show</group>
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
             <group>shop:order:account:show</group>
-            <group>shop:payment:read</group>
-            <group>shop:payment_method:read</group>
+            <group>shop:payment:show</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="instructions">
             <group>admin:payment_method:create</group>
-            <group>admin:payment_method:read</group>
+            <group>admin:payment_method:index</group>
+            <group>admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
-            <group>shop:payment_method:read</group>
+            <group>shop:payment_method:index</group>
+            <group>shop:payment_method:show</group>
         </attribute>
 
         <attribute name="locale">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PerChannelCustomerStatistics.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PerChannelCustomerStatistics.xml
@@ -17,16 +17,16 @@
 >
     <class name="Sylius\Component\Core\Customer\Statistics\PerChannelCustomerStatistics">
         <attribute name="channel">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
         <attribute name="ordersCount">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
         <attribute name="ordersValue">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
         <attribute name="averageOrderValue">
-            <group>admin:customer:statistics:read</group>
+            <group>admin:customer:statistics:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
@@ -17,95 +17,128 @@
 >
     <class name="Sylius\Component\Core\Model\Product">
         <attribute name="id">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="variantSelectionMethod">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
         </attribute>
         <attribute name="enabled">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
         <attribute name="name">
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="description">
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="slug">
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="shortDescription">
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
         <attribute name="mainTaxon">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="productTaxons">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="options">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="variants">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="images">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="reviews">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="averageRating">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="associations">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="attributes">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
         <attribute name="channels">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociation.xml
@@ -17,22 +17,25 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAssociation">
         <attribute name="id">
-            <group>shop:product_association:read</group>
+            <group>shop:product_association:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:product_association:read</group>
+            <group>admin:product_association:index</group>
+            <group>admin:product_association:show</group>
             <group>admin:product_association:create</group>
-            <group>shop:product_association:read</group>
+            <group>shop:product_association:show</group>
         </attribute>
         <attribute name="owner">
-            <group>admin:product_association:read</group>
+            <group>admin:product_association:index</group>
+            <group>admin:product_association:show</group>
             <group>admin:product_association:create</group>
         </attribute>
         <attribute name="associatedProducts">
-            <group>admin:product_association:read</group>
+            <group>admin:product_association:index</group>
+            <group>admin:product_association:show</group>
             <group>admin:product_association:create</group>
             <group>admin:product_association:update</group>
-            <group>shop:product_association:read</group>
+            <group>shop:product_association:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationType.xml
@@ -17,28 +17,34 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAssociationType">
         <attribute name="id">
-            <group>admin:product_association_type:read</group>
-            <group>shop:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
+            <group>shop:product_association_type:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
-            <group>shop:product_association_type:read</group>
+            <group>shop:product_association_type:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product_association_type:read</group>
-            <group>shop:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
+            <group>shop:product_association_type:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:product_association_type:read</group>
-            <group>shop:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
+            <group>shop:product_association_type:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:product_association_type:read</group>
-            <group>shop:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
+            <group>shop:product_association_type:show</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
             <group>admin:product_association_type:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationTypeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationTypeTranslation.xml
@@ -17,10 +17,12 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAssociationTypeTranslation">
         <attribute name="id">
-            <group>admin:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product_association_type:read</group>
+            <group>admin:product_association_type:index</group>
+            <group>admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
             <group>admin:product_association_type:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttribute.xml
@@ -17,41 +17,48 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAttribute">
         <attribute name="id">
-            <group>shop:product_attribute:read</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
         <attribute name="name">
-            <group>shop:product_attribute:read</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
         <attribute name="code">
-            <group>shop:product_attribute:read</group>
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
         <attribute name="type">
-            <group>shop:product_attribute:read</group>
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
         <attribute name="storageType">
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
         </attribute>
         <attribute name="translatable">
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
         </attribute>
         <attribute name="position">
-            <group>shop:product_attribute:read</group>
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
+            <group>shop:product_attribute:show</group>
             <group>admin:product_attribute:update</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeTranslation.xml
@@ -17,18 +17,20 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAttributeTranslation">
         <attribute name="id">
-            <group>shop:product_attribute:read</group>
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
         </attribute>
         <attribute name="name">
-            <group>shop:product_attribute:read</group>
-            <group>admin:product_attribute:read</group>
+            <group>admin:product_attribute:index</group>
+            <group>admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>shop:product_attribute:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeValue.xml
@@ -17,35 +17,39 @@
 >
     <class name="Sylius\Component\Product\Model\ProductAttributeValue">
         <attribute name="id">
-            <group>admin:product:read</group>
-            <group>shop:product_attribute_value:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="attribute">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="value">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="localeCode">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="name">
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="type">
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="code">
-            <group>shop:product_attribute_value:read</group>
+            <group>shop:product_attribute_value:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
@@ -17,31 +17,43 @@
 >
     <class name="Sylius\Component\Core\Model\ProductImage">
         <attribute name="id">
-            <group>admin:product_image:read</group>
-            <group>shop:product_image:read</group>
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product_image:index</group>
+            <group>admin:product_image:show</group>
+            <group>shop:product_image:show</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="path">
-            <group>admin:product_image:read</group>
-            <group>shop:product_image:read</group>
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product_image:index</group>
+            <group>admin:product_image:show</group>
+            <group>shop:product_image:show</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="owner">
-            <group>admin:product_image:read</group>
+            <group>admin:product_image:index</group>
+            <group>admin:product_image:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:product_image:read</group>
+            <group>admin:product_image:index</group>
+            <group>admin:product_image:show</group>
             <group>admin:product_image:update</group>
-            <group>shop:product_image:read</group>
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>shop:product_image:show</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="productVariants">
-            <group>admin:product_image:read</group>
+            <group>admin:product_image:index</group>
+            <group>admin:product_image:show</group>
             <group>admin:product_image:update</group>
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
@@ -17,34 +17,41 @@
 >
     <class name="Sylius\Component\Product\Model\ProductOption">
         <attribute name="id">
-            <group>admin:product_option:read</group>
-            <group>shop:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
             <group>admin:product_option:create</group>
-            <group>shop:product_option:read</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product_option:read</group>
-            <group>shop:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:product_option:read</group>
-            <group>shop:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:product_option:read</group>
-            <group>shop:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="values">
-            <group>admin:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
-            <group>shop:product_option:read</group>
+            <group>shop:product_option:show</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionTranslation.xml
@@ -17,10 +17,12 @@
 >
     <class name="Sylius\Component\Product\Model\ProductOptionTranslation">
         <attribute name="id">
-            <group>admin:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product_option:read</group>
+            <group>admin:product_option:index</group>
+            <group>admin:product_option:show</group>
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
@@ -17,28 +17,28 @@
 >
     <class name="Sylius\Component\Product\Model\ProductOptionValue">
         <attribute name="id">
-            <group>admin:product_option_value:read</group>
-            <group>shop:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
+            <group>shop:product_option_value:show</group>
         </attribute>
         <attribute name="value">
-            <group>admin:product_option_value:read</group>
-            <group>shop:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
+            <group>shop:product_option_value:show</group>
         </attribute>
         <attribute name="option">
-            <group>admin:product_option_value:read</group>
-            <group>shop:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
+            <group>shop:product_option_value:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
-            <group>admin:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
-            <group>shop:product_option_value:read</group>
+            <group>shop:product_option_value:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
-            <group>admin:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValueTranslation.xml
@@ -17,12 +17,12 @@
 >
     <class name="Sylius\Component\Product\Model\ProductOptionValueTranslation">
         <attribute name="id">
-            <group>admin:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
         </attribute>
         <attribute name="value">
             <group>admin:product_option:create</group>
             <group>admin:product_option:update</group>
-            <group>admin:product_option_value:read</group>
+            <group>admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
         </attribute>
         <attribute name="locale">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
@@ -17,43 +17,61 @@
 >
     <class name="Sylius\Component\Core\Model\ProductReview">
         <attribute name="id">
-            <group>admin:product_review:read</group>
-            <group>shop:product_review:read</group>
+            <group>admin:product_review:index</group>
+            <group>admin:product_review:show</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:product_review:read</group>
-            <group>shop:product_review:read</group>
+            <group>admin:product_review:index</group>
+            <group>admin:product_review:show</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
        </attribute>
         <attribute name="updatedAt">
-            <group>admin:product_review:read</group>
-            <group>shop:product_review:read</group>
+            <group>admin:product_review:index</group>
+            <group>admin:product_review:show</group>
+            <group>shop:product_review:index</group>
+            <group>shop:product_review:show</group>
        </attribute>
        <attribute name="title">
-           <group>admin:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
            <group>admin:product_review:update</group>
-           <group>shop:product_review:read</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
        <attribute name="rating">
-           <group>admin:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
            <group>admin:product_review:update</group>
-           <group>shop:product_review:read</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
        <attribute name="comment">
-           <group>admin:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
            <group>admin:product_review:update</group>
-           <group>shop:product_review:read</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
        <attribute name="author">
-           <group>admin:product_review:read</group>
-           <group>shop:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
        <attribute name="status">
-           <group>admin:product_review:read</group>
-           <group>shop:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
        <attribute name="reviewSubject">
-           <group>admin:product_review:read</group>
-           <group>shop:product_review:read</group>
+           <group>admin:product_review:index</group>
+           <group>admin:product_review:show</group>
+           <group>shop:product_review:index</group>
+           <group>shop:product_review:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
@@ -17,26 +17,30 @@
 
     <class name="Sylius\Component\Core\Model\ProductTaxon">
         <attribute name="id">
-            <group>admin:product_taxon:read</group>
-            <group>shop:product_taxon:read</group>
+            <group>admin:product_taxon:index</group>
+            <group>admin:product_taxon:show</group>
+            <group>shop:product_taxon:show</group>
         </attribute>
         <attribute name="taxon">
-            <group>admin:product_taxon:read</group>
+            <group>admin:product_taxon:index</group>
+            <group>admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
-            <group>shop:product_taxon:read</group>
+            <group>shop:product_taxon:show</group>
         </attribute>
         <attribute name="product">
-            <group>admin:product_taxon:read</group>
+            <group>admin:product_taxon:index</group>
+            <group>admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
-            <group>shop:product_taxon:read</group>
+            <group>shop:product_taxon:show</group>
         </attribute>
         <attribute name="position">
-            <group>admin:product_taxon:read</group>
+            <group>admin:product_taxon:index</group>
+            <group>admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
-            <group>shop:product_taxon:read</group>
+            <group>shop:product_taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
@@ -17,48 +17,62 @@
 >
     <class name="Sylius\Component\Product\Model\ProductTranslation">
         <attribute name="id">
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product:create</group>
             <group>admin:product:update</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="slug">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="description">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="shortDescription">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="metaKeywords">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
         <attribute name="metaDescription">
-            <group>admin:product:read</group>
+            <group>admin:product:index</group>
+            <group>admin:product:show</group>
             <group>admin:product:create</group>
             <group>admin:product:update</group>
-            <group>shop:product:read</group>
+            <group>shop:product:index</group>
+            <group>shop:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -17,99 +17,122 @@
 >
     <class name="Sylius\Component\Core\Model\ProductVariant">
         <attribute name="code">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
         </attribute>
         <attribute name="product">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="optionValues">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
         </attribute>
         <attribute name="channelPricings">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="name">
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
         </attribute>
         <attribute name="enabled">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="position">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="tracked">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="onHold">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="onHand">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="weight">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="width">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="height">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="depth">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="taxCategory">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="shippingCategory">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="shippingRequired">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
@@ -17,19 +17,23 @@
 >
     <class name="Sylius\Component\Product\Model\ProductVariantTranslation">
         <attribute name="id">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
             <group>shop:order:account:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:index</group>
+            <group>admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>shop:product_variant:read</group>
+            <group>shop:product_variant:index</group>
+            <group>shop:product_variant:show</group>
             <group>shop:order:account:show</group>
         </attribute>
         <attribute name="locale">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
@@ -18,17 +18,19 @@
     <class name="Sylius\Component\Product\Model\ProductVariantTranslation">
         <attribute name="id">
             <group>admin:product_variant:read</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:product_variant:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_variant:read</group>
             <group>admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>shop:product_variant:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:order:account:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_variant:create</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
@@ -13,104 +13,123 @@
 >
     <class name="Sylius\Component\Core\Model\Promotion">
         <attribute name="id">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="createdAt">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="updatedAt">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="name">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="code">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
         </attribute>
 
         <attribute name="description">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="priority">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="exclusive">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="appliesToDiscounted">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="usageLimit">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="used">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="startsAt">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="endsAt">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="couponBased">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="coupons">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="rules">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="actions">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="channels">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
 
         <attribute name="translations">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionAction.xml
@@ -13,15 +13,18 @@
 >
     <class name="Sylius\Component\Promotion\Model\PromotionAction">
         <attribute name="id">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionCoupon.xml
@@ -17,47 +17,56 @@
 >
     <class name="Sylius\Component\Core\Model\PromotionCoupon">
         <attribute name="createdAt">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="updatedAt">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="code">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
         </attribute>
 
         <attribute name="usageLimit">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="perCustomerUsageLimit">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="used">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="reusableFromCancelledOrders">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="promotion">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
         </attribute>
 
         <attribute name="expiresAt">
-            <group>admin:promotion_coupon:read</group>
+            <group>admin:promotion_coupon:index</group>
+            <group>admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionRule.xml
@@ -13,15 +13,18 @@
 >
     <class name="Sylius\Component\Promotion\Model\PromotionRule">
         <attribute name="id">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
@@ -17,11 +17,13 @@
 >
     <class name="Sylius\Component\Promotion\Model\PromotionTranslation">
         <attribute name="id">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
         </attribute>
 
         <attribute name="label">
-            <group>admin:promotion:read</group>
+            <group>admin:promotion:index</group>
+            <group>admin:promotion:show</group>
             <group>admin:promotion:create</group>
             <group>admin:promotion:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
@@ -19,13 +19,15 @@
        <attribute name="code">
            <group>admin:country:create</group>
            <group>admin:country:update</group>
-           <group>shop:country:read</group>
+           <group>shop:country:index</group>
+           <group>shop:country:show</group>
            <group>admin:province:read</group>
        </attribute>
        <attribute name="name">
            <group>admin:country:create</group>
            <group>admin:country:update</group>
-           <group>shop:country:read</group>
+           <group>shop:country:index</group>
+           <group>shop:country:show</group>
            <group>admin:province:read</group>
            <group>admin:province:update</group>
        </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
@@ -21,20 +21,20 @@
            <group>admin:country:update</group>
            <group>shop:country:index</group>
            <group>shop:country:show</group>
-           <group>admin:province:read</group>
+           <group>admin:province:show</group>
        </attribute>
        <attribute name="name">
            <group>admin:country:create</group>
            <group>admin:country:update</group>
            <group>shop:country:index</group>
            <group>shop:country:show</group>
-           <group>admin:province:read</group>
+           <group>admin:province:show</group>
            <group>admin:province:update</group>
        </attribute>
        <attribute name="abbreviation">
            <group>admin:country:create</group>
            <group>admin:country:update</group>
-           <group>admin:province:read</group>
+           <group>admin:province:show</group>
            <group>admin:province:update</group>
        </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
@@ -19,53 +19,62 @@
         <attribute name="id">
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>admin:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
             <group>shop:cart:show</group>
-            <group>shop:shipment:read</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="createdAt">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="updatedAt">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="state">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="method">
             <group>admin:order:index</group>
             <group>admin:order:show</group>
-            <group>admin:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
             <group>shop:cart:show</group>
             <group>shop:order:account:show</group>
-            <group>shop:shipment:read</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="units">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="tracking">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="shippedAt">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="order">
-            <group>admin:shipment:read</group>
-            <group>shop:shipment:read</group>
+            <group>admin:shipment:index</group>
+            <group>admin:shipment:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
@@ -17,9 +17,10 @@
 >
     <class name="Sylius\Component\Core\Model\Shipment">
         <attribute name="id">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>admin:shipment:read</group>
-            <group>shop:cart:read</group>
+            <group>shop:cart:show</group>
             <group>shop:shipment:read</group>
         </attribute>
 
@@ -39,10 +40,11 @@
         </attribute>
 
         <attribute name="method">
-            <group>admin:order:read</group>
+            <group>admin:order:index</group>
+            <group>admin:order:show</group>
             <group>admin:shipment:read</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
             <group>shop:shipment:read</group>
         </attribute>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingCategory.xml
@@ -17,27 +17,33 @@
 >
     <class name="Sylius\Component\Shipping\Model\ShippingCategory">
         <attribute name="id">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
             <group>admin:shipping_category:create</group>
         </attribute>
         <attribute name="name">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
             <group>admin:shipping_category:update</group>
             <group>admin:shipping_category:create</group>
         </attribute>
         <attribute name="description">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
             <group>admin:shipping_category:update</group>
             <group>admin:shipping_category:create</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:shipping_category:read</group>
+            <group>admin:shipping_category:index</group>
+            <group>admin:shipping_category:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
@@ -17,83 +17,101 @@
 >
     <class name="Sylius\Component\Core\Model\ShippingMethod">
         <attribute name="id">
-            <group>admin:shipping_method:read</group>
-            <group>shop:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="translations">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
-            <group>shop:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="name">
-            <group>shop:shipping_method:read</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="description">
-            <group>shop:shipping_method:read</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="position">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
-            <group>shop:shipping_method:read</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="zone">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="calculator">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="configuration">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="rules">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="createdAt">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="updatedAt">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="archivedAt">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodRule.xml
@@ -17,15 +17,18 @@
 >
     <class name="Sylius\Component\Shipping\Model\ShippingMethodRule">
         <attribute name="id">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
         </attribute>
         <attribute name="configuration">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
@@ -24,8 +24,8 @@
             <group>admin:shipping_method:create</group>
             <group>admin:shipping_method:read</group>
             <group>admin:shipping_method:update</group>
-            <group>shop:cart:read</group>
-            <group>shop:order:account:read</group>
+            <group>shop:cart:show</group>
+            <group>shop:order:account:show</group>
             <group>shop:shipping_method:read</group>
             <group>shop:shipment:read</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
@@ -17,24 +17,29 @@
 >
     <class name="Sylius\Component\Shipping\Model\ShippingMethodTranslation">
         <attribute name="id">
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="name">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
             <group>shop:cart:show</group>
             <group>shop:order:account:show</group>
-            <group>shop:shipping_method:read</group>
-            <group>shop:shipment:read</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
+            <group>shop:shipment:show</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:shipping_method:create</group>
-            <group>admin:shipping_method:read</group>
+            <group>admin:shipping_method:index</group>
+            <group>admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
-            <group>shop:shipping_method:read</group>
+            <group>shop:shipping_method:index</group>
+            <group>shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="locale">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopBillingData.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopBillingData.xml
@@ -17,37 +17,37 @@
 >
     <class name="Sylius\Component\Core\Model\ShopBillingData">
         <attribute name="id">
-            <group>admin:shop_billing_data:read</group>
+            <group>admin:shop_billing_data:show</group>
         </attribute>
        <attribute name="company">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="taxId">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="countryCode">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="street">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="city">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="postcode">
            <group>admin:channel:create</group>
            <group>admin:channel:update</group>
-           <group>admin:shop_billing_data:read</group>
+           <group>admin:shop_billing_data:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
@@ -23,13 +23,15 @@
 
         <attribute name="enabled">
             <group>admin:customer:create</group>
-            <group>admin:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
             <group>admin:customer:update</group>
         </attribute>
 
         <attribute name="verified">
-            <group>admin:customer:read</group>
-            <group>shop:customer:read</group>
+            <group>admin:customer:index</group>
+            <group>admin:customer:show</group>
+            <group>shop:customer:show</group>
         </attribute>
 
         <attribute name="verifiedAt" serialized-name="verified">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxCategory.xml
@@ -17,26 +17,32 @@
 >
     <class name="Sylius\Component\Taxation\Model\TaxCategory">
         <attribute name="id">
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:tax_category:create</group>
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:tax_category:create</group>
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
             <group>admin:tax_category:update</group>
         </attribute>
         <attribute name="description">
             <group>admin:tax_category:create</group>
-            <group>admin:tax_category:read</group>
+            <group>admin:tax_category:index</group>
+            <group>admin:tax_category:show</group>
             <group>admin:tax_category:update</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
@@ -17,55 +17,67 @@
 >
     <class name="Sylius\Component\Taxation\Model\TaxRate">
         <attribute name="id">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
         </attribute>
         <attribute name="zone">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="name">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="category">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="calculator">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="amount">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="includedInPrice">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="startDate">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>
         <attribute name="endDate">
-            <group>admin:tax_rate:read</group>
+            <group>admin:tax_rate:index</group>
+            <group>admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
@@ -17,48 +17,62 @@
 >
     <class name="Sylius\Component\Core\Model\Taxon">
         <attribute name="id">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
             <group>admin:taxon:create</group>
         </attribute>
         <attribute name="name">
-            <group>shop:taxon:read</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="slug">
-            <group>shop:taxon:read</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="description">
-            <group>shop:taxon:read</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="parent">
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="children">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="enabled">
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="position">
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="images">
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
@@ -17,23 +17,30 @@
 >
     <class name="Sylius\Component\Core\Model\TaxonImage">
         <attribute name="id">
-            <group>admin:taxon_image:read</group>
-            <group>admin:taxon:read</group>
+            <group>admin:taxon_image:index</group>
+            <group>admin:taxon_image:show</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
         </attribute>
 
         <attribute name="path">
-            <group>admin:taxon_image:read</group>
-            <group>admin:taxon:read</group>
+            <group>admin:taxon_image:index</group>
+            <group>admin:taxon_image:show</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
         </attribute>
 
         <attribute name="owner">
-            <group>admin:taxon_image:read</group>
+            <group>admin:taxon_image:index</group>
+            <group>admin:taxon_image:show</group>
         </attribute>
 
         <attribute name="type">
-            <group>admin:taxon_image:read</group>
+            <group>admin:taxon_image:index</group>
+            <group>admin:taxon_image:show</group>
             <group>admin:taxon_image:update</group>
-            <group>admin:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
@@ -17,24 +17,30 @@
 >
     <class name="Sylius\Component\Taxonomy\Model\TaxonTranslation">
         <attribute name="id">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
-            <group>admin:taxon_translation:read</group>
-            <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
+            <group>admin:taxon_translation:show</group>
+            <group>shop:taxon_translation:show</group>
         </attribute>
         <attribute name="name">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
-            <group>admin:taxon_translation:read</group>
-            <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
+            <group>admin:taxon_translation:show</group>
+            <group>shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="description">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
-            <group>admin:taxon_translation:read</group>
-            <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
+            <group>admin:taxon_translation:show</group>
+            <group>shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
@@ -43,10 +49,12 @@
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="slug">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
-            <group>admin:taxon_translation:read</group>
-            <group>shop:taxon_translation:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
+            <group>admin:taxon_translation:show</group>
+            <group>shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Zone.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Zone.xml
@@ -17,34 +17,42 @@
 >
     <class name="Sylius\Component\Addressing\Model\Zone">
         <attribute name="id">
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:zone:create</group>
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:zone:create</group>
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
             <group>admin:zone:update</group>
         </attribute>
         <attribute name="type">
             <group>admin:zone:create</group>
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="scope">
             <group>admin:zone:create</group>
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="createdAt">
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="updatedAt">
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
         </attribute>
         <attribute name="members">
             <group>admin:zone:create</group>
-            <group>admin:zone:read</group>
+            <group>admin:zone:index</group>
+            <group>admin:zone:show</group>
             <group>admin:zone:update</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ZoneMember.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ZoneMember.xml
@@ -17,12 +17,12 @@
 >
     <class name="Sylius\Component\Addressing\Model\ZoneMember">
         <attribute name="id">
-            <group>admin:zone_member:read</group>
+            <group>admin:zone_member:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:zone:create</group>
             <group>admin:zone:update</group>
-            <group>admin:zone_member:read</group>
+            <group>admin:zone_member:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Country.xml
@@ -35,7 +35,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries/new/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:read</attribute>
+                    <attribute name="groups">shop:country:show</attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Promotion.xml
@@ -24,7 +24,7 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -33,7 +33,7 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:read</attribute>
+                    <attribute name="groups">admin:promotion:show</attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="admin_delete">

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Taxon.xml
@@ -12,7 +12,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:index</attribute>
                 </attribute>
             </collectionOperation>
 
@@ -28,7 +28,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:read</attribute>
+                    <attribute name="groups">shop:taxon:index</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -38,7 +38,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:read</attribute>
+                    <attribute name="groups">admin:taxon:show</attribute>
                 </attribute>
             </itemOperation>
 
@@ -54,7 +54,7 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:read</attribute>
+                    <attribute name="groups">shop:taxon:show</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/config.yaml
@@ -11,7 +11,7 @@
             method: GET
             path: /shop/channels-new-path
             normalization_context:
-                groups: ['shop:channel:read']
+                groups: ['shop:channel:index']
             filters: ['test.channel.id_filter']
 
 '%sylius.model.order.class%':

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/config.yaml
@@ -29,7 +29,7 @@
         admin_get:
             method: GET
             normalization_context:
-                groups: ['admin:promotion:read']
+                groups: ['admin:promotion:index']
         admin_post:
             method: GET
             denormalization_context:
@@ -38,6 +38,6 @@
         admin_get:
             method: GET
             normalization_context:
-                groups: ['admin:promotion:read']
+                groups: ['admin:promotion:show']
         admin_delete:
             method: DELETE

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Taxon.xml
@@ -6,22 +6,30 @@
 >
     <class name="Sylius\Bundle\ApiBundle\Application\Entity\Taxon">
         <attribute name="id">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="code">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
             <group>admin:taxon:create</group>
             <group>admin:taxon:update</group>
         </attribute>
         <attribute name="translations">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
         <attribute name="type">
-            <group>admin:taxon:read</group>
-            <group>shop:taxon:read</group>
+            <group>admin:taxon:index</group>
+            <group>admin:taxon:show</group>
+            <group>shop:taxon:index</group>
+            <group>shop:taxon:show</group>
         </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

here is only split of the read group to show and index, in another PR there is a [BC layer](https://github.com/Sylius/Sylius/pull/15780) to handle it

