### PR TITLE
Bump Sylius Twig Hooks to 0.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "sylius/resource": "^1.10",
         "sylius/resource-bundle": "^1.10",
         "sylius/theme-bundle": "^2.3",
-        "sylius/twig-hooks": "dev-main",
+        "sylius/twig-hooks": "0.2.*",
         "symfony/asset": "^6.4.0",
         "symfony/clock": "^6.4.0",
         "symfony/config": "^6.4.0",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -35,7 +35,7 @@
         "knplabs/knp-menu-bundle": "^3.0",
         "sylius/core-bundle": "^2.0",
         "sylius/ui-bundle": "^2.0",
-        "sylius/twig-hooks": "dev-main",
+        "sylius/twig-hooks": "0.2.*",
         "symfony/framework-bundle": "^6.4.1",
         "symfony/stimulus-bundle": "^2.12",
         "symfony/ux-autocomplete": "^2.16",


### PR DESCRIPTION
I've decided to use `0.2.*` as `^0.2` works in the same way, but it's more explicit now :).