### PR TITLE
[Maintenance][Behat] Autoload calendar contexts into container

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: "../vendor/sylius/calendar/tests/Behat/Resources/services.yaml" }
     - { resource: "../src/Sylius/Behat/Resources/config/services.xml" }
 
 # workaround needed for strange "test.client.history" problem

--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/_calendar_services.php" />
         <import resource="services/api.xml" />
         <import resource="services/contexts.xml" />
         <import resource="services/elements.xml" />

--- a/src/Sylius/Behat/Resources/config/services/_calendar_services.php
+++ b/src/Sylius/Behat/Resources/config/services/_calendar_services.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+// Calendar ^0.5 changed the location of behat services
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $baseSyliusCalendarDir = __DIR__ . '/../../../../../../vendor/sylius/calendar/tests/Behat/Resources/services.yaml';
+    if (file_exists($baseSyliusCalendarDir)) {
+        $containerConfigurator->import($baseSyliusCalendarDir);
+
+        return;
+    }
+
+    $appSyliusCalendarDir = __DIR__ . '/../../../../../../../../sylius/calendar/tests/Behat/Resources/services.yaml';
+    if (file_exists($appSyliusCalendarDir)) {
+        $containerConfigurator->import($appSyliusCalendarDir);
+    }
+};


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | kinda                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | cause https://github.com/Sylius/Calendar/pull/13  |
| License         | MIT                                                          |

Long story short, it's a BC layer for `sylius/calendar:^0.5`.

It's either fixing it here, almost at the source, or in every app/plugin that uses Behat with our contexts.