### PR TITLE
Convert variables in Twig templates to snake_case

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
@@ -49,6 +49,7 @@ class FormComponent
 
     /** @var array<string> */
     #[LiveProp(writable: true, hydrateWith: 'hydrateAttributesToBeAdded', dehydrateWith: 'dehydrateAttributesToBeAdded')]
+    #[ExposeInTemplate('attributes_to_be_added')]
     public array $attributesToBeAdded = [];
 
     #[LiveProp(writable: false)]
@@ -81,7 +82,7 @@ class FormComponent
     /**
      * @return array<string, array<string, FormView>>
      */
-    #[ExposeInTemplate]
+    #[ExposeInTemplate('mapped_product_attributes')]
     public function getMappedProductAttributes(): array
     {
         $mappedAttributes = [];

--- a/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections/personal_information/avatar.html.twig
@@ -1,16 +1,16 @@
 {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
-{% set adminUser = hookable_metadata.context.resource %}
+{% set admin_user = hookable_metadata.context.resource %}
 
 {{ form_label(hookable_metadata.context.form.avatar) }}
 
 <div class="row g-6">
     <div class="col-auto m-0">
-        {% if adminUser.avatar is not null and adminUser.avatar.path is not empty %}
+        {% if admin_user.avatar is not null and admin_user.avatar.path is not empty %}
             <div
                 class="avatar avatar-xl"
-                style="background: url('{{ adminUser.avatar.path|imagine_filter('sylius_admin_admin_user_avatar') }}');"
-                {{ sylius_test_html_attribute('avatar-image', adminUser.avatar.path) }}
+                style="background: url('{{ admin_user.avatar.path|imagine_filter('sylius_admin_admin_user_avatar') }}');"
+                {{ sylius_test_html_attribute('avatar-image', admin_user.avatar.path) }}
             ></div>
         {% else %}
             <div class="avatar avatar-xl" {{ sylius_test_html_attribute('avatar-image', null) }}></div>
@@ -18,9 +18,9 @@
     </div>
     <div class="col m-0">
         {{ form_widget(hookable_metadata.context.form.avatar) }}
-        {% if adminUser.id is not null and adminUser.avatar is not null and adminUser.avatar.path is not empty %}
+        {% if admin_user.id is not null and admin_user.avatar is not null and admin_user.avatar.path is not empty %}
             <button
-                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': adminUser.id, '_csrf_token': csrf_token(adminUser.id)}) }}"
+                formaction="{{ path('sylius_admin_admin_user_remove_avatar', {'id': admin_user.id, '_csrf_token': csrf_token(admin_user.id)}) }}"
                 type="submit"
                 class="btn btn-danger"
                 {{ sylius_test_html_attribute('delete-avatar-button') }}

--- a/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form/sections/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form/sections/translations.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusAdmin/shared/helper/translations.html.twig' as _translations %}
 
 <div class="bg-white mb-3">
-    {{ _translations.default(hookable_metadata.context.form.translations, null, {accordionId: 'catalog-promotion-translations'}) }}
+    {{ _translations.default(hookable_metadata.context.form.translations, null, { accordion_id: 'catalog-promotion-translations'}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/show/content/sections/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/show/content/sections/translations.html.twig
@@ -1,8 +1,8 @@
-{% set catalogPromotion = hookable_metadata.context.resource %}
+{% set catalog_promotion = hookable_metadata.context.resource %}
 
 <div class="bg-white mb-3">
     <div class="accordion" id="catalog-promotion-translations">
-        {% for translation in catalogPromotion.translations %}
+        {% for translation in catalog_promotion.translations %}
             {% set locale = translation.locale %}
 
             <div class="accordion-item">

--- a/src/Sylius/Bundle/AdminBundle/templates/channel_pricing_log_entry/index/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/channel_pricing_log_entry/index/content/header/breadcrumbs.html.twig
@@ -6,7 +6,7 @@
 {% set product = configuration.vars.product_variant.product %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index'), active: false },
     { name: product.name|default(product.code), url: path('sylius_admin_product_show', {'id': product.id }), active: false },
     { name: 'sylius.ui.variants'|trans, url: path('sylius_admin_product_variant_index', {'productId': product.id }), active: false },

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/breadcrumbs.html.twig
@@ -5,9 +5,9 @@
 
 {% if hookable_metadata.context.metadata is defined %}
     {% set metadata = hookable_metadata.context.metadata %}
-    {% set resourceName = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
+    {% set resource_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 {% else %}
-    {% set resourceName = hookable_metadata.configuration.resource_name %}
+    {% set resource_name = hookable_metadata.configuration.resource_name %}
 {% endif %}
 
 {% set index_url = path(

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/breadcrumbs.html.twig
@@ -17,7 +17,7 @@
 %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: metadata.applicationName~'.ui.'~metadata.pluralName, url: index_url, active: false },
     { name: resource.email, active: true },
 ]) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/statistics.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/component/statistics.html.twig
@@ -1,6 +1,6 @@
 <div class="container-xl" {{ attributes }}>
     {% hook 'statistics' with {
-        statisticsData: statistics,
+        statistics_data: statistics,
         range,
     } %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_chart.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_chart.html.twig
@@ -1,5 +1,5 @@
-{% set statisticsData = hookable_metadata.context.statisticsData %}
-{% set rangeName = hookable_metadata.context.range %}
+{% set statistics_data = hookable_metadata.context.statistics_data %}
+{% set range_name = hookable_metadata.context.range %}
 
 <div class="card mb-3">
     <div data-loading>
@@ -13,7 +13,7 @@
             <div class="btn-group" role="group">
                 <button
                     type="button"
-                    class="btn btn-sm {% if rangeName == '2weeks' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
+                    class="btn btn-sm {% if range_name == '2weeks' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
                     data-action="live#action"
                     data-live-action-param="prevent|changeRange"
                     data-live-name-param="2weeks"
@@ -25,7 +25,7 @@
                 </button>
                 <button
                     type="button"
-                    class="btn btn-sm {% if rangeName == 'month' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
+                    class="btn btn-sm {% if range_name == 'month' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
                     data-action="live#action"
                     data-live-action-param="prevent|changeRange"
                     data-live-name-param="month"
@@ -37,7 +37,7 @@
                 </button>
                 <button
                     type="button"
-                    class="btn btn-sm {% if rangeName == 'year' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
+                    class="btn btn-sm {% if range_name == 'year' %}btn-secondary{% else %}btn-outline-secondary{% endif %}"
                     data-action="live#action"
                     data-live-action-param="prevent|changeRange"
                     data-live-name-param="year"
@@ -49,6 +49,6 @@
                 </button>
             </div>
         </div>
-        <div id="statistics-chart" class="chart-lg" data-intervals="{{ statisticsData.sales_summary.intervals|json_encode }}" data-sales="{{ statisticsData.sales_summary.sales|json_encode }}"></div>
+        <div id="statistics-chart" class="chart-lg" data-intervals="{{ statistics_data.sales_summary.intervals|json_encode }}" data-sales="{{ statistics_data.sales_summary.sales|json_encode }}"></div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/average_order_value.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/average_order_value.html.twig
@@ -1,6 +1,6 @@
 {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
-{% set statisticsData = hookable_metadata.context.statisticsData %}
+{% set statistics_data = hookable_metadata.context.statistics_data %}
 
 <div class="col-sm-6 col-lg-3 mb-3">
     <div class="card card-sm">
@@ -18,7 +18,7 @@
                 </div>
                 <div class="col">
                     <div class="subheader">{{ 'sylius.ui.average_order_value'|trans }}</div>
-                    <div class="h2 mb-0 me-2">{{ _context.statisticsData.statistics.average_order_value }}</div>
+                    <div class="h2 mb-0 me-2">{{ _context.statistics_data.statistics.average_order_value }}</div>
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/customers.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/customers.html.twig
@@ -1,6 +1,6 @@
 {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
-{% set statisticsData = hookable_metadata.context.statisticsData %}
+{% set statistics_data = hookable_metadata.context.statistics_data %}
 
 <div class="col-sm-6 col-lg-3 mb-3">
     <div class="card card-sm">
@@ -18,7 +18,7 @@
                 </div>
                 <div class="col">
                     <div class="subheader">{{ 'sylius.ui.customers'|trans }}</div>
-                    <div class="h2 mb-0 me-2">{{ _context.statisticsData.statistics.number_of_new_customers }}</div>
+                    <div class="h2 mb-0 me-2">{{ _context.statistics_data.statistics.number_of_new_customers }}</div>
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/paid_orders.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/paid_orders.html.twig
@@ -1,6 +1,6 @@
 {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
-{% set statisticsData = hookable_metadata.context.statisticsData %}
+{% set statistics_data = hookable_metadata.context.statistics_data %}
 
 <div class="col-sm-6 col-lg-3 mb-3">
     <div class="card card-sm">
@@ -18,7 +18,7 @@
                 </div>
                 <div class="col">
                     <div class="subheader">{{ 'sylius.ui.paid_orders'|trans }}</div>
-                    <div class="h2 mb-0 me-2">{{ _context.statisticsData.statistics.number_of_new_orders }}</div>
+                    <div class="h2 mb-0 me-2">{{ _context.statistics_data.statistics.number_of_new_orders }}</div>
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/sales.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/dashboard/index/content/statistics_grid/sales.html.twig
@@ -1,6 +1,6 @@
 {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
-{% set statisticsData = hookable_metadata.context.statisticsData %}
+{% set statistics_data = hookable_metadata.context.statistics_data %}
 
 <div class="col-sm-6 col-lg-3 mb-3">
     <div class="card card-sm">
@@ -18,7 +18,7 @@
                 </div>
                 <div class="col">
                     <div class="subheader">{{ 'sylius.ui.sales'|trans }}</div>
-                    <div class="h2 mb-0 me-2">{{ _context.statisticsData.statistics.total_sales }}</div>
+                    <div class="h2 mb-0 me-2">{{ _context.statistics_data.statistics.total_sales }}</div>
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form.html.twig
@@ -12,8 +12,8 @@
             {{ form_widget(form._token) }}
 
             {% hook 'form' with {
-                mappedProductAttributes,
-                attributesToBeAdded,
+                mapped_product_attributes,
+                attributes_to_be_added,
                 resource,
                 form,
             } %}

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
@@ -19,12 +19,12 @@
             <div class="col-12 col-sm-4">
                 <div class="border-end">
                     <div id="product_attribute_tabs" class="list-group list-group-flush" role="tablist">
-                        {% for productAttributeCode, productAttributeValue in product_attributes %}
-                            {% set product_attribute_name = (productAttributeValue|first).vars.data.name %}
+                        {% for product_attribute_code, product_attribute_value in product_attributes %}
+                            {% set product_attribute_name = (product_attribute_value|first).vars.data.name %}
                             <div
                                 class="py-2 cursor-pointer list-group-item list-group-item-action {% if loop.first %}active{% endif %}"
                                 data-bs-toggle="tab"
-                                data-bs-target="#{{ productAttributeCode }}"
+                                data-bs-target="#{{ product_attribute_code }}"
                                 aria-selected="{{ loop.first ? 'true' : 'false' }}"
                                 role="tab"
                                 {{ sylius_test_html_attribute('product-attribute-tab', product_attribute_name) }}
@@ -37,7 +37,7 @@
                                             class="btn btn-sm border-0 shadow-none"
                                             data-action="live#action:stop"
                                             data-live-action-param="prevent|removeAttribute"
-                                            data-live-attribute-code-param="{{ productAttributeCode }}"
+                                            data-live-attribute-code-param="{{ product_attribute_code }}"
                                             {{ sylius_test_html_attribute('product-attribute-delete-button', product_attribute_name) }}
                                         >
                                             <svg xmlns="http://www.w3.org/2000/svg" class="text-muted" width="12" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -56,14 +56,14 @@
             <div class="col-12 col-sm-8">
                 <div class="py-3 px-5">
                     <div class="tab-content">
-                        {% for productAttributeCode, productAttributeValues in product_attributes %}
+                        {% for product_attribute_code, product_attribute_values in product_attributes %}
                             <div
                                 class="tab-pane show {% if loop.first %}active{% endif %}"
-                                id="{{ productAttributeCode }}"
+                                id="{{ product_attribute_code }}"
                                 role="tabpanel"
                             >
-                                {% for productAttributeValue in productAttributeValues %}
-                                    {% set locale_code = productAttributeValue.vars.data.localeCode %}
+                                {% for product_attribute_value in product_attribute_values %}
+                                    {% set locale_code = product_attribute_value.vars.data.localeCode %}
                                     <div class="d-flex gap-2 mb-3">
                                         <div>
                                             {% if locale_code is not null %}
@@ -74,28 +74,28 @@
                                         </div>
                                         <div class="flex-grow-1">
                                             <div class="d-flex justify-content-between align-items-center">
-                                                {{ form_label(productAttributeValue.value) }}
+                                                {{ form_label(product_attribute_value.value) }}
                                                 {% if locale_code is not null %}
                                                     <button
                                                         class="btn btn-secondary btn-sm"
                                                         data-action="live#action"
-                                                        data-live-action-param="prevent|applyToAll(attributeCode={{ productAttributeCode }},localeCode={{ productAttributeValue.vars.data.localeCode }})"
+                                                        data-live-action-param="prevent|applyToAll(attributeCode={{ product_attribute_code }},localeCode={{ product_attribute_value.vars.data.localeCode }})"
                                                     >
                                                         {{ 'sylius.ui.apply_to_all'|trans }}
                                                     </button>
                                                 {% endif %}
                                             </div>
                                             {{ form_widget(
-                                                productAttributeValue.value,
+                                                product_attribute_value.value,
                                                 sylius_test_form_attributes({
                                                     'attribute-value': '',
-                                                    'attribute-name': productAttributeValue.value.vars.label,
-                                                    'locale-code': productAttributeValue.localeCode.vars.value,
+                                                    'attribute-name': product_attribute_value.value.vars.label,
+                                                    'locale-code': product_attribute_value.localeCode.vars.value,
                                                 })
                                             ) }}
 
-                                            <input type="hidden" name="{{ productAttributeValue.attribute.vars.full_name }}" value="{{ productAttributeValue.attribute.vars.value }}">
-                                            <input type="hidden" name="{{ productAttributeValue.localeCode.vars.full_name }}" value="{{ productAttributeValue.localeCode.vars.value }}">
+                                            <input type="hidden" name="{{ product_attribute_value.attribute.vars.full_name }}" value="{{ product_attribute_value.attribute.vars.value }}">
+                                            <input type="hidden" name="{{ product_attribute_value.localeCode.vars.full_name }}" value="{{ product_attribute_value.localeCode.vars.value }}">
                                         </div>
                                     </div>
                                 {% endfor %}

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
@@ -1,5 +1,4 @@
-{% set productAttributes = hookable_metadata.context.mappedProductAttributes %}
-{% set attributesToBeAdded = hookable_metadata.context.attributesToBeAdded %}
+{% set product_attributes = hookable_metadata.context.mapped_product_attributes %}
 
 <div class="tab-pane" id="product-attributes" role="tabpanel" tabindex="0">
     <div class="card mb-3">
@@ -10,7 +9,7 @@
         </div>
         <div class="card-body py-4 border-bottom">
             <div class="sylius-admin-product-attribute-autocomplete">
-                <twig:sylius_admin:product:product_attribute_autocomplete data-model="attributesToBeAdded:selectedAttributeCodes" :excludedAttributeCodes="productAttributes|keys" />
+                <twig:sylius_admin:product:product_attribute_autocomplete data-model="attributesToBeAdded:selectedAttributeCodes" :excludedAttributeCodes="product_attributes|keys" />
                 <button type="button" class="btn btn-primary" data-action="live#action" data-live-action-param="prevent|addAttributes">
                     {{ 'sylius.ui.add'|trans }}
                 </button>
@@ -20,18 +19,18 @@
             <div class="col-12 col-sm-4">
                 <div class="border-end">
                     <div id="product_attribute_tabs" class="list-group list-group-flush" role="tablist">
-                        {% for productAttributeCode, productAttributeValue in productAttributes %}
-                            {% set productAttributeName = (productAttributeValue|first).vars.data.name %}
+                        {% for productAttributeCode, productAttributeValue in product_attributes %}
+                            {% set product_attribute_name = (productAttributeValue|first).vars.data.name %}
                             <div
                                 class="py-2 cursor-pointer list-group-item list-group-item-action {% if loop.first %}active{% endif %}"
                                 data-bs-toggle="tab"
                                 data-bs-target="#{{ productAttributeCode }}"
                                 aria-selected="{{ loop.first ? 'true' : 'false' }}"
                                 role="tab"
-                                {{ sylius_test_html_attribute('product-attribute-tab', productAttributeName) }}
+                                {{ sylius_test_html_attribute('product-attribute-tab', product_attribute_name) }}
                             >
                                 <div class="d-flex justify-content-between align-items-center">
-                                    <div>{{ productAttributeName }}</div>
+                                    <div>{{ product_attribute_name }}</div>
                                     <div style="transform: translateX(1rem)">
                                         <button
                                             type="button"
@@ -39,7 +38,7 @@
                                             data-action="live#action:stop"
                                             data-live-action-param="prevent|removeAttribute"
                                             data-live-attribute-code-param="{{ productAttributeCode }}"
-                                            {{ sylius_test_html_attribute('product-attribute-delete-button', productAttributeName) }}
+                                            {{ sylius_test_html_attribute('product-attribute-delete-button', product_attribute_name) }}
                                         >
                                             <svg xmlns="http://www.w3.org/2000/svg" class="text-muted" width="12" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                                                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -57,18 +56,18 @@
             <div class="col-12 col-sm-8">
                 <div class="py-3 px-5">
                     <div class="tab-content">
-                        {% for productAttributeCode, productAttributeValues in productAttributes %}
+                        {% for productAttributeCode, productAttributeValues in product_attributes %}
                             <div
                                 class="tab-pane show {% if loop.first %}active{% endif %}"
                                 id="{{ productAttributeCode }}"
                                 role="tabpanel"
                             >
                                 {% for productAttributeValue in productAttributeValues %}
-                                    {% set localeCode = productAttributeValue.vars.data.localeCode %}
+                                    {% set locale_code = productAttributeValue.vars.data.localeCode %}
                                     <div class="d-flex gap-2 mb-3">
                                         <div>
-                                            {% if localeCode is not null %}
-                                                <span class="flag flag-sm flag-country-{{ localeCode|lower|split('_')|last }} me-3"></span>
+                                            {% if locale_code is not null %}
+                                                <span class="flag flag-sm flag-country-{{ locale_code|lower|split('_')|last }} me-3"></span>
                                             {% else %}
                                                 <span class="flag flag-sm flag-country-eu me-3"></span>
                                             {% endif %}
@@ -76,7 +75,7 @@
                                         <div class="flex-grow-1">
                                             <div class="d-flex justify-content-between align-items-center">
                                                 {{ form_label(productAttributeValue.value) }}
-                                                {% if localeCode is not null %}
+                                                {% if locale_code is not null %}
                                                     <button
                                                         class="btn btn-secondary btn-sm"
                                                         data-action="live#action"

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/channel_pricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/channel_pricing.html.twig
@@ -28,16 +28,16 @@
             {% endif %}
             <div class="card-header">
                 <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs" role="tablist">
-                    {% for channelCode, channelPricing in variant_form.channelPricings %}
+                    {% for channel_code, channel_pricing in variant_form.channelPricings %}
                         <li class="nav-item">
                             <a
                                 class="nav-link {% if loop.index0 == 0 %}active{% endif %}"
                                 data-bs-toggle="tab"
-                                href="#{{ channelCode }}"
+                                href="#{{ channel_code }}"
                                 role="tab"
-                                {{ sylius_test_html_attribute('channel-tab', channelCode) }}
+                                {{ sylius_test_html_attribute('channel-tab', channel_code) }}
                             >
-                                {{ channelPricing.vars.label }}
+                                {{ channel_pricing.vars.label }}
                             </a>
                         </li>
                     {% endfor %}
@@ -45,14 +45,14 @@
             </div>
             <div class="card-body">
                 <div class="tab-content">
-                    {% for channelCode, channelPricing in variant_form.channelPricings %}
-                        <div class="tab-pane fade {% if loop.index0 == 0 %}show{% endif %} active" id="{{ channelCode }}" role="tabpanel">
-                            {% if channelCode not in product.channels|map(channel => channel.code) %}
+                    {% for channel_code, channel_pricing in variant_form.channelPricings %}
+                        <div class="tab-pane fade {% if loop.index0 == 0 %}show{% endif %} active" id="{{ channel_code }}" role="tabpanel">
+                            {% if channel_code not in product.channels|map(channel => channel.code) %}
                                 <div class="alert alert-info">
                                     {{ 'sylius.ui.product.product_not_active_in_channel'|trans }}
                                 </div>
                             {% endif %}
-                            {{ form_row(channelPricing, {'label': false}) }}
+                            {{ form_row(channel_pricing, {'label': false}) }}
                         </div>
                     {% endfor %}
                 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/channel_pricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/channel_pricing.html.twig
@@ -2,11 +2,11 @@
 
 {% if product.isSimple %}
     <div class="tab-pane" id="product-channel-pricing" role="tabpanel" tabindex="0">
-        {% set variantForm = hookable_metadata.context.form.variant %}
+        {% set variant_form = hookable_metadata.context.form.variant %}
 
-        {% set isChannelPricingInvalid = variantForm.channelPricings.vars.errors is not empty %}
+        {% set is_channel_pricing_invalid = variant_form.channelPricings.vars.errors is not empty %}
 
-        {% if isChannelPricingInvalid %}
+        {% if is_channel_pricing_invalid %}
             {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
             <div class="alert alert-danger" role="alert">
@@ -15,20 +15,20 @@
                         {{ _icon({ 'icon': 'danger', 'class': 'alert-icon' }) }}
                     </div>
                     <div>
-                        {% set firstError = variantForm.channelPricings.vars.errors|first %}
-                        {{ firstError.messageTemplate|trans({}, 'validators') }}
+                        {% set first_error = variant_form.channelPricings.vars.errors|first %}
+                        {{ first_error.messageTemplate|trans({}, 'validators') }}
                     </div>
                 </div>
             </div>
         {% endif %}
 
         <div class="card mb-3">
-            {% if isChannelPricingInvalid %}
+            {% if is_channel_pricing_invalid %}
                 <div class="card-status-top bg-danger"></div>
             {% endif %}
             <div class="card-header">
                 <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs" role="tablist">
-                    {% for channelCode, channelPricing in variantForm.channelPricings %}
+                    {% for channelCode, channelPricing in variant_form.channelPricings %}
                         <li class="nav-item">
                             <a
                                 class="nav-link {% if loop.index0 == 0 %}active{% endif %}"
@@ -45,7 +45,7 @@
             </div>
             <div class="card-body">
                 <div class="tab-content">
-                    {% for channelCode, channelPricing in variantForm.channelPricings %}
+                    {% for channelCode, channelPricing in variant_form.channelPricings %}
                         <div class="tab-pane fade {% if loop.index0 == 0 %}show{% endif %} active" id="{{ channelCode }}" role="tabpanel">
                             {% if channelCode not in product.channels|map(channel => channel.code) %}
                                 <div class="alert alert-info">

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/inventory.html.twig
@@ -1,16 +1,16 @@
 {% set product = hookable_metadata.context.resource %}
 
 {% if product.isSimple %}
-    {% set variantForm = hookable_metadata.context.form.variant %}
+    {% set variant_form = hookable_metadata.context.form.variant %}
     <div class="tab-pane" id="product-inventory" role="tabpanel" tabindex="0">
         <div class="card mb-3">
             <div class="card-header">
                 <h2 id="inventory" class="card-title">{{ 'sylius.ui.inventory'|trans }}</h2>
             </div>
             <div class="card-body">
-                {{ form_row(variantForm.onHand) }}
-                {{ form_row(variantForm.tracked) }}
-                {{ form_row(variantForm.version) }}
+                {{ form_row( variant_form.onHand) }}
+                {{ form_row( variant_form.tracked) }}
+                {{ form_row( variant_form.version) }}
             </div>
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/shipping.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/shipping.html.twig
@@ -1,7 +1,7 @@
 {% set product = hookable_metadata.context.resource %}
 
 {% if product.isSimple %}
-    {% set variantForm = hookable_metadata.context.form.variant %}
+    {% set variant_form = hookable_metadata.context.form.variant %}
     <div class="tab-pane" id="shipping" role="tabpanel" tabindex="0">
         <div class="card mb-3">
             <div class="card-header">
@@ -9,19 +9,19 @@
             </div>
             <div class="card-body">
                 <div class="mb-3">
-                    {{ form_row(variantForm.shippingCategory) }}
+                    {{ form_row( variant_form.shippingCategory) }}
                 </div>
                 <div class="mb-3">
-                    {{ form_row(variantForm.width) }}
+                    {{ form_row( variant_form.width) }}
                 </div>
                 <div class="mb-3">
-                    {{ form_row(variantForm.height) }}
+                    {{ form_row( variant_form.height) }}
                 </div>
                 <div class="mb-3">
-                    {{ form_row(variantForm.depth) }}
+                    {{ form_row( variant_form.depth) }}
                 </div>
                 <div class="mb-3">
-                    {{ form_row(variantForm.weight) }}
+                    {{ form_row( variant_form.weight) }}
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxes.html.twig
@@ -1,7 +1,7 @@
 {% set product = hookable_metadata.context.resource %}
 
 {% if product.isSimple %}
-    {% set variantForm = hookable_metadata.context.form.variant %}
+    {% set variant_form = hookable_metadata.context.form.variant %}
     <div class="tab-pane" id="taxes" role="tabpanel" tabindex="0">
         <div class="card mb-3">
             <div class="card-header">
@@ -9,7 +9,7 @@
             </div>
             <div class="card-body">
                 <div class="mb-3">
-                    {{ form_row(variantForm.taxCategory) }}
+                    {{ form_row( variant_form.taxCategory) }}
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/translations.html.twig
@@ -39,6 +39,6 @@
                 </div>
             {% endverbatim %}
         {% endset %}
-        {{ _translations.default(hookable_metadata.context.form.translations, body, {accordionId: 'product-translations'}) }}
+        {{ _translations.default(hookable_metadata.context.form.translations, body, { accordion_id: 'product-translations'}) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/description.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/description.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.ui.description'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.description }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.description }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/meta_description.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/meta_description.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.ui.meta_description'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.metaDescription }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.metaDescription }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/meta_keywords.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/meta_keywords.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.ui.meta_keywords'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.metaKeywords }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.metaKeywords }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/product_name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/product_name.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.ui.name'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.name }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.name }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/short_description.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/short_description.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.form.product.short_description'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.shortDescription }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.shortDescription }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/slug.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translation_content/slug.html.twig
@@ -1,4 +1,4 @@
 <div class="row">
     <div class="col-12 col-md-4 fw-bold">{{ 'sylius.ui.slug'|trans }}:</div>
-    <div class="col-12 col-md-8">{{ hookable_metadata.context.productTranslation.slug }}</div>
+    <div class="col-12 col-md-8">{{ hookable_metadata.context.product_translation.slug }}</div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/translations.html.twig
@@ -2,8 +2,8 @@
 
 <div class="bg-white mb-3">
     <div class="accordion" id="product-translations">
-        {% for productTranslation in product.translations %}
-            {% set locale = productTranslation.locale %}
+        {% for product_translation in product.translations %}
+            {% set locale = product_translation.locale %}
 
             <div class="accordion-item">
                 <h2 class="accordion-header">
@@ -21,7 +21,7 @@
                                 </div>
                                 <div class="card-body">
                                     <div class="divide-y">
-                                        {% hook 'translations' with { productTranslation } %}
+                                        {% hook 'translations' with { product_translation } %}
                                     </div>
                                 </div>
                             </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/form/sections/channel_pricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/form/sections/channel_pricing.html.twig
@@ -12,9 +12,9 @@
             {% verbatim %}
                 <div class="row">
                     <div class="col-12 col-md-6">
-                        {% set isChannelPricingInvalid = channelPricingForm.vars.errors.form.parent.errors is not empty %}
+                        {% set is_channel_pricing_invalid = channelPricingForm.vars.errors.form.parent.errors is not empty %}
 
-                        {% if isChannelPricingInvalid %}
+                        {% if is_channel_pricing_invalid %}
                             {% from '@SyliusAdmin/shared/helper/icon.html.twig' import icon as _icon %}
 
                             <div class="alert alert-danger" role="alert">
@@ -23,8 +23,8 @@
                                         {{ _icon({ 'icon': 'danger', 'class': 'alert-icon' }) }}
                                     </div>
                                     <div>
-                                        {% set firstError = channelPricingForm.vars.errors.form.parent.errors|first %}
-                                        {{ firstError.messageTemplate|trans({}, 'validators') }}
+                                        {% set first_error = channelPricingForm.vars.errors.form.parent.errors|first %}
+                                        {{ first_error.messageTemplate|trans({}, 'validators') }}
                                     </div>
                                 </div>
                             </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/form/sections/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/form/sections/translations.html.twig
@@ -11,6 +11,6 @@
                 </div>
             {% endverbatim %}
         {% endset %}
-        {{ _translations.default(hookable_metadata.context.form.translations, body, {accordionId: 'product-variant-translations'}) }}
+        {{ _translations.default(hookable_metadata.context.form.translations, body, { accordion_id: 'product-variant-translations'}) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/index/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/index/content/header/breadcrumbs.html.twig
@@ -4,7 +4,7 @@
 {% set product = configuration.vars.product %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index'), active: false },
     { name: product.name|default(product.code), url: path('sylius_admin_product_show', {'id': product.id }), active: false },
     { name: 'sylius.ui.variants'|trans, active: true },

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form/sections/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form/sections/translations.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusAdmin/shared/helper/translations.html.twig' as _translations %}
 
 <div class="bg-white mb-3">
-    {{ _translations.default(hookable_metadata.context.form.translations, null, {accordionId: 'promotion-translations'}) }}
+    {{ _translations.default(hookable_metadata.context.form.translations, null, { accordion_id: 'promotion-translations'}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/security/login/content/form/error.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/security/login/content/form/error.html.twig
@@ -1,7 +1,7 @@
-{% set lastError = hookable_metadata.context.last_error|default(null) %}
+{% set last_error = hookable_metadata.context.last_error|default(null) %}
 
-{% if lastError is not null %}
+{% if last_error is not null %}
     <div class="alert alert-danger" {{ sylius_test_html_attribute('invalid-credentials-message') }}>
-        {{ lastError.messageKey|trans }}
+        {{ last_error.messageKey|trans }}
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/menu.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/menu.html.twig
@@ -29,8 +29,8 @@
         {%- set classes = classes|merge([options.lastClass]) %}
     {%- endif %}
 
-    {% set alwaysOpen = ['catalog', 'sales', 'customers'] %}
-    {% set isActive = matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth) or item.name in alwaysOpen %}
+    {% set always_open = ['catalog', 'sales', 'customers'] %}
+    {% set is_active = matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth)  or item.name in always_open %}
 
     {# Mark item as "leaf" (no children) or as "branch" (has children that are displayed) #}
     {% if item.hasChildren and options.depth is not same as(0) %}
@@ -47,13 +47,13 @@
     {%- endif %}
     {% if item.hasChildren %}
         <li class="nav-item {% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
-            <a class="nav-link dropdown-toggle {{ isActive ? 'show' : '' }}" href="#navbar-{{ item.name }}" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ isActive ? 'true' : 'false' }}">
+            <a class="nav-link dropdown-toggle {{ is_active ? 'show' : '' }}" href="#navbar-{{ item.name }}" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button" aria-expanded="{{ is_active ? 'true' : 'false' }}">
                 <span class="nav-link-icon d-md-none d-lg-inline-block">
                     {{ block('icon') }}
                 </span>
                 <span class="nav-link-title">{{ item.label|trans }}</span>
             </a>
-            <div class="dropdown-menu {{ isActive ? 'show' : '' }}">
+            <div class="dropdown-menu {{ is_active ? 'show' : '' }}">
                 <div class="dropdown-menu-columns">
                     <div class="dropdown-menu-column">
                         {{ block('childrenList') }}
@@ -92,14 +92,14 @@
         {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
     {%- endif %}
 
-    {% set isActive = matcher.isCurrent(item) %}
+    {% set is_active = matcher.isCurrent(item) %}
 
-    <a class="dropdown-item {{ isActive ? '' : 'text-muted' }} {% if attributes.class is defined %}{{ attributes.class }}{% endif %}" href="{{ item.uri }}" target="{{ target }}">
+    <a class="dropdown-item {{ is_active ? '' : 'text-muted' }} {% if attributes.class is defined %}{{ attributes.class }}{% endif %}" href="{{ item.uri }}" target="{{ target }}">
         {{ item.label|trans }}{% if target == '_blank' %}{{ icon({ icon: 'external-link', class: 'icon icon-tabler icon-sm ms-1 mb-2 opacity-75' }) }}{% endif %}
     </a>
 {% endblock %}
 
 {% block icon %}
-    {% set iconName = item.labelAttribute('icon') %}
-    {% if iconName %}{{ icon({ icon: iconName }) }}{% endif %}
+    {% set icon_name = item.labelAttribute('icon') %}
+    {% if icon_name %}{{ icon({ icon: icon_name }) }}{% endif %}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/form.html.twig
@@ -5,10 +5,10 @@
 {% set form = hookable_metadata.context.form %}
 
 {% set route = configuration.vars.route|default(null) %}
-{% set indexRoute = configuration.vars.index.route|default(null) %}
+{% set index_route = configuration.vars.index.route|default(null) %}
 {% set index_url = path(
-    indexRoute.name|default(_context.configuration.getRouteName('index')),
-    indexRoute.parameters|default(route.parameters|default({}))
+    index_route.name|default(_context.configuration.getRouteName('index')),
+    index_route.parameters|default(route.parameters|default({}))
 )
 %}
 
@@ -17,9 +17,9 @@
 <div class="page-body">
     <div class="container-xl">
         {% block content %}
-            {% set renderRest = hookable_metadata.configuration.render_rest %}
+            {% set render_rest = hookable_metadata.configuration.render_rest %}
 
-            {% if renderRest %}
+            {% if render_rest %}
                 <div class="card">
                 <div class="card-body">
             {% endif %}
@@ -30,8 +30,8 @@
 
                     {% hook 'form' with { form } %}
                 {% endblock %}
-            {{ form_end(form, {'render_rest': renderRest}) }}
-            {% if renderRest %}
+            {{ form_end(form, {'render_rest': render_rest}) }}
+            {% if render_rest %}
                 </div>
                 <div class="card-footer">
                     <div class="row align-items-center">

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/breadcrumbs.html.twig
@@ -2,9 +2,9 @@
 
 {% if hookable_metadata.context.metadata is defined %}
     {% set metadata = hookable_metadata.context.metadata %}
-    {% set resourceName = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
+    {% set resource_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 {% else %}
-    {% set resourceName = hookable_metadata.configuration.resource_name %}
+    {% set resource_name = hookable_metadata.configuration.resource_name %}
 {% endif %}
 
 {% set configuration = hookable_metadata.context.configuration %}
@@ -16,6 +16,6 @@
 
 {{ _breadcrumbs.default([
     { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
-    { name: resourceName, url: index_url, active: false },
+    { name: resource_name, url: index_url, active: false },
     { name: 'sylius.ui.new'|trans, active: true}
 ]) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/breadcrumbs.html.twig
@@ -15,7 +15,7 @@
 %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: resource_name, url: index_url, active: false },
     { name: 'sylius.ui.new'|trans, active: true}
 ]) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/title_block/title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/title_block/title.html.twig
@@ -4,15 +4,15 @@
     {% set configuration = hookable_metadata.context.configuration %}
     {% set metadata = hookable_metadata.context.metadata %}
 
-    {% set singularName = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
+    {% set singular_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
     {% set header = hookable_metadata.configuration.header|default(null) %}
 {% else %}
-    {% set singularName = hookable_metadata.configuration.resource_name %}
+    {% set singular_name = hookable_metadata.configuration.resource_name %}
     {% set header = hookable_metadata.configuration.header %}
 {% endif %}
 
 <div class="col-12 col-md-6">
     <div class="d-md-flex gap-2 align-items-center">
-        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.new'|trans ~ ' ' ~ singularName|trans) }}
+        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.new'|trans ~ ' ' ~ singular_name|trans) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/filters.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/filters.html.twig
@@ -4,7 +4,7 @@
 {% set resources = hookable_metadata.context.resources %}
 
 {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')) %}
-{% set areCriteriaSet = app.request.query.has('criteria') %}
+{% set are_criteria_set = app.request.query.has('criteria') %}
 
 <div class="bg-white mb-5">
     {% set content %}
@@ -29,5 +29,5 @@
         title: 'sylius.ui.filters'|trans,
         content: content,
         icon: 'adjustments',
-    }], areCriteriaSet) }}
+    }], are_criteria_set) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/breadcrumbs.html.twig
@@ -5,9 +5,9 @@
 
 {% if hookable_metadata.context.metadata is defined %}
     {% set metadata = hookable_metadata.context.metadata %}
-    {% set resourceName = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
+    {% set resource_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 {% else %}
-    {% set resourceName = hookable_metadata.configuration.resource_name %}
+    {% set resource_name = hookable_metadata.configuration.resource_name %}
 {% endif %}
 
 {% set index_url = path(

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/breadcrumbs.html.twig
@@ -17,7 +17,7 @@
 %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: metadata.applicationName~'.ui.'~metadata.pluralName, url: index_url, active: false },
     { name: resource.name|default(resource.code|default(resource.id)), active: true },
     { name: 'sylius.ui.show'|trans, active: false }

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/title_block/title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/title_block/title.html.twig
@@ -4,15 +4,15 @@
     {% set configuration = hookable_metadata.context.configuration %}
     {% set metadata = hookable_metadata.context.metadata %}
 
-    {% set singularName = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
+    {% set singular_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
     {% set header = hookable_metadata.configuration.header|default(null) %}
 {% else %}
-    {% set singularName = hookable_metadata.configuration.resource_name %}
+    {% set singular_name = hookable_metadata.configuration.resource_name %}
     {% set header = hookable_metadata.configuration.header %}
 {% endif %}
 
 <div class="col-12 col-md-6">
     <div class="d-md-flex gap-2 align-items-center">
-        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.show'|trans ~ ' ' ~ singularName|trans) }}
+        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.show'|trans ~ ' ' ~ singular_name|trans) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/form.html.twig
@@ -5,10 +5,10 @@
 {% set form = hookable_metadata.context.form %}
 
 {% set route = configuration.vars.route|default(null) %}
-{% set indexRoute = configuration.vars.index.route|default(null) %}
+{% set index_route = configuration.vars.index.route|default(null) %}
 {% set index_url = path(
-    indexRoute.name|default(_context.configuration.getRouteName('index')),
-    indexRoute.parameters|default(route.parameters|default({}))
+    index_route.name|default(_context.configuration.getRouteName('index')),
+    index_route.parameters|default(route.parameters|default({}))
 ) %}
 
 {% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}
@@ -16,9 +16,9 @@
 <div class="page-body">
     <div class="container-xl">
         {% block content %}
-            {% set renderRest = hookable_metadata.configuration.render_rest %}
+            {% set render_rest = hookable_metadata.configuration.render_rest %}
 
-            {% if renderRest %}
+            {% if render_rest %}
                 <div class="card">
                 <div class="card-body">
             {% endif %}
@@ -30,8 +30,8 @@
 
                 {% hook 'form' with { form } %}
             {% endblock %}
-            {{ form_end(form, {'render_rest': renderRest}) }}
-            {% if renderRest %}
+            {{ form_end(form, {'render_rest': render_rest}) }}
+            {% if render_rest %}
                 </div>
                 <div class="card-footer">
                     <div class="row align-items-center">

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/breadcrumbs.html.twig
@@ -6,9 +6,9 @@
 
 {% if hookable_metadata.context.metadata is defined %}
     {% set metadata = hookable_metadata.context.metadata %}
-    {% set resourceName = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
+    {% set resource_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 {% else %}
-    {% set resourceName = hookable_metadata.configuration.resource_name %}
+    {% set resource_name = hookable_metadata.configuration.resource_name %}
 {% endif %}
 
 {% set index_url = path(
@@ -19,7 +19,7 @@
 
 {{ _breadcrumbs.default([
     { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
-    { name: resourceName, url: index_url, active: false },
+    { name: resource_name, url: index_url, active: false },
     { name: resource.name|default(resource.code|default(resource.id)), active: true },
     { name: 'sylius.ui.edit'|trans, active: false }
 ]) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/breadcrumbs.html.twig
@@ -18,7 +18,7 @@
 %}
 
 {{ _breadcrumbs.default([
-    { name: 'Dashboard', url: path('sylius_admin_dashboard'), active: false },
+    { name: 'sylius.ui.dashboard', url: path('sylius_admin_dashboard'), active: false },
     { name: resource_name, url: index_url, active: false },
     { name: resource.name|default(resource.code|default(resource.id)), active: true },
     { name: 'sylius.ui.edit'|trans, active: false }

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/title.html.twig
@@ -4,15 +4,15 @@
     {% set configuration = hookable_metadata.context.configuration %}
     {% set metadata = hookable_metadata.context.metadata %}
 
-    {% set singularName = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
+    {% set singular_name = hookable_metadata.configuration.resource_name|default(metadata.applicationName ~ '.ui.' ~ _context.metadata.name) %}
     {% set header = hookable_metadata.configuration.header|default(null) %}
 {% else %}
-    {% set singularName = hookable_metadata.configuration.resource_name %}
+    {% set singular_name = hookable_metadata.configuration.resource_name %}
     {% set header = hookable_metadata.configuration.header %}
 {% endif %}
 
 <div class="col-12 col-md-6">
     <div class="d-md-flex gap-2 align-items-center">
-        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.edit'|trans ~ ' ' ~ singularName|trans) }}
+        {{ _header.h1(header is not null ? header|trans : 'sylius.ui.edit'|trans ~ ' ' ~ singular_name|trans) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
@@ -44,7 +44,7 @@
         <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs" role="tablist">
                 {% for channelCode, channelConfiguration in form %}
-                    {% set channelErrorCount = form.vars.channels_errors_count[channelCode] %}
+                    {% set channel_error_count = form.vars.channels_errors_count[channelCode] %}
                     <li class="nav-item">
                         <a
                             class="nav-link {% if loop.index0 == 0 %}active{% endif %}"
@@ -55,8 +55,8 @@
                             {{ sylius_test_html_attribute('channel-tab', channelCode) }}
                         >
                             <span>{{- channelConfiguration.vars.label -}}</span>
-                            {% if channelErrorCount > 0 %}
-                                <span class="text-white badge rounded-pill bg-danger ms-1">{{ channelErrorCount }}</span>
+                            {% if channel_error_count > 0 %}
+                                <span class="text-white badge rounded-pill bg-danger ms-1">{{ channel_error_count }}</span>
                             {% endif %}
                         </a>
                     </li>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
@@ -43,18 +43,18 @@
     <div{% with {attr: row_attr|merge({class: row_attr.class|default('mb-3 card')|trim})} %}{{ block('attributes') }}{% endwith %}>
         <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs" data-bs-toggle="tabs" role="tablist">
-                {% for channelCode, channelConfiguration in form %}
-                    {% set channel_error_count = form.vars.channels_errors_count[channelCode] %}
+                {% for channel_code, channel_configuration in form %}
+                    {% set channel_error_count = form.vars.channels_errors_count[channel_code] %}
                     <li class="nav-item">
                         <a
                             class="nav-link {% if loop.index0 == 0 %}active{% endif %}"
                             data-bs-toggle="tab"
-                            href="#{{ channelCode }}"
+                            href="#{{ channel_code }}"
                             role="tab"
-                            {{ sylius_test_html_attribute('tab', channelCode) }}
-                            {{ sylius_test_html_attribute('channel-tab', channelCode) }}
+                            {{ sylius_test_html_attribute('tab', channel_code) }}
+                            {{ sylius_test_html_attribute('channel-tab', channel_code) }}
                         >
-                            <span>{{- channelConfiguration.vars.label -}}</span>
+                            <span>{{- channel_configuration.vars.label -}}</span>
                             {% if channel_error_count > 0 %}
                                 <span class="text-white badge rounded-pill bg-danger ms-1">{{ channel_error_count }}</span>
                             {% endif %}
@@ -65,14 +65,14 @@
         </div>
         <div class="card-body">
             <div class="tab-content">
-                {% for channelCode, channelConfiguration in form %}
+                {% for channel_code, channel_configuration in form %}
                     <div
                         class="tab-pane fade {% if loop.index0 == 0 %}show active{% endif %}"
-                        id="{{ channelCode }}"
+                        id="{{ channel_code }}"
                         role="tabpanel"
-                        {{ sylius_test_html_attribute('channel-tab-content', channelCode) }}
+                        {{ sylius_test_html_attribute('channel-tab-content', channel_code) }}
                     >
-                        {{ form_row(channelConfiguration, sylius_test_form_attribute('tab-content')|merge({'label': false})) }}
+                        {{ form_row(channel_configuration, sylius_test_form_attribute('tab-content')|merge({'label': false})) }}
                     </div>
                 {% endfor %}
             </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/accordion.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/accordion.html.twig
@@ -1,7 +1,7 @@
-{% macro default(items, open = false, autoClose = null, flush = false) %}
+{% macro default(items, open = false, auto_close = null, flush = false) %}
     {% from "@SyliusAdmin/shared/helper/icon.html.twig" import icon %}
 
-    {% set autoClose = autoClose|default(true) %}
+    {% set auto_close = auto_close|default(true) %}
     {% set id = id|default(random()) %}
 
     <div class="accordion{% if flush %} accordion-flush{% endif %}" id="{{ id }}">
@@ -35,7 +35,7 @@
                 </h2>
                 <div id="{{ item_id }}"
                      class="accordion-collapse collapse {{ item.open == true ? 'show' : '' }}"
-                     {% if autoClose == true %}data-bs-parent="#{{ id }}"{% endif %}>
+                     {% if auto_close == true %}data-bs-parent="#{{ id }}"{% endif %}>
 
                     <div class="accordion-body">
                         {{ item.content|default('Content') }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
@@ -16,7 +16,7 @@
         form: null,
     }|merge(params) %}
 
-    {% set buttonClass = 'btn' ~
+    {% set button_class = 'btn' ~
         (p.class ? ' ' ~ p.class : '') ~
         (p.dropdown ? ' dropdown-toggle' : '') ~
         (p.iconOnly ? ' btn-icon' : '') ~
@@ -26,7 +26,7 @@
     {% if p.url %}
         <a href="{{ p.url }}"
            {% if p.id %}id="{{ p.id }}"{% endif %}
-           class="{{ buttonClass }}"
+           class="{{ button_class }}"
             {% if p.disabled %}aria-disabled="true"{% endif %}
             {% if p.dropdown %}data-bs-toggle="dropdown"{% endif %}
             {{ p.attr is iterable ? block('attributes') : (p.attr ? ' ' ~ p.attr) }}>
@@ -37,7 +37,7 @@
         <button type="{{ p.type }}"
                 {% if p.id %}id="{{ p.id }}"{% endif %}
                 {% if p.form %}form="{{ p.form }}"{% endif %}
-                class="{{ buttonClass }}"
+                class="{{ button_class }}"
             {% if p.disabled %}disabled{% endif %}
             {% if p.dropdown %}data-bs-toggle="dropdown"{% endif %}
             {{ p.attr is iterable ? block('attributes') : (p.attr ? ' ' ~ p.attr ) }}>
@@ -53,8 +53,8 @@
         class: null,
     }|merge(params) %}
 
-    {% set newParams = params|merge({ class: 'btn-primary ' ~ params.class }) %}
-    {{ _.default(newParams) }}
+    {% set new_params = params|merge({ class: 'btn-primary ' ~ params.class }) %}
+    {{ _.default( new_params) }}
 {% endmacro %}
 
 {% macro delete(params = {}) %}
@@ -63,8 +63,8 @@
         class: null,
     }|merge(params) %}
 
-    {% set newParams = { text: 'Delete' }|merge(params)|merge({ class: 'btn btn-ghost-danger ' ~ params.class }) %}
-    {{ _.default(newParams) }}
+    {% set new_params = { text: 'Delete' }|merge(params)|merge({ class: 'btn btn-ghost-danger ' ~ params.class }) %}
+    {{ _.default( new_params) }}
 {% endmacro %}
 
 {% macro create(params = {}) %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/channelPricings.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/channelPricings.html.twig
@@ -1,9 +1,9 @@
 {% macro default(channelPricingForms, product_variant, body = null, options = {}) %}
     {% set options = {
-        accordionId: 'product-channel-pricings'
+        accordion_id: 'product-channel-pricings'
     }|merge(options) %}
 
-    <div class="accordion" id="{{ options.accordionId }}">
+    <div class="accordion" id="{{ options. accordion_id }}">
         {% for channelCode, channelPricingForm in channelPricingForms %}
             <div class="accordion-item">
                 <h2 class="accordion-header">

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/dropdown.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/dropdown.html.twig
@@ -50,6 +50,6 @@
         {% endfor %}
     {% endset %}
 
-    {% set newParams = params|merge({ content: content }) %}
-    {{ _.default(newParams) }}
+    {% set new_params = params|merge({ content: content }) %}
+    {{ _.default(new_params) }}
 {% endmacro %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/icon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/icon.html.twig
@@ -4,7 +4,7 @@
     {% set width = params.width|default(24) %}
     {% set height = params.height|default(24) %}
     {% set stroke = params.stroke|default(2) %}
-    {% set strokeColor = params.strokeColor|default('currentColor') %}
+    {% set stroke_color = params.strokeColor|default('currentColor') %}
     {% set fill = params.fill|default('none') %}
 
     <svg xmlns="http://www.w3.org/2000/svg"
@@ -13,7 +13,7 @@
          height="{{ height }}"
          viewBox="0 0 24 24"
          stroke-width="{{ stroke }}"
-         stroke="{{ strokeColor }}"
+         stroke="{{ stroke_color }}"
          fill="{{ fill }}"
          stroke-linecap="round"
          stroke-linejoin="round">

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/translations.html.twig
@@ -1,12 +1,12 @@
 {% macro default(translationFields, body = null, options = {}) %}
     {% from _self import accordion_header %}
 
-    {% set accordionId = options.accordionId|default('translations') %}
-    <div class="accordion" id="{{ accordionId }}">
+    {% set accordion_id = options. accordion_id|default('translations') %}
+    <div class="accordion" id="{{ accordion_id }}">
         {% for locale, translationForm in translationFields %}
             <div class="accordion-item">
-                {{ accordion_header(locale, accordionId, loop.first) }}
-                <div id="translation-{{ locale }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" data-bs-parent="#{{ accordionId }}">
+                {{ accordion_header(locale, accordion_id, loop.first) }}
+                <div id="translation-{{ locale }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" data-bs-parent="#{{ accordion_id }}">
                     <div class="accordion-body">
                         {% if body is not null %}
                             {{ include(template_from_string(body), { locale: locale, translationForm: translationForm }) }}
@@ -25,12 +25,12 @@
 {% macro with_hook(translationFields, prefixes, hook_name = null, options = {}) %}
     {% from _self import accordion_header %}
 
-    {% set accordionId = options.accordionId|default('translations') %}
-    <div class="accordion" id="{{ accordionId }}">
+    {% set accordion_id = options. accordion_id|default('translations') %}
+    <div class="accordion" id="{{ accordion_id }}">
         {% for locale, translationForm in translationFields %}
             <div class="accordion-item">
-                {{ accordion_header(locale, accordionId, loop.first) }}
-                <div id="translation-{{ locale }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" data-bs-parent="#{{ accordionId }}">
+                {{ accordion_header(locale, accordion_id, loop.first) }}
+                <div id="translation-{{ locale }}" class="accordion-collapse collapse {% if loop.first %}show{% endif %}" data-bs-parent="#{{ accordion_id }}">
                     <div class="accordion-body">
                         {% hook hook_name|default('translations') with { form: translationForm, locale, _prefixes: prefixes } %}
                     </div>
@@ -40,7 +40,7 @@
     </div>
 {% endmacro %}
 
-{% macro accordion_header(locale, accordionId, is_first = false) %}
+{% macro accordion_header(locale, accordion_id, is_first = false) %}
     <h2 class="accordion-header">
         <button
             class="accordion-button {% if is_first == false %}collapsed{% endif %}"
@@ -49,7 +49,7 @@
             data-bs-target="#translation-{{ locale }}"
             aria-expanded="{% if is_first %}true{% else %}false{% endif %}"
             aria-controls="translation-{{ locale }}"
-            {{ sylius_test_html_attribute(accordionId ~ '-accordion', locale) }}
+            {{ sylius_test_html_attribute( accordion_id ~ '-accordion', locale) }}
         >
             <span class="flag flag-sm flag-country-{{ locale|lower|split('_')|last }} me-3"></span>
             {{ locale|sylius_locale_name }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form/shipping_charges/configuration.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form/shipping_charges/configuration.html.twig
@@ -6,8 +6,8 @@
             {{ form_row(form.configuration) }}
         {% else %}
             {% for name, calculatorConfigurationPrototype in form.vars.prototypes %}
-                {% set chosenCalculator = 'calculators_' ~ form.calculator.vars.value %}
-                {% if chosenCalculator == name %}
+                {% set chosen_calculator = 'calculators_' ~ form.calculator.vars.value %}
+                {% if chosen_calculator == name %}
                     {{ form_row(calculatorConfigurationPrototype) }}
                 {% endif %}
             {% endfor %}

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/form/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/form/translations.html.twig
@@ -22,5 +22,5 @@
             </div>
         {% endverbatim %}
     {% endset %}
-    {{ _translations.default(hookable_metadata.context.form.translations, body, {accordionId: 'taxon-translations'}) }}
+    {{ _translations.default(hookable_metadata.context.form.translations, body, { accordion_id: 'taxon-translations'}) }}
 </div>


### PR DESCRIPTION
So far, we have been using `camelCase`, but we agreed to follow the Twig standard and switch to `snake_case` where applicable. Of course, property access on objects is still done using `camelCase`.