### PR TITLE
FEATURE: [2.2] [AdminBundle] #15888 Introduce sylius:admin-user:delete CLI Command

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Console/Command/DeleteAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Console/Command/DeleteAdminUserCommand.php
@@ -53,41 +53,24 @@ final class DeleteAdminUserCommand extends Command
     {
         $this->io->title('Delete admin user');
 
-        if ($input->isInteractive()) {
-            $emailArgument = $input->getArgument('email');
+        $email = $input->getArgument('email');
 
-            $email = $this->userRepository->findOneBy(['email' => $emailArgument]);
-            if ($email === null) {
-                $this->io->error(sprintf('Admin Account with the email "%s" does not exist', $emailArgument));
+        $adminUser = $this->userRepository->findOneBy(['email' => $email]);
+        if ($adminUser === null) {
+            $this->io->error(sprintf('Admin Account with the email "%s" does not exist', $email));
 
-                return Command::FAILURE;
-            }
-
-            if (!$this->io->confirm(
-                sprintf('Are you sure you want to delete the admin user "%s"?', $emailArgument),
-                false,
-            )) {
-                return Command::FAILURE;
-            }
-        } else {
-            $emailArgument = $input->getArgument('email');
-
-            if (!$emailArgument) {
-                $this->io->error('Email argument is required when using --no-interaction.');
-
-                return Command::FAILURE;
-            }
-
-            $email = $this->userRepository->findOneBy(['email' => $emailArgument]);
-            if ($email === null) {
-                $this->io->error(sprintf('Admin Account with the email "%s" does not exist', $emailArgument));
-
-                return Command::FAILURE;
-            }
+            return Command::FAILURE;
         }
 
-        $this->userRepository->remove($email);
-        $this->io->success(sprintf('Admin Account with the email "%s" has been deleted successfully', $emailArgument));
+        if ($input->isInteractive() && !$this->io->confirm(
+            sprintf('Are you sure you want to delete the admin user "%s"?', $email),
+            false,
+        )) {
+            return Command::FAILURE;
+        }
+
+        $this->userRepository->remove($adminUser);
+        $this->io->success(sprintf('Admin Account with the email "%s" has been deleted successfully', $email));
 
         return Command::SUCCESS;
     }

--- a/src/Sylius/Bundle/AdminBundle/Console/Command/DeleteAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Console/Command/DeleteAdminUserCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Console\Command;
+
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'sylius:admin-user:delete',
+    description: 'Deletes an admin user account by the given email',
+)]
+final class DeleteAdminUserCommand extends Command
+{
+    protected SymfonyStyle $io;
+
+    /** @param UserRepositoryInterface<AdminUserInterface> $userRepository */
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Deletes an admin user')
+            ->addArgument('email', InputArgument::REQUIRED, 'The email of the admin user to delete');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->title('Delete admin user');
+
+        if ($input->isInteractive()) {
+            $emailArgument = $input->getArgument('email');
+
+            $email = $this->userRepository->findOneBy(['email' => $emailArgument]);
+            if ($email === null) {
+                $this->io->error(sprintf('Admin Account with the email "%s" does not exist', $emailArgument));
+
+                return Command::FAILURE;
+            }
+
+            if (!$this->io->confirm(
+                sprintf('Are you sure you want to delete the admin user "%s"?', $emailArgument),
+                false,
+            )) {
+                return Command::FAILURE;
+            }
+        } else {
+            $emailArgument = $input->getArgument('email');
+
+            if (!$emailArgument) {
+                $this->io->error('Email argument is required when using --no-interaction.');
+
+                return Command::FAILURE;
+            }
+
+            $email = $this->userRepository->findOneBy(['email' => $emailArgument]);
+            if ($email === null) {
+                $this->io->error(sprintf('Admin Account with the email "%s" does not exist', $emailArgument));
+
+                return Command::FAILURE;
+            }
+        }
+
+        $this->userRepository->remove($email);
+        $this->io->success(sprintf('Admin Account with the email "%s" has been deleted successfully', $emailArgument));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -44,7 +44,7 @@
             <tag name="console.command" />
         </service>
 
-        <service id="Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand">
+        <service id="sylius_admin.command_handler.delete_admin_user" class="Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand">
             <argument type="service" id="sylius.repository.admin_user" />
             <tag name="console.command" />
         </service>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -44,7 +44,7 @@
             <tag name="console.command" />
         </service>
 
-        <service id="sylius_admin.command_handler.delete_admin_user" class="Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand">
+        <service id="sylius_admin.console.command.delete_admin_user" class="Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand">
             <argument type="service" id="sylius.repository.admin_user" />
             <tag name="console.command" />
         </service>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -44,6 +44,11 @@
             <tag name="console.command" />
         </service>
 
+        <service id="Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand">
+            <argument type="service" id="sylius.repository.admin_user" />
+            <tag name="console.command" />
+        </service>
+
         <service id="sylius_admin.command_handler.create_admin_user" class="Sylius\Bundle\AdminBundle\CommandHandler\CreateAdminUserHandler">
             <argument type="service" id="sylius.repository.admin_user" />
             <argument type="service" id="sylius.factory.admin_user" />

--- a/src/Sylius/Bundle/AdminBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/AdminBundle/phpunit.xml.dist
@@ -16,6 +16,7 @@
         <!-- ###+ symfony/framework-bundle ### -->
         <env name="APP_ENV" value="test"/>
         <env name="SHELL_VERBOSITY" value="-1" />
+        <env name="COLUMNS" value="300" />
         <!-- ###- symfony/framework-bundle ### -->
 
         <server name="KERNEL_CLASS" value="\Sylius\Bundle\AdminBundle\Application\Kernel" />

--- a/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\AdminBundle\Console\Command;
+namespace Tests\Sylius\Bundle\AdminBundle\Console\Command;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -26,8 +26,7 @@ final class DeleteAdminUserCommandTest extends TestCase
 {
     private CommandTester $commandTester;
 
-    /** @var MockObject&UserRepositoryInterface<AdminUserInterface> */
-    private MockObject $userRepository;
+    private MockObject&UserRepositoryInterface $userRepository;
 
     protected function setUp(): void
     {
@@ -39,7 +38,7 @@ final class DeleteAdminUserCommandTest extends TestCase
     }
 
     #[Test]
-    public function test_it_fails_when_admin_user_does_not_exist(): void
+    public function it_fails_when_admin_user_does_not_exist(): void
     {
         $this->userRepository
             ->expects($this->once())
@@ -60,7 +59,8 @@ final class DeleteAdminUserCommandTest extends TestCase
         );
     }
 
-    public function test_it_deletes_existing_admin_user_successfully(): void
+    #[Test]
+    public function it_deletes_existing_admin_user_successfully(): void
     {
         $adminUser = $this->createMock(AdminUserInterface::class);
 
@@ -88,7 +88,8 @@ final class DeleteAdminUserCommandTest extends TestCase
         );
     }
 
-    public function test_it_requires_email_argument_in_non_interactive_mode(): void
+    #[Test]
+    public function it_requires_email_argument_in_non_interactive_mode(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Not enough arguments (missing: "email").');
@@ -98,7 +99,8 @@ final class DeleteAdminUserCommandTest extends TestCase
         ]);
     }
 
-    public function test_it_aborts_when_user_declines_confirmation(): void
+    #[Test]
+    public function it_aborts_when_user_declines_confirmation(): void
     {
         $adminUser = $this->createMock(AdminUserInterface::class);
 
@@ -108,9 +110,7 @@ final class DeleteAdminUserCommandTest extends TestCase
             ->with(['email' => 'decline@example.com'])
             ->willReturn($adminUser);
 
-        $this->userRepository
-            ->expects($this->never())
-            ->method('remove');
+        $this->userRepository->expects($this->never())->method('remove');
 
         // simulate user typing "no" at confirmation
         $this->commandTester->setInputs(['no']);

--- a/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
@@ -16,6 +16,7 @@ namespace Tests\Sylius\Bundle\AdminBundle\Console\Command;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Console\Command\DeleteAdminUserCommand;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Console\Command\Command;

--- a/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Console/Command/DeleteAdminUserCommandTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Console\Command;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class DeleteAdminUserCommandTest extends TestCase
+{
+    private CommandTester $commandTester;
+
+    /** @var MockObject&UserRepositoryInterface<AdminUserInterface> */
+    private MockObject $userRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
+        $command = new DeleteAdminUserCommand($this->userRepository);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    #[Test]
+    public function test_it_fails_when_admin_user_does_not_exist(): void
+    {
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['email' => 'missing@example.com'])
+            ->willReturn(null);
+
+        $exitCode = $this->commandTester->execute([
+            'email' => 'missing@example.com',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString(
+            'Admin Account with the email "missing@example.com" does not exist',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    public function test_it_deletes_existing_admin_user_successfully(): void
+    {
+        $adminUser = $this->createMock(AdminUserInterface::class);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['email' => 'admin@example.com'])
+            ->willReturn($adminUser);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('remove')
+            ->with($adminUser);
+
+        $exitCode = $this->commandTester->execute([
+            'email' => 'admin@example.com',
+        ], [
+            'interactive' => false,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString(
+            'Admin Account with the email "admin@example.com" has been deleted successfully',
+            $this->commandTester->getDisplay(),
+        );
+    }
+
+    public function test_it_requires_email_argument_in_non_interactive_mode(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "email").');
+
+        $this->commandTester->execute([], [
+            'interactive' => false,
+        ]);
+    }
+
+    public function test_it_aborts_when_user_declines_confirmation(): void
+    {
+        $adminUser = $this->createMock(AdminUserInterface::class);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['email' => 'decline@example.com'])
+            ->willReturn($adminUser);
+
+        $this->userRepository
+            ->expects($this->never())
+            ->method('remove');
+
+        // simulate user typing "no" at confirmation
+        $this->commandTester->setInputs(['no']);
+
+        $exitCode = $this->commandTester->execute([
+            'email' => 'decline@example.com',
+        ], [
+            'interactive' => true,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $exitCode);
+        $this->assertStringContainsString(
+            'Are you sure you want to delete the admin user "decline@example.com"?',
+            $this->commandTester->getDisplay(),
+        );
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 2.2         <!-- see the comment below -->                  |
| Bug fix?        | no.                                                          |
| New feature?    | yes.                                                         |
| Deprecations?   | no.    <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | #15888                                                       |
| License         | MIT                                                          |

This change introduced the new CLI Command:

```bash
bin/console sylius:admin-user:delete [email]
```

This deletes an admin backend user by the given email.

Its also possible to run the command non-interactive:

```bash
bin/console sylius:admin-user:delete [email] --no-interaction
```