### PR TITLE
Core ItemTotalRuleChecker is missing type constant

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/ItemTotalRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/ItemTotalRuleChecker.php
@@ -20,6 +20,8 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 final class ItemTotalRuleChecker implements RuleCheckerInterface
 {
+    public const TYPE = 'item_total';
+
     public function __construct(private ?RuleCheckerInterface $itemTotalRuleChecker = null)
     {
         if ($this->itemTotalRuleChecker instanceof self) {


### PR DESCRIPTION
This is inconsistent with the promotion version `\Sylius\Component\Promotion\Checker\Rule\ItemTotalRuleChecker` as well as all other RuleCheckers/Action commands

| Q               | A
|-----------------|-----
| Branch?         | 1.14 -- can rebase onto 1.13 if you prefer it as a bugfix
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
