### PR TITLE
[FLYSYSTEM] Add directory visibility as public to local storage

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -51,6 +51,7 @@ flysystem:
             adapter: 'local'
             options:
                 directory: '%sylius_core.images_dir%'
+            directory_visibility: 'public'
 
 knp_gaufrette:
     adapters:


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Currently, the local `sylius.storage` configuration for Flysystem creates folders in `media/image` with 700 permissions.Using the option `directory_visibility: public`, it creates them with 755 permission.