### PR TITLE
[ProductAttribute] Use value of options when use "Apply to all"

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -85,7 +85,8 @@ const copyValueToAllLanguages = function copyValueToAllLanguages() {
           input.checked = $masterAttributeInputs[i].checked;
         } else if (input.nodeName === 'SELECT') {
           for (let x = 0; x < $inputs[i].length; x++) {
-            input[x].selected = $masterAttributeInputs[i][x].selected;
+            const masterOption = Array.from($masterAttributeInputs[i].options).find((option) => option.value === input[x].value);
+            input[x].selected = masterOption ? masterOption.selected : false;
           }
         } else {
           input.value = $masterAttributeInputs[i].value;


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #15852                      |
| License         | MIT                                                          |

See #15852, depending on language, some attribute value appears in different order. 

When we apply to all, there is a mismatch of selected value.

This fix check the value of option before copying if it selected or not.



https://github.com/Sylius/Sylius/assets/3168281/1f75bdf8-d3ec-4b21-9083-bf24853db3bd


https://github.com/Sylius/Sylius/assets/3168281/fe9edb9c-548a-4e9d-8089-23b7dfd43c51




