### PR TITLE
[Admin] Add base form type for every resource used in AdminBundle

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1,3 +1,8 @@
 # UPGRADE FROM `v1.13.X` TO `v1.14.0`
 
+### Deprecations
+
+1. The `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionScopeTypeExtension` and `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionActionTypeExtension` have been deprecated and will be removed in Sylius 2.0.
+   Starting with this version, form types will be extended using the parent form instead of through form extensions, like it's done in the `Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionScopeType` and `Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionActionType` classes.
+
 1. The class `Sylius\Bundle\CoreBundle\Twig\StateMachineExtension` has been deprecated and will be removed in Sylius 2.0. Use `Sylius\Abstraction\StateMachine\Twig\StateMachineExtension` instead.

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/CatalogPromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/CatalogPromotionActionTypeExtension.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Extension;
 
-use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionActionType;
+use Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionActionType;
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionActionType as BaseCatalogPromotionActionType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -22,8 +23,9 @@ use Twig\Environment;
 trigger_deprecation(
     'sylius/admin-bundle',
     '1.14',
-    'The "%s" class is deprecated and will be removed in Sylius 2.0.',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Starting with this version, form types will be extended using the parent form like in %s.',
     CatalogPromotionActionTypeExtension::class,
+    CatalogPromotionActionType::class,
 );
 
 /** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
@@ -65,6 +67,6 @@ final class CatalogPromotionActionTypeExtension extends AbstractTypeExtension
 
     public static function getExtendedTypes(): iterable
     {
-        return [CatalogPromotionActionType::class];
+        return [BaseCatalogPromotionActionType::class];
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Form/Extension/CatalogPromotionScopeTypeExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Extension/CatalogPromotionScopeTypeExtension.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Extension;
 
-use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionScopeType;
+use Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionScopeType;
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionScopeType as BaseCatalogPromotionScopeType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -22,8 +23,9 @@ use Twig\Environment;
 trigger_deprecation(
     'sylius/admin-bundle',
     '1.14',
-    'The "%s" class is deprecated and will be removed in Sylius 2.0.',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Starting with this version, form types will be extended using the parent form like in %s.',
     CatalogPromotionScopeTypeExtension::class,
+    CatalogPromotionScopeType::class,
 );
 
 /** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
@@ -61,6 +63,6 @@ final class CatalogPromotionScopeTypeExtension extends AbstractTypeExtension
 
     public static function getExtendedTypes(): iterable
     {
-        return [CatalogPromotionScopeType::class];
+        return [BaseCatalogPromotionScopeType::class];
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/AddressType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\AddressType as BaseAddressType;
+use Symfony\Component\Form\AbstractType;
+
+final class AddressType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_address';
+    }
+
+    public function getParent(): string
+    {
+        return BaseAddressType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/AdminUserType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/AdminUserType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CoreBundle\Form\Type\User\AdminUserType as BaseAdminUserType;
+use Symfony\Component\Form\AbstractType;
+
+final class AdminUserType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_admin_user';
+    }
+
+    public function getParent(): string
+    {
+        return BaseAdminUserType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionActionType.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionActionType as BaseCatalogPromotionActionType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Twig\Environment;
+
+final class CatalogPromotionActionType extends AbstractType
+{
+    /** @var array<string, string> */
+    private array $actionTypes = [];
+
+    /** @var array<string, string> */
+    private array $actionConfigurationTypes;
+
+    /**
+     * @param iterable<string, object> $actionConfigurationTypes
+     */
+    public function __construct(iterable $actionConfigurationTypes, private Environment $twig)
+    {
+        foreach ($actionConfigurationTypes as $type => $formType) {
+            $this->actionConfigurationTypes[$type] = $formType::class;
+            $this->actionTypes['sylius.form.catalog_promotion.action.' . $type] = $type;
+        }
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('type', ChoiceType::class, [
+                'label' => 'sylius.ui.type',
+                'choices' => $this->actionTypes,
+                'choice_attr' => function (?string $type) use ($builder): array {
+                    return [
+                        'data-configuration' => $this->twig->render(
+                            '@SyliusAdmin/CatalogPromotion/_action.html.twig',
+                            ['field' => $builder->create(
+                                'configuration',
+                                $this->actionConfigurationTypes[$type],
+                                ['label' => false, 'csrf_protection' => false],
+                            )->getForm()->createView()],
+                        ),
+                    ];
+                },
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_catalog_promotion_action';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCatalogPromotionActionType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionScopeType.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionScopeType as BaseCatalogPromotionScopeType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Twig\Environment;
+
+final class CatalogPromotionScopeType extends AbstractType
+{
+    /** @var array<string, string> */
+    private array $scopeTypes = [];
+
+    /** @var array<string, string> */
+    private array $scopeConfigurationTypes;
+
+    /**
+     * @param iterable<string, object> $scopeConfigurationTypes
+     */
+    public function __construct(iterable $scopeConfigurationTypes, private Environment $twig)
+    {
+        foreach ($scopeConfigurationTypes as $type => $formType) {
+            $this->scopeConfigurationTypes[$type] = $formType::class;
+            $this->scopeTypes['sylius.form.catalog_promotion.scope.' . $type] = $type;
+        }
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('type', ChoiceType::class, [
+                'label' => 'sylius.ui.type',
+                'choices' => $this->scopeTypes,
+                'choice_attr' => function (?string $type) use ($builder): array {
+                    return [
+                        'data-configuration' => $this->twig->render(
+                            '@SyliusAdmin/CatalogPromotion/Scope/' . $type . '.html.twig',
+                            ['field' => $builder->create('configuration', $this->scopeConfigurationTypes[$type])->getForm()->createView()],
+                        ),
+                    ];
+                },
+            ])
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_catalog_promotion_scope';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCatalogPromotionScopeType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CatalogPromotionType.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionType as BaseCatalogPromotionType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class CatalogPromotionType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('scopes', CollectionType::class, [
+            'label' => 'sylius.ui.scopes',
+            'entry_type' => CatalogPromotionScopeType::class,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'by_reference' => false,
+            'required' => false,
+        ])
+        ->add('actions', CollectionType::class, [
+            'label' => 'sylius.ui.actions',
+            'entry_type' => CatalogPromotionActionType::class,
+            'allow_add' => true,
+            'allow_delete' => true,
+            'by_reference' => false,
+            'required' => false,
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_catalog_promotion';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCatalogPromotionType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ChannelType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ChannelType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ChannelBundle\Form\Type\ChannelType as BaseChannelType;
+use Symfony\Component\Form\AbstractType;
+
+final class ChannelType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_channel';
+    }
+
+    public function getParent(): string
+    {
+        return BaseChannelType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CountryType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CountryType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\CountryType as BaseCountryType;
+use Symfony\Component\Form\AbstractType;
+
+final class CountryType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_country';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCountryType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CurrencyType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CurrencyType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CurrencyBundle\Form\Type\CurrencyType as BaseCurrencyType;
+use Symfony\Component\Form\AbstractType;
+
+final class CurrencyType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_currency';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCurrencyType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerGroupType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerGroupType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CustomerBundle\Form\Type\CustomerGroupType as BaseCustomerGroupType;
+use Symfony\Component\Form\AbstractType;
+
+final class CustomerGroupType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_customer_group';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCustomerGroupType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CustomerBundle\Form\Type\CustomerType as BaseCustomerType;
+use Symfony\Component\Form\AbstractType;
+
+final class CustomerType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_customer';
+    }
+
+    public function getParent(): string
+    {
+        return BaseCustomerType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ExchangeRateType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ExchangeRateType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CurrencyBundle\Form\Type\ExchangeRateType as BaseExchangeRateType;
+use Symfony\Component\Form\AbstractType;
+
+final class ExchangeRateType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_exchange_rate';
+    }
+
+    public function getParent(): string
+    {
+        return BaseExchangeRateType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/LocaleType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/LocaleType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\LocaleBundle\Form\Type\LocaleType as BaseLocaleType;
+use Symfony\Component\Form\AbstractType;
+
+final class LocaleType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_locale';
+    }
+
+    public function getParent(): string
+    {
+        return BaseLocaleType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/OrderType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/OrderType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\OrderBundle\Form\Type\OrderType as BaseOrderType;
+use Symfony\Component\Form\AbstractType;
+
+final class OrderType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_order';
+    }
+
+    public function getParent(): string
+    {
+        return BaseOrderType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/PaymentMethodType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/PaymentMethodType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PaymentBundle\Form\Type\PaymentMethodType as BasePaymentMethodType;
+use Symfony\Component\Form\AbstractType;
+
+final class PaymentMethodType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_payment_method';
+    }
+
+    public function getParent(): string
+    {
+        return BasePaymentMethodType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAssociationTypeType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAssociationTypeType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductAssociationTypeType as BaseProductAssociationTypeType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductAssociationTypeType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_association_type';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductAssociationTypeType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductAttributeType as BaseProductAttributeType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductAttributeType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_attribute';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductAttributeType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductGenerateVariantsType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductGenerateVariantsType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductGenerateVariantsType as BaseProductGenerateVariantsType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductGenerateVariantsType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_generate_variants';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductGenerateVariantsType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductOptionType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductOptionType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductOptionType as BaseProductOptionType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductOptionType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_option';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductOptionType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductReviewType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductReviewType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\CoreBundle\Form\Type\Product\ProductReviewType as BaseProductReviewType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductReviewType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_review';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductReviewType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductType as BaseProductType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ProductBundle\Form\Type\ProductVariantType as BaseProductVariantType;
+use Symfony\Component\Form\AbstractType;
+
+final class ProductVariantType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_product_variant';
+    }
+
+    public function getParent(): string
+    {
+        return BaseProductVariantType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/PromotionCouponType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/PromotionCouponType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponType as BasePromotionCouponType;
+use Symfony\Component\Form\AbstractType;
+
+final class PromotionCouponType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_promotion_coupon';
+    }
+
+    public function getParent(): string
+    {
+        return BasePromotionCouponType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/PromotionType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/PromotionType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionType as BasePromotionType;
+use Symfony\Component\Form\AbstractType;
+
+final class PromotionType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_promotion';
+    }
+
+    public function getParent(): string
+    {
+        return BasePromotionType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ShippingCategoryType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ShippingCategoryType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ShippingBundle\Form\Type\ShippingCategoryType as BaseShippingCategoryType;
+use Symfony\Component\Form\AbstractType;
+
+final class ShippingCategoryType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_shipping_category';
+    }
+
+    public function getParent(): string
+    {
+        return BaseShippingCategoryType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ShippingMethodType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ShippingMethodType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType as BaseShippingMethodType;
+use Symfony\Component\Form\AbstractType;
+
+final class ShippingMethodType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_shipping_method';
+    }
+
+    public function getParent(): string
+    {
+        return BaseShippingMethodType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxCategoryType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxCategoryType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryType as BaseTaxCategoryType;
+use Symfony\Component\Form\AbstractType;
+
+final class TaxCategoryType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_tax_category';
+    }
+
+    public function getParent(): string
+    {
+        return BaseTaxCategoryType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxRateType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxRateType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxRateType as BaseTaxRateType;
+use Symfony\Component\Form\AbstractType;
+
+final class TaxRateType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_tax_rate';
+    }
+
+    public function getParent(): string
+    {
+        return BaseTaxRateType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonType as BaseTaxonType;
+use Symfony\Component\Form\AbstractType;
+
+final class TaxonType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_taxon';
+    }
+
+    public function getParent(): string
+    {
+        return BaseTaxonType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ZoneType.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Form\Type;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\ZoneType as BaseZoneType;
+use Symfony\Component\Form\AbstractType;
+
+final class ZoneType extends AbstractType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_admin_zone';
+    }
+
+    public function getParent(): string
+    {
+        return BaseZoneType::class;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
@@ -45,5 +45,121 @@
             <argument>%sylius.form.type.admin.reset_password.validation_groups%</argument>
             <tag name="form.type" />
         </service>
+
+        <service id="sylius_admin.form.type.address" class="Sylius\Bundle\AdminBundle\Form\Type\AddressType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.admin_user" class="Sylius\Bundle\AdminBundle\Form\Type\AdminUserType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.catalog_promotion_action" class="Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionActionType" >
+            <argument type="tagged_iterator" tag="sylius.catalog_promotion.action_configuration_type" index-by="key" />
+            <argument type="service" id="twig" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.catalog_promotion_scope" class="Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionScopeType" >
+            <argument type="tagged_iterator" tag="sylius.catalog_promotion.scope_configuration_type" index-by="key" />
+            <argument type="service" id="twig" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.catalog_promotion_type" class="Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.channel" class="Sylius\Bundle\AdminBundle\Form\Type\ChannelType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.country" class="Sylius\Bundle\AdminBundle\Form\Type\CountryType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.currency" class="Sylius\Bundle\AdminBundle\Form\Type\CurrencyType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.customer" class="Sylius\Bundle\AdminBundle\Form\Type\CustomerType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.customer_group" class="Sylius\Bundle\AdminBundle\Form\Type\CustomerGroupType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.exchange_rate" class="Sylius\Bundle\AdminBundle\Form\Type\ExchangeRateType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.locale" class="Sylius\Bundle\AdminBundle\Form\Type\LocaleType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.order" class="Sylius\Bundle\AdminBundle\Form\Type\OrderType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.payment_method" class="Sylius\Bundle\AdminBundle\Form\Type\PaymentMethodType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product" class="Sylius\Bundle\AdminBundle\Form\Type\ProductType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_association_type" class="Sylius\Bundle\AdminBundle\Form\Type\ProductAssociationTypeType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_attribute" class="Sylius\Bundle\AdminBundle\Form\Type\ProductAttributeType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_generate_variants" class="Sylius\Bundle\AdminBundle\Form\Type\ProductGenerateVariantsType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_option" class="Sylius\Bundle\AdminBundle\Form\Type\ProductOptionType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_review" class="Sylius\Bundle\AdminBundle\Form\Type\ProductReviewType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.product_variant" class="Sylius\Bundle\AdminBundle\Form\Type\ProductVariantType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.promotion" class="Sylius\Bundle\AdminBundle\Form\Type\PromotionType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.promotion_coupon" class="Sylius\Bundle\AdminBundle\Form\Type\PromotionCouponType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.shipping_category" class="Sylius\Bundle\AdminBundle\Form\Type\ShippingCategoryType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.shipping_method" class="Sylius\Bundle\AdminBundle\Form\Type\ShippingMethodType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.tax_category" class="Sylius\Bundle\AdminBundle\Form\Type\TaxCategoryType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.taxon" class="Sylius\Bundle\AdminBundle\Form\Type\TaxonType" >
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius_admin.form.type.tax_rate" class="Sylius\Bundle\AdminBundle\Form\Type\TaxRateType" >
+            <tag name="form.type" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
related to https://github.com/Sylius/Sylius/pull/16257