### PR TITLE
Use Sylius State Machine Abstraction inside the Resource Controller State Machine

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideResourceControllerStateMachinePass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideResourceControllerStateMachinePass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class OverrideResourceControllerStateMachinePass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine', CompositeStateMachine::class);
         $stateMachineDefinition->setPublic(false);

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideResourceControllerStateMachinePass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideResourceControllerStateMachinePass.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Sylius\Bundle\CoreBundle\Resource\StateMachine\Controller\CompositeStateMachine;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class OverrideResourceControllerStateMachinePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $stateMachineDefinition = $container->register('sylius.resource_controller.state_machine', CompositeStateMachine::class);
+        $stateMachineDefinition->setPublic(false);
+        $stateMachineDefinition->addArgument(new Reference('sylius_abstraction.state_machine'));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resource/StateMachine/Controller/CompositeStateMachine.php
+++ b/src/Sylius/Bundle/CoreBundle/Resource/StateMachine/Controller/CompositeStateMachine.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Resource\StateMachine\Controller;
+
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Controller\StateMachineInterface as ResourceStateMachineInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
+use Webmozart\Assert\Assert;
+
+final class CompositeStateMachine implements ResourceStateMachineInterface
+{
+    public function __construct (
+        private readonly StateMachineInterface $compositeStateMachine,
+    ) {
+    }
+
+    public function can(RequestConfiguration $configuration, ResourceInterface $resource): bool
+    {
+        Assert::true($configuration->hasStateMachine(), 'State machine must be configured to apply transition, check your routing.');
+
+        $graph = $configuration->getStateMachineGraph();
+
+        /** @var string $transitionName */
+        $transitionName = $configuration->getStateMachineTransition();
+
+        return $this->compositeStateMachine->can($resource, $graph, $transitionName);
+    }
+
+    public function apply(RequestConfiguration $configuration, ResourceInterface $resource): void
+    {
+        Assert::true($configuration->hasStateMachine(), 'State machine must be configured to apply transition, check your routing.');
+
+        $graph = $configuration->getStateMachineGraph();
+
+        /** @var string $transitionName */
+        $transitionName = $configuration->getStateMachineTransition();
+
+        $this->compositeStateMachine->apply($resource, $graph, $transitionName);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -158,14 +158,3 @@ sonata_block:
                 resources: ~
                 statistics: ~
                 taxon: ~
-
-sylius_state_machine_abstraction:
-    graphs_to_adapters_mapping:
-        sylius_catalog_promotion: symfony_workflow
-        sylius_order: symfony_workflow
-        sylius_order_checkout: symfony_workflow
-        sylius_order_payment: symfony_workflow
-        sylius_order_shipping: symfony_workflow
-        sylius_payment: symfony_workflow
-        sylius_product_review: symfony_workflow
-        sylius_shipment: symfony_workflow

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -30,6 +30,7 @@ use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\CircularDependencyBrea
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\IgnoreAnnotationsPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LazyCacheWarmupPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LiipImageFiltersPass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\OverrideResourceControllerStateMachinePass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterTaxCalculationStrategiesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterUriBasedSectionResolverPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\SyliusPriceHistoryLegacyAliasesPass;
@@ -97,6 +98,7 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         $container->addCompilerPass(new CancelOrderStateMachineCallbackPass());
         $container->addCompilerPass(new SyliusPriceHistoryLegacyAliasesPass());
         $container->addCompilerPass(new CheckStatisticsOrdersTotalsProviderTypePass());
+        $container->addCompilerPass(new OverrideResourceControllerStateMachinePass(), priority: -1024);
     }
 
     protected function getModelNamespace(): string

--- a/src/Sylius/Bundle/CoreBundle/spec/Resource/StateMachine/Controller/CompositeStateMachineSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Resource/StateMachine/Controller/CompositeStateMachineSpec.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Resource\StateMachine\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+final class CompositeStateMachineSpec extends ObjectBehavior
+{
+    function let(StateMachineInterface $stateMachine): void
+    {
+        $this->beConstructedWith($stateMachine);
+    }
+
+    function it_returns_true_if_can_transition(
+        StateMachineInterface $stateMachine,
+        RequestConfiguration $requestConfiguration,
+        ResourceInterface $resource,
+    ): void
+    {
+        $requestConfiguration->hasStateMachine()->willReturn(true);
+        $requestConfiguration->getStateMachineGraph()->willReturn('default');
+        $requestConfiguration->getStateMachineTransition()->willReturn('transition');
+
+        $stateMachine->can($resource, 'default', 'transition')->willReturn(true);
+
+        $this->can($requestConfiguration, $resource)->shouldReturn(true);
+    }
+
+    function it_applies_transition(
+        StateMachineInterface $stateMachine,
+        RequestConfiguration $requestConfiguration,
+        ResourceInterface $resource,
+    ): void
+    {
+        $requestConfiguration->hasStateMachine()->willReturn(true);
+        $requestConfiguration->getStateMachineGraph()->willReturn('default');
+        $requestConfiguration->getStateMachineTransition()->willReturn('transition');
+
+        $stateMachine->apply($resource, 'default', 'transition')->shouldBeCalled();
+
+        $this->apply($requestConfiguration, $resource);
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13


Previously, despite we've been using new state machine abstraction everywhere, the Resource controllers have been still using the Resource Bundle abstraction. From now, everything goes through the abstraction.

P.S. I also let myself to remove setting the state machine to Symfony Workflow for all existing Sylius' graphs, as it could cause some BC issues.
