### PR TITLE
Update php-entrypoint to give www-data permissions to public/media

### DIFF
--- a/.bunnyshell/docker/php/entrypoints/php-entrypoint
+++ b/.bunnyshell/docker/php/entrypoints/php-entrypoint
@@ -13,8 +13,9 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	mkdir -p var/cache var/log var/sessions public/media
 
 	# @note: certain filesystems might not support setfacl
-	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media || true
- 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media || true
+	#setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media || true
+ 	#setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media || true
+        chown -R www-data:www-data var public/media
 
 	if [ "$APP_ENV" != 'prod' ]; then
 		composer install --prefer-dist --no-progress --no-interaction


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13  |
| Bug fix?        | yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | fixes #X, partially #Y, mentioned in #Z                      |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
