### PR TITLE
Dispatch events when user is created/update from oauth

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -538,4 +538,7 @@ List of affected classes:
                     subject: 'Email address verification'
    ```
 
-1 Extracted the section responsible for the `ShopBundle` from `@SyliusCore/Email/accountVerification.html.twig` and relocated it to `@SyliusShop/Email/verification.html.twig`.
+1. Extracted the section responsible for the `ShopBundle` from `@SyliusCore/Email/accountVerification.html.twig` and relocated it to `@SyliusShop/Email/verification.html.twig`.
+
+1. Not passing an instance of `Symfony\Component\EventDispatcher\EventDispatcherInterface`
+   to `Sylius\Bundle\CoreBundle\OAuth\UserProvider` as the tenth argument is deprecated.

--- a/src/Sylius/Bundle/CoreBundle/Event/UserByOAuthResponseCreatedEvent.php
+++ b/src/Sylius/Bundle/CoreBundle/Event/UserByOAuthResponseCreatedEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Event;
+
+use Sylius\Component\Core\Model\ShopUserInterface;
+
+final class UserByOAuthResponseCreatedEvent
+{
+    public function __construct(private ShopUserInterface $user)
+    {
+    }
+
+    public function getUser(): ShopUserInterface
+    {
+        return $this->user;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Event/UserByOAuthResponseUpdatedEvent.php
+++ b/src/Sylius/Bundle/CoreBundle/Event/UserByOAuthResponseUpdatedEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Event;
+
+use Sylius\Component\Core\Model\ShopUserInterface;
+
+final class UserByOAuthResponseUpdatedEvent
+{
+    public function __construct(private ShopUserInterface $user)
+    {
+    }
+
+    public function getUser(): ShopUserInterface
+    {
+        return $this->user;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="sylius.manager.shop_user" />
             <argument type="service" id="sylius.canonicalizer" />
             <argument type="service" id="sylius.repository.customer" />
+            <argument type="service" id="event_dispatcher" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                          |
| Bug fix?        | no                                                       |
| New feature?    | yes                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes  |
| Related tickets | None                      |
| License         | MIT                                                          |

With this PR the `Sylius\Bundle\CoreBundle\OAuth\UserProvider` dispatches the two following events when the user is created or updated by an OAuth response:

* `Sylius\Bundle\CoreBundle\Event\UserByOAuthResponseCreatedEvent`
* `Sylius\Bundle\CoreBundle\Event\UserByOAuthResponseUpdatedEvent`

This could be useful to implement custom workflows when a user and its customer are created or updated through OAuth.