### PR TITLE
Remove seconds from checkoutCompletedAt Order grid column

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
@@ -18,7 +18,7 @@ sylius_grid:
                     path: checkoutCompletedAt
                     sortable: checkoutCompletedAt
                     options:
-                        format: d-m-Y H:i:s
+                        format: d-m-Y H:i
                 number:
                     type: twig
                     label: sylius.ui.number


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13              |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                     |
| License         | MIT                                                          |

This might be open for debate, but I think nobody really cares at which exact second the order has been completed. The hour & minute is probably sufficient.
