### PR TITLE
Fix serialization groups config formatting

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Adjustment.xml
@@ -40,7 +40,7 @@
             <group>sylius:shop:adjustment:show</group>
             <group>shop:cart:show</group>
             <group>sylius:shop:cart:show</group>
-       </attribute>
+        </attribute>
 
         <attribute name="label">
             <group>admin:adjustment:index</group>
@@ -53,76 +53,76 @@
             <group>sylius:shop:adjustment:show</group>
             <group>shop:cart:show</group>
             <group>sylius:shop:cart:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="amount">
-           <group>admin:adjustment:index</group>
+        <attribute name="amount">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-           <group>shop:cart:show</group>
+            <group>shop:cart:show</group>
             <group>sylius:shop:cart:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="order">
-           <group>admin:adjustment:index</group>
+        <attribute name="order">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="order_item">
-           <group>admin:adjustment:index</group>
+        <attribute name="order_item">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="order_item_unit">
-           <group>admin:adjustment:index</group>
+        <attribute name="order_item_unit">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="neutral">
-           <group>admin:adjustment:index</group>
+        <attribute name="neutral">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-           <group>shop:cart:show</group>
+            <group>shop:cart:show</group>
             <group>sylius:shop:cart:show</group>
-       </attribute>
+        </attribute>
 
-       <attribute name="locked">
-           <group>admin:adjustment:index</group>
+        <attribute name="locked">
+            <group>admin:adjustment:index</group>
             <group>sylius:admin:adjustment:index</group>
-           <group>admin:adjustment:show</group>
+            <group>admin:adjustment:show</group>
             <group>sylius:admin:adjustment:show</group>
-           <group>shop:adjustment:index</group>
+            <group>shop:adjustment:index</group>
             <group>sylius:shop:adjustment:index</group>
-           <group>shop:adjustment:show</group>
+            <group>shop:adjustment:show</group>
             <group>sylius:shop:adjustment:show</group>
-       </attribute>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
@@ -24,49 +24,49 @@
         </attribute>
        <attribute name="code">
            <group>admin:country:index</group>
-            <group>sylius:admin:country:index</group>
+           <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
-            <group>sylius:admin:country:show</group>
+           <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
-            <group>sylius:admin:country:create</group>
+           <group>sylius:admin:country:create</group>
            <group>shop:country:index</group>
-            <group>sylius:shop:country:index</group>
+           <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
-            <group>sylius:shop:country:show</group>
+           <group>sylius:shop:country:show</group>
        </attribute>
        <attribute name="name">
            <group>admin:country:index</group>
-            <group>sylius:admin:country:index</group>
+           <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
-            <group>sylius:admin:country:show</group>
+           <group>sylius:admin:country:show</group>
            <group>shop:country:index</group>
-            <group>sylius:shop:country:index</group>
+           <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
-            <group>sylius:shop:country:show</group>
+           <group>sylius:shop:country:show</group>
        </attribute>
        <attribute name="enabled">
            <group>admin:country:index</group>
-            <group>sylius:admin:country:index</group>
+           <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
-            <group>sylius:admin:country:show</group>
+           <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
-            <group>sylius:admin:country:create</group>
+           <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
-            <group>sylius:admin:country:update</group>
+           <group>sylius:admin:country:update</group>
        </attribute>
        <attribute name="provinces">
            <group>admin:country:index</group>
-            <group>sylius:admin:country:index</group>
+           <group>sylius:admin:country:index</group>
            <group>admin:country:show</group>
-            <group>sylius:admin:country:show</group>
+           <group>sylius:admin:country:show</group>
            <group>admin:country:create</group>
-            <group>sylius:admin:country:create</group>
+           <group>sylius:admin:country:create</group>
            <group>admin:country:update</group>
-            <group>sylius:admin:country:update</group>
+           <group>sylius:admin:country:update</group>
            <group>shop:country:index</group>
-            <group>sylius:shop:country:index</group>
+           <group>sylius:shop:country:index</group>
            <group>shop:country:show</group>
-            <group>sylius:shop:country:show</group>
+           <group>sylius:shop:country:show</group>
        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Currency.xml
@@ -16,18 +16,18 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Component\Currency\Model\Currency">
-       <attribute name="code">
-           <group>admin:currency:index</group>
+        <attribute name="code">
+            <group>admin:currency:index</group>
             <group>sylius:admin:currency:index</group>
-           <group>admin:currency:show</group>
+            <group>admin:currency:show</group>
             <group>sylius:admin:currency:show</group>
-           <group>admin:currency:create</group>
+            <group>admin:currency:create</group>
             <group>sylius:admin:currency:create</group>
-           <group>shop:currency:index</group>
+            <group>shop:currency:index</group>
             <group>sylius:shop:currency:index</group>
-           <group>shop:currency:show</group>
+            <group>shop:currency:show</group>
             <group>sylius:shop:currency:show</group>
-       </attribute>
+        </attribute>
         <attribute name="name">
             <group>admin:currency:index</group>
             <group>sylius:admin:currency:index</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductReview.xml
@@ -35,7 +35,7 @@
             <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
+        </attribute>
         <attribute name="updatedAt">
             <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
@@ -45,72 +45,72 @@
             <group>sylius:shop:product_review:index</group>
             <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="title">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="title">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>admin:product_review:update</group>
+            <group>admin:product_review:update</group>
             <group>sylius:admin:product_review:update</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="rating">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="rating">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>admin:product_review:update</group>
+            <group>admin:product_review:update</group>
             <group>sylius:admin:product_review:update</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="comment">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="comment">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>admin:product_review:update</group>
+            <group>admin:product_review:update</group>
             <group>sylius:admin:product_review:update</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="author">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="author">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="status">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="status">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
-       <attribute name="reviewSubject">
-           <group>admin:product_review:index</group>
+        </attribute>
+        <attribute name="reviewSubject">
+            <group>admin:product_review:index</group>
             <group>sylius:admin:product_review:index</group>
-           <group>admin:product_review:show</group>
+            <group>admin:product_review:show</group>
             <group>sylius:admin:product_review:show</group>
-           <group>shop:product_review:index</group>
+            <group>shop:product_review:index</group>
             <group>sylius:shop:product_review:index</group>
-           <group>shop:product_review:show</group>
+            <group>shop:product_review:show</group>
             <group>sylius:shop:product_review:show</group>
-       </attribute>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Province.xml
@@ -16,41 +16,41 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Component\Addressing\Model\Province">
-       <attribute name="code">
-           <group>admin:country:create</group>
+        <attribute name="code">
+            <group>admin:country:create</group>
             <group>sylius:admin:country:create</group>
-           <group>admin:country:update</group>
+            <group>admin:country:update</group>
             <group>sylius:admin:country:update</group>
-           <group>shop:country:index</group>
+            <group>shop:country:index</group>
             <group>sylius:shop:country:index</group>
-           <group>shop:country:show</group>
+            <group>shop:country:show</group>
             <group>sylius:shop:country:show</group>
-           <group>admin:province:show</group>
+            <group>admin:province:show</group>
             <group>sylius:admin:province:show</group>
-       </attribute>
-       <attribute name="name">
-           <group>admin:country:create</group>
+        </attribute>
+        <attribute name="name">
+            <group>admin:country:create</group>
             <group>sylius:admin:country:create</group>
-           <group>admin:country:update</group>
+            <group>admin:country:update</group>
             <group>sylius:admin:country:update</group>
-           <group>shop:country:index</group>
+            <group>shop:country:index</group>
             <group>sylius:shop:country:index</group>
-           <group>shop:country:show</group>
+            <group>shop:country:show</group>
             <group>sylius:shop:country:show</group>
-           <group>admin:province:show</group>
+            <group>admin:province:show</group>
             <group>sylius:admin:province:show</group>
-           <group>admin:province:update</group>
+            <group>admin:province:update</group>
             <group>sylius:admin:province:update</group>
-       </attribute>
-       <attribute name="abbreviation">
-           <group>admin:country:create</group>
+        </attribute>
+        <attribute name="abbreviation">
+            <group>admin:country:create</group>
             <group>sylius:admin:country:create</group>
-           <group>admin:country:update</group>
+            <group>admin:country:update</group>
             <group>sylius:admin:country:update</group>
-           <group>admin:province:show</group>
+            <group>admin:province:show</group>
             <group>sylius:admin:province:show</group>
-           <group>admin:province:update</group>
+            <group>admin:province:update</group>
             <group>sylius:admin:province:update</group>
-       </attribute>
+        </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 <!-- see the comment below -->                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Duplicating the serialization groups exposed some places where formatting is wrong [REF](https://github.com/Sylius/Sylius/pull/15803)