### PR TITLE
Add wider support for deprecation contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "symfony/config": "^5.4.21 || ^6.4",
         "symfony/console": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/deprecation-contracts": "^2.5",
+        "symfony/deprecation-contracts": "^2.5 || ^3.0",
         "symfony/doctrine-bridge": "^5.4.21 || ^6.4",
         "symfony/doctrine-messenger": "^5.4.21 || ^6.4",
         "symfony/event-dispatcher": "^5.4.21 || ^6.4",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Hello, 

I wanted to add a library, but I got stuck with the deprecation-contract, the library I wanted only accept `^3.0`

As we can see on the [diff](https://github.com/symfony/deprecation-contracts/compare/2.5...3.4), there is not so much change between the two version.

I think we can add that version too without changing anything else.

Tell me if I should target `1.12` instead. 

Thanks 
