### PR TITLE
Adding an index for the `address_log_entries`

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/AddressLogEntry.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/AddressLogEntry.orm.xml
@@ -28,5 +28,10 @@
             </options>
         </field>
         <field name="username" column="username" type="string" nullable="true" />
+
+        <indexes>
+            <index name="object_id_index" columns="object_id" />
+            <index name="object_class_index" columns="object_class" />
+        </indexes>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20241018075040.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20241018075040.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
+
+final class Version20241018075040 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes to the Sylius address log table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX object_id_index ON sylius_address_log_entries (object_id)');
+        $this->addSql('CREATE INDEX object_class_index ON sylius_address_log_entries (object_class)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX object_id_index ON sylius_address_log_entries');
+        $this->addSql('DROP INDEX object_class_index ON sylius_address_log_entries');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20241018081002.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20241018081002.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20241018081002 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexes to the Sylius address log table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX object_id_index ON sylius_address_log_entries (object_id)');
+        $this->addSql('CREATE INDEX object_class_index ON sylius_address_log_entries (object_class)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX object_id_index');
+        $this->addSql('DROP INDEX object_class_index');
+    }
+}


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.14    |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | -                    |
| License         | MIT                                                          |

## What's inside
Adding indicies to the `address_order_log_entry`.

## Why?
I don't know how exactly gedomo's loggable trait works but appereantly it querries the current version for an object like this:
```sql
SELECT MAX(s?_.version) AS sclr_? 
FROM sylius_address_log_entries s?_ 
WHERE s?_.object_id = ? AND s?_.object_class = ?
```

Which is very expensive if you have a lot of entries.