### PR TITLE
Using the service name for the availibilty checker

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -544,6 +544,10 @@ To ease the update process, we have grouped the changes into the following categ
 1. The `sylius.payum.http_client` has become a service ID of newly
    created `Sylius\Bundle\PayumBundle\HttpClient\HttpClient`.
 
+1. The argument of `Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener` has been changed
+   from `Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface` to `sylius.availability_checker`.
+   This is the alias to the same service.
+
 ### Configuration
 
 1. To ease customization we've introduced attributes for some services in `1.13`:

--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -790,6 +790,8 @@ and use one of the new attributes accordingly to the type of your class, e.g.:
         max_int_value: 9223372036854775807
     ```
 
+1. The `sylius_inventory.checker` parameter has been deprecated and will be removed in 2.0.
+
 ### State Machine
 
 1. We have configured all existing Sylius graphs to be usable with the Symfony Workflow out of the box.

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -111,7 +111,7 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener">
-            <argument type="service" id="Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface" />
+            <argument type="service" id="sylius.availability_checker" />
             <tag name="kernel.event_listener" event="sylius.payment.pre_complete" method="checkStockAvailability" />
         </service>
 

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
@@ -34,7 +34,11 @@ final class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
-                ->scalarNode('checker')->defaultValue('sylius.availability_checker.default')->cannotBeEmpty()->end()
+                ->scalarNode('checker')
+                    ->setDeprecated('sylius/inventory-bundle', '1.13', 'The "%path%.%node%" parameter is deprecated and will be removed in 2.0.')
+                    ->defaultValue('sylius.availability_checker.default')
+                    ->cannotBeEmpty()
+                ->end()
             ->end()
         ;
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12        |
| Bug fix?        | yes (for plus users)                                                   |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                      |
| License         | MIT                                                          |

## The problem

With Sylius plus the  `sylius.availability_checker` service is overwritten with a more complicated logic. Using the autowireable interface will always default to the Sylius core implemenation.

## The solution
Use the service name.

In the long run maybe deprecate the service name and only overwrite the interface in Sylius Plus.
