### PR TITLE
Prepare Sylius\Behat to be installed as a separate package

### DIFF
--- a/src/Sylius/Behat/LICENSE
+++ b/src/Sylius/Behat/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024 Sylius Sp. z o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Sylius/Behat/composer.json
+++ b/src/Sylius/Behat/composer.json
@@ -1,0 +1,42 @@
+{
+    "name": "sylius/behat",
+    "description": "Set of Behat steps, helpers and contexts for Sylius",
+    "type": "package",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Sylius project",
+            "homepage": "https://sylius.com"
+        },
+        {
+            "name": "Community contributions",
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Sylius\\Behat\\": "./"
+        }
+    },
+    "require": {
+        "php": "^8.1",
+        "behat/behat": "^3.6.1",
+        "behat/mink-selenium2-driver": "^1.4",
+        "dbrekelmans/bdi": "^1.1",
+        "dmore/behat-chrome-extension": "^1.3",
+        "dmore/chrome-mink-driver": "^2.7",
+        "friends-of-behat/mink": "^1.8",
+        "friends-of-behat/mink-browserkit-driver": "^1.4",
+        "friends-of-behat/mink-debug-extension": "^2.0",
+        "friends-of-behat/mink-extension": "^2.4",
+        "friends-of-behat/page-object-extension": "^0.3",
+        "friends-of-behat/symfony-extension": "^2.1",
+        "friends-of-behat/variadic-extension": "^1.3",
+        "robertfausk/behat-panther-extension": "^1.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.13-dev"
+        }
+    }
+}


### PR DESCRIPTION
We've faced some issues with supporting both `1.12` and `1.13` (easily) in the Behat scenarios. So, here's a concept where the `Sylius\Behat` can be installed separately c:.