### PR TITLE
fix merging of api resource data fails or has existing data go missing

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/Merger/LegacyResourceMetadataMerger.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/Merger/LegacyResourceMetadataMerger.php
@@ -23,6 +23,10 @@ final class LegacyResourceMetadataMerger implements MetadataMergerInterface
 
         foreach ($newMetadata as $key => $value) {
             if ('properties' === $key) {
+                if ($value === null) {
+                    continue;
+                }
+
                 foreach ($value as $keyProperty => $property) {
                     $oldMetadata[$key][$keyProperty] = $property;
                 }
@@ -47,7 +51,9 @@ final class LegacyResourceMetadataMerger implements MetadataMergerInterface
                 continue;
             }
 
-            $oldMetadata[$key] = $value;
+            if ($value !== null || !isset($oldMetadata[$key])) {
+                $oldMetadata[$key] = $value;
+            }
         }
 
         return $oldMetadata;

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/MergingXmlExtractor.php
@@ -107,8 +107,8 @@ final class MergingXmlExtractor extends AbstractResourceExtractor implements Pro
                     $resourceMetadata,
                 );
                 $this->properties[$resourceClass] = array_merge(
-                    $this->properties[$resourceClass],
-                    $resourceMetadata['properties'],
+                    $this->properties[$resourceClass] ?? [],
+                    $resourceMetadata['properties'] ?? [],
                 );
 
                 continue;

--- a/src/Sylius/Bundle/ApiBundle/spec/ApiPlatform/Metadata/Merger/LegacyResourceMetadataMergerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/ApiPlatform/Metadata/Merger/LegacyResourceMetadataMergerSpec.php
@@ -170,6 +170,21 @@ final class LegacyResourceMetadataMergerSpec extends ObjectBehavior
         ]);
     }
 
+    function it_keeps_existing_subresource_operations_when_the_new_one_doesnt_have_them(): void
+    {
+        $this->merge([
+            'subresourceOperations' => [
+                'get' => ['foo' => 'bar'],
+            ],
+        ], [
+            'subresourceOperations' => null,
+        ])->shouldReturn([
+            'subresourceOperations' => [
+                'get' => ['foo' => 'bar'],
+            ],
+        ]);
+    }
+
     function it_merges_complex_metadata(): void
     {
         $this->merge([


### PR DESCRIPTION
in case certain xml keys are missing from extending config like properties, item opteration, collection operations or resources

| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.13 - i know it is a bugfix, but the merger tests are missing from 1.12                  |
| Bug fix?        |yes                                                       |
| New feature?    | no                                                       |
| BC breaks?      | no                                                       |
| Deprecations?   | no |
| Related tickets | /                      |
| License         | MIT                                                          |



Basically what happens is that when you define api extension configuration through app (or multiple bundles)
you have to set at least 1 property in the file, oven though you do not want to make any changes (potentially overriding any future changes to it)
and you have to explicitly set every operation type (itemOperations, collectionOperations, resourceOperations) explictly
like `<itemOperations />` etc or you will end up (based on order of execution) with eg default item operation configuration  from api platform, or subresouce configation goes mising (e.g order override caused order adjustment subresource config from going awol)