### PR TITLE
[BootstrapAdminPanel] Basic Order Address Edit Form

### DIFF
--- a/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address.feature
+++ b/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address.feature
@@ -15,7 +15,7 @@ Feature: Modifying a customer billing address after an order has been placed
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address
         When I view the summary of the order "#00000001"
         And I want to modify a customer's billing address of this order
@@ -24,7 +24,7 @@ Feature: Modifying a customer billing address after an order has been placed
         Then I should be notified that it has been successfully edited
         And this order should have "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States" as its billing address
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address when a product's price has been changed
         Given the product "Suit" changed its price to "$300.00"
         When I view the summary of the order "#00000001"
@@ -35,7 +35,7 @@ Feature: Modifying a customer billing address after an order has been placed
         And this order should have "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States" as its billing address
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address when a channel has been disabled
         Given the channel "Web" has been disabled
         When I view the summary of the order "#00000001"
@@ -46,7 +46,7 @@ Feature: Modifying a customer billing address after an order has been placed
         And this order should have "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States" as its billing address
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address when the currency has been disabled
         Given the currency "USD" has been disabled
         When I view the summary of the order "#00000001"
@@ -57,7 +57,7 @@ Feature: Modifying a customer billing address after an order has been placed
         And this order should have "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States" as its billing address
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address when the product is out of stock
         Given the product "Suit" is out of stock
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_coupon.feature
+++ b/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_coupon.feature
@@ -19,7 +19,7 @@ Feature: Modifying a customer's billing address on an order with an applied coup
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address when the applied coupon is no longer valid
         Given the coupon "HOLIDAY" was used up to its usage limit
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_promotion.feature
+++ b/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_promotion.feature
@@ -19,7 +19,7 @@ Feature: Modifying a customer's billing address on an order with an applied prom
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address of already placed order when the applied promotion is no longer valid
         Given the promotion was disabled for the channel "Web"
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_taxes.feature
+++ b/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_on_order_with_taxes.feature
@@ -17,7 +17,7 @@ Feature: Modifying a customer's billing address on an order with taxes
         And the customer chose "Free" shipping method with "Offline" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's billing address of already placed order after the VAT tax rate has been changed
         Given the "VAT" tax rate has changed to 10%
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_validation.feature
+++ b/features/admin/order/managing_orders/modifying_billing_address/modifying_billing_address_validation.feature
@@ -16,7 +16,7 @@ Feature: Modifying a customer's billing address validation
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Attempt to save an order with incomplete billing address
         When I view the summary of the order "#00000001"
         And I want to modify a customer's billing address of this order

--- a/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address.feature
+++ b/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address.feature
@@ -16,7 +16,7 @@ Feature: Modifying a customer shipping address after an order has been placed
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address
         When I view the summary of the order "#00000001"
         And I want to modify a customer's shipping address of this order
@@ -25,7 +25,7 @@ Feature: Modifying a customer shipping address after an order has been placed
         Then I should be notified that it has been successfully edited
         And this order should be shipped to "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address when a product's price has been changed
         Given the product "Suit" changed its price to "$300.00"
         When I view the summary of the order "#00000001"
@@ -36,7 +36,7 @@ Feature: Modifying a customer shipping address after an order has been placed
         And this order should be shipped to "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States"
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address when a channel has been disabled
         Given the channel "Web" has been disabled
         When I view the summary of the order "#00000001"
@@ -47,7 +47,7 @@ Feature: Modifying a customer shipping address after an order has been placed
         And this order should be shipped to "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States"
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address when the currency has been disabled
         Given the currency "USD" has been disabled
         When I view the summary of the order "#00000001"
@@ -58,7 +58,7 @@ Feature: Modifying a customer shipping address after an order has been placed
         And this order should be shipped to "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States"
         And the order's total should still be "$400.00"
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address when the product is out of stock
         Given the product "Suit" is out of stock
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_coupon.feature
+++ b/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_coupon.feature
@@ -20,7 +20,7 @@ Feature: Modifying a customer's shipping address on an order with an applied cou
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address when the applied coupon is no longer valid
         Given the coupon "HOLIDAY" was used up to its usage limit
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_promotion.feature
+++ b/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_promotion.feature
@@ -20,7 +20,7 @@ Feature: Modifying a customer's shipping address on an order with an applied pro
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address of already placed order when the applied promotion is no longer valid
         Given the promotion was disabled for the channel "Web"
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_taxes.feature
+++ b/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_taxes.feature
@@ -18,7 +18,7 @@ Feature: Modifying a customer's shipping address on an order with taxes
         And the customer chose "Free" shipping method with "Offline" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Modifying a customer's shipping address of already placed order after the VAT tax rate has been changed
         Given the "VAT" tax rate has changed to 10%
         When I view the summary of the order "#00000001"

--- a/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
+++ b/features/admin/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
@@ -16,7 +16,7 @@ Feature: Modifying a customer's shipping address validation
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @api @todo @ui
+    @api @ui
     Scenario: Attempt to save an order with incomplete shipping address
         When I view the summary of the order "#00000001"
         And I want to modify a customer's shipping address of this order

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -405,7 +405,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
-            'billing_address' => '#billing-address',
+            'billing_address' => '[data-test-billing-address]',
             'currency' => '#sylius-order-currency',
             'customer' => '#customer',
             'ip_address' => '#ipAddress',
@@ -417,24 +417,22 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'payments' => '#sylius-payments',
             'promotion_discounts' => '#promotion-discounts',
             'promotion_shipping_discounts' => '#shipping-discount-value',
-            'promotion_total' => '#promotion-total',
+            'promotion_total' => '[data-test-promotion-total]',
             'resend_order_confirmation_email' => '[data-test-resend-order-confirmation-email]',
             'resend_shipment_confirmation_email' => '[data-test-resend-shipment-confirmation-email]',
             'shipment_shipped_at_date' => '#sylius-shipments .shipped-at-date',
-
             'shipments' => '[data-test-shipments]',
             'shipment_tracking' => '[data-test-shipment-tracking]',
             'shipment_ship_button' => '[data-test-shipment-ship-button]',
-
-            'shipping_address' => '#shipping-address',
+            'shipping_address' => '[data-test-shipping-address]',
             'shipping_adjustment_name' => '#shipping-adjustment-label',
             'shipping_charges' => '#shipping-base-value',
             'shipping_tax' => '#shipping-tax-value',
             'shipping_total' => '#shipping-total',
             'table' => '.table',
-            'tax_total' => '#tax-total',
+            'tax_total' => '[data-test-tax-total]',
             'taxes' => '#taxes',
-            'total' => '#total',
+            'total' => '[data-test-total]',
         ]);
     }
 

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -52,12 +52,12 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.invalid-feedback');
         }
 
-        $validationMessage = $foundElement->find('css', '.sylius-validation-error');
+        $validationMessage = $foundElement->find('css', '.invalid-feedback');
         if (null === $validationMessage) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.invalid-feedback');
         }
 
         return $message === $validationMessage->getText();

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_billingAddress.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_billingAddress.html.twig
@@ -5,6 +5,6 @@
 <div>
     <strong>{{ 'sylius.ui.billing_address'|trans }}</strong>
 </div>
-<div class="mb-3" id="billing-address">
+<div class="mb-3" {{ sylius_test_html_attribute('billing-address') }}>
     {{ _address.default(order.billingAddress) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_billingAddress.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_billingAddress.html.twig
@@ -3,8 +3,8 @@
 {% set order = hookable_data.resource %}
 
 <div>
-    <strong>{{ 'sylius.ui.shipping_address'|trans }}:</strong>
+    <strong>{{ 'sylius.ui.billing_address'|trans }}</strong>
 </div>
-<div class="mb-3">
+<div class="mb-3" id="billing-address">
     {{ _address.default(order.billingAddress) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
@@ -3,7 +3,7 @@
 {% set order = hookable_data.resource %}
 
 <div>
-    <strong>Shipping address:</strong>
+    <strong>{{ 'sylius.ui.shipping_address'|trans }}</strong>
 </div>
 <div class="mb-3">
     {{ _address.default(_context.order.shippingAddress) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
@@ -5,6 +5,6 @@
 <div>
     <strong>{{ 'sylius.ui.shipping_address'|trans }}</strong>
 </div>
-<div class="mb-3" id="shipping-address">
+<div class="mb-3" {{ sylius_test_html_attribute('shipping-address') }}>
     {{ _address.default(_context.order.shippingAddress) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Customer/_shippingAddress.html.twig
@@ -5,6 +5,6 @@
 <div>
     <strong>{{ 'sylius.ui.shipping_address'|trans }}</strong>
 </div>
-<div class="mb-3">
+<div class="mb-3" id="shipping-address">
     {{ _address.default(_context.order.shippingAddress) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_itemsTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_itemsTotal.html.twig
@@ -4,5 +4,5 @@
 
 <tr>
     <td><strong>{{ 'sylius.ui.items_total'|trans }}:</strong></td>
-    <td class="text-end" id="total">{{ _money.format(order.itemsTotal, order.currencyCode) }}</td>
+    <td class="text-end" {{ sylius_test_html_attribute('total') }}>{{ _money.format(order.itemsTotal, order.currencyCode) }}</td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_itemsTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_itemsTotal.html.twig
@@ -4,5 +4,5 @@
 
 <tr>
     <td><strong>{{ 'sylius.ui.items_total'|trans }}:</strong></td>
-    <td class="text-end">{{ _money.format(order.itemsTotal, order.currencyCode) }}</td>
+    <td class="text-end" id="total">{{ _money.format(order.itemsTotal, order.currencyCode) }}</td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_promotionTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_promotionTotal.html.twig
@@ -16,7 +16,7 @@
             <div><strong>{{ 'sylius.ui.promotion_total'|trans }}:</strong></div>
         </div>
     </td>
-    <td class="text-end" id="promotion-total">
+    <td class="text-end" {{ sylius_test_html_attribute('promotion-total') }}>
         {% if totalAdjustments == 0 %}
             <p>{{ 'sylius.ui.no_promotion'|trans }}</p>
         {% else %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_promotionTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_promotionTotal.html.twig
@@ -1,11 +1,26 @@
+{% import '@SyliusAdmin/Shared/Helper/money.html.twig' as _money %}
+
+{% set order = hookable_data.resource %}
+
+{% set orderPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
+{% set unitPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT') %}
+
+{% set orderPromotionAdjustments = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderPromotionAdjustment)) %}
+{% set unitPromotionAdjustments = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(unitPromotionAdjustment)) %}
+{% set promotionAdjustments = orderPromotionAdjustments|merge(unitPromotionAdjustments) %}
+{% set totalAdjustments = promotionAdjustments|reduce((carry, v) => carry + v) %}
+
 <tr>
     <td>
         <div class="d-md-flex justify-content-between">
-            <div><strong>Promotion total:</strong></div>
-            <div class="text-muted text-md-end">
-                <div>No promotion applied</div>
-            </div>
+            <div><strong>{{ 'sylius.ui.promotion_total'|trans }}:</strong></div>
         </div>
     </td>
-    <td class="text-end">$0.00</td>
+    <td class="text-end" id="promotion-total">
+        {% if totalAdjustments == 0 %}
+            <p>{{ 'sylius.ui.no_promotion'|trans }}</p>
+        {% else %}
+            {{ _money.format(totalAdjustments, order.currencyCode) }}
+        {% endif %}
+    </td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_taxTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_taxTotal.html.twig
@@ -4,5 +4,5 @@
 
 <tr>
     <td><strong>{{ 'sylius.ui.tax_total'|trans }}:</strong></td>
-    <td class="text-end" id="tax-total">{{ _money.format(order.taxTotal, order.currencyCode) }}</td>
+    <td class="text-end" {{ sylius_test_html_attribute('tax-total') }}>{{ _money.format(order.taxTotal, order.currencyCode) }}</td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_taxTotal.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Content/Sections/Summary/_taxTotal.html.twig
@@ -4,5 +4,5 @@
 
 <tr>
     <td><strong>{{ 'sylius.ui.tax_total'|trans }}:</strong></td>
-    <td class="text-end">{{ _money.format(order.taxTotal, order.currencyCode) }}</td>
+    <td class="text-end" id="tax-total">{{ _money.format(order.taxTotal, order.currencyCode) }}</td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Shared/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Shared/form_theme.html.twig
@@ -1,5 +1,10 @@
 {% extends 'bootstrap_5_layout.html.twig' %}
 
+{%- block form_row -%}
+    {% set row_attr = row_attr|default({})|merge({ class: (row_attr.class|default('mb-3') ~ ' field')|trim }) %}
+    {{ parent() }}
+{%- endblock form_row %}
+
 {% block sylius_resource_autocomplete_choice_row %}
     <div class="{% if required %}required {% endif %}{% if disabled %}disabled {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
         {{- form_label(form) -}}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         |  bootstrap-admin-panel          |
| Bug fix?        | no                                                      |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| License         | MIT                                                          |

This PR re-enables Behat tests for editing placed orders addresses.
We have two types of forms - a basic one with the province field as a text input (when no provinces are configured for the given country) and with the province as a select. The second case will be covered in a separate Pull Request.

Order Show:
<img width="1391" alt="image" src="https://github.com/Sylius/Sylius/assets/40125720/1918d677-4fa6-4a88-aa38-975e3a3db16b">

Order Address Edit:
<img width="1355" alt="image" src="https://github.com/Sylius/Sylius/assets/40125720/841ffc02-3afe-4334-b702-a13281daf8e9">
