### PR TITLE
[Maintenance] Adjust Sylius version on 1.14 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sylius/sylius",
     "type": "library",
-    "version": "v1.13.2-dev",
+    "version": "v1.14.0-dev",
     "description": "E-Commerce platform for PHP, based on Symfony framework.",
     "homepage": "https://sylius.com",
     "license": "MIT",
@@ -265,7 +265,7 @@
             "require": "^6.4"
         },
         "branch-alias": {
-            "dev-main": "1.13-dev"
+            "dev-main": "1.14-dev"
         }
     },
     "autoload": {

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -43,15 +43,15 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class SyliusCoreBundle extends AbstractResourceBundle
 {
-    public const VERSION = '1.13.2-DEV';
+    public const VERSION = '1.14.0-DEV';
 
-    public const VERSION_ID = '11302';
+    public const VERSION_ID = '11400';
 
     public const MAJOR_VERSION = '1';
 
-    public const MINOR_VERSION = '13';
+    public const MINOR_VERSION = '14';
 
-    public const RELEASE_VERSION = '2';
+    public const RELEASE_VERSION = '0';
 
     public const EXTRA_VERSION = 'DEV';
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
