### PR TITLE
[FIX] Move a config to the Core 

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -101,6 +101,16 @@ liip_imagine:
             filters:
                 thumbnail: { size: [640, 480], mode: outbound }
 
+sylius_payum:
+    gateway_config:
+        validation_groups:
+            paypal_express_checkout:
+                - 'sylius'
+                - 'sylius_paypal_express_checkout'
+            stripe_checkout:
+                - 'sylius'
+                - 'sylius_stripe_checkout'
+
 payum:
     storages:
         "%sylius.model.order.class%": { doctrine: orm }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -11,6 +11,7 @@ imports:
     - { resource: "@SyliusLocaleBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusOrderBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusPaymentBundle/Resources/config/app/config.yml" }
+    - { resource: "@SyliusPayumBundle/Resources/config/app/config.yaml" }
     - { resource: "@SyliusProductBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusPromotionBundle/Resources/config/app/config.yml" }
     - { resource: "@SyliusShippingBundle/Resources/config/app/config.yml" }
@@ -100,16 +101,6 @@ liip_imagine:
         sylius_large:
             filters:
                 thumbnail: { size: [640, 480], mode: outbound }
-
-sylius_payum:
-    gateway_config:
-        validation_groups:
-            paypal_express_checkout:
-                - 'sylius'
-                - 'sylius_paypal_express_checkout'
-            stripe_checkout:
-                - 'sylius'
-                - 'sylius_stripe_checkout'
 
 payum:
     storages:

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/app/config.yml
@@ -7,13 +7,3 @@ jms_serializer:
             sylius-payment:
                 namespace_prefix: "Sylius\\Component\\Payment"
                 path: "@SyliusPaymentBundle/Resources/config/serializer"
-
-sylius_payum:
-    gateway_config:
-        validation_groups:
-            paypal_express_checkout:
-                - 'sylius'
-                - 'sylius_paypal_express_checkout'
-            stripe_checkout:
-                - 'sylius'
-                - 'sylius_stripe_checkout'

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/app/config.yaml
@@ -1,0 +1,12 @@
+# This file is part of the Sylius package.
+# (c) Sylius Sp. z o.o.
+
+sylius_payum:
+    gateway_config:
+        validation_groups:
+            paypal_express_checkout:
+                - 'sylius'
+                - 'sylius_paypal_express_checkout'
+            stripe_checkout:
+                - 'sylius'
+                - 'sylius_stripe_checkout'


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                  |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no --> |
| Related tickets | none                      |
| License         | MIT                                                          |

SyliusPaymentBundle do not requires SyliusPayumBundle that why this config has to be moved to the SyliusCoreBundle.
