### PR TITLE
BUGFIX: [ShopBundle] #16068 wrap long text in product description

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/scss/theme.scss
@@ -1331,3 +1331,7 @@ address {
     width: 30px !important;
     padding: 7px 0 !important;
 }
+
+.text-break {
+    word-break: break-word;
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_details.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_details.html.twig
@@ -1,3 +1,3 @@
-<div class="ui bottom attached tab segment active" data-tab="details">
+<div class="ui bottom attached tab segment active text-break" data-tab="details">
     {{ sylius_template_event('sylius.shop.product.show.tab_details', _context) }}
 </div>


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12.                                                        |
| Bug fix?        | yes.                                                         |
| New feature?    | no                                                           |
| BC breaks?      | no.                                                          |
| Deprecations?   | no                                                           |
| Related tickets | fixes #16068,                                                |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Its the same behavior as in: #16031 

![SCR-20240406-hdyh](https://github.com/Sylius/Sylius/assets/39345336/4fc9f839-3070-4b04-bde7-754fdef69307)

