### PR TITLE
Bump up Node.js only to supported LTS versions (18 and 20)

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -172,6 +172,7 @@ jobs:
                     legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
+                    node_version: "20.x"
 
             -   name: Install Behat driver
                 run: vendor/bin/bdi detect drivers

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -127,12 +127,6 @@
     "frontend": {
       "include": [
         {
-          "node": "14.x"
-        },
-        {
-          "node": "16.x"
-        },
-        {
           "node": "18.x"
         },
         {

--- a/docs/book/frontend/overview.rst
+++ b/docs/book/frontend/overview.rst
@@ -8,7 +8,7 @@ Overview
 Requirements
 ------------
 
-We recommend using Node.js ``16.x`` as it is the current LTS version. However, Sylius frontend is also compatible with Node.js ``14.x`` and ``18.x``.
+We recommend using Node.js ``20.x`` as it is the current LTS version. However, Sylius frontend is also compatible with Node.js ``18.x``.
 
 In Sylius, we use ``yarn`` as a package manager, but there are no obstacles to using ``npm``.
 

--- a/docs/book/installation/requirements.rst
+++ b/docs/book/installation/requirements.rst
@@ -73,10 +73,10 @@ NPM Package Manager
 -------------------
 
 Sylius Frontend depends on `npm packages <https://docs.npmjs.com/about-npm>`_ for it to run you need to have Node.js installed.
-Current minimum supported version of Node.js is:
+Current supported versions of Node.js are:
 
 +---------------+-----------------------+
-| Node.js       | 14.x                  |
+| Node.js       | 18.x, 20.x            |
 +---------------+-----------------------+
 
 Access rights

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "yargs": "^17.5.1"
   },
   "engines": {
-    "node": "^14 || ^16 || ^18 || ^20"
+    "node": "^18 || ^20"
   },
   "engineStrict": true
 }


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13|
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | |
| License         | MIT                                                          |

According to the title, bump up Node.js only to supported LTS versions (18 and 20) in our requirements and builds.
<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
