### PR TITLE
[Behat] Allow to use ApiPlatformSecurityClient with another login endpoint

### DIFF
--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -33,7 +33,7 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
     public function prepareLoginRequest(): void
     {
         $this->request['url'] = sprintf(
-            '%s/%s/token',
+            '%s/%s',
             $this->apiUrlPrefix,
             $this->section,
         );

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -36,14 +36,14 @@
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument>%sylius.security.new_api_route%</argument>
-            <argument>admin/administrators</argument>
+            <argument>admin/administrators/token</argument>
         </service>
 
         <service id="sylius.behat.client.shop_api_platform_security_client" class="Sylius\Behat\Client\ApiPlatformSecurityClient">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument>%sylius.security.new_api_route%</argument>
-            <argument>shop/customers</argument>
+            <argument>shop/customers/token</argument>
         </service>
 
         <service id="sylius.behat.content_type_guide" class="Sylius\Behat\Client\ContentTypeGuide" />


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

I was trying to create new features to handle the transition from `/shop/authentication-token` to `/shop/customers/token` and I was forced to rewrite the class `ApiPlatformSecurityClient` because the endpoint url is hardcoded: `'%s/%s/token'`.

This PR is allowing to use `ApiPlatformSecurityClient` without copying it and override it, by simply setting the full endpoint name inside the `$section` parameter.
