### PR TITLE
Fix: finds the max number of products for the correct taxon

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -72,6 +72,9 @@ class ProductTaxonController extends ResourceController
             return $this->redirectHandler->redirectToReferer($configuration);
         }
 
+        // Add the first product taxon id to the criteria to get the retrieved the right taxon
+        $firstProductTaxonId = array_key_first($productTaxonsPositions);
+        $configuration->getParameters()->set('criteria', ['id' => $firstProductTaxonId]);
         $maxPosition = $this->getMaxPosition($configuration);
 
         try {
@@ -128,7 +131,7 @@ class ProductTaxonController extends ResourceController
         /** @var EntityRepository&RepositoryInterface $repository */
         $repository = $this->repository;
 
-        return $repository->count(['taxon' => $productTaxon->getTaxon()]) - 1;
+        return $repository->count(['taxon' => $productTaxon->getTaxon()]);
     }
 
     private function validateCsrfProtection(Request $request, RequestConfiguration $configuration): void


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12                 |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no |
| Related tickets | fixes #15954                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
