### PR TITLE
BUGFIX: #15908 [AdminBundle] missing br tag for spacing for product media tab button

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
@@ -4,6 +4,7 @@
     <h3 class="ui top attached header">{{ 'sylius.ui.media'|trans }}</h3>
 
     <div class="ui attached segment">
+        <br>
         {{ form_row(form.images, {'label': false}) }}
 
         {{ sylius_template_event(['sylius.admin.product.' ~ action ~ '.tab_media', 'sylius.admin.product.tab_media'], {'form': form}) }}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                                                         |
| Bug fix?        | yes.                                                         |
| New feature?    | no.                                                          |
| BC breaks?      | no.                                                          |
| Deprecations?   | no                                                           |
| Related tickets | fixes #15908                                                 |
| License         | MIT                                                          |

**Description**

As described in #15908

In the media tab in the new product dialog there is a button for uploading multiple media files. But right now the button has no spacing so the button looks very squizzed to the header:

![SCR-20240227-pdsi](https://github.com/Sylius/Sylius/assets/39345336/bdef0e7b-a462-4bc3-a5cc-8ecc8ce2d7f6)


In the Taxons management there is also a media section for uploading multiple media files. Its in a different twig template. And there, is a `<br>` tag which provides the distance between the button, and the header. With my change it looks like:

![SCR-20240227-pdnq](https://github.com/Sylius/Sylius/assets/39345336/6ecdf577-5ae3-4d67-b2b9-795d2d134e88)