### PR TITLE
[Maintenance] Deprecate `SyliusLocaleEvents`

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -548,6 +548,8 @@ To ease the update process, we have grouped the changes into the following categ
    from `Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface` to `sylius.availability_checker`.
    This is the alias to the same service.
 
+1. The interface `Sylius\Component\Core\SyliusLocaleEvents` has been deprecated and will be removed in Sylius 2.0.
+
 ### Configuration
 
 1. To ease customization we've introduced attributes for some services in `1.13`:

--- a/src/Sylius/Component/Core/SyliusLocaleEvents.php
+++ b/src/Sylius/Component/Core/SyliusLocaleEvents.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. */
 interface SyliusLocaleEvents
 {
     public const CODE_CHANGED = 'sylius.locale.code_changed';


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 |
| Bug fix?        | no                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | yes |
| Related tickets | -                      |
| License         | MIT                                                          |

It's not used anywhere 🤷 