### PR TITLE
[Maintenance] Revert deprecating and aliasing PaymentFixture

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -525,9 +525,6 @@ To ease the update process, we have grouped the changes into the following categ
    same reason. Both changes affect
    `sylius_admin_order` and `sylius_admin_customer_order` grids configuration.
 
-1. The `Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture` has been deprecated.
-   Use `Sylius\Bundle\CoreBundle\Fixture\PaymentFixture` instead.
-
 1. The `Sylius\Bundle\CoreBundle\Provider\SessionProvider` has been deprecated and will be removed in Sylius 2.0.
 
 1. The `Sylius\Component\Addressing\Repository\ZoneRepositoryInterface` and

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
@@ -211,5 +211,12 @@
             <argument type="service" id="sylius.fixture.example_factory.address" />
             <tag name="sylius_fixtures.fixture" />
         </service>
+
+        <service id="sylius.fixture.payment" class="Sylius\Bundle\CoreBundle\Fixture\PaymentFixture">
+            <argument type="service" id="sylius.repository.payment" />
+            <argument type="service" id="sylius_abstraction.state_machine" />
+            <argument type="service" id="sylius.manager.payment" />
+            <tag name="sylius_fixtures.fixture" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -182,14 +182,5 @@
             <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
             <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
         </service>
-
-        <service id="Sylius\Bundle\CoreBundle\Fixture\PaymentFixture">
-            <argument type="service" id="sylius.repository.payment" />
-            <argument type="service" id="sylius_abstraction.state_machine" />
-            <argument type="service" id="sylius.manager.payment" />
-            <tag name="sylius_fixtures.fixture" />
-        </service>
-
-        <service id="Sylius\Bundle\CoreBundle\Fixture\Factory\PaymentFixture" alias="Sylius\Bundle\CoreBundle\Fixture\PaymentFixture" />
     </services>
 </container>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | kinda                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

The original service has been added in 1.13, no point in aliasing/deprecating it, we can just move it.