### PR TITLE
Remove unneeded placeholder from zone's scope select

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -52,7 +52,7 @@ final class ZoneType extends AbstractResourceType
                 ->add('scope', ChoiceType::class, [
                     'choices' => array_flip($this->scopeChoices),
                     'label' => 'sylius.form.zone.scope',
-                    'placeholder' => 'sylius.form.zone.select_scope',
+                    'placeholder' => null,
                     'required' => false,
                 ])
             ;

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -34,6 +34,5 @@ sylius:
             scopes:
                 all: All
             select: Select
-            select_scope: Select scope
         zone_member:
             select: Select


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12 <!-- see the comment below -->
| Bug fix?        | a bit
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
![Screenshot 2024-05-07 at 12 05 25](https://github.com/Sylius/Sylius/assets/53942444/67c35100-11a7-48bd-9e0a-76579aacf792)
![Screenshot 2024-05-07 at 12 05 32](https://github.com/Sylius/Sylius/assets/53942444/f93d4409-abaf-48df-936d-5bdcea27c17f)

