### PR TITLE
BUGFIX: #12681 add missing required class  to provincecode select input

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
@@ -61,7 +61,7 @@ $.fn.extend({
                 .replace('option value="" selected="selected"', 'option value=""')
                 .replace(`option ${provinceSelectValue}`, `option ${provinceSelectValue}" selected="selected"`)
             ));
-
+            provinceContainer.addClass('required');
             provinceContainer.removeAttr('data-loading');
 
             provinceContainer.fadeIn('fast', () => {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12         <!-- see the comment below -->                  |
| Bug fix?        | yes.                                                         |
| New feature?    | no.                                                          |
| BC breaks?      | no.                                                          |
| Deprecations?   | no.    <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #12681.                                                |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

## Description

As described in #12681:

Currently when you choose a country with configured provinces, the province select input isnt visualy marked as required with a `*`. When you try to submit the address form without choosing a province, it will tell you:

![SCR-20240226-nkag](https://github.com/Sylius/Sylius/assets/39345336/c8f58729-cc6d-4f09-bb63-f56dddd086ad)

With this change, the `required` class will be added to the `provinceContainer`. Then it becomes visible again:

![SCR-20240226-nioq](https://github.com/Sylius/Sylius/assets/39345336/0f9137f9-84c1-4d12-a267-c53ff9949146)