### PR TITLE
Add default locale paramter to core

### DIFF
--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -7,6 +7,8 @@ imports:
 
     - { resource: "@SyliusApiBundle/Resources/config/app/config.yaml" }
 
+    - { resource: "../parameters.yaml" }
+
 parameters:
     sylius_core.public_dir: '%kernel.project_dir%/public'
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,2 +1,1 @@
-imports:
-    - { resource: "parameters.yaml" }
+

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -31,6 +31,7 @@ imports:
 parameters:
     sylius_core.public_dir: "%kernel.project_dir%/web"
     sylius_core.images_dir: "%sylius_core.public_dir%/media/image"
+    locale: en_US
 
 doctrine:
     orm:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
continuation of https://github.com/Sylius/Sylius/pull/15740
done to prevent exception when locale does not exists in `parameters.yaml` during installation