### PR TITLE
Revert conflict to twig/intl-extra

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -69,7 +69,6 @@ references related issues.
     - https://github.com/stof/StofDoctrineExtensionsBundle/issues/455
     - https://github.com/doctrine-extensions/DoctrineExtensions/issues/2600
 
-
 - `api-platform/core:2.7.17`:
 
   This version introduced class aliases, which lead to a fatal error:
@@ -79,8 +78,3 @@ references related issues.
 
   This version has a bug, which lead to a fatal error:
   `An exception has been thrown during the rendering of a template ("Warning: Undefined variable $blocks").`
-
-- `twig/intl-extra:3.9.0`:
-
-  This version call function `dateConverter` which is only available in `twig/twig:3.9.0`, that leads to a fatal error:
-  `An exception has been thrown during the rendering of a template ("Call to undefined method Twig\Extension\CoreExtension::dateConverter()").`

--- a/composer.json
+++ b/composer.json
@@ -190,8 +190,7 @@
         "symfony/framework-bundle": "5.4.5 || 6.2.8",
         "symfony/validator": "5.4.25 || 6.2.12 || 6.3.1",
         "liip/imagine-bundle": "2.7.0",
-        "twig/twig": "3.9.0",
-        "twig/intl-extra": "3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -48,8 +48,7 @@
         "php-http/message-factory": "^1.0"
     },
     "conflict": {
-        "twig/twig": "3.9.0",
-        "twig/intl-extra": "3.9.0"
+        "twig/twig": "3.9.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -44,8 +44,7 @@
         "symfony/dependency-injection": "^5.4 || ^6.0"
     },
     "conflict": {
-        "twig/twig": "3.9.0",
-        "twig/intl-extra": "3.9.0"
+        "twig/twig": "3.9.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.12|
| Bug fix?        | no                                                      |
| New feature?    | no                                                      |
| BC breaks?      | no                                                      |
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file --> |
| Related tickets | |
| License         | MIT                                                          |

I would like to remove the added conflict to `twig/intl-extra` as the newest [v3.9.1 tag](https://github.com/twigphp/Twig/releases/tag/v3.9.1) of `twig/twig` seems to resolve this problem.

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
