### PR TITLE
[StateMachne] Fix container compilation with `Sylius 1.13` and `SyliusResourceBundle ^1.11.x-dev`

### DIFF
--- a/src/Sylius/Abstraction/StateMachine/src/CompositeStateMachine.php
+++ b/src/Sylius/Abstraction/StateMachine/src/CompositeStateMachine.php
@@ -30,13 +30,13 @@ class CompositeStateMachine implements StateMachineInterface
         private string $defaultAdapter,
         private array $graphsToAdaptersMapping,
     ) {
-        Assert::notEmpty($stateMachineAdapters, 'At least one state machine adapter should be provided.');
-        Assert::allIsInstanceOf(
+        $validStateMachineAdapters = array_filter(
             $stateMachineAdapters,
-            StateMachineInterface::class,
-            sprintf('All state machine adapters should implement the "%s" interface.', StateMachineInterface::class),
+            fn (mixed $stateMachineAdapter) => $stateMachineAdapter instanceof StateMachineInterface,
         );
-        $this->stateMachineAdapters = $stateMachineAdapters instanceof Traversable ? iterator_to_array($stateMachineAdapters) : $stateMachineAdapters;
+
+        Assert::notEmpty($validStateMachineAdapters, 'At least one state machine adapter should be provided.');
+        $this->stateMachineAdapters = $validStateMachineAdapters;
     }
 
     /**


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

With SyliusResourceBundle 1.11.x onboard it results in the following container compilation error:
<img width="1081" alt="image" src="https://github.com/Sylius/Sylius/assets/40125720/f9fb27e8-c926-4806-b3ed-858bbdcd682b">

This problem should be investigated to determine why SyliusResourceBundle provides excess objects.