### PR TITLE
Remove hard dependency in DefaultChannelFactory.php

### DIFF
--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
@@ -55,9 +55,6 @@ final class DefaultChannelFactory implements DefaultChannelFactoryInterface
 
         $channel->addLocale($locale);
         $channel->setDefaultLocale($locale);
-        if ($channel->getShopBillingData() === null) {
-            $channel->setShopBillingData(new ShopBillingData());
-        }
 
         $this->channelRepository->add($channel);
 

--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
@@ -15,7 +15,6 @@ namespace Sylius\Component\Core\Test\Services;
 
 use Sylius\Component\Channel\Factory\ChannelFactoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\ShopBillingData;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;


### PR DESCRIPTION
This hard dependency on the ShopBillingData class makes it extremely difficult to extend the code and is not a good practice. Alternatively, instead of removing the code again, a factory could be created for the ShopBillingData class.

| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
