### PR TITLE
[Inventory] Fix deprecation note of sylius_inventory.checker configuration

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -790,7 +790,7 @@ and use one of the new attributes accordingly to the type of your class, e.g.:
         max_int_value: 9223372036854775807
     ```
 
-1. The `sylius_inventory.checker` parameter has been deprecated and will be removed in 2.0.
+1. The `sylius_inventory.checker` configuration node has been deprecated and will be removed in 2.0.
 
 ### State Machine
 

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
@@ -35,7 +35,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
                 ->scalarNode('checker')
-                    ->setDeprecated('sylius/inventory-bundle', '1.13', 'The "%path%.%node%" parameter is deprecated and will be removed in 2.0.')
+                    ->setDeprecated('sylius/inventory-bundle', '1.13', 'The "%path%.%node%" is deprecated and will be removed in 2.0.')
                     ->defaultValue('sylius.availability_checker.default')
                     ->cannotBeEmpty()
                 ->end()


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13|
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | nox                                                       |
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | after https://github.com/Sylius/Sylius/pull/16062|
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
