### PR TITLE
Update the Upmerge workflow

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -69,5 +69,4 @@ jobs:
                         ```
                     branch: "upmerge/${{ matrix.base_branch }}_${{ matrix.target_branch }}"
                     delete-branch: true
-                    branch-suffix: "short-commit-hash"
                     base: ${{ matrix.target_branch }}

--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -63,10 +63,7 @@ jobs:
                         
                         If you use other name for the upstream remote, please replace `upstream` with the name of your remote pointing to the `Sylius/Sylius` repository.
                         
-                        Once the conflicts are resolved, please run `git merge --continue` and change the commit title to
-                        ```
-                        Resolve conflicts between ${{ matrix.base_branch }} and ${{ matrix.target_branch }}
-                        ```
+                        Once the conflicts are resolved, please run `git merge --continue` and push the changes to this PR.
                     branch: "upmerge/${{ matrix.base_branch }}_${{ matrix.target_branch }}"
                     delete-branch: true
                     base: ${{ matrix.target_branch }}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13

- the upmerge instruction has been updated
- this worklow won't create new PRs for a given `base -> target` if it already exist; it will update the existing PR instead.