### PR TITLE
[Admin] Add CSRF token and form errors to base form templates

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/admin_user/form/sections.html.twig
@@ -1,5 +1,3 @@
 <div class="row">
     {% hook 'sections' %}
-
-    {{ form_row(hookable_metadata.context.form._token) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/form.html.twig
@@ -25,6 +25,9 @@
             {% endif %}
             {{ form_start(form, {'action': path(configuration.vars.route.name|default(configuration.getRouteName('create')), configuration.vars.route.parameters|default({})), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate', 'id': form.vars.id}}) }}
                 {% block form_content %}
+                    {{ form_errors(form) }}
+                    {%- if form._token is defined %}{{ form_widget(form._token) }}{% endif %}
+
                     {% hook 'form' with { form } %}
                 {% endblock %}
             {{ form_end(form, {'render_rest': renderRest}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/form.html.twig
@@ -25,6 +25,8 @@
             {{ form_start(form, {'action': path(configuration.vars.route.name|default(configuration.getRouteName('update')), configuration.vars.route.parameters|default({ 'id': resource.id })), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate', 'id': form.vars.id}}) }}
             {% block form_content %}
                 <input type="hidden" name="_method" value="PUT"/>
+                {{ form_errors(form) }}
+                {%- if form._token is defined %}{{ form_widget(form._token) }}{% endif %}
 
                 {% hook 'form' with { form } %}
             {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/tax_rate/form/sections.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/tax_rate/form/sections.html.twig
@@ -1,5 +1,3 @@
 <div class="row">
     {% hook 'sections' %}
-
-    {{ form_row(hookable_metadata.context.form._token) }}
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | related to #16308 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
