### PR TITLE
Bump up PHP to 8.1

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -3,7 +3,7 @@
     "static-checks": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4",
           "api-platform": "^2.7.10"
         },
@@ -17,7 +17,7 @@
     "e2e-mariadb": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4",
           "mariadb": "10.4.10",
           "state_machine_adapter": "winzou_state_machine"
@@ -34,7 +34,7 @@
     "e2e-mysql": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4",
           "api-platform": "^2.7.10",
           "mysql": "5.7",
@@ -52,7 +52,7 @@
     "e2e-pgsql": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4",
           "postgres": "13.9"
         },
@@ -73,7 +73,7 @@
     "packages": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4"
         },
         {
@@ -85,7 +85,7 @@
     "packages-swiftmailer": {
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4"
         }
       ]
@@ -93,60 +93,36 @@
   },
   "full": {
     "static-checks": {
-      "php": [ "8.0", "8.1", "8.2" ],
+      "php": [ "8.1", "8.2" ],
       "symfony": [ "^5.4", "^6.4" ],
-      "api-platform": [ "^2.7.10" ],
-      "exclude": [
-        {
-          "php": "8.0",
-          "symfony": "^6.4"
-        }
-      ]
+      "api-platform": [ "^2.7.10" ]
     },
     "e2e-mariadb": {
-      "php": [ "8.0", "8.1", "8.2" ],
+      "php": [ "8.1", "8.2" ],
       "symfony": [ "^5.4", "^6.4" ],
       "mariadb": [ "10.4.10" ],
-      "state_machine_adapter": [ "winzou_state_machine", "symfony_workflow" ],
-      "exclude": [
-        {
-          "php": "8.0",
-          "symfony": "^6.4"
-        }
-      ]
+      "state_machine_adapter": [ "winzou_state_machine", "symfony_workflow" ]
     },
     "e2e-mysql": {
-      "php": [ "8.0", "8.1", "8.2" ],
+      "php": [ "8.1", "8.2" ],
       "symfony": [ "^5.4", "^6.4" ],
       "api-platform": [ "^2.7.10" ],
       "mysql": [ "5.7", "8.0" ],
       "twig": [ "^3.3" ],
       "include": [
         {
-          "php": "8.0",
+          "php": "8.1",
           "symfony": "^5.4",
           "api-platform": "^2.7.10",
           "mysql": "5.7",
           "twig": "^2.12"
         }
-      ],
-      "exclude": [
-        {
-          "php": "8.0",
-          "symfony": "^6.4"
-        }
       ]
     },
     "e2e-pgsql": {
-      "php": [ "8.0", "8.1", "8.2" ],
+      "php": [ "8.1", "8.2" ],
       "symfony": [ "^5.4", "^6.4" ],
-      "postgres": [ "13.9", "14.6" ],
-      "exclude": [
-        {
-          "php": "8.0",
-          "symfony": "^6.4"
-        }
-      ]
+      "postgres": [ "13.9", "14.6" ]
     },
     "frontend": {
       "include": [
@@ -165,17 +141,11 @@
       ]
     },
     "packages": {
-      "php": [ "8.0", "8.1", "8.2" ],
-      "symfony": [ "^5.4", "^6.4" ],
-      "exclude": [
-        {
-          "php": "8.0",
-          "symfony": "^6.4"
-        }
-      ]
+      "php": [ "8.1", "8.2" ],
+      "symfony": [ "^5.4", "^6.4" ]
     },
     "packages-swiftmailer": {
-      "php": [ "8.0", "8.1" ],
+      "php": [ "8.1" ],
       "symfony": [ "^5.4" ]
     }
   }

--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -23,7 +23,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                branch: ["1.12", "1.13"]
+                include:
+                    -
+                        branch: "1.12"
+                        php: "8.0"
+                    -
+                        branch: "1.13"
+                        php: "8.1"
 
         steps:
             -
@@ -35,7 +41,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1 # the lowest PHP version working with ECS
+                    php-version: ${{ matrix.php }}
 
             -
                 name: Install PHP dependencies

--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -35,7 +35,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0 # the lowest PHP version working with ECS
+                    php-version: 8.1 # the lowest PHP version working with ECS
 
             -
                 name: Install PHP dependencies

--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -1,5 +1,15 @@
 # UPGRADE FROM `v1.12.X` TO `v1.13.0`
 
+## Preconditions
+
+### PHP 8.1 support
+
+Sylius 1.13 comes with a bump of minimum PHP version to 8.1. We strongly advice to make upgrade process step by step,
+so it is highly recommended updating your PHP version being still on Sylius 1.12. After ensuring, that previous step succeed, 
+you may move forward to the Sylius 1.13 update.
+
+## Main update
+
 1. Starting with Sylius `1.13` we provided a possibility to use the Symfony Workflow as your State Machine. To allow a smooth transition
     we created a new package called `sylius/state-machine-abstraction`,
    which provides a configurable abstraction,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-dom": "*",
         "ext-exif": "*",
         "ext-fileinfo": "*",

--- a/docs/book/contributing/code/patches.rst
+++ b/docs/book/contributing/code/patches.rst
@@ -14,7 +14,7 @@ Before working on Sylius, set a Symfony friendly environment up with the followi
 software:
 
 * Git
-* PHP version 8.0 or above
+* PHP version 8.1 or above
 * MySQL
 
 Configure Git

--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -7,7 +7,7 @@ Installation
 The Sylius main application can serve as an end-user app, as well as a foundation
 for your custom e-commerce application.
 
-To create your Sylius-based application, first make sure you use PHP 8.0 or higher
+To create your Sylius-based application, first make sure you use PHP 8.1 or higher
 and have `Composer`_ installed.
 
 .. note::
@@ -30,7 +30,7 @@ To begin creating your new project, run this command:
 
 .. note::
 
-    Make sure to use PHP ^8.0. Using an older PHP version will result in installing an older version of Sylius.
+    Make sure to use PHP ^8.1. Using an older PHP version will result in installing an older version of Sylius.
 
 This will create a new Symfony project in the ``acme`` directory. Next, move to the project directory:
 

--- a/docs/book/installation/requirements.rst
+++ b/docs/book/installation/requirements.rst
@@ -29,7 +29,7 @@ PHP required modules and configuration
 **PHP version**:
 
 +---------------+-----------------------+
-| PHP           | ^8.0                  |
+| PHP           | ^8.1                  |
 +---------------+-----------------------+
 
 **PHP extensions**:

--- a/src/Sylius/Abstraction/StateMachine/composer.json
+++ b/src/Sylius/Abstraction/StateMachine/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/dependency-injection": "^5.4.21 || ^6.0",
         "symfony/http-kernel": "^5.4.21 || ^6.0",
         "symfony/workflow": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/addressing": "^1.13",
         "sylius/resource-bundle": "^1.9",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -30,7 +30,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "sylius/core-bundle": "^1.13",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/dbal": "^3.0",
         "api-platform/core": "^2.7.10",
         "enshrined/svg-sanitize": "^0.16",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ramsey/uuid": "^4.0",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/attribute": "^1.13",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/channel": "^1.13",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0"

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/doctrine-migrations-bundle": "^3.0.1",
         "egulias/email-validator": "^3.1",
         "fakerphp/faker": "^1.10",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/currency": "^1.13",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -35,7 +35,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/orm": "^2.13",
         "egulias/email-validator": "^3.1",
         "sylius/customer": "^1.13",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/inventory": "^1.13",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/locale": "^1.13",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0",
         "symfony/intl": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius-labs/polyfill-symfony-framework-bundle": "^1.0 || ^1.1",
         "sylius/money-bundle": "^1.13",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/payment": "^1.13",
         "sylius/resource-bundle": "^1.9",
         "symfony/framework-bundle": "^5.4.21 || ^6.0"

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "payum/offline": "^1.7.3",
         "payum/payum-bundle": "^2.5",
         "sylius/core": "^1.13",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/attribute-bundle": "^1.13",
         "sylius/locale-bundle": "^1.13",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/calendar": "^0.3 || ^0.4 || ^0.5",
         "sylius/money-bundle": "^1.13",

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -38,7 +38,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/mailer-bundle": "^1.8 || ^2.0@beta",
         "sylius/resource-bundle": "^1.9",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/calendar": "^0.3 || ^0.4 || ^0.5",
         "sylius/money-bundle": "^1.13",

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/core-bundle": "^1.13",
         "sylius/ui-bundle": "^1.13",
         "symfony/framework-bundle": "^5.4.21 || ^6.0",

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/calendar": "^0.3 || ^0.4 || ^0.5",
         "sylius/registry": "^1.5",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "stof/doctrine-extensions-bundle": "^1.4",
         "sylius/resource-bundle": "^1.9",
         "sylius/taxonomy": "^1.13",

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/collections": "^1.6",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/orm": "^2.13",
         "egulias/email-validator": "^3.1",
         "sylius-labs/polyfill-symfony-event-dispatcher": "^1.0.1",

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9",
         "symfony/intl": "^5.4.21 || ^6.0"

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/collections": "^1.6",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9",

--- a/src/Sylius/Component/Channel/composer.json
+++ b/src/Sylius/Component/Channel/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource": "^1.9",
         "symfony/form": "^5.4.21 || ^6.0",
         "symfony/http-foundation": "^5.4.21 || ^6.0",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "enshrined/svg-sanitize": "^0.16",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "knplabs/gaufrette": "^0.10 || ^0.11",

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource": "^1.9",
         "symfony/intl": "^5.4.21 || ^6.0",
         "laminas/laminas-stdlib": "^3.3.1"

--- a/src/Sylius/Component/Customer/composer.json
+++ b/src/Sylius/Component/Customer/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/collections": "^1.6",
         "sylius/resource": "^1.9"
     },

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource": "^1.9",
         "webmozart/assert": "^1.9"
     },

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource": "^1.9",
         "symfony/intl": "^5.4.21 || ^6.0",
         "laminas/laminas-stdlib": "^3.3.1"

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/resource": "^1.9",
         "webmozart/assert": "^1.9",
         "laminas/laminas-stdlib": "^3.3.1"

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9"
     },

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "behat/transliterator": "^1.3",
         "sylius/attribute": "^1.13",
         "sylius/resource": "^1.9",

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/orm": "^2.13",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9"

--- a/src/Sylius/Component/Review/composer.json
+++ b/src/Sylius/Component/Review/composer.json
@@ -37,7 +37,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/collections": "^1.6",
         "sylius/resource": "^1.9"
     },

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9",
         "symfony/options-resolver": "^5.4.21 || ^6.0"

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/calendar": "^0.3 || ^0.4 || ^0.5",
         "sylius/registry": "^1.5",
         "sylius/resource": "^1.9"

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "behat/transliterator": "^1.3",
         "sylius/resource": "^1.9",
         "webmozart/assert": "^1.9"

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "doctrine/collections": "^1.6",
         "sylius-labs/polyfill-symfony-security": "^1.1",
         "sylius/resource": "^1.9",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13|
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | |
| License         | MIT                                                          |

As PHP in version 8.0 is no longer supported (maintenance and security), we would like to remove support for this version also in the upcoming release of Sylius.

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
