### PR TITLE
[Order] Remove dead argument from OrderRepository::countByCustomerAndCoupon

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -183,7 +183,6 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     public function countByCustomerAndCoupon(
         CustomerInterface $customer,
         PromotionCouponInterface $coupon,
-        bool $includeCancelled = false,
     ): int {
         $states = [OrderInterface::STATE_CART];
         if ($coupon->isReusableFromCancelledOrders()) {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13                   |
| Bug fix?        | kinda                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

Rationale:
1. The argument is only present in the implementation's signature
2. If someone overwritten the method, nothing changes
3. If someone implemented the interface on their own, nothing changes since the interface doesn't have this argument
4. If someone uses the method w/ 3 arguments, nothing changes since it's not used in the method itself and PHP allows passing more than declared arguments to a method