### PR TITLE
BUGFIX: [AdminBundle] #16031 wrap long text in notes section

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -362,3 +362,11 @@ div[id^="sylius_catalog_promotion_actions"] {
         top: 60px;
     }
 }
+
+// ----------------------------------
+// ------------ Order Notes Info
+// ----------------------------------
+
+.text-break {
+    word-break: break-word;
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_notes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_notes.html.twig
@@ -2,7 +2,7 @@
     <h4 class="ui top attached styled header">
         {{ 'sylius.ui.notes'|trans }}
     </h4>
-    <div class="ui attached segment" id="sylius-order-notes">
+    <div class="ui attached segment text-break" id="sylius-order-notes">
         {{ order.notes }}
     </div>
 {% endif %}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12.        <!-- see the comment below -->                  |
| Bug fix?        | yes.                                                         |
| New feature?    | no.                                                          |
| BC breaks?      | no.                                                          |
| Deprecations?   | no.    <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | fixes #16031                       |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

As already described in #16031 

When you have a long text in the notes info without any spaces and new lines, the text doesent wrap and therefore it breaks out of the container.

So i added a `word-break: break-word;` to the ID: `sylius-order-notes` in the `_ui.scss` file.

### Result

![SCR-20240330-mypw](https://github.com/Sylius/Sylius/assets/39345336/a7c7b395-70bf-40c3-882b-f7a1b044591e)
