### PR TITLE
FEATURE: [2.2] [AdminBundle] #15890 Introduce sylius:admin-user:list command

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Console/Command/ListAdminUsersCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Console/Command/ListAdminUsersCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Console\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'sylius:admin-user:list',
+    description: 'Displays a list of all admin users along with their details.',
+)]
+final class ListAdminUsersCommand extends Command
+{
+    protected SymfonyStyle $io;
+
+    /** @param UserRepositoryInterface<AdminUserInterface> $adminUserRepository */
+    public function __construct(
+        private readonly UserRepositoryInterface $adminUserRepository,
+        private readonly EntityManagerInterface $adminManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'search',
+            's',
+            InputOption::VALUE_OPTIONAL,
+            'Filter users based on a search term. If not provided, all users will be displayed.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io->title('List available admin users');
+
+        $searchTerm = $input->getOption('search');
+        if ($searchTerm === null || $searchTerm === '') {
+            $this->renderUsersTable($output, $this->adminUserRepository->findAll());
+
+            return Command::SUCCESS;
+        }
+
+        $users = $this->searchUsers($searchTerm);
+        if (empty($users)) {
+            $this->io->warning(sprintf('No users found matching "%s"', $searchTerm));
+
+            return Command::SUCCESS;
+        }
+
+        $this->io->success(sprintf('Found %d user(s) matching "%s"', count($users), $searchTerm));
+        $this->renderUsersTable($output, $users);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<AdminUserInterface>
+     */
+    private function searchUsers(string $searchTerm): array
+    {
+        $criteria = '%' . mb_strtolower($searchTerm) . '%';
+
+        return $this->adminManager->createQueryBuilder()
+            ->from(AdminUserInterface::class, 'u')
+            ->select('u')
+            ->where('LOWER(u.email) LIKE :criteria
+                OR LOWER(u.username) LIKE :criteria
+                OR LOWER(u.firstName) LIKE :criteria
+                OR LOWER(u.lastName) LIKE :criteria')
+            ->setParameter('criteria', $criteria)
+            ->orderBy('u.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @param array<AdminUserInterface> $adminUsers
+     */
+    private function renderUsersTable(OutputInterface $output, array $adminUsers): void
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            'ID', 'E-Mail', 'Username', 'First name', 'Last name', 'Locale code', 'Enabled', 'Roles',
+        ]);
+
+        foreach ($adminUsers as $adminUser) {
+            $table->addRow([
+                $adminUser->getId(),
+                $adminUser->getEmail(),
+                $adminUser->getUsername(),
+                $adminUser->getFirstName() ?? '',
+                $adminUser->getLastName() ?? '',
+                $adminUser->getLocaleCode(),
+                $adminUser->isEnabled() ? 'Enabled' : 'Disabled',
+                $adminUser->getRoles() !== [] ? implode(', ', $adminUser->getRoles()) : 'No roles assigned',
+            ]);
+        }
+
+        $tableStyle = new TableStyle();
+        $tableStyle->setPadType(\STR_PAD_BOTH);
+        $table->setStyle($tableStyle)->render();
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Console/Command/ListAdminUsersCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Console/Command/ListAdminUsersCommand.php
@@ -19,7 +19,6 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -36,7 +35,7 @@ final class ListAdminUsersCommand extends Command
     /** @param UserRepositoryInterface<AdminUserInterface> $adminUserRepository */
     public function __construct(
         private readonly UserRepositoryInterface $adminUserRepository,
-        private readonly EntityManagerInterface $adminManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
         parent::__construct();
     }
@@ -48,6 +47,7 @@ final class ListAdminUsersCommand extends Command
 
     protected function configure(): void
     {
+        $this->setAliases(['sylius:admin-users:list']);
         $this->addOption(
             'search',
             's',
@@ -87,7 +87,7 @@ final class ListAdminUsersCommand extends Command
     {
         $criteria = '%' . mb_strtolower($searchTerm) . '%';
 
-        return $this->adminManager->createQueryBuilder()
+        return $this->entityManager->createQueryBuilder()
             ->from(AdminUserInterface::class, 'u')
             ->select('u')
             ->where('LOWER(u.email) LIKE :criteria
@@ -107,7 +107,7 @@ final class ListAdminUsersCommand extends Command
     {
         $table = new Table($output);
         $table->setHeaders([
-            'ID', 'E-Mail', 'Username', 'First name', 'Last name', 'Locale code', 'Enabled', 'Roles',
+            'ID', 'E-Mail', 'Username', 'First name', 'Last name', 'Locale', 'Enabled', 'Roles',
         ]);
 
         foreach ($adminUsers as $adminUser) {
@@ -118,13 +118,28 @@ final class ListAdminUsersCommand extends Command
                 $adminUser->getFirstName() ?? '',
                 $adminUser->getLastName() ?? '',
                 $adminUser->getLocaleCode(),
-                $adminUser->isEnabled() ? 'Enabled' : 'Disabled',
-                $adminUser->getRoles() !== [] ? implode(', ', $adminUser->getRoles()) : 'No roles assigned',
+                $adminUser->isEnabled() ? '✔' : '✘',
+                $this->formatRoles($adminUser->getRoles()),
             ]);
         }
 
-        $tableStyle = new TableStyle();
-        $tableStyle->setPadType(\STR_PAD_BOTH);
-        $table->setStyle($tableStyle)->render();
+        $table->render();
+    }
+
+    /**
+     * @param array<string> $roles
+     */
+    private function formatRoles(array $roles): string
+    {
+        if ($roles === []) {
+            return 'No roles';
+        }
+
+        $formatted = array_map(
+            static fn (string $role): string => str_replace('ROLE_', '', $role),
+            $roles,
+        );
+
+        return implode(",\n", $formatted);
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -53,6 +53,12 @@
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
+         <service id="sylius_admin.console.command.list_admin_users" class="Sylius\Bundle\AdminBundle\Console\Command\ListAdminUsersCommand">
+            <argument type="service" id="sylius.repository.admin_user" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <tag name="console.command" />
+        </service>
+
         <service id="sylius_admin.console.command_factory.question" class="Sylius\Bundle\AdminBundle\Console\Command\Factory\QuestionFactory" />
         <service id="Sylius\Bundle\AdminBundle\Console\Command\Factory\QuestionFactoryInterface" alias="sylius_admin.console.command_factory.question" />
 

--- a/src/Sylius/Bundle/AdminBundle/tests/Console/Command/ListAdminUsersCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Console/Command/ListAdminUsersCommandTest.php
@@ -83,7 +83,25 @@ final class ListAdminUsersCommandTest extends TestCase
         self::assertStringContainsString('List available admin users', $output);
         self::assertStringContainsString('admin@example.com', $output);
         self::assertStringContainsString('John', $output);
-        self::assertStringContainsString('ROLE_ADMINISTRATION_ACCESS', $output);
+        self::assertStringContainsString('ADMINISTRATION_ACCESS', $output);
+    }
+
+    #[Test]
+    public function it_displays_empty_table_when_no_admin_users_exist(): void
+    {
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findAll')
+            ->willReturn([]);
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('List available admin users', $output);
+        self::assertStringContainsString('ID', $output);
+        self::assertStringContainsString('E-Mail', $output);
     }
 
     #[Test]

--- a/src/Sylius/Bundle/AdminBundle/tests/Console/Command/ListAdminUsersCommandTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Console/Command/ListAdminUsersCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\AdminBundle\Console\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\AdminBundle\Console\Command\ListAdminUsersCommand;
+use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class ListAdminUsersCommandTest extends TestCase
+{
+    private CommandTester $commandTester;
+
+    /** @var MockObject&UserRepositoryInterface<AdminUserInterface> */
+    private MockObject $userRepository;
+
+    /** @var MockObject&EntityManagerInterface */
+    private MockObject $entityManager;
+
+    /** @var MockObject&QueryBuilder */
+    private MockObject $queryBuilder;
+
+    /** @var MockObject&Query */
+    private MockObject $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->query = $this->createMock(Query::class);
+
+        $entityManager = $this->entityManager;
+        $command = new ListAdminUsersCommand($this->userRepository, $entityManager);
+
+        $this->commandTester = new CommandTester($command);
+    }
+
+    #[Test]
+    public function it_lists_all_admin_users(): void
+    {
+        $adminUser = $this->createConfiguredMock(AdminUserInterface::class, [
+            'getId' => 1,
+            'getEmail' => 'admin@example.com',
+            'getUsername' => 'admin',
+            'getFirstName' => 'John',
+            'getLastName' => 'Doe',
+            'getLocaleCode' => 'en_US',
+            'isEnabled' => true,
+            'getRoles' => ['ROLE_ADMINISTRATION_ACCESS'],
+        ]);
+
+        $this->userRepository
+            ->expects($this->once())
+            ->method('findAll')
+            ->willReturn([$adminUser]);
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('List available admin users', $output);
+        self::assertStringContainsString('admin@example.com', $output);
+        self::assertStringContainsString('John', $output);
+        self::assertStringContainsString('ROLE_ADMINISTRATION_ACCESS', $output);
+    }
+
+    #[Test]
+    public function it_filters_users_by_search_term(): void
+    {
+        $matchingUser = $this->createConfiguredMock(AdminUserInterface::class, [
+            'getId' => 2,
+            'getEmail' => 'sylius@example.com',
+            'getUsername' => 'sylius',
+            'getFirstName' => 'Luke',
+            'getLastName' => 'Brushwood',
+            'getLocaleCode' => 'en_US',
+            'isEnabled' => true,
+            'getRoles' => ['ROLE_ADMINISTRATION_ACCESS'],
+        ]);
+
+        $this->entityManager->method('createQueryBuilder')->willReturn($this->queryBuilder);
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('where')->willReturnSelf();
+        $this->queryBuilder->method('andWhere')->willReturnSelf();
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+        $this->queryBuilder->method('orderBy')->willReturnSelf();
+        $this->queryBuilder->method('getQuery')->willReturn($this->query);
+
+        $this->query->method('getResult')->willReturn([$matchingUser]);
+
+        $exitCode = $this->commandTester->execute(['--search' => 'sylius']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('Found 1 user(s) matching "sylius"', $output);
+        self::assertStringContainsString('sylius@example.com', $output);
+    }
+
+    #[Test]
+    public function it_shows_zero_results_when_no_user_matches_search_term(): void
+    {
+        $this->entityManager->method('createQueryBuilder')->willReturn($this->queryBuilder);
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('where')->willReturnSelf();
+        $this->queryBuilder->method('andWhere')->willReturnSelf();
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+        $this->queryBuilder->method('orderBy')->willReturnSelf();
+        $this->queryBuilder->method('getQuery')->willReturn($this->query);
+
+        $this->query->method('getResult')->willReturn([]);
+
+        $exitCode = $this->commandTester->execute(['--search' => 'ghost']);
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('No users found matching "ghost"', $output);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 2.2                                                        |
| Bug fix?        | no.                                                          |
| New feature?    | yes.                                                         |
| BC breaks?      | no.                                                          |
| Deprecations?   | no                                                           |
| Related tickets | fixes #15890                                                 |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

**Description:**

As described in: #15890

This pull request introduces a new CLI command:

```bash
bin/console sylius:admin-users:list
```

By default all available admin users are listed, and each data of a user is showed in a table:

![SCR-20240304-nxdu](https://github.com/Sylius/Sylius/assets/39345336/db0f292c-8978-4a06-bcc8-1d8e11d4e66e)

If you want to see only one admin user, you can use the `--username` option:

```bash
bin/console sylius:admin-user:list --username simon
```

Any feedback or improvement ideas are much appreciated!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a console command sylius:admin-user:list (alias sylius:admin-users:list) to display admin users.
  * Supports an optional --username flag to show a single user or list all users.
  * Outputs a formatted table with ID, E‑mail, username, first/last name, locale, and enabled/disabled status.
  * Registered as a CLI service and returns clear success/failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->