### PR TITLE
Bump the @sylius-ui/frontend version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sylius-ui/frontend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "author": "Sylius Sp. z o.o.",
   "dependencies": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

We've bumped the supported node.js version. Once this PR merged, I'll release a new version of the `@sylius-ui/frontend` package.
