### PR TITLE
More informative errror in ShowPage.php

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -322,7 +322,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         } while (!$isOpen && microtime(true) < $end);
 
         if (!$isOpen) {
-            throw new UnexpectedPageException();
+            throw new UnexpectedPageException('Is not open: ' . $e->getMessage()  . ' ' . json_encode($urlParameters));
         }
     }
 


### PR DESCRIPTION
I always didn't like behat errors like:

  Given I have product "Xxxx" in the cart
  (FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException)

Not informative. Is it unexpected page (i.e. wrong page opened)? Or is it unexpected exception?

Now it shows:

 Is not open: Could not open the page: "http://localhost:8080/en_US/products/xxx". Received an error status code: 500 {"slug":"xxx"} (FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException)

Feel free to improve or change this commit.




| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         |  1.13 (1.12 would be nice too)                  |
| Bug fix?        | no   |
| New feature?    | no |
| BC breaks?      | ?                                                    |
| Deprecations?   | no? |
| Related tickets | none    |
| License         | MIT                                                          |

<!--
 - Bug fixes must be submitted against the 1.12 branch
 - Features and deprecations must be submitted against the 1.13 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
