### PR TITLE
Display test attributes when debug mode is enabled

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -21,11 +21,13 @@
 
         <service id="sylius.twig.extension.form_test_attribute_array" class="Sylius\Bundle\UiBundle\Twig\TestFormAttributeExtension">
             <argument>%kernel.environment%</argument>
+            <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>
 
         <service id="sylius.twig.extension.form_test_attribute_name" class="Sylius\Bundle\UiBundle\Twig\TestHtmlAttributeExtension">
             <argument>%kernel.environment%</argument>
+            <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/UiBundle/Twig/TestFormAttributeExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TestFormAttributeExtension.php
@@ -18,7 +18,7 @@ use Twig\TwigFunction;
 
 final class TestFormAttributeExtension extends AbstractExtension
 {
-    public function __construct(private string $environment)
+    public function __construct(private readonly string $environment, private readonly bool $isDebugEnabled)
     {
     }
 
@@ -36,7 +36,7 @@ final class TestFormAttributeExtension extends AbstractExtension
             new TwigFunction(
                 'sylius_test_form_attributes',
                 function (array $attributes): array {
-                    if (!str_starts_with($this->environment, 'test')) {
+                    if (!str_starts_with($this->environment, 'test') && $this->isDebugEnabled === false) {
                         return [];
                     }
 
@@ -58,7 +58,7 @@ final class TestFormAttributeExtension extends AbstractExtension
      */
     public function getTestFormAttribute(string $name, ?string $value = null): array
     {
-        if (str_starts_with($this->environment, 'test')) {
+        if (str_starts_with($this->environment, 'test') || $this->isDebugEnabled) {
             return ['attr' => ['data-test-' . $name => (string) $value]];
         }
 

--- a/src/Sylius/Bundle/UiBundle/Twig/TestHtmlAttributeExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TestHtmlAttributeExtension.php
@@ -18,7 +18,7 @@ use Twig\TwigFunction;
 
 final class TestHtmlAttributeExtension extends AbstractExtension
 {
-    public function __construct(private string $env)
+    public function __construct(private readonly string $environment, private readonly bool $isDebugEnabled)
     {
     }
 
@@ -31,7 +31,7 @@ final class TestHtmlAttributeExtension extends AbstractExtension
             new TwigFunction(
                 'sylius_test_html_attribute',
                 function (string $name, ?string $value = null): string {
-                    if (str_starts_with($this->env, 'test')) {
+                    if (str_starts_with($this->environment, 'test') || $this->isDebugEnabled) {
                         return sprintf('data-test-%s="%s"', $name, (string) $value);
                     }
 


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | `bootstrap-admin-panel`                  |

Currently the `sylius_test_html_attribute` and `sylius_test_form_attribute` are rendered only when the env starts with `test_`. I believe basing on the `kernel.debug` parameter is better, as we can enable displaying these attributes on the dev mode, so it's easier to write/debug Behat tests without enabling the test env c:.