### PR TITLE
Fix issues #16160

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
@@ -33,7 +33,7 @@ final class PaymentPreCompleteListener
         foreach ($orderItems as $orderItem) {
             $variant = $orderItem->getVariant();
 
-            if (!$this->availabilityChecker->isStockSufficient($variant, $orderItem->getQuantity())) {
+            if (!$this->availabilityChecker->isStockSufficient($variant, $orderItem->getQuantity(), true)) {
                 $event->setMessageType('error');
                 $event->setMessage('sylius.resource.payment.cannot_be_completed');
                 $event->setMessageParameters(['%productVariantCode%' => $variant->getCode()]);

--- a/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
+++ b/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
@@ -22,7 +22,7 @@ final class AvailabilityChecker implements AvailabilityCheckerInterface
         return $this->isStockSufficient($stockable, 1);
     }
 
-    public function isStockSufficient(StockableInterface $stockable, int $quantity, $deferPayment = false): bool
+    public function isStockSufficient(StockableInterface $stockable, int $quantity, ?bool $deferPayment = false): bool
     {
         if($deferPayment) {
             return !$stockable->isTracked() || $quantity <= $stockable->getOnHand();

--- a/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
+++ b/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
@@ -22,8 +22,11 @@ final class AvailabilityChecker implements AvailabilityCheckerInterface
         return $this->isStockSufficient($stockable, 1);
     }
 
-    public function isStockSufficient(StockableInterface $stockable, int $quantity): bool
+    public function isStockSufficient(StockableInterface $stockable, int $quantity, $deferPayment = false): bool
     {
+        if($deferPayment) {
+            return !$stockable->isTracked() || $quantity <= $stockable->getOnHand();
+        }
         return !$stockable->isTracked() || $quantity <= ($stockable->getOnHand() - $stockable->getOnHold());
     }
 }

--- a/src/Sylius/Component/Inventory/Checker/AvailabilityCheckerInterface.php
+++ b/src/Sylius/Component/Inventory/Checker/AvailabilityCheckerInterface.php
@@ -19,5 +19,5 @@ interface AvailabilityCheckerInterface
 {
     public function isStockAvailable(StockableInterface $stockable): bool;
 
-    public function isStockSufficient(StockableInterface $stockable, int $quantity): bool;
+    public function isStockSufficient(StockableInterface $stockable, int $quantity, ?bool $deferPayment = false): bool;
 }

--- a/src/Sylius/Component/Inventory/spec/Checker/AvailabilityCheckerSpec.php
+++ b/src/Sylius/Component/Inventory/spec/Checker/AvailabilityCheckerSpec.php
@@ -89,4 +89,43 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
         $this->isStockAvailable($stockable)->shouldReturn(true);
         $this->isStockSufficient($stockable, 42)->shouldReturn(true);
     }
+
+    function it_recognizes_stockable_as_sufficient_if_on_hand_minus_quantity_is_greater_than_zero_in_defer_payment(
+        StockableInterface $stockable,
+    ): void {
+        $stockable->isTracked()->willReturn(true);
+        $stockable->getOnHand()->willReturn(10);
+        $stockable->getOnHold()->willReturn(0);
+
+        $this->isStockSufficient($stockable, 5, true)->shouldReturn(true);
+    }
+
+    function it_recognizes_stockable_as_sufficient_if_on_hand_minus_quantity_is_equal_to_zero_in_defer_payment(
+        StockableInterface $stockable,
+    ): void {
+        $stockable->isTracked()->willReturn(true);
+        $stockable->getOnHand()->willReturn(5);
+        $stockable->getOnHold()->willReturn(0);
+
+        $this->isStockSufficient($stockable, 5, true)->shouldReturn(true);
+    }
+
+    function it_recognizes_stockable_as_insufficient_if_on_hand_minus_quantity_is_lower_to_zero_in_defer_payment(
+        StockableInterface $stockable,
+    ): void {
+        $stockable->isTracked()->willReturn(true);
+        $stockable->getOnHand()->willReturn(5);
+        $stockable->getOnHold()->willReturn(0);
+
+        $this->isStockSufficient($stockable, 10, true)->shouldReturn(false);
+    }
+
+    function it_recognizes_stockable_as_available_or_sufficent_if_it_is_not_tracked_in_defer_payment(
+        StockableInterface $stockable): void
+    {
+        $stockable->isTracked()->willReturn(false);
+
+        $this->isStockAvailable($stockable)->shouldReturn(true);
+        $this->isStockSufficient($stockable, 42, true)->shouldReturn(true);
+    }
 }


### PR DESCRIPTION
Updated the 'isStockSufficient' function in the AvailabilityChecker class to include an optional argument for deferring payment check. Also adjusted the logic in PaymentPreCompleteListener accordingly.

| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16160
| License         | MIT

During an order, the requested quantity of products is deducted from the available stock and set aside. However, when proceeding to payment via the admin interface (payment plugins do not trigger the same event), the stock verification function subtracts the reserved stock from the total stock to determine if there is enough left to fulfill the order. This approach yields an incorrect value (false) when the available stock is just sufficient to cover the order, as the quantity to be paid for is already deducted from the total stock. To address this issue, here is a proposal.

To reproduce the error on the demo:

- Add a product with a stock of 10.
- Place an order for 10 units of this product with deferred payment (as payment plugins do not trigger the same event).
- Verify the stock of the product changing to 0, with 10 units reserved.
- As an administrator, validate the payment.
- A message indicates that there is not enough stock remaining, as the calculation performed is as follows: requested quantity (10) <= total stock (10) - reserved stock (10), which is 10 <= 0. However, the 10 reserved units are those for which the payment is validated and should not be subtracted.

At this stage, it is sufficient to verify that there are still a total of 10 units in stock, without needing to check the reserved units, as this verification has already been performed.
