### PR TITLE
Duplicate all serializer groups with sylius prefix

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,5 +1,13 @@
 # UPGRADE FROM `v1.X.X` TO `v2.0.0`
 
+1. Non-prefix serialization groups in Sylius resources have been removed. 
+   If you have extended any of them, you must prefix them with `sylius:`, for example:
+
+    ```diff
+    - #[Groups(['admin:product:index'])]
+    + #[Groups(['sylius:admin:product:index'])]
+    ```
+
 ## Codebase
 
 * Doctrine MongoDB and PHPCR is not longer supported in ResourceBundle and GridBundle:

--- a/UPGRADE-API-1.13.md
+++ b/UPGRADE-API-1.13.md
@@ -13,6 +13,10 @@
             skip_adding_read_group: true
     ```
 
+1. Sylius serialization groups have been updated with a new prefix of `sylius:some_resource`.
+   If you extend any of the Sylius resources, you should update your serialization groups to use the new prefix.
+   Non-prefix serialization groups are deprecated and will be removed in Sylius 2.0.
+
 1. The constructor of `Sylius\Bundle\ApiBundle\Serializer\ChannelDenormalizer` has been changed:
 
     ```diff

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AccountResetPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AccountResetPassword.xml
@@ -27,7 +27,10 @@
                 <attribute name="output">false</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:reset_password:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:reset_password:create</attribute>
+                        <attribute>sylius:shop:reset_password:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Requests password reset</attribute>
@@ -43,7 +46,10 @@
                 <attribute name="output">false</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:reset_password:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:reset_password:update</attribute>
+                        <attribute>sylius:shop:reset_password:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Resets password</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
@@ -19,7 +19,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/addresses</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:index</attribute>
+                        <attribute>sylius:shop:address:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -27,10 +30,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/shop/addresses</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:address:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:create</attribute>
+                        <attribute>sylius:shop:address:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:show</attribute>
+                        <attribute>sylius:shop:address:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -42,6 +51,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:address:show</attribute>
+                        <attribute>sylius:admin:address:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -52,11 +62,13 @@
                 <attribute name="denormalization_context">
                     <attribute name="groups">
                         <attribute>admin:address:update</attribute>
+                        <attribute>sylius:admin:address:update</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:address:show</attribute>
+                        <attribute>sylius:admin:address:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -66,7 +78,10 @@
                 <attribute name="path">/admin/addresses/{id}/log-entries</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetAddressLogEntryCollectionAction</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:address:log_entry:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:address:log_entry:show</attribute>
+                        <attribute>sylius:admin:address:log_entry:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Retrieves the collection of AddressLogEntry resources.</attribute>
@@ -78,7 +93,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/addresses/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:show</attribute>
+                        <attribute>sylius:shop:address:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -91,10 +109,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/shop/addresses/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:address:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:update</attribute>
+                        <attribute>sylius:shop:address:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:address:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:address:show</attribute>
+                        <attribute>sylius:shop:address:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Adjustment.xml
@@ -24,7 +24,10 @@
                     <attribute>sylius.api.order_token_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:adjustment:index</attribute>
+                        <attribute>sylius:admin:adjustment:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -34,7 +37,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/adjustments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:adjustment:show</attribute>
+                        <attribute>sylius:admin:adjustment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -42,7 +48,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/adjustments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:adjustment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:adjustment:show</attribute>
+                        <attribute>sylius:shop:adjustment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -50,12 +59,18 @@
         <subresourceOperations>
             <subresourceOperation name="api_orders_adjustments_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
             <subresourceOperation name="api_orders_items_adjustments_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminResetPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminResetPassword.xml
@@ -27,7 +27,10 @@
                 <attribute name="output">false</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:reset_password:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:reset_password:create</attribute>
+                        <attribute>sylius:admin:reset_password:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Requests administrator's password reset</attribute>
@@ -43,7 +46,10 @@
                 <attribute name="output">false</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:reset_password:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:reset_password:update</attribute>
+                        <attribute>sylius:admin:reset_password:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Resets administrator's password</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AdminUser.xml
@@ -24,7 +24,10 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:index</attribute>
+                        <attribute>sylius:admin:admin_user:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -35,10 +38,16 @@
                     <attribute>sylius_user_create</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:admin_user:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:create</attribute>
+                        <attribute>sylius:admin:admin_user:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:show</attribute>
+                        <attribute>sylius:admin:admin_user:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -47,17 +56,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:show</attribute>
+                        <attribute>sylius:admin:admin_user:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:admin_user:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:update</attribute>
+                        <attribute>sylius:admin:admin_user:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:admin_user:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:admin_user:show</attribute>
+                        <attribute>sylius:admin:admin_user:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AvatarImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/AvatarImage.xml
@@ -45,7 +45,10 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:avatar_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:avatar_image:show</attribute>
+                        <attribute>sylius:admin:avatar_image:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -54,7 +57,10 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:avatar_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:avatar_image:show</attribute>
+                        <attribute>sylius:admin:avatar_image:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
@@ -36,7 +36,10 @@
                     <attribute>sylius.api.order_filter.priority</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:index</attribute>
+                        <attribute>sylius:admin:catalog_promotion:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -44,10 +47,16 @@
                 <attribute name="path">/admin/catalog-promotions</attribute>
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:catalog_promotion:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:create</attribute>
+                        <attribute>sylius:admin:catalog_promotion:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:show</attribute>
+                        <attribute>sylius:admin:catalog_promotion:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -84,7 +93,10 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="path">/admin/catalog-promotions/{code}</attribute>
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:show</attribute>
+                        <attribute>sylius:admin:catalog_promotion:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -92,7 +104,10 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="path">/shop/catalog-promotions/{code}</attribute>
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:catalog_promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:catalog_promotion:show</attribute>
+                        <attribute>sylius:shop:catalog_promotion:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -100,10 +115,16 @@ Example configuration for `percentage_discount` action type:
                 <attribute name="path">/admin/catalog-promotions/{code}</attribute>
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:catalog_promotion:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:update</attribute>
+                        <attribute>sylius:admin:catalog_promotion:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:show</attribute>
+                        <attribute>sylius:admin:catalog_promotion:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionTranslation.xml
@@ -25,7 +25,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/catalog-promotion-translations/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:catalog_promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:catalog_promotion:show</attribute>
+                        <attribute>sylius:admin:catalog_promotion:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
@@ -21,7 +21,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channels</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:index</attribute>
+                        <attribute>sylius:admin:channel:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -29,7 +32,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/channels</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:channel:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:channel:index</attribute>
+                        <attribute>sylius:shop:channel:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -37,10 +43,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/channels</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:channel:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:create</attribute>
+                        <attribute>sylius:admin:channel:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:show</attribute>
+                        <attribute>sylius:admin:channel:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="validation_groups">sylius</attribute>
             </collectionOperation>
@@ -54,7 +66,10 @@
                     <attribute name="summary">Use $code to retrieve a channel resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:show</attribute>
+                        <attribute>sylius:admin:channel:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +77,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/channels/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:channel:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:channel:show</attribute>
+                        <attribute>sylius:shop:channel:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Use $code to retrieve a channel resource.</attribute>
@@ -73,10 +91,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/channels/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:channel:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:update</attribute>
+                        <attribute>sylius:admin:channel:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel:show</attribute>
+                        <attribute>sylius:admin:channel:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="validation_groups">sylius</attribute>
             </itemOperation>
@@ -92,7 +116,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channels/{code}/shop-billing-data</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shop_billing_data:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shop_billing_data:show</attribute>
+                        <attribute>sylius:admin:shop_billing_data:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPriceHistoryConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPriceHistoryConfig.xml
@@ -25,16 +25,25 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_price_history_config:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel_price_history_config:show</attribute>
+                        <attribute>sylius:admin:channel_price_history_config:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:channel_price_history_config:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel_price_history_config:update</attribute>
+                        <attribute>sylius:admin:channel_price_history_config:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_price_history_config:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel_price_history_config:show</attribute>
+                        <attribute>sylius:admin:channel_price_history_config:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricingLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricingLogEntry.xml
@@ -21,7 +21,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channel-pricing-log-entries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_pricing_log_entry:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel_pricing_log_entry:index</attribute>
+                        <attribute>sylius:admin:channel_pricing_log_entry:index</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.channel_pricing_channel_filter</attribute>
@@ -38,7 +41,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/channel-pricing-log-entries/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:channel_pricing_log_entry:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:channel_pricing_log_entry:show</attribute>
+                        <attribute>sylius:admin:channel_pricing_log_entry:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ContactRequest.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ContactRequest.xml
@@ -30,7 +30,10 @@
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\SendContactRequest</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:contact_request:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:contact_request:create</attribute>
+                        <attribute>sylius:shop:contact_request:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Send contact request</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
@@ -23,7 +23,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:index</attribute>
+                        <attribute>sylius:admin:country:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,7 +34,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:country:index</attribute>
+                        <attribute>sylius:shop:country:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -39,10 +45,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/countries</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:country:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:create</attribute>
+                        <attribute>sylius:admin:country:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:show</attribute>
+                        <attribute>sylius:admin:country:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -52,14 +64,20 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:show</attribute>
+                        <attribute>sylius:admin:country:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:country:show</attribute>
+                        <attribute>sylius:shop:country:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -67,10 +85,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/countries/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:country:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:update</attribute>
+                        <attribute>sylius:admin:country:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:country:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:country:show</attribute>
+                        <attribute>sylius:admin:country:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Currency.xml
@@ -23,7 +23,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/currencies</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:currency:index</attribute>
+                        <attribute>sylius:admin:currency:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,10 +34,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/currencies</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:currency:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:currency:create</attribute>
+                        <attribute>sylius:admin:currency:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:currency:show</attribute>
+                        <attribute>sylius:admin:currency:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -43,7 +52,10 @@
                 <attribute name="route_prefix">shop</attribute>
                 <attribute name="path">/shop/currencies</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:currency:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:currency:index</attribute>
+                        <attribute>sylius:shop:currency:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -53,7 +65,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/currencies/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:currency:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:currency:show</attribute>
+                        <attribute>sylius:admin:currency:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +77,10 @@
                 <attribute name="route_prefix">shop</attribute>
                 <attribute name="path">/shop/currencies/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:currency:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:currency:show</attribute>
+                        <attribute>sylius:shop:currency:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
@@ -24,7 +24,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/customers</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:index</attribute>
+                        <attribute>sylius:admin:customer:index</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.customer_group_filter</attribute>
@@ -35,10 +38,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/customers</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:customer:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:create</attribute>
+                        <attribute>sylius:admin:customer:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:show</attribute>
+                        <attribute>sylius:admin:customer:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="validation_groups">
                     <attribute>sylius</attribute>
@@ -54,7 +63,10 @@
                     <attribute name="summary">Registers a new customer</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:customer:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:customer:create</attribute>
+                        <attribute>sylius:shop:customer:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Account\RegisterShopUser</attribute>
@@ -67,7 +79,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/customers/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:show</attribute>
+                        <attribute>sylius:admin:customer:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -76,7 +91,10 @@
                 <attribute name="path">/admin/customers/{id}/statistics</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetCustomerStatisticsAction</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:statistics:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:statistics:show</attribute>
+                        <attribute>sylius:admin:customer:statistics:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -84,10 +102,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/customers/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:customer:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:update</attribute>
+                        <attribute>sylius:admin:customer:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer:show</attribute>
+                        <attribute>sylius:admin:customer:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="validation_groups">
                     <attribute>sylius</attribute>
@@ -107,6 +131,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:customer:show</attribute>
+                        <attribute>sylius:shop:customer:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -118,7 +143,10 @@
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Account\ChangeShopUserPassword</attribute>
                 <attribute name="output">false</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:customer:password:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:customer:password:update</attribute>
+                        <attribute>sylius:shop:customer:password:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Change password for logged in customer</attribute>
@@ -129,10 +157,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/shop/customers/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:customer:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:customer:update</attribute>
+                        <attribute>sylius:shop:customer:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:customer:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:customer:show</attribute>
+                        <attribute>sylius:shop:customer:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CustomerGroup.xml
@@ -23,17 +23,26 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:index</attribute>
+                        <attribute>sylius:admin:customer_group:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:customer_group:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:create</attribute>
+                        <attribute>sylius:admin:customer_group:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:show</attribute>
+                        <attribute>sylius:admin:customer_group:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -42,17 +51,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:show</attribute>
+                        <attribute>sylius:admin:customer_group:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:customer_group:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:update</attribute>
+                        <attribute>sylius:admin:customer_group:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:customer_group:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:customer_group:show</attribute>
+                        <attribute>sylius:admin:customer_group:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ExchangeRate.xml
@@ -26,7 +26,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ExchangeRateFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:index</attribute>
+                        <attribute>sylius:admin:exchange_rate:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +37,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/exchange-rates</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:exchange_rate:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:exchange_rate:index</attribute>
+                        <attribute>sylius:shop:exchange_rate:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -42,10 +48,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/exchange-rates</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:exchange_rate:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:create</attribute>
+                        <attribute>sylius:admin:exchange_rate:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:show</attribute>
+                        <attribute>sylius:admin:exchange_rate:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -55,7 +67,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/exchange-rates/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:show</attribute>
+                        <attribute>sylius:admin:exchange_rate:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -63,7 +78,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/exchange-rates/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:exchange_rate:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:exchange_rate:show</attribute>
+                        <attribute>sylius:shop:exchange_rate:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -71,10 +89,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/exchange-rates/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:exchange_rate:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:update</attribute>
+                        <attribute>sylius:admin:exchange_rate:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:exchange_rate:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:exchange_rate:show</attribute>
+                        <attribute>sylius:admin:exchange_rate:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/GatewayConfig.xml
@@ -28,7 +28,10 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:gateway_config:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:gateway_config:show</attribute>
+                        <attribute>sylius:admin:gateway_config:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Locale.xml
@@ -24,7 +24,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/locales</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:locale:index</attribute>
+                        <attribute>sylius:admin:locale:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -32,10 +35,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/locales</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:locale:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:locale:create</attribute>
+                        <attribute>sylius:admin:locale:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:locale:show</attribute>
+                        <attribute>sylius:admin:locale:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -43,7 +52,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/locales</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:locale:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:locale:index</attribute>
+                        <attribute>sylius:shop:locale:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -53,7 +65,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/locales/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:locale:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:locale:show</attribute>
+                        <attribute>sylius:admin:locale:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -66,7 +81,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/locales/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:locale:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:locale:show</attribute>
+                        <attribute>sylius:shop:locale:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -37,7 +37,10 @@
                     <attribute name="number">DESC</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order:index</attribute>
+                        <attribute>sylius:admin:order:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -47,12 +50,17 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\PickupCart</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:order:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:create</attribute>
+                        <attribute>sylius:shop:order:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
                         <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -64,7 +72,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/orders</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:index</attribute>
+                        <attribute>sylius:shop:order:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -74,7 +85,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/orders/{tokenValue}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order:show</attribute>
+                        <attribute>sylius:admin:order:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -84,7 +98,10 @@
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\GetOrderAdjustmentsAction</attribute>
                 <attribute name="write">false</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:adjustment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:adjustment:show</attribute>
+                        <attribute>sylius:admin:adjustment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -92,7 +109,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/orders/{tokenValue}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -103,7 +123,10 @@
                     <attribute name="summary">Deletes cart</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -113,10 +136,16 @@
                 <attribute name="input">false</attribute>
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Applicator\OrderStateMachineTransitionApplicatorInterface::cancel</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:order:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order:update</attribute>
+                        <attribute>sylius:admin:order:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order:show</attribute>
+                        <attribute>sylius:admin:order:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Cancels Order</attribute>
@@ -129,10 +158,16 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:add_item</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:add_item</attribute>
+                        <attribute>sylius:shop:cart:add_item</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Adds Item to cart</attribute>
@@ -148,12 +183,17 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:select_shipping_method</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:select_shipping_method</attribute>
+                        <attribute>sylius:shop:cart:select_shipping_method</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
                         <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -185,12 +225,17 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:select_payment_method</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:select_payment_method</attribute>
+                        <attribute>sylius:shop:cart:select_payment_method</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
                         <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -222,10 +267,16 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:order:account:change_payment_method</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:account:change_payment_method</attribute>
+                        <attribute>sylius:shop:order:account:change_payment_method</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:account:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order:account:show</attribute>
+                        <attribute>sylius:shop:order:account:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Change the payment method as logged shop user</attribute>
@@ -287,12 +338,17 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:complete</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:complete</attribute>
+                        <attribute>sylius:shop:cart:complete</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
                         <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">
@@ -306,7 +362,10 @@
                 <attribute name="controller">Sylius\Bundle\ApiBundle\Controller\DeleteOrderItemAction</attribute>
                 <attribute name="write">false</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:remove_item</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:remove_item</attribute>
+                        <attribute>sylius:shop:cart:remove_item</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="parameters">
@@ -336,10 +395,16 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:change_quantity</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:change_quantity</attribute>
+                        <attribute>sylius:shop:cart:change_quantity</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Changes quantity of order item</attribute>
@@ -370,12 +435,17 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:update</attribute>
+                        <attribute>sylius:shop:cart:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:order:show</attribute>
+                        <attribute>sylius:shop:order:show</attribute>
                         <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="openapi_context">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItem.xml
@@ -23,7 +23,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-items/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order_item:show</attribute>
+                        <attribute>sylius:admin:order_item:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -31,8 +34,14 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/order-items/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order_item:show</attribute>
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order_item:show</attribute>
+                        <attribute>sylius:shop:order_item:show</attribute>
+                    </attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -42,12 +51,18 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-items/{id}/adjustments</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order_item:show</attribute>
+                        <attribute>sylius:admin:order_item:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
             <subresourceOperation name="api_orders_items_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:cart:show</attribute>
+                        <attribute>sylius:shop:cart:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/OrderItemUnit.xml
@@ -23,7 +23,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/order-item-units/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:order_item_unit:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:order_item_unit:show</attribute>
+                        <attribute>sylius:admin:order_item_unit:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -31,7 +34,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/order-item-units/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:order_item_unit:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:order_item_unit:show</attribute>
+                        <attribute>sylius:shop:order_item_unit:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
@@ -30,7 +30,10 @@
                     <attribute>sylius.api.search_payment_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment:index</attribute>
+                        <attribute>sylius:admin:payment:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -40,7 +43,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment:show</attribute>
+                        <attribute>sylius:admin:payment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -48,7 +54,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/payments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:payment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:payment:show</attribute>
+                        <attribute>sylius:shop:payment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
@@ -34,6 +34,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:payment_method:index</attribute>
+                        <attribute>sylius:shop:payment_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -48,6 +49,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:payment_method:index</attribute>
+                        <attribute>sylius:admin:payment_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -56,10 +58,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/payment-methods</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:payment_method:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment_method:create</attribute>
+                        <attribute>sylius:admin:payment_method:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment_method:show</attribute>
+                        <attribute>sylius:admin:payment_method:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -69,7 +77,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payment-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment_method:show</attribute>
+                        <attribute>sylius:admin:payment_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -77,10 +88,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/payment-methods/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:payment_method:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment_method:update</attribute>
+                        <attribute>sylius:admin:payment_method:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:payment_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:payment_method:show</attribute>
+                        <attribute>sylius:admin:payment_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -93,7 +110,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/payment-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:payment_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:payment_method:show</attribute>
+                        <attribute>sylius:shop:payment_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -103,7 +123,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/payment-methods/{code}/gateway-config</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:gateway_config:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:gateway_config:show</attribute>
+                        <attribute>sylius:admin:gateway_config:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -34,7 +34,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TranslationOrderNameAndLocaleFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:index</attribute>
+                        <attribute>sylius:admin:product:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -50,7 +53,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TaxonFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product:index</attribute>
+                        <attribute>sylius:shop:product:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -58,10 +64,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/products</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:create</attribute>
+                        <attribute>sylius:admin:product:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:show</attribute>
+                        <attribute>sylius:admin:product:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -74,7 +86,10 @@
                     <attribute name="summary">Use code to retrieve a product resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:show</attribute>
+                        <attribute>sylius:admin:product:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -85,7 +100,10 @@
                     <attribute name="summary">Use code to retrieve a product resource.</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product:show</attribute>
+                        <attribute>sylius:shop:product:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -108,7 +126,10 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product:show</attribute>
+                        <attribute>sylius:shop:product:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -116,10 +137,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/products/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:update</attribute>
+                        <attribute>sylius:admin:product:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product:show</attribute>
+                        <attribute>sylius:admin:product:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociation.xml
@@ -28,6 +28,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:index</attribute>
+                        <attribute>sylius:admin:product_association:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -38,11 +39,13 @@
                 <attribute name="denormalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:create</attribute>
+                        <attribute>sylius:admin:product_association:create</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:show</attribute>
+                        <attribute>sylius:admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -55,6 +58,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:show</attribute>
+                        <attribute>sylius:admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -65,11 +69,13 @@
                 <attribute name="denormalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:update</attribute>
+                        <attribute>sylius:admin:product_association:update</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_association:show</attribute>
+                        <attribute>sylius:admin:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -85,6 +91,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:product_association:show</attribute>
+                        <attribute>sylius:shop:product_association:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
@@ -26,7 +26,10 @@
                     <attribute>sylius.api.product_association_type_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:index</attribute>
+                        <attribute>sylius:admin:product_association_type:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,10 +37,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-association-types</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_association_type:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:create</attribute>
+                        <attribute>sylius:admin:product_association_type:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:show</attribute>
+                        <attribute>sylius:admin:product_association_type:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -47,7 +56,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-association-types/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:show</attribute>
+                        <attribute>sylius:admin:product_association_type:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -55,7 +67,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-association-types/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_association_type:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_association_type:show</attribute>
+                        <attribute>sylius:shop:product_association_type:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -63,10 +78,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-association-types/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_association_type:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:update</attribute>
+                        <attribute>sylius:admin:product_association_type:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_association_type:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_association_type:show</attribute>
+                        <attribute>sylius:admin:product_association_type:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
@@ -30,7 +30,10 @@
                     <attribute>sylius.api.order_filter.position</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:index</attribute>
+                        <attribute>sylius:admin:product_attribute:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -38,10 +41,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-attributes</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_attribute:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:create</attribute>
+                        <attribute>sylius:admin:product_attribute:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:show</attribute>
+                        <attribute>sylius:admin:product_attribute:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -111,7 +120,10 @@ Example configuration for a `select` type attribute:
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-attributes/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:show</attribute>
+                        <attribute>sylius:admin:product_attribute:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -124,10 +136,16 @@ Example configuration for a `select` type attribute:
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-attributes/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_attribute:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:update</attribute>
+                        <attribute>sylius:admin:product_attribute:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute:show</attribute>
+                        <attribute>sylius:admin:product_attribute:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -195,7 +213,10 @@ Example configuration for a `select` type attribute:
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-attributes/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_attribute:show</attribute>
+                        <attribute>sylius:shop:product_attribute:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeTranslation.xml
@@ -27,7 +27,9 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:product_attribute:show</attribute>
+                        <attribute>sylius:admin:product_attribute:show</attribute>
                         <attribute>admin:product_attribute_translation:show</attribute>
+                        <attribute>sylius:admin:product_attribute_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttributeValue.xml
@@ -29,7 +29,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-attribute-values/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_attribute_value:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_attribute_value:show</attribute>
+                        <attribute>sylius:admin:product_attribute_value:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -37,7 +40,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-attribute-values/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute_value:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_attribute_value:show</attribute>
+                        <attribute>sylius:shop:product_attribute_value:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -45,7 +51,10 @@
         <subresourceOperations>
             <subresourceOperation name="api_products_attributes_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_attribute_value:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_attribute_value:show</attribute>
+                        <attribute>sylius:shop:product_attribute_value:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -15,7 +15,10 @@
                     <attribute>sylius.api.product_image_product_variants_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:index</attribute>
+                        <attribute>sylius:admin:product_image:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -68,7 +71,10 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:show</attribute>
+                        <attribute>sylius:admin:product_image:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -78,7 +84,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:show</attribute>
+                        <attribute>sylius:admin:product_image:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -86,7 +95,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_image:show</attribute>
+                        <attribute>sylius:shop:product_image:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="parameters">
@@ -106,10 +118,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-images/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_image:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:update</attribute>
+                        <attribute>sylius:admin:product_image:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:show</attribute>
+                        <attribute>sylius:admin:product_image:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -122,7 +140,10 @@
         <subresourceOperations>
             <subresourceOperation name="api_products_images_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_image:show</attribute>
+                        <attribute>sylius:admin:product_image:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -27,7 +27,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:index</attribute>
+                        <attribute>sylius:admin:product_option:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -35,10 +38,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-options</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_option:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:create</attribute>
+                        <attribute>sylius:admin:product_option:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:show</attribute>
+                        <attribute>sylius:admin:product_option:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -48,7 +57,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:show</attribute>
+                        <attribute>sylius:admin:product_option:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -56,7 +68,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-options/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_option:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_option:show</attribute>
+                        <attribute>sylius:shop:product_option:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -64,10 +79,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-options/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_option:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:update</attribute>
+                        <attribute>sylius:admin:product_option:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:show</attribute>
+                        <attribute>sylius:admin:product_option:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -77,7 +98,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-options/{code}/values</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option:show</attribute>
+                        <attribute>sylius:admin:product_option:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -25,7 +25,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-option-values/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_option_value:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_option_value:show</attribute>
+                        <attribute>sylius:admin:product_option_value:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -33,7 +36,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-option-values/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_option_value:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_option_value:show</attribute>
+                        <attribute>sylius:shop:product_option_value:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
@@ -27,7 +27,10 @@
                     <attribute>sylius.api.product_review_status_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:index</attribute>
+                        <attribute>sylius:admin:product_review:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -37,10 +40,16 @@
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:product_review:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_review:create</attribute>
+                        <attribute>sylius:shop:product_review:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_review:show</attribute>
+                        <attribute>sylius:shop:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -52,7 +61,10 @@
                     <attribute>sylius.api.product_review_date_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_review:index</attribute>
+                        <attribute>sylius:shop:product_review:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -62,7 +74,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-reviews/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:show</attribute>
+                        <attribute>sylius:admin:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -70,7 +85,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-reviews/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_review:show</attribute>
+                        <attribute>sylius:shop:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -78,7 +96,10 @@
                 <attribute name="method">DELETE</attribute>
                 <attribute name="path">/admin/product-reviews/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_review:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:update</attribute>
+                        <attribute>sylius:admin:product_review:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -86,10 +107,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-reviews/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_review:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:update</attribute>
+                        <attribute>sylius:admin:product_review:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:show</attribute>
+                        <attribute>sylius:admin:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -102,7 +129,10 @@
                     <attribute name="summary">Accepts Product Review</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:show</attribute>
+                        <attribute>sylius:admin:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -115,7 +145,10 @@
                     <attribute name="summary">Rejects Product Review</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_review:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_review:show</attribute>
+                        <attribute>sylius:admin:product_review:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTaxon.xml
@@ -32,7 +32,10 @@
                     <attribute>sylius.api.order_filter.position</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_taxon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_taxon:index</attribute>
+                        <attribute>sylius:admin:product_taxon:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -40,7 +43,10 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-taxons</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_taxon:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_taxon:create</attribute>
+                        <attribute>sylius:admin:product_taxon:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -50,7 +56,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-taxons/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_taxon:show</attribute>
+                        <attribute>sylius:admin:product_taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -58,7 +67,10 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-taxons/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_taxon:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_taxon:update</attribute>
+                        <attribute>sylius:admin:product_taxon:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -66,7 +78,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-taxons/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_taxon:show</attribute>
+                        <attribute>sylius:shop:product_taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -23,7 +23,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-variants/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:show</attribute>
+                        <attribute>sylius:admin:product_variant:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -31,10 +34,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/product-variants/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_variant:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:update</attribute>
+                        <attribute>sylius:admin:product_variant:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:show</attribute>
+                        <attribute>sylius:admin:product_variant:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -42,7 +51,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-variants/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_variant:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_variant:show</attribute>
+                        <attribute>sylius:shop:product_variant:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -62,7 +74,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ProductVariantCatalogPromotionFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:index</attribute>
+                        <attribute>sylius:admin:product_variant:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -70,10 +85,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-variants</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:product_variant:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:create</attribute>
+                        <attribute>sylius:admin:product_variant:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_variant:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:product_variant:show</attribute>
+                        <attribute>sylius:admin:product_variant:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -85,7 +106,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\ProductVariantOptionValueFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_variant:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:product_variant:index</attribute>
+                        <attribute>sylius:shop:product_variant:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -31,10 +31,16 @@
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:promotion:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:create</attribute>
+                        <attribute>sylius:admin:promotion:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:show</attribute>
+                        <attribute>sylius:admin:promotion:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -71,7 +77,10 @@ Example configuration for `order_fixed_discount` action type:
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:index</attribute>
+                        <attribute>sylius:admin:promotion:index</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.promotion_coupon_search_filter</attribute>
@@ -84,17 +93,26 @@ Example configuration for `order_fixed_discount` action type:
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:show</attribute>
+                        <attribute>sylius:admin:promotion:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:promotion:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:update</attribute>
+                        <attribute>sylius:admin:promotion:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:show</attribute>
+                        <attribute>sylius:admin:promotion:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PromotionCoupon.xml
@@ -28,7 +28,10 @@
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\PromotionCouponPromotionFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:index</attribute>
+                        <attribute>sylius:admin:promotion_coupon:index</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="order">
                     <attribute name="used">DESC</attribute>
@@ -38,10 +41,16 @@
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:show</attribute>
+                        <attribute>sylius:admin:promotion_coupon:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:promotion_coupon:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:create</attribute>
+                        <attribute>sylius:admin:promotion_coupon:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -51,10 +60,16 @@
                 <attribute name="path">/promotion-coupons/generate</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Promotion\GeneratePromotionCoupon</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:promotion_coupon:generate</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:generate</attribute>
+                        <attribute>sylius:admin:promotion_coupon:generate</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:show</attribute>
+                        <attribute>sylius:admin:promotion_coupon:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Generates promotion coupons</attribute>
@@ -67,17 +82,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:show</attribute>
+                        <attribute>sylius:admin:promotion_coupon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:show</attribute>
+                        <attribute>sylius:admin:promotion_coupon:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:promotion_coupon:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:update</attribute>
+                        <attribute>sylius:admin:promotion_coupon:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -89,7 +113,10 @@
         <subresourceOperations>
             <subresourceOperation name="api_promotions_coupons_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion_coupon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion_coupon:show</attribute>
+                        <attribute>sylius:admin:promotion_coupon:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Province.xml
@@ -26,17 +26,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:province:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:province:show</attribute>
+                        <attribute>sylius:admin:province:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:province:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:province:update</attribute>
+                        <attribute>sylius:admin:province:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:province:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:province:show</attribute>
+                        <attribute>sylius:admin:province:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Shipment.xml
@@ -30,7 +30,10 @@
                     <attribute>sylius.api.search_shipment_filter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipment:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipment:index</attribute>
+                        <attribute>sylius:admin:shipment:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -40,7 +43,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/shipments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipment:show</attribute>
+                        <attribute>sylius:admin:shipment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -48,7 +54,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/shipments/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:shipment:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:shipment:show</attribute>
+                        <attribute>sylius:shop:shipment:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -61,7 +70,10 @@
                     <attribute name="summary">Ships Shipment</attribute>
                 </attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:shipment:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipment:update</attribute>
+                        <attribute>sylius:admin:shipment:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
@@ -24,17 +24,26 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:index</attribute>
+                        <attribute>sylius:admin:shipping_category:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:shipping_category:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:create</attribute>
+                        <attribute>sylius:admin:shipping_category:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:show</attribute>
+                        <attribute>sylius:admin:shipping_category:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -43,17 +52,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:show</attribute>
+                        <attribute>sylius:admin:shipping_category:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:shipping_category:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:update</attribute>
+                        <attribute>sylius:admin:shipping_category:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_category:show</attribute>
+                        <attribute>sylius:admin:shipping_category:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -27,7 +27,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/shipping-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:show</attribute>
+                        <attribute>sylius:admin:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -35,7 +38,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/shipping-methods/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:shipping_method:show</attribute>
+                        <attribute>sylius:shop:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -43,10 +49,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/shipping-methods/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:shipping_method:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:update</attribute>
+                        <attribute>sylius:admin:shipping_method:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:show</attribute>
+                        <attribute>sylius:admin:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">
@@ -91,7 +103,10 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute name="summary">Archives Shipping Method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:show</attribute>
+                        <attribute>sylius:admin:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -104,7 +119,10 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute name="summary">Restores archived Shipping Method</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:show</attribute>
+                        <attribute>sylius:admin:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>
@@ -119,7 +137,10 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                     <attribute>Sylius\Bundle\ApiBundle\Filter\Doctrine\TranslationOrderNameAndLocaleFilter</attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:index</attribute>
+                        <attribute>sylius:admin:shipping_method:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
             <collectionOperation name="shop_get">
@@ -132,6 +153,7 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:shipping_method:index</attribute>
+                        <attribute>sylius:shop:shipping_method:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -140,10 +162,16 @@ Example configuration for `order_total_greater_than_or_equal` rule type:
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/shipping-methods</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:shipping_method:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:create</attribute>
+                        <attribute>sylius:admin:shipping_method:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shipping_method:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shipping_method:show</attribute>
+                        <attribute>sylius:admin:shipping_method:show</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="description">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopBillingData.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopBillingData.xml
@@ -26,7 +26,10 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:shop_billing_data:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:shop_billing_data:show</attribute>
+                        <attribute>sylius:admin:shop_billing_data:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxCategory.xml
@@ -24,17 +24,26 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:index</attribute>
+                        <attribute>sylius:admin:tax_category:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:tax_category:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:create</attribute>
+                        <attribute>sylius:admin:tax_category:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:show</attribute>
+                        <attribute>sylius:admin:tax_category:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -43,17 +52,26 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:show</attribute>
+                        <attribute>sylius:admin:tax_category:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:tax_category:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:update</attribute>
+                        <attribute>sylius:admin:tax_category:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:tax_category:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:tax_category:show</attribute>
+                        <attribute>sylius:admin:tax_category:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxRate.xml
@@ -25,6 +25,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:show</attribute>
+                        <attribute>sylius:admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -34,11 +35,13 @@
                 <attribute name="denormalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:update</attribute>
+                        <attribute>sylius:admin:tax_rate:update</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:show</attribute>
+                        <attribute>sylius:admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -57,6 +60,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:index</attribute>
+                        <attribute>sylius:admin:tax_rate:index</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>
@@ -66,11 +70,13 @@
                 <attribute name="denormalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:create</attribute>
+                        <attribute>sylius:admin:tax_rate:create</attribute>
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:tax_rate:show</attribute>
+                        <attribute>sylius:admin:tax_rate:show</attribute>
                     </attribute>
                 </attribute>
             </collectionOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
@@ -12,7 +12,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:index</attribute>
+                        <attribute>sylius:admin:taxon:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -20,10 +23,16 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:taxon:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:create</attribute>
+                        <attribute>sylius:admin:taxon:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:show</attribute>
+                        <attribute>sylius:admin:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -31,7 +40,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:taxon:index</attribute>
+                        <attribute>sylius:shop:taxon:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -41,7 +53,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:show</attribute>
+                        <attribute>sylius:admin:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -49,10 +64,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:taxon:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:update</attribute>
+                        <attribute>sylius:admin:taxon:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:show</attribute>
+                        <attribute>sylius:admin:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -65,7 +86,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:taxon:show</attribute>
+                        <attribute>sylius:shop:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonImage.xml
@@ -12,7 +12,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxon-images</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:index</attribute>
+                        <attribute>sylius:admin:taxon_image:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -52,7 +55,10 @@
                     </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:show</attribute>
+                        <attribute>sylius:admin:taxon_image:show</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -62,7 +68,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxon-images/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:show</attribute>
+                        <attribute>sylius:admin:taxon_image:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -70,10 +79,16 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/taxon-images/{id}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:taxon_image:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:update</attribute>
+                        <attribute>sylius:admin:taxon_image:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:show</attribute>
+                        <attribute>sylius:admin:taxon_image:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -86,7 +101,10 @@
         <subresourceOperations>
             <subresourceOperation name="api_taxa_images_get_subresource">
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon_image:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon_image:show</attribute>
+                        <attribute>sylius:admin:taxon_image:show</attribute>
+                    </attribute>
                 </attribute>
             </subresourceOperation>
         </subresourceOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
@@ -16,7 +16,9 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>admin:taxon:show</attribute>
+                        <attribute>sylius:admin:taxon:show</attribute>
                         <attribute>admin:taxon_translation:show</attribute>
+                        <attribute>sylius:admin:taxon_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>
@@ -27,6 +29,7 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">
                         <attribute>shop:taxon_translation:show</attribute>
+                        <attribute>sylius:shop:taxon_translation:show</attribute>
                     </attribute>
                 </attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/VerifyCustomerAccount.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/VerifyCustomerAccount.xml
@@ -28,7 +28,10 @@
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Account\ResendVerificationEmail</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:resend_verification_email:create</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:resend_verification_email:create</attribute>
+                        <attribute>sylius:shop:resend_verification_email:create</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Resends verification email</attribute>
@@ -44,7 +47,10 @@
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Account\VerifyCustomerAccount</attribute>
                 <attribute name="status">202</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">shop:account_verification:update</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:account_verification:update</attribute>
+                        <attribute>sylius:shop:account_verification:update</attribute>
+                    </attribute>
                 </attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Verifies Customer account</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Zone.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Zone.xml
@@ -24,14 +24,20 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:zone:index</attribute>
+                        <attribute>sylius:admin:zone:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:zone:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:zone:create</attribute>
+                        <attribute>sylius:admin:zone:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -40,14 +46,20 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:zone:show</attribute>
+                        <attribute>sylius:admin:zone:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
             <itemOperation name="admin_put">
                 <attribute name="method">PUT</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:zone:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:zone:update</attribute>
+                        <attribute>sylius:admin:zone:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ZoneMember.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ZoneMember.xml
@@ -26,7 +26,10 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:zone_member:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:zone_member:show</attribute>
+                        <attribute>sylius:admin:zone_member:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Address.xml
@@ -18,151 +18,275 @@
     <class name="Sylius\Component\Core\Model\Address">
         <attribute name="id">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
         </attribute>
         <attribute name="customer">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
         </attribute>
         <attribute name="firstName">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="lastName">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="phoneNumber">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="company">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="city">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="street">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="postcode">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="countryCode">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="provinceCode">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="provinceName">
             <group>admin:address:index</group>
+            <group>sylius:admin:address:index</group>
             <group>admin:address:show</group>
+            <group>sylius:admin:address:show</group>
             <group>admin:address:update</group>
+            <group>sylius:admin:address:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:address:create</group>
+            <group>sylius:shop:address:create</group>
             <group>shop:address:index</group>
+            <group>sylius:shop:address:index</group>
             <group>shop:address:show</group>
+            <group>sylius:shop:address:show</group>
             <group>shop:address:update</group>
+            <group>sylius:shop:address:update</group>
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AddressLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AddressLogEntry.xml
@@ -18,15 +18,19 @@
     <class name="Sylius\Component\Addressing\Model\AddressLogEntry">
         <attribute name="action">
             <group>admin:address:log_entry:show</group>
+            <group>sylius:admin:address:log_entry:show</group>
         </attribute>
         <attribute name="logged_at">
             <group>admin:address:log_entry:show</group>
+            <group>sylius:admin:address:log_entry:show</group>
         </attribute>
         <attribute name="version">
             <group>admin:address:log_entry:show</group>
+            <group>sylius:admin:address:log_entry:show</group>
         </attribute>
         <attribute name="data">
             <group>admin:address:log_entry:show</group>
+            <group>sylius:admin:address:log_entry:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
@@ -18,70 +18,111 @@
     <class name="Sylius\Component\Order\Model\Adjustment">
         <attribute name="id">
             <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
             <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="type">
             <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
             <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
        </attribute>
 
         <attribute name="label">
             <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
             <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
             <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
             <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
        </attribute>
 
        <attribute name="amount">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
            <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
        </attribute>
 
        <attribute name="order">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
        </attribute>
 
        <attribute name="order_item">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
        </attribute>
 
        <attribute name="order_item_unit">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
        </attribute>
 
        <attribute name="neutral">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
            <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
        </attribute>
 
        <attribute name="locked">
            <group>admin:adjustment:index</group>
+            <group>sylius:admin:adjustment:index</group>
            <group>admin:adjustment:show</group>
+            <group>sylius:admin:adjustment:show</group>
            <group>shop:adjustment:index</group>
+            <group>sylius:shop:adjustment:index</group>
            <group>shop:adjustment:show</group>
+            <group>sylius:shop:adjustment:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AdminUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AdminUser.xml
@@ -18,67 +18,105 @@
     <class name="Sylius\Component\Core\Model\AdminUser">
         <attribute name="id">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
         <attribute name="email">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="username">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="plainPassword">
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="enabled">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="firstName">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="lastName">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="localeCode">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
             <group>admin:admin_user:create</group>
+            <group>sylius:admin:admin_user:create</group>
             <group>admin:admin_user:update</group>
+            <group>sylius:admin:admin_user:update</group>
         </attribute>
         <attribute name="avatar">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
         <attribute name="verifiedAt">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
         <attribute name="lastLogin">
             <group>admin:admin_user:index</group>
+            <group>sylius:admin:admin_user:index</group>
             <group>admin:admin_user:show</group>
+            <group>sylius:admin:admin_user:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AvatarImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/AvatarImage.xml
@@ -18,12 +18,15 @@
     <class name="Sylius\Component\Core\Model\AvatarImage">
         <attribute name="id">
             <group>admin:avatar_image:show</group>
+            <group>sylius:admin:avatar_image:show</group>
         </attribute>
         <attribute name="path">
             <group>admin:avatar_image:show</group>
+            <group>sylius:admin:avatar_image:show</group>
         </attribute>
         <attribute name="owner">
             <group>admin:avatar_image:show</group>
+            <group>sylius:admin:avatar_image:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotion.xml
@@ -14,99 +14,154 @@
     <class name="Sylius\Component\Promotion\Model\CatalogPromotion">
         <attribute name="id">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>shop:catalog_promotion:show</group>
+            <group>sylius:shop:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
         </attribute>
 
         <attribute name="name">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="startDate">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="endDate">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="priority">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="state">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="label">
             <group>shop:catalog_promotion:show</group>
+            <group>sylius:shop:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="translations">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="scopes">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="actions">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="exclusive">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionAction.xml
@@ -14,19 +14,29 @@
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionAction">
         <attribute name="id">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionScope.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionScope.xml
@@ -18,19 +18,29 @@
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionScope">
         <attribute name="id">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CatalogPromotionTranslation.xml
@@ -18,26 +18,38 @@
     <class name="Sylius\Component\Promotion\Model\CatalogPromotionTranslation">
         <attribute name="id">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
         </attribute>
 
         <attribute name="label">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:catalog_promotion:index</group>
+            <group>sylius:admin:catalog_promotion:index</group>
             <group>admin:catalog_promotion:show</group>
+            <group>sylius:admin:catalog_promotion:show</group>
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
 
         <attribute name="locale">
             <group>admin:catalog_promotion:create</group>
+            <group>sylius:admin:catalog_promotion:create</group>
             <group>admin:catalog_promotion:update</group>
+            <group>sylius:admin:catalog_promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Channel.xml
@@ -18,151 +18,253 @@
     <class name="Sylius\Component\Core\Model\Channel">
         <attribute name="code">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="enabled">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="description">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="hostname">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="color">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="baseCurrency">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="defaultLocale">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="defaultTaxZone">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="taxCalculationStrategy">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="currencies">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="locales">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
             <group>shop:channel:index</group>
+            <group>sylius:shop:channel:index</group>
             <group>shop:channel:show</group>
+            <group>sylius:shop:channel:show</group>
         </attribute>
         <attribute name="countries">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="themeName">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="contactEmail">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="contactPhoneNumber">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="skippingShippingStepAllowed">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="skippingPaymentStepAllowed">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="accountVerificationRequired">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="shippingAddressInCheckoutRequired">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="shopBillingData">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="menuTaxon">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
         <attribute name="channelPriceHistoryConfig">
             <group>admin:channel:index</group>
+            <group>sylius:admin:channel:index</group>
             <group>admin:channel:show</group>
+            <group>sylius:admin:channel:show</group>
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPriceHistoryConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPriceHistoryConfig.xml
@@ -18,21 +18,31 @@
     <class name="Sylius\Component\Core\Model\ChannelPriceHistoryConfig">
         <attribute name="id">
             <group>admin:channel_price_history_config:show</group>
+            <group>sylius:admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="lowestPriceForDiscountedProductsVisible">
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
+            <group>sylius:admin:channel_price_history_config:update</group>
             <group>admin:channel_price_history_config:show</group>
+            <group>sylius:admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="lowestPriceForDiscountedProductsCheckingPeriod">
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
+            <group>sylius:admin:channel_price_history_config:update</group>
             <group>admin:channel_price_history_config:show</group>
+            <group>sylius:admin:channel_price_history_config:show</group>
         </attribute>
         <attribute name="taxonsExcludedFromShowingLowestPrice">
             <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
             <group>admin:channel_price_history_config:update</group>
+            <group>sylius:admin:channel_price_history_config:update</group>
             <group>admin:channel_price_history_config:show</group>
+            <group>sylius:admin:channel_price_history_config:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
@@ -18,38 +18,56 @@
     <class name="Sylius\Component\Core\Model\ChannelPricing">
         <attribute name="channelCode">
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
 
         <attribute name="price">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
 
         <attribute name="originalPrice">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
 
         <attribute name="minimumPrice">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
 
         <attribute name="lowestPriceBeforeDiscount">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
         </attribute>
 
         <attribute name="appliedPromotions">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricingLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricingLogEntry.xml
@@ -18,19 +18,27 @@
     <class name="Sylius\Component\Core\Model\ChannelPricingLogEntry">
         <attribute name="channelPricing">
             <group>admin:channel_pricing_log_entry:index</group>
+            <group>sylius:admin:channel_pricing_log_entry:index</group>
             <group>admin:channel_pricing_log_entry:show</group>
+            <group>sylius:admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="price">
             <group>admin:channel_pricing_log_entry:index</group>
+            <group>sylius:admin:channel_pricing_log_entry:index</group>
             <group>admin:channel_pricing_log_entry:show</group>
+            <group>sylius:admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="originalPrice">
             <group>admin:channel_pricing_log_entry:index</group>
+            <group>sylius:admin:channel_pricing_log_entry:index</group>
             <group>admin:channel_pricing_log_entry:show</group>
+            <group>sylius:admin:channel_pricing_log_entry:show</group>
         </attribute>
         <attribute name="loggedAt">
             <group>admin:channel_pricing_log_entry:index</group>
+            <group>sylius:admin:channel_pricing_log_entry:index</group>
             <group>admin:channel_pricing_log_entry:show</group>
+            <group>sylius:admin:channel_pricing_log_entry:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePasswordShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePasswordShopUser.xml
@@ -18,12 +18,15 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\ChangeShopUserPassword">
         <attribute name="currentPassword">
             <group>shop:customer:password:update</group>
+            <group>sylius:shop:customer:password:update</group>
         </attribute>
         <attribute name="newPassword">
             <group>shop:customer:password:update</group>
+            <group>sylius:shop:customer:password:update</group>
         </attribute>
         <attribute name="confirmNewPassword">
             <group>shop:customer:password:update</group>
+            <group>sylius:shop:customer:password:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePaymentMethod.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod">
         <attribute name="paymentMethodCode" serialized-name="paymentMethod">
             <group>shop:order:account:change_payment_method</group>
+            <group>sylius:shop:order:account:change_payment_method</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/RegisterShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/RegisterShopUser.xml
@@ -18,18 +18,23 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\RegisterShopUser">
         <attribute name="firstName">
             <group>shop:customer:create</group>
+            <group>sylius:shop:customer:create</group>
         </attribute>
         <attribute name="lastName">
             <group>shop:customer:create</group>
+            <group>sylius:shop:customer:create</group>
         </attribute>
         <attribute name="email">
             <group>shop:customer:create</group>
+            <group>sylius:shop:customer:create</group>
         </attribute>
         <attribute name="password">
             <group>shop:customer:create</group>
+            <group>sylius:shop:customer:create</group>
         </attribute>
         <attribute name="subscribedToNewsletter">
             <group>shop:customer:create</group>
+            <group>sylius:shop:customer:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/RequestResetPasswordToken.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/RequestResetPasswordToken.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\RequestResetPasswordToken">
         <attribute name="email">
             <group>shop:reset_password:create</group>
+            <group>sylius:shop:reset_password:create</group>
         </attribute>
         <attribute name="localeCode" serialized-name="locale">
             <group>shop:reset_password:create</group>
+            <group>sylius:shop:reset_password:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ResendVerificationEmail.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ResendVerificationEmail.xml
@@ -18,12 +18,15 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\ResendVerificationEmail">
         <attribute name="shopUserId">
             <group>shop:resend_verification_email:create</group>
+            <group>sylius:shop:resend_verification_email:create</group>
         </attribute>
         <attribute name="channelCode">
             <group>shop:resend_verification_email:create</group>
+            <group>sylius:shop:resend_verification_email:create</group>
         </attribute>
         <attribute name="localeCode">
             <group>shop:resend_verification_email:create</group>
+            <group>sylius:shop:resend_verification_email:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ResetPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ResetPassword.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\ResetPassword">
         <attribute name="newPassword">
             <group>shop:reset_password:update</group>
+            <group>sylius:shop:reset_password:update</group>
         </attribute>
         <attribute name="confirmNewPassword">
             <group>shop:reset_password:update</group>
+            <group>sylius:shop:reset_password:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/VerifyCustomerAccount.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/VerifyCustomerAccount.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Account\VerifyCustomerAccount">
         <attribute name="token">
             <group>shop:account_verification:update</group>
+            <group>sylius:shop:account_verification:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/AddProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/AddProductReview.xml
@@ -18,28 +18,43 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview">
         <attribute name="title">
             <group>shop:product_review:create</group>
+            <group>sylius:shop:product_review:create</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
         <attribute name="rating">
             <group>shop:product_review:create</group>
+            <group>sylius:shop:product_review:create</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
         <attribute name="comment">
             <group>shop:product_review:create</group>
+            <group>sylius:shop:product_review:create</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
         <attribute name="productCode" serialized-name="product">
             <group>shop:product_review:create</group>
+            <group>sylius:shop:product_review:create</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
         <attribute name="email">
             <group>shop:product_review:create</group>
+            <group>sylius:shop:product_review:create</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/AddItemToCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/AddItemToCart.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart">
         <attribute name="productVariantCode" serialized-name="productVariant">
             <group>shop:cart:add_item</group>
+            <group>sylius:shop:cart:add_item</group>
         </attribute>
         <attribute name="quantity">
             <group>shop:cart:add_item</group>
+            <group>sylius:shop:cart:add_item</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/ChangeItemQuantityInCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/ChangeItemQuantityInCart.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart">
         <attribute name="quantity">
             <group>shop:cart:change_quantity</group>
+            <group>sylius:shop:cart:change_quantity</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/RemoveItemFromCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/RemoveItemFromCart.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Cart\RemoveItemFromCart">
         <attribute name="orderItemId">
             <group>shop:cart:remove_item</group>
+            <group>sylius:shop:cart:remove_item</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChoosePaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChoosePaymentMethod.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod">
         <attribute name="paymentMethodCode" serialized-name="paymentMethod">
             <group>shop:cart:select_payment_method</group>
+            <group>sylius:shop:cart:select_payment_method</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChooseShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChooseShippingMethod.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod">
         <attribute name="shippingMethodCode" serialized-name="shippingMethod">
             <group>shop:cart:select_shipping_method</group>
+            <group>sylius:shop:cart:select_shipping_method</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/CompleteOrder.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/CompleteOrder.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder">
         <attribute name="notes">
             <group>shop:cart:complete</group>
+            <group>sylius:shop:cart:complete</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ShipShipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ShipShipment.xml
@@ -18,6 +18,7 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\ShipShipment">
         <attribute name="trackingCode">
             <group>admin:shipment:update</group>
+            <group>sylius:admin:shipment:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/UpdateCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/UpdateCart.xml
@@ -18,15 +18,19 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart">
         <attribute name="billingAddress">
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
         </attribute>
         <attribute name="shippingAddress">
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
         </attribute>
         <attribute name="email">
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
         </attribute>
         <attribute name="couponCode">
             <group>shop:cart:update</group>
+            <group>sylius:shop:cart:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Promotion/GeneratePromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Promotion/GeneratePromotionCoupon.xml
@@ -18,24 +18,31 @@
     <class name="Sylius\Bundle\ApiBundle\Command\Promotion\GeneratePromotionCoupon">
         <attribute name="promotionCode">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="prefix">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="codeLength">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="suffix">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="amount">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="expiresAt">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
         <attribute name="usageLimit">
             <group>admin:promotion_coupon:generate</group>
+            <group>sylius:admin:promotion_coupon:generate</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/SendContactRequest.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/SendContactRequest.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Bundle\ApiBundle\Command\SendContactRequest">
         <attribute name="email">
             <group>shop:contact_request:create</group>
+            <group>sylius:shop:contact_request:create</group>
         </attribute>
         <attribute name="message">
             <group>shop:contact_request:create</group>
+            <group>sylius:shop:contact_request:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
@@ -18,34 +18,55 @@
     <class name="Sylius\Component\Addressing\Model\Country">
         <attribute name="id">
             <group>admin:country:index</group>
+            <group>sylius:admin:country:index</group>
             <group>admin:country:show</group>
+            <group>sylius:admin:country:show</group>
         </attribute>
        <attribute name="code">
            <group>admin:country:index</group>
+            <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
+            <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>shop:country:index</group>
+            <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
+            <group>sylius:shop:country:show</group>
        </attribute>
        <attribute name="name">
            <group>admin:country:index</group>
+            <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
+            <group>sylius:admin:country:show</group>
            <group>shop:country:index</group>
+            <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
+            <group>sylius:shop:country:show</group>
        </attribute>
        <attribute name="enabled">
            <group>admin:country:index</group>
+            <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
+            <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
+            <group>sylius:admin:country:update</group>
        </attribute>
        <attribute name="provinces">
            <group>admin:country:index</group>
+            <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
+            <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
+            <group>sylius:admin:country:update</group>
            <group>shop:country:index</group>
+            <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
+            <group>sylius:shop:country:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
@@ -18,16 +18,25 @@
     <class name="Sylius\Component\Currency\Model\Currency">
        <attribute name="code">
            <group>admin:currency:index</group>
+            <group>sylius:admin:currency:index</group>
            <group>admin:currency:show</group>
+            <group>sylius:admin:currency:show</group>
            <group>admin:currency:create</group>
+            <group>sylius:admin:currency:create</group>
            <group>shop:currency:index</group>
+            <group>sylius:shop:currency:index</group>
            <group>shop:currency:show</group>
+            <group>sylius:shop:currency:show</group>
        </attribute>
         <attribute name="name">
             <group>admin:currency:index</group>
+            <group>sylius:admin:currency:index</group>
             <group>admin:currency:show</group>
+            <group>sylius:admin:currency:show</group>
             <group>shop:currency:index</group>
+            <group>sylius:shop:currency:index</group>
             <group>shop:currency:show</group>
+            <group>sylius:shop:currency:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Customer.xml
@@ -18,99 +18,157 @@
     <class name="Sylius\Component\Core\Model\Customer">
         <attribute name="id">
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
         </attribute>
 
         <attribute name="email">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="firstName">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="lastName">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="fullName">
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
         </attribute>
 
         <attribute name="defaultAddress">
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="user">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
         </attribute>
 
         <attribute name="group">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
         </attribute>
 
         <attribute name="gender">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="birthday">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
         </attribute>
 
         <attribute name="phoneNumber">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
         </attribute>
 
         <attribute name="subscribedToNewsletter">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
             <group>shop:customer:update</group>
+            <group>sylius:shop:customer:update</group>
         </attribute>
 
         <attribute name="createdAt">
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerGroup.xml
@@ -18,18 +18,27 @@
     <class name="Sylius\Component\Customer\Model\CustomerGroup">
         <attribute name="id">
             <group>admin:customer_group:index</group>
+            <group>sylius:admin:customer_group:index</group>
             <group>admin:customer_group:show</group>
+            <group>sylius:admin:customer_group:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:customer_group:index</group>
+            <group>sylius:admin:customer_group:index</group>
             <group>admin:customer_group:show</group>
+            <group>sylius:admin:customer_group:show</group>
             <group>admin:customer_group:create</group>
+            <group>sylius:admin:customer_group:create</group>
         </attribute>
         <attribute name="name">
             <group>admin:customer_group:index</group>
+            <group>sylius:admin:customer_group:index</group>
             <group>admin:customer_group:show</group>
+            <group>sylius:admin:customer_group:show</group>
             <group>admin:customer_group:create</group>
+            <group>sylius:admin:customer_group:create</group>
             <group>admin:customer_group:update</group>
+            <group>sylius:admin:customer_group:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerStatistics.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/CustomerStatistics.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Component\Core\Customer\Statistics\CustomerStatistics">
         <attribute name="allOrdersCount">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
         <attribute name="perChannelsStatistics">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ExchangeRate.xml
@@ -18,31 +18,51 @@
     <class name="Sylius\Component\Currency\Model\ExchangeRate">
         <attribute name="id">
             <group>admin:exchange_rate:index</group>
+            <group>sylius:admin:exchange_rate:index</group>
             <group>admin:exchange_rate:show</group>
+            <group>sylius:admin:exchange_rate:show</group>
             <group>shop:exchange_rate:index</group>
+            <group>sylius:shop:exchange_rate:index</group>
             <group>shop:exchange_rate:show</group>
+            <group>sylius:shop:exchange_rate:show</group>
         </attribute>
         <attribute name="ratio">
             <group>admin:exchange_rate:create</group>
+            <group>sylius:admin:exchange_rate:create</group>
             <group>admin:exchange_rate:index</group>
+            <group>sylius:admin:exchange_rate:index</group>
             <group>admin:exchange_rate:show</group>
+            <group>sylius:admin:exchange_rate:show</group>
             <group>admin:exchange_rate:update</group>
+            <group>sylius:admin:exchange_rate:update</group>
             <group>shop:exchange_rate:index</group>
+            <group>sylius:shop:exchange_rate:index</group>
             <group>shop:exchange_rate:show</group>
+            <group>sylius:shop:exchange_rate:show</group>
         </attribute>
         <attribute name="sourceCurrency">
             <group>admin:exchange_rate:create</group>
+            <group>sylius:admin:exchange_rate:create</group>
             <group>admin:exchange_rate:index</group>
+            <group>sylius:admin:exchange_rate:index</group>
             <group>admin:exchange_rate:show</group>
+            <group>sylius:admin:exchange_rate:show</group>
             <group>shop:exchange_rate:index</group>
+            <group>sylius:shop:exchange_rate:index</group>
             <group>shop:exchange_rate:show</group>
+            <group>sylius:shop:exchange_rate:show</group>
         </attribute>
         <attribute name="targetCurrency">
             <group>admin:exchange_rate:create</group>
+            <group>sylius:admin:exchange_rate:create</group>
             <group>admin:exchange_rate:index</group>
+            <group>sylius:admin:exchange_rate:index</group>
             <group>admin:exchange_rate:show</group>
+            <group>sylius:admin:exchange_rate:show</group>
             <group>shop:exchange_rate:index</group>
+            <group>sylius:shop:exchange_rate:index</group>
             <group>shop:exchange_rate:show</group>
+            <group>sylius:shop:exchange_rate:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/GatewayConfig.xml
@@ -18,19 +18,27 @@
     <class name="Sylius\Bundle\PayumBundle\Model\GatewayConfig">
         <attribute name="id">
             <group>admin:gateway_config:show</group>
+            <group>sylius:admin:gateway_config:show</group>
         </attribute>
         <attribute name="config">
             <group>admin:gateway_config:show</group>
+            <group>sylius:admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
         </attribute>
         <attribute name="gatewayName">
             <group>admin:gateway_config:show</group>
+            <group>sylius:admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
         </attribute>
         <attribute name="factoryName">
             <group>admin:gateway_config:show</group>
+            <group>sylius:admin:gateway_config:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Locale.xml
@@ -18,20 +18,31 @@
     <class name="Sylius\Component\Locale\Model\Locale">
         <attribute name="id">
             <group>admin:locale:index</group>
+            <group>sylius:admin:locale:index</group>
             <group>admin:locale:show</group>
+            <group>sylius:admin:locale:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:locale:index</group>
+            <group>sylius:admin:locale:index</group>
             <group>admin:locale:show</group>
+            <group>sylius:admin:locale:show</group>
             <group>admin:locale:create</group>
+            <group>sylius:admin:locale:create</group>
             <group>shop:locale:index</group>
+            <group>sylius:shop:locale:index</group>
             <group>shop:locale:show</group>
+            <group>sylius:shop:locale:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:locale:index</group>
+            <group>sylius:admin:locale:index</group>
             <group>admin:locale:show</group>
+            <group>sylius:admin:locale:show</group>
             <group>shop:locale:index</group>
+            <group>sylius:shop:locale:index</group>
             <group>shop:locale:show</group>
+            <group>sylius:shop:locale:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
@@ -18,202 +18,318 @@
     <class name="Sylius\Component\Core\Model\Order">
         <attribute name="id">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
         </attribute>
 
         <attribute name="number">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
         </attribute>
 
         <attribute name="currencyCode">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="channel">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
         </attribute>
 
         <attribute name="customer">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
         </attribute>
 
         <attribute name="payments">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="shipments">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="checkoutState">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="state">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
         </attribute>
 
         <attribute name="paymentState">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="shippingState">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
 
         <attribute name="total">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="orderPromotionTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingPromotionTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="tokenValue">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
         </attribute>
 
         <attribute name="items">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="notes">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
         </attribute>
 
         <attribute name="itemsTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="itemsSubtotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:index</group>
+            <group>sylius:shop:order:index</group>
             <group>shop:order:show</group>
+            <group>sylius:shop:order:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingTaxTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxExcludedTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="taxIncludedTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="itemsSubtotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="localeCode">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:cart:update</group>
+            <group>sylius:admin:cart:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingTotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="shippingAddress">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
 
         <attribute name="billingAddress">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
@@ -18,102 +18,167 @@
     <class name="Sylius\Component\Core\Model\OrderItem">
         <attribute name="id">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="order">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="variant">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="quantity">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="unitPrice">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
         <attribute name="originalUnitPrice">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
         <attribute name="discountedUnitPrice">
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
         <attribute name="units">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="adjustments">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsRecursively">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsTotal">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="adjustmentsTotalRecursively">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="product">
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="productName">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="subtotal">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
         </attribute>
         <attribute name="total">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
             <group>shop:order_item:show</group>
+            <group>sylius:shop:order_item:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
         </attribute>
         <attribute name="fullDiscountedUnitPrice">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:order_item:show</group>
+            <group>sylius:admin:order_item:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItemUnit.xml
@@ -18,11 +18,15 @@
     <class name="Sylius\Component\Core\Model\OrderItemUnit">
         <attribute name="id">
             <group>admin:order_item_unit:show</group>
+            <group>sylius:admin:order_item_unit:show</group>
             <group>shop:order_item_unit:show</group>
+            <group>sylius:shop:order_item_unit:show</group>
         </attribute>
         <attribute name="shippable">
             <group>admin:order_item_unit:show</group>
+            <group>sylius:admin:order_item_unit:show</group>
             <group>shop:order_item_unit:show</group>
+            <group>sylius:shop:order_item_unit:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Payment.xml
@@ -18,55 +18,89 @@
     <class name="Sylius\Component\Core\Model\Payment">
         <attribute name="id">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="method">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="currencyCode">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="amount">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="state">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="details">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
         <attribute name="order">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -18,73 +18,114 @@
     <class name="Sylius\Component\Core\Model\PaymentMethod">
         <attribute name="id">
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="translations">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
         </attribute>
 
         <attribute name="name">
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="description">
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="instructions">
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
         </attribute>
 
         <attribute name="position">
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="gatewayConfig">
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethodTranslation.xml
@@ -18,43 +18,69 @@
     <class name="Sylius\Component\Payment\Model\PaymentMethodTranslation">
         <attribute name="id">
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
         </attribute>
 
         <attribute name="name">
             <group>admin:payment:index</group>
+            <group>sylius:admin:payment:index</group>
             <group>admin:payment:show</group>
+            <group>sylius:admin:payment:show</group>
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:payment:show</group>
+            <group>sylius:shop:payment:show</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="instructions">
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:index</group>
+            <group>sylius:admin:payment_method:index</group>
             <group>admin:payment_method:show</group>
+            <group>sylius:admin:payment_method:show</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
             <group>shop:payment_method:index</group>
+            <group>sylius:shop:payment_method:index</group>
             <group>shop:payment_method:show</group>
+            <group>sylius:shop:payment_method:show</group>
         </attribute>
 
         <attribute name="locale">
             <group>admin:payment_method:create</group>
+            <group>sylius:admin:payment_method:create</group>
             <group>admin:payment_method:update</group>
+            <group>sylius:admin:payment_method:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PerChannelCustomerStatistics.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PerChannelCustomerStatistics.xml
@@ -18,15 +18,19 @@
     <class name="Sylius\Component\Core\Customer\Statistics\PerChannelCustomerStatistics">
         <attribute name="channel">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
         <attribute name="ordersCount">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
         <attribute name="ordersValue">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
         <attribute name="averageOrderValue">
             <group>admin:customer:statistics:show</group>
+            <group>sylius:admin:customer:statistics:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
@@ -18,127 +18,209 @@
     <class name="Sylius\Component\Core\Model\Product">
         <attribute name="id">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="variantSelectionMethod">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
         </attribute>
         <attribute name="enabled">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
         </attribute>
         <attribute name="name">
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="description">
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="slug">
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="shortDescription">
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
         </attribute>
         <attribute name="mainTaxon">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="productTaxons">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="options">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="variants">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="images">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="reviews">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="averageRating">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="associations">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="attributes">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
         </attribute>
         <attribute name="channels">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociation.xml
@@ -18,24 +18,37 @@
     <class name="Sylius\Component\Product\Model\ProductAssociation">
         <attribute name="id">
             <group>shop:product_association:show</group>
+            <group>sylius:shop:product_association:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:product_association:index</group>
+            <group>sylius:admin:product_association:index</group>
             <group>admin:product_association:show</group>
+            <group>sylius:admin:product_association:show</group>
             <group>admin:product_association:create</group>
+            <group>sylius:admin:product_association:create</group>
             <group>shop:product_association:show</group>
+            <group>sylius:shop:product_association:show</group>
         </attribute>
         <attribute name="owner">
             <group>admin:product_association:index</group>
+            <group>sylius:admin:product_association:index</group>
             <group>admin:product_association:show</group>
+            <group>sylius:admin:product_association:show</group>
             <group>admin:product_association:create</group>
+            <group>sylius:admin:product_association:create</group>
         </attribute>
         <attribute name="associatedProducts">
             <group>admin:product_association:index</group>
+            <group>sylius:admin:product_association:index</group>
             <group>admin:product_association:show</group>
+            <group>sylius:admin:product_association:show</group>
             <group>admin:product_association:create</group>
+            <group>sylius:admin:product_association:create</group>
             <group>admin:product_association:update</group>
+            <group>sylius:admin:product_association:update</group>
             <group>shop:product_association:show</group>
+            <group>sylius:shop:product_association:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationType.xml
@@ -18,35 +18,55 @@
     <class name="Sylius\Component\Product\Model\ProductAssociationType">
         <attribute name="id">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>shop:product_association_type:show</group>
+            <group>sylius:shop:product_association_type:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
+            <group>sylius:admin:product_association_type:create</group>
             <group>shop:product_association_type:show</group>
+            <group>sylius:shop:product_association_type:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>shop:product_association_type:show</group>
+            <group>sylius:shop:product_association_type:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>shop:product_association_type:show</group>
+            <group>sylius:shop:product_association_type:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>shop:product_association_type:show</group>
+            <group>sylius:shop:product_association_type:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
+            <group>sylius:admin:product_association_type:create</group>
             <group>admin:product_association_type:update</group>
+            <group>sylius:admin:product_association_type:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationTypeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAssociationTypeTranslation.xml
@@ -18,17 +18,25 @@
     <class name="Sylius\Component\Product\Model\ProductAssociationTypeTranslation">
         <attribute name="id">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_association_type:index</group>
+            <group>sylius:admin:product_association_type:index</group>
             <group>admin:product_association_type:show</group>
+            <group>sylius:admin:product_association_type:show</group>
             <group>admin:product_association_type:create</group>
+            <group>sylius:admin:product_association_type:create</group>
             <group>admin:product_association_type:update</group>
+            <group>sylius:admin:product_association_type:update</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_association_type:create</group>
+            <group>sylius:admin:product_association_type:create</group>
             <group>admin:product_association_type:update</group>
+            <group>sylius:admin:product_association_type:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttribute.xml
@@ -18,49 +18,77 @@
     <class name="Sylius\Component\Product\Model\ProductAttribute">
         <attribute name="id">
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
         <attribute name="name">
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
         <attribute name="storageType">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
         </attribute>
         <attribute name="translatable">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
         </attribute>
         <attribute name="position">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeTranslation.xml
@@ -18,19 +18,29 @@
     <class name="Sylius\Component\Product\Model\ProductAttributeTranslation">
         <attribute name="id">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_attribute:index</group>
+            <group>sylius:admin:product_attribute:index</group>
             <group>admin:product_attribute:show</group>
+            <group>sylius:admin:product_attribute:show</group>
             <group>admin:product_attribute:create</group>
+            <group>sylius:admin:product_attribute:create</group>
             <group>admin:product_attribute:update</group>
+            <group>sylius:admin:product_attribute:update</group>
             <group>shop:product_attribute:show</group>
+            <group>sylius:shop:product_attribute:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductAttributeValue.xml
@@ -18,38 +18,59 @@
     <class name="Sylius\Component\Product\Model\ProductAttributeValue">
         <attribute name="id">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="attribute">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="value">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="localeCode">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="name">
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="type">
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
         <attribute name="code">
             <group>shop:product_attribute_value:show</group>
+            <group>sylius:shop:product_attribute_value:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
@@ -18,42 +18,71 @@
     <class name="Sylius\Component\Core\Model\ProductImage">
         <attribute name="id">
             <group>admin:product_image:index</group>
+            <group>sylius:admin:product_image:index</group>
             <group>admin:product_image:show</group>
+            <group>sylius:admin:product_image:show</group>
             <group>shop:product_image:show</group>
+            <group>sylius:shop:product_image:show</group>
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="path">
             <group>admin:product_image:index</group>
+            <group>sylius:admin:product_image:index</group>
             <group>admin:product_image:show</group>
+            <group>sylius:admin:product_image:show</group>
             <group>shop:product_image:show</group>
+            <group>sylius:shop:product_image:show</group>
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="owner">
             <group>admin:product_image:index</group>
+            <group>sylius:admin:product_image:index</group>
             <group>admin:product_image:show</group>
+            <group>sylius:admin:product_image:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:product_image:index</group>
+            <group>sylius:admin:product_image:index</group>
             <group>admin:product_image:show</group>
+            <group>sylius:admin:product_image:show</group>
             <group>admin:product_image:update</group>
+            <group>sylius:admin:product_image:update</group>
             <group>shop:product_image:show</group>
+            <group>sylius:shop:product_image:show</group>
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="productVariants">
             <group>admin:product_image:index</group>
+            <group>sylius:admin:product_image:index</group>
             <group>admin:product_image:show</group>
+            <group>sylius:admin:product_image:show</group>
             <group>admin:product_image:update</group>
+            <group>sylius:admin:product_image:update</group>
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
@@ -18,42 +18,67 @@
     <class name="Sylius\Component\Product\Model\ProductOption">
         <attribute name="id">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="values">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
             <group>shop:product_option:show</group>
+            <group>sylius:shop:product_option:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionTranslation.xml
@@ -18,17 +18,25 @@
     <class name="Sylius\Component\Product\Model\ProductOptionTranslation">
         <attribute name="id">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_option:index</group>
+            <group>sylius:admin:product_option:index</group>
             <group>admin:product_option:show</group>
+            <group>sylius:admin:product_option:show</group>
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
@@ -18,28 +18,43 @@
     <class name="Sylius\Component\Product\Model\ProductOptionValue">
         <attribute name="id">
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>shop:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="value">
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>shop:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="option">
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>shop:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
+            <group>sylius:admin:product_option_value:write</group>
             <group>shop:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
+            <group>sylius:admin:product_option_value:write</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValueTranslation.xml
@@ -18,17 +18,25 @@
     <class name="Sylius\Component\Product\Model\ProductOptionValueTranslation">
         <attribute name="id">
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
         </attribute>
         <attribute name="value">
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
             <group>admin:product_option_value:show</group>
+            <group>sylius:admin:product_option_value:show</group>
             <group>admin:product_option_value:write</group>
+            <group>sylius:admin:product_option_value:write</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_option:create</group>
+            <group>sylius:admin:product_option:create</group>
             <group>admin:product_option:update</group>
+            <group>sylius:admin:product_option:update</group>
             <group>admin:product_option_value:write</group>
+            <group>sylius:admin:product_option_value:write</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
@@ -18,60 +18,99 @@
     <class name="Sylius\Component\Core\Model\ProductReview">
         <attribute name="id">
             <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
             <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
             <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
         <attribute name="updatedAt">
             <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
             <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
             <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="title">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>admin:product_review:update</group>
+            <group>sylius:admin:product_review:update</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="rating">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>admin:product_review:update</group>
+            <group>sylius:admin:product_review:update</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="comment">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>admin:product_review:update</group>
+            <group>sylius:admin:product_review:update</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="author">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="status">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
        <attribute name="reviewSubject">
            <group>admin:product_review:index</group>
+            <group>sylius:admin:product_review:index</group>
            <group>admin:product_review:show</group>
+            <group>sylius:admin:product_review:show</group>
            <group>shop:product_review:index</group>
+            <group>sylius:shop:product_review:index</group>
            <group>shop:product_review:show</group>
+            <group>sylius:shop:product_review:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
@@ -18,29 +18,47 @@
     <class name="Sylius\Component\Core\Model\ProductTaxon">
         <attribute name="id">
             <group>admin:product_taxon:index</group>
+            <group>sylius:admin:product_taxon:index</group>
             <group>admin:product_taxon:show</group>
+            <group>sylius:admin:product_taxon:show</group>
             <group>shop:product_taxon:show</group>
+            <group>sylius:shop:product_taxon:show</group>
         </attribute>
         <attribute name="taxon">
             <group>admin:product_taxon:index</group>
+            <group>sylius:admin:product_taxon:index</group>
             <group>admin:product_taxon:show</group>
+            <group>sylius:admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
+            <group>sylius:admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
+            <group>sylius:admin:product_taxon:create</group>
             <group>shop:product_taxon:show</group>
+            <group>sylius:shop:product_taxon:show</group>
         </attribute>
         <attribute name="product">
             <group>admin:product_taxon:index</group>
+            <group>sylius:admin:product_taxon:index</group>
             <group>admin:product_taxon:show</group>
+            <group>sylius:admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
+            <group>sylius:admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
+            <group>sylius:admin:product_taxon:create</group>
             <group>shop:product_taxon:show</group>
+            <group>sylius:shop:product_taxon:show</group>
         </attribute>
         <attribute name="position">
             <group>admin:product_taxon:index</group>
+            <group>sylius:admin:product_taxon:index</group>
             <group>admin:product_taxon:show</group>
+            <group>sylius:admin:product_taxon:show</group>
             <group>admin:product_taxon:update</group>
+            <group>sylius:admin:product_taxon:update</group>
             <group>admin:product_taxon:create</group>
+            <group>sylius:admin:product_taxon:create</group>
             <group>shop:product_taxon:show</group>
+            <group>sylius:shop:product_taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
@@ -18,61 +18,103 @@
     <class name="Sylius\Component\Product\Model\ProductTranslation">
         <attribute name="id">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
         </attribute>
         <attribute name="name">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="slug">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="description">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="shortDescription">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="metaKeywords">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="metaDescription">
             <group>admin:product:index</group>
+            <group>sylius:admin:product:index</group>
             <group>admin:product:show</group>
+            <group>sylius:admin:product:show</group>
             <group>admin:product:create</group>
+            <group>sylius:admin:product:create</group>
             <group>admin:product:update</group>
+            <group>sylius:admin:product:update</group>
             <group>shop:product:index</group>
+            <group>sylius:shop:product:index</group>
             <group>shop:product:show</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -18,121 +18,199 @@
     <class name="Sylius\Component\Core\Model\ProductVariant">
         <attribute name="code">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
         </attribute>
         <attribute name="product">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="optionValues">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
         </attribute>
         <attribute name="channelPricings">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="name">
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
         </attribute>
         <attribute name="enabled">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="position">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="tracked">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="onHold">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="onHand">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="weight">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="width">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="height">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="depth">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="taxCategory">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="shippingCategory">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="shippingRequired">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
@@ -18,27 +18,45 @@
     <class name="Sylius\Component\Product\Model\ProductVariantTranslation">
         <attribute name="id">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:product_variant:index</group>
+            <group>sylius:admin:product_variant:index</group>
             <group>admin:product_variant:show</group>
+            <group>sylius:admin:product_variant:show</group>
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>shop:product_variant:index</group>
+            <group>sylius:shop:product_variant:index</group>
             <group>shop:product_variant:show</group>
+            <group>sylius:shop:product_variant:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
         </attribute>
         <attribute name="locale">
             <group>admin:product_variant:create</group>
+            <group>sylius:admin:product_variant:create</group>
             <group>admin:product_variant:update</group>
+            <group>sylius:admin:product_variant:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
@@ -14,124 +14,189 @@
     <class name="Sylius\Component\Core\Model\Promotion">
         <attribute name="id">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="createdAt">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="updatedAt">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="name">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="priority">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="exclusive">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="appliesToDiscounted">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="usageLimit">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="used">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="startsAt">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="endsAt">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="couponBased">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="coupons">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="rules">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="actions">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="translations">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionAction.xml
@@ -14,19 +14,29 @@
     <class name="Sylius\Component\Promotion\Model\PromotionAction">
         <attribute name="id">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionCoupon.xml
@@ -18,57 +18,85 @@
     <class name="Sylius\Component\Core\Model\PromotionCoupon">
         <attribute name="createdAt">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="updatedAt">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
         </attribute>
 
         <attribute name="usageLimit">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
+            <group>sylius:admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="perCustomerUsageLimit">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
+            <group>sylius:admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="used">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
         </attribute>
 
         <attribute name="reusableFromCancelledOrders">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
+            <group>sylius:admin:promotion_coupon:update</group>
         </attribute>
 
         <attribute name="promotion">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
         </attribute>
 
         <attribute name="expiresAt">
             <group>admin:promotion_coupon:index</group>
+            <group>sylius:admin:promotion_coupon:index</group>
             <group>admin:promotion_coupon:show</group>
+            <group>sylius:admin:promotion_coupon:show</group>
             <group>admin:promotion_coupon:create</group>
+            <group>sylius:admin:promotion_coupon:create</group>
             <group>admin:promotion_coupon:update</group>
+            <group>sylius:admin:promotion_coupon:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionRule.xml
@@ -14,19 +14,29 @@
     <class name="Sylius\Component\Promotion\Model\PromotionRule">
         <attribute name="id">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PromotionTranslation.xml
@@ -18,19 +18,27 @@
     <class name="Sylius\Component\Promotion\Model\PromotionTranslation">
         <attribute name="id">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
         </attribute>
 
         <attribute name="label">
             <group>admin:promotion:index</group>
+            <group>sylius:admin:promotion:index</group>
             <group>admin:promotion:show</group>
+            <group>sylius:admin:promotion:show</group>
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
 
         <attribute name="locale">
             <group>admin:promotion:create</group>
+            <group>sylius:admin:promotion:create</group>
             <group>admin:promotion:update</group>
+            <group>sylius:admin:promotion:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
@@ -18,24 +18,39 @@
     <class name="Sylius\Component\Addressing\Model\Province">
        <attribute name="code">
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
+            <group>sylius:admin:country:update</group>
            <group>shop:country:index</group>
+            <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
+            <group>sylius:shop:country:show</group>
            <group>admin:province:show</group>
+            <group>sylius:admin:province:show</group>
        </attribute>
        <attribute name="name">
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
+            <group>sylius:admin:country:update</group>
            <group>shop:country:index</group>
+            <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
+            <group>sylius:shop:country:show</group>
            <group>admin:province:show</group>
+            <group>sylius:admin:province:show</group>
            <group>admin:province:update</group>
+            <group>sylius:admin:province:update</group>
        </attribute>
        <attribute name="abbreviation">
            <group>admin:country:create</group>
+            <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
+            <group>sylius:admin:country:update</group>
            <group>admin:province:show</group>
+            <group>sylius:admin:province:show</group>
            <group>admin:province:update</group>
+            <group>sylius:admin:province:update</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Shipment.xml
@@ -18,63 +18,97 @@
     <class name="Sylius\Component\Core\Model\Shipment">
         <attribute name="id">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="createdAt">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="updatedAt">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="state">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="method">
             <group>admin:order:index</group>
+            <group>sylius:admin:order:index</group>
             <group>admin:order:show</group>
+            <group>sylius:admin:order:show</group>
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="units">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="tracking">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="shippedAt">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="order">
             <group>admin:shipment:index</group>
+            <group>sylius:admin:shipment:index</group>
             <group>admin:shipment:show</group>
+            <group>sylius:admin:shipment:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingCategory.xml
@@ -18,32 +18,49 @@
     <class name="Sylius\Component\Shipping\Model\ShippingCategory">
         <attribute name="id">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
             <group>admin:shipping_category:create</group>
+            <group>sylius:admin:shipping_category:create</group>
         </attribute>
         <attribute name="name">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
             <group>admin:shipping_category:update</group>
+            <group>sylius:admin:shipping_category:update</group>
             <group>admin:shipping_category:create</group>
+            <group>sylius:admin:shipping_category:create</group>
         </attribute>
         <attribute name="description">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
             <group>admin:shipping_category:update</group>
+            <group>sylius:admin:shipping_category:update</group>
             <group>admin:shipping_category:create</group>
+            <group>sylius:admin:shipping_category:create</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:shipping_category:index</group>
+            <group>sylius:admin:shipping_category:index</group>
             <group>admin:shipping_category:show</group>
+            <group>sylius:admin:shipping_category:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethod.xml
@@ -18,100 +18,153 @@
     <class name="Sylius\Component\Core\Model\ShippingMethod">
         <attribute name="id">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="translations">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="code">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="name">
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="description">
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="position">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="zone">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="channels">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="calculator">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="configuration">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="rules">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
 
         <attribute name="createdAt">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="updatedAt">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="archivedAt">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodRule.xml
@@ -18,19 +18,29 @@
     <class name="Sylius\Component\Shipping\Model\ShippingMethodRule">
         <attribute name="id">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
         <attribute name="configuration">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
@@ -18,33 +18,52 @@
     <class name="Sylius\Component\Shipping\Model\ShippingMethodTranslation">
         <attribute name="id">
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="name">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
             <group>shop:cart:show</group>
+            <group>sylius:shop:cart:show</group>
             <group>shop:order:account:show</group>
+            <group>sylius:shop:order:account:show</group>
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
             <group>shop:shipment:show</group>
+            <group>sylius:shop:shipment:show</group>
         </attribute>
 
         <attribute name="description">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:index</group>
+            <group>sylius:admin:shipping_method:index</group>
             <group>admin:shipping_method:show</group>
+            <group>sylius:admin:shipping_method:show</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
             <group>shop:shipping_method:index</group>
+            <group>sylius:shop:shipping_method:index</group>
             <group>shop:shipping_method:show</group>
+            <group>sylius:shop:shipping_method:show</group>
         </attribute>
 
         <attribute name="locale">
             <group>admin:shipping_method:create</group>
+            <group>sylius:admin:shipping_method:create</group>
             <group>admin:shipping_method:update</group>
+            <group>sylius:admin:shipping_method:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopBillingData.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopBillingData.xml
@@ -18,36 +18,55 @@
     <class name="Sylius\Component\Core\Model\ShopBillingData">
         <attribute name="id">
             <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
         </attribute>
        <attribute name="company">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="taxId">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="countryCode">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="street">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="city">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
        <attribute name="postcode">
            <group>admin:channel:create</group>
+            <group>sylius:admin:channel:create</group>
            <group>admin:channel:update</group>
+            <group>sylius:admin:channel:update</group>
            <group>admin:shop_billing_data:show</group>
+            <group>sylius:admin:shop_billing_data:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
@@ -18,25 +18,36 @@
     <class name="Sylius\Component\Core\Model\ShopUser">
         <attribute name="plainPassword">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
         </attribute>
 
         <attribute name="enabled">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
         </attribute>
 
         <attribute name="verified">
             <group>admin:customer:index</group>
+            <group>sylius:admin:customer:index</group>
             <group>admin:customer:show</group>
+            <group>sylius:admin:customer:show</group>
             <group>shop:customer:show</group>
+            <group>sylius:shop:customer:show</group>
         </attribute>
 
         <attribute name="verifiedAt" serialized-name="verified">
             <group>admin:customer:create</group>
+            <group>sylius:admin:customer:create</group>
             <group>admin:customer:update</group>
+            <group>sylius:admin:customer:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxCategory.xml
@@ -18,32 +18,49 @@
     <class name="Sylius\Component\Taxation\Model\TaxCategory">
         <attribute name="id">
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:tax_category:create</group>
+            <group>sylius:admin:tax_category:create</group>
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:tax_category:create</group>
+            <group>sylius:admin:tax_category:create</group>
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
             <group>admin:tax_category:update</group>
+            <group>sylius:admin:tax_category:update</group>
         </attribute>
         <attribute name="description">
             <group>admin:tax_category:create</group>
+            <group>sylius:admin:tax_category:create</group>
             <group>admin:tax_category:index</group>
+            <group>sylius:admin:tax_category:index</group>
             <group>admin:tax_category:show</group>
+            <group>sylius:admin:tax_category:show</group>
             <group>admin:tax_category:update</group>
+            <group>sylius:admin:tax_category:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxRate.xml
@@ -18,68 +18,109 @@
     <class name="Sylius\Component\Taxation\Model\TaxRate">
         <attribute name="id">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
         </attribute>
         <attribute name="zone">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="name">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="category">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="calculator">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="amount">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="includedInPrice">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="startDate">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
         <attribute name="endDate">
             <group>admin:tax_rate:index</group>
+            <group>sylius:admin:tax_rate:index</group>
             <group>admin:tax_rate:show</group>
+            <group>sylius:admin:tax_rate:show</group>
             <group>admin:tax_rate:create</group>
+            <group>sylius:admin:tax_rate:create</group>
             <group>admin:tax_rate:update</group>
+            <group>sylius:admin:tax_rate:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
@@ -18,61 +18,97 @@
     <class name="Sylius\Component\Core\Model\Taxon">
         <attribute name="id">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
         </attribute>
         <attribute name="name">
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="slug">
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="description">
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="translations">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="parent">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="children">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="enabled">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="position">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="images">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
@@ -18,29 +18,44 @@
     <class name="Sylius\Component\Core\Model\TaxonImage">
         <attribute name="id">
             <group>admin:taxon_image:index</group>
+            <group>sylius:admin:taxon_image:index</group>
             <group>admin:taxon_image:show</group>
+            <group>sylius:admin:taxon_image:show</group>
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
         </attribute>
 
         <attribute name="path">
             <group>admin:taxon_image:index</group>
+            <group>sylius:admin:taxon_image:index</group>
             <group>admin:taxon_image:show</group>
+            <group>sylius:admin:taxon_image:show</group>
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
         </attribute>
 
         <attribute name="owner">
             <group>admin:taxon_image:index</group>
+            <group>sylius:admin:taxon_image:index</group>
             <group>admin:taxon_image:show</group>
+            <group>sylius:admin:taxon_image:show</group>
         </attribute>
 
         <attribute name="type">
             <group>admin:taxon_image:index</group>
+            <group>sylius:admin:taxon_image:index</group>
             <group>admin:taxon_image:show</group>
+            <group>sylius:admin:taxon_image:show</group>
             <group>admin:taxon_image:update</group>
+            <group>sylius:admin:taxon_image:update</group>
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
@@ -18,45 +18,77 @@
     <class name="Sylius\Component\Taxonomy\Model\TaxonTranslation">
         <attribute name="id">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
             <group>admin:taxon_translation:show</group>
+            <group>sylius:admin:taxon_translation:show</group>
             <group>shop:taxon_translation:show</group>
+            <group>sylius:shop:taxon_translation:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
             <group>admin:taxon_translation:show</group>
+            <group>sylius:admin:taxon_translation:show</group>
             <group>shop:taxon_translation:show</group>
+            <group>sylius:shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="description">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
             <group>admin:taxon_translation:show</group>
+            <group>sylius:admin:taxon_translation:show</group>
             <group>shop:taxon_translation:show</group>
+            <group>sylius:shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="locale">
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="slug">
             <group>admin:taxon:index</group>
+            <group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+            <group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+            <group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+            <group>sylius:shop:taxon:show</group>
             <group>admin:taxon_translation:show</group>
+            <group>sylius:admin:taxon_translation:show</group>
             <group>shop:taxon_translation:show</group>
+            <group>sylius:shop:taxon_translation:show</group>
             <group>admin:taxon:create</group>
+            <group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+            <group>sylius:admin:taxon:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Zone.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Zone.xml
@@ -18,42 +18,65 @@
     <class name="Sylius\Component\Addressing\Model\Zone">
         <attribute name="id">
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="name">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
             <group>admin:zone:update</group>
+            <group>sylius:admin:zone:update</group>
         </attribute>
         <attribute name="type">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="scope">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="createdAt">
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="updatedAt">
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
         </attribute>
         <attribute name="members">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:index</group>
+            <group>sylius:admin:zone:index</group>
             <group>admin:zone:show</group>
+            <group>sylius:admin:zone:show</group>
             <group>admin:zone:update</group>
+            <group>sylius:admin:zone:update</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ZoneMember.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ZoneMember.xml
@@ -18,11 +18,15 @@
     <class name="Sylius\Component\Addressing\Model\ZoneMember">
         <attribute name="id">
             <group>admin:zone_member:show</group>
+            <group>sylius:admin:zone_member:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:zone:create</group>
+            <group>sylius:admin:zone:create</group>
             <group>admin:zone:update</group>
+            <group>sylius:admin:zone:update</group>
             <group>admin:zone_member:show</group>
+            <group>sylius:admin:zone_member:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Country.xml
@@ -35,7 +35,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/countries/new/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:country:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:country:show</attribute>
+                        <attribute>sylius:shop:country:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Foo.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Foo.xml
@@ -16,14 +16,20 @@
             <collectionOperation name="get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo:read</attribute>
+                        <attribute>sylius:foo:read</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">foo:create</attribute>
+                    <attribute name="groups">
+                        <attribute>foo:create</attribute>
+                        <attribute>sylius:foo:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -34,7 +40,10 @@
                 <attribute name="input">Sylius\Bundle\ApiBundle\Application\Command\FooCommand</attribute>
                 <attribute name="output">false</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo:read</attribute>
+                        <attribute>sylius:foo:read</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -43,7 +52,10 @@
             <itemOperation name="get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo:read</attribute>
+                        <attribute>sylius:foo:read</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -51,7 +63,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/foos/{id}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo:read</attribute>
+                        <attribute>sylius:foo:read</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/FooSyliusResource.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/FooSyliusResource.xml
@@ -16,14 +16,20 @@
             <collectionOperation name="get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo-sylius-resource:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo-sylius-resource:read</attribute>
+                        <attribute>sylius:foo-sylius-resource:read</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
             <collectionOperation name="post">
                 <attribute name="method">POST</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">foo-sylius-resource:create</attribute>
+                    <attribute name="groups">
+                        <attribute>foo-sylius-resource:create</attribute>
+                        <attribute>sylius:foo-sylius-resource:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -32,7 +38,10 @@
             <itemOperation name="get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">foo-sylius-resource:read</attribute>
+                    <attribute name="groups">
+                        <attribute>foo-sylius-resource:read</attribute>
+                        <attribute>sylius:foo-sylius-resource:read</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Promotion.xml
@@ -24,7 +24,10 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:index</attribute>
+                        <attribute>sylius:admin:promotion:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -33,7 +36,10 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:promotion:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:promotion:show</attribute>
+                        <attribute>sylius:admin:promotion:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
             <itemOperation name="admin_delete">

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/api_platform/Taxon.xml
@@ -12,7 +12,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:index</attribute>
+                        <attribute>sylius:admin:taxon:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -20,7 +23,10 @@
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/taxons</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:taxon:create</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:create</attribute>
+                        <attribute>sylius:admin:taxon:create</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
 
@@ -28,7 +34,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:index</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:taxon:index</attribute>
+                        <attribute>sylius:shop:taxon:index</attribute>
+                    </attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>
@@ -38,7 +47,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">admin:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:show</attribute>
+                        <attribute>sylius:admin:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -46,7 +58,10 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/admin/taxons/{code}</attribute>
                 <attribute name="denormalization_context">
-                    <attribute name="groups">admin:taxon:update</attribute>
+                    <attribute name="groups">
+                        <attribute>admin:taxon:update</attribute>
+                        <attribute>sylius:admin:taxon:update</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -54,7 +69,10 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/taxons/{code}</attribute>
                 <attribute name="normalization_context">
-                    <attribute name="groups">shop:taxon:show</attribute>
+                    <attribute name="groups">
+                        <attribute>shop:taxon:show</attribute>
+                        <attribute>sylius:shop:taxon:show</attribute>
+                    </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Foo.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Foo.xml
@@ -18,18 +18,25 @@
     <class name="Sylius\Bundle\ApiBundle\Application\Entity\Foo">
         <attribute name="id">
             <group>foo:read</group>
+			<group>sylius:foo:read</group>
         </attribute>
         <attribute name="name">
             <group>foo:read</group>
+			<group>sylius:foo:read</group>
             <group>foo:create</group>
+			<group>sylius:foo:create</group>
         </attribute>
         <attribute name="owner">
             <group>foo:read</group>
+			<group>sylius:foo:read</group>
             <group>foo:create</group>
+			<group>sylius:foo:create</group>
         </attribute>
         <attribute name="fooSyliusResource">
             <group>foo:read</group>
+			<group>sylius:foo:read</group>
             <group>foo:create</group>
+			<group>sylius:foo:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/FooSyliusResource.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/FooSyliusResource.xml
@@ -18,10 +18,13 @@
     <class name="Sylius\Bundle\ApiBundle\Application\Entity\FooSyliusResource">
         <attribute name="id">
             <group>foo-sylius-resource:read</group>
+			<group>sylius:foo-sylius-resource:read</group>
         </attribute>
         <attribute name="name">
             <group>foo-sylius-resource:read</group>
+			<group>sylius:foo-sylius-resource:read</group>
             <group>foo-sylius-resource:create</group>
+			<group>sylius:foo-sylius-resource:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Application/config/serialization/Taxon.xml
@@ -7,29 +7,47 @@
     <class name="Sylius\Bundle\ApiBundle\Application\Entity\Taxon">
         <attribute name="id">
             <group>admin:taxon:index</group>
+			<group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+			<group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+			<group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+			<group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="code">
             <group>admin:taxon:index</group>
+			<group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+			<group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+			<group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+			<group>sylius:shop:taxon:show</group>
             <group>admin:taxon:create</group>
+			<group>sylius:admin:taxon:create</group>
             <group>admin:taxon:update</group>
+			<group>sylius:admin:taxon:update</group>
         </attribute>
         <attribute name="translations">
             <group>admin:taxon:index</group>
+			<group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+			<group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+			<group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+			<group>sylius:shop:taxon:show</group>
         </attribute>
         <attribute name="type">
             <group>admin:taxon:index</group>
+			<group>sylius:admin:taxon:index</group>
             <group>admin:taxon:show</group>
+			<group>sylius:admin:taxon:show</group>
             <group>shop:taxon:index</group>
+			<group>sylius:shop:taxon:index</group>
             <group>shop:taxon:show</group>
+			<group>sylius:shop:taxon:show</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serialization/Messages/Admin/Account/RequestResetPasswordEmail.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serialization/Messages/Admin/Account/RequestResetPasswordEmail.xml
@@ -16,6 +16,7 @@
     <class name="Sylius\Bundle\CoreBundle\Message\Admin\Account\RequestResetPasswordEmail">
         <attribute name="email">
             <group>admin:reset_password:create</group>
+            <group>sylius:admin:reset_password:create</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serialization/Messages/Admin/Account/ResetPassword.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serialization/Messages/Admin/Account/ResetPassword.xml
@@ -18,9 +18,11 @@
     <class name="Sylius\Bundle\CoreBundle\Message\Admin\Account\ResetPassword">
         <attribute name="newPassword">
             <group>admin:reset_password:update</group>
+            <group>sylius:admin:reset_password:update</group>
         </attribute>
         <attribute name="confirmNewPassword">
             <group>admin:reset_password:update</group>
+            <group>sylius:admin:reset_password:update</group>
         </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

To avoid conflicts with duplicated naming for the end apps, we have introduced prefixed serialization groups in the Sylius serialization groups configurations.