### PR TITLE
Fix disappearing newly added product attributes when a validation err…

### DIFF
--- a/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
+++ b/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
@@ -15,7 +15,7 @@ Feature: Adding a product attribute without providing any value
     Scenario: Adding a product attribute without providing any value
         When I want to create a new configurable product
         And I specify its code as "Jeans"
-        And I name it "Colored jeans" in "English (United States)"
+        And I name it "Colored jeans" in "English (United States)" locale
         And I add the "Color" attribute
         And I try to add it
         Then I should be notified that the "Color" attribute value for "English (United States)" is required

--- a/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
+++ b/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
@@ -11,7 +11,7 @@ Feature: Adding a product attribute without providing any value
         And the store has text product attribute "Color"
         And I am logged in as an administrator
 
-    @ui @javascript @no-api
+    @ui @mink:chromedriver @no-api
     Scenario: Adding a product attribute without providing any value
         When I want to create a new configurable product
         And I specify its code as "Jeans"

--- a/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
+++ b/features/admin/product/managing_products/adding_product_attribute_without_providing_any_value.feature
@@ -1,0 +1,21 @@
+@managing_products
+Feature: Adding a product attribute without providing any value
+    In order to avoid mistakes while adding a product attribute
+    As an Administrator
+    I want to be informed when I try to add an empty product attribute
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the locale "French (France)" is enabled
+        And the store also operates in "French (France)" locale
+        And the store has text product attribute "Color"
+        And I am logged in as an administrator
+
+    @ui @javascript @no-api
+    Scenario: Adding a product attribute without providing any value
+        When I want to create a new configurable product
+        And I specify its code as "Jeans"
+        And I name it "Colored jeans" in "English (United States)"
+        And I add the "Color" attribute
+        And I try to add it
+        Then I should be notified that the "Color" attribute value for "English (United States)" is required

--- a/features/admin/product/managing_products/product_validation.feature
+++ b/features/admin/product/managing_products/product_validation.feature
@@ -171,39 +171,43 @@ Feature: Products validation
         Then I should be notified that slug has to be unique
         And product with code "7-WONDERS-BABEL" should not be added
 
-    @ui @javascript @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in default locale
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"
         And I name it "PHP Mug" in "English (United States)" locale
+        And I add the "Mug material" attribute
         And I set its "Mug material" attribute to "Drewno" in "Polish (Poland)" locale
         But I do not set its "Mug material" attribute in "English (United States)" locale
         And I add it
         Then I should be notified that I have to define the "Mug material" attribute in "English (United States)" locale
         And product with code "X-18-MUG" should not be added
 
-    @ui @javascript @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in additional locale with proper length
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"
         And I name it "PHP Mug" in "English (United States)" locale
+        And I add the "Mug material" attribute
         And I set its "Mug material" attribute to "Dr" in "Polish (Poland)" locale
         And I set its "Mug material" attribute to "Wood" in "English (United States)" locale
         And I add it
         Then I should be notified that the "Mug material" attribute in "Polish (Poland)" locale should be longer than 3
         And product with code "X-18-MUG" should not be added
 
-    @ui @javascript @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a text attribute in different locales to an existing product without specifying its value in default locale
         When I want to modify the "Symfony Mug" product
+        And I add the "Mug material" attribute
         And I set its "Mug material" attribute to "Drewno" in "Polish (Poland)" locale
         But I do not set its "Mug material" attribute in "English (United States)" locale
         And I save my changes
         Then I should be notified that I have to define the "Mug material" attribute in "English (United States)" locale
 
-    @ui @javascript @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a text attribute in different locales to an existing product without specifying its value in additional locale with proper length
         When I want to modify the "Symfony Mug" product
+        And I add the "Mug material" attribute
         And I set its "Mug material" attribute to "Dr" in "Polish (Poland)" locale
         And I set its "Mug material" attribute to "Wood" in "English (United States)" locale
         And I save my changes

--- a/features/admin/product/managing_products/product_validation.feature
+++ b/features/admin/product/managing_products/product_validation.feature
@@ -171,7 +171,7 @@ Feature: Products validation
         Then I should be notified that slug has to be unique
         And product with code "7-WONDERS-BABEL" should not be added
 
-    @ui @mink:chromedriver @api
+    @ui @javascript @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in default locale
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"
@@ -182,7 +182,7 @@ Feature: Products validation
         Then I should be notified that I have to define the "Mug material" attribute in "English (United States)" locale
         And product with code "X-18-MUG" should not be added
 
-    @ui @mink:chromedriver @api
+    @ui @javascript @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in additional locale with proper length
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"

--- a/features/admin/product/managing_products/product_validation.feature
+++ b/features/admin/product/managing_products/product_validation.feature
@@ -171,7 +171,7 @@ Feature: Products validation
         Then I should be notified that slug has to be unique
         And product with code "7-WONDERS-BABEL" should not be added
 
-    @todo @ui @mink:chromedriver @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in default locale
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"
@@ -182,7 +182,7 @@ Feature: Products validation
         Then I should be notified that I have to define the "Mug material" attribute in "English (United States)" locale
         And product with code "X-18-MUG" should not be added
 
-    @todo @ui @mink:chromedriver @api
+    @ui @mink:chromedriver @api
     Scenario: Trying to add a new product with a text attribute without specifying its value in additional locale with proper length
         When I want to create a new configurable product
         And I specify its code as "X-18-MUG"
@@ -193,7 +193,7 @@ Feature: Products validation
         Then I should be notified that the "Mug material" attribute in "Polish (Poland)" locale should be longer than 3
         And product with code "X-18-MUG" should not be added
 
-    @todo @ui @javascript @api
+    @ui @javascript @api
     Scenario: Trying to add a text attribute in different locales to an existing product without specifying its value in default locale
         When I want to modify the "Symfony Mug" product
         And I set its "Mug material" attribute to "Drewno" in "Polish (Poland)" locale
@@ -201,7 +201,7 @@ Feature: Products validation
         And I save my changes
         Then I should be notified that I have to define the "Mug material" attribute in "English (United States)" locale
 
-    @todo @ui @javascript @api
+    @ui @javascript @api
     Scenario: Trying to add a text attribute in different locales to an existing product without specifying its value in additional locale with proper length
         When I want to modify the "Symfony Mug" product
         And I set its "Mug material" attribute to "Dr" in "Polish (Poland)" locale

--- a/features/admin/product/managing_products/viewing_non_translatable_attributes.feature
+++ b/features/admin/product/managing_products/viewing_non_translatable_attributes.feature
@@ -10,7 +10,7 @@ Feature: Viewing product's non translatable attributes on edit page
         And this product has non-translatable percent attribute "crit chance" with value 10%
         And I am logged in as an administrator
 
-    @todo @ui @api
+    @ui @api
     Scenario: Viewing product's attributes defined in different locales
         When I modify the "Iron Pickaxe" product
         And I should see non-translatable attribute "crit chance" with value 10%

--- a/features/shop/checkout/addressing_order/sign_in_during_addressing_step.feature
+++ b/features/shop/checkout/addressing_order/sign_in_during_addressing_step.feature
@@ -16,7 +16,7 @@ Feature: Sign in to the store during checkout
         When I specify the email as "francis@underwood.com"
         Then I should be able to log in
 
-    @ui @no-api @javascript
+    @ui @no-api @mink:chromedriver
     Scenario: Successful sign in
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -819,7 +819,7 @@ final readonly class ManagingProductsContext implements Context
      */
     public function iShouldSeeNonTranslatableAttributeWithValue(string $attribute, string $value): void
     {
-        Assert::true($this->attributesFormElement->hasNonTranslatableAttributeWithValue($attribute, $value));
+        Assert::same($this->attributesFormElement->getValueNonTranslatableAttribute($attribute), $value);
     }
 
     /**
@@ -1247,7 +1247,7 @@ final readonly class ManagingProductsContext implements Context
     public function iShouldBeNotifiedThatTheAttributeInShouldBeLongerThan(string $attribute, string $localeCode, int $number): void
     {
         Assert::same(
-            $this->resolveCurrentPage()->getAttributeValidationErrors($attribute, $localeCode),
+            $this->attributesFormElement->getAttributeValidationErrors($attribute, $localeCode),
             sprintf('This value is too short. It should have %s characters or more.', $number),
         );
     }
@@ -1435,7 +1435,7 @@ final readonly class ManagingProductsContext implements Context
      */
     public function iShouldBeNotifiedThatTheAttributeValueIsRequired(string $attributeName, LocaleInterface $locale): void
     {
-        Assert::true($this->productAttributesFormElement->hasAttributeError($attributeName, $locale->getCode()));
+        Assert::true($this->attributesFormElement->hasAttributeError($attributeName, $locale->getCode()));
     }
 
     private function assertValidationMessage(string $element, string $message): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -42,6 +42,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 use Webmozart\Assert\Assert;
 
@@ -1427,6 +1428,14 @@ final readonly class ManagingProductsContext implements Context
             $showProductPageUrl,
             sprintf('/%s/products/%s', $localeCode, $productTranslation->getSlug()),
         );
+    }
+
+    /**
+     * @Then I should be notified that the :attributeName attribute value for :locale is required
+     */
+    public function iShouldBeNotifiedThatTheAttributeValueIsRequired(string $attributeName, LocaleInterface $locale): void
+    {
+        Assert::true($this->productAttributesFormElement->hasAttributeError($attributeName, $locale->getCode()));
     }
 
     private function assertValidationMessage(string $element, string $message): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -1431,11 +1431,11 @@ final readonly class ManagingProductsContext implements Context
     }
 
     /**
-     * @Then I should be notified that the :attributeName attribute value for :locale is required
+     * @Then I should be notified that the :attributeName attribute value for :localeCode is required
      */
-    public function iShouldBeNotifiedThatTheAttributeValueIsRequired(string $attributeName, LocaleInterface $locale): void
+    public function iShouldBeNotifiedThatTheAttributeValueIsRequired(string $attributeName, string $localeCode): void
     {
-        Assert::true($this->attributesFormElement->hasAttributeError($attributeName, $locale->getCode()));
+        Assert::true($this->attributesFormElement->hasAttributeError($attributeName, $localeCode));
     }
 
     private function assertValidationMessage(string $element, string $message): void

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
@@ -140,6 +140,16 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         return count($this->getDocument()->findAll('css', '[data-test-product-attribute-tab]'));
     }
 
+    public function hasAttributeError(string $attributeName, string $localeCode): bool
+    {
+        $this->changeTab();
+        $this->changeAttributeTab($attributeName);
+
+        $attributeValue = $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode]);
+
+        return $attributeValue->hasClass('is-invalid');
+    }
+
     protected function getDefinedElements(): array
     {
         return [

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
@@ -82,12 +82,12 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         return count($this->getDocument()->findAll('css', '[data-test-attribute-tab]'));
     }
 
-    public function getAttributeValue(string $attribute, string $localeCode): string
+    public function getAttributeValue(string $attributeName, string $localeCode): string
     {
         $this->changeTab();
-        $this->changeAttributeTab($attribute);
+        $this->changeAttributeTab($attributeName);
 
-        $attributeValue = $this->getElement('attribute_value', ['%attribute_name%' => $attribute, '%locale_code%' => $localeCode]);
+        $attributeValue = $this->getElement('attribute_value', ['%attribute_name%' => $attributeName, '%locale_code%' => $localeCode]);
 
         return match ($attributeValue->getTagName()) {
             'input' => $attributeValue->getValue(),
@@ -96,11 +96,11 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         };
     }
 
-    public function getAttributeSelectText(string $attribute, string $localeCode): string
+    public function getAttributeSelectText(string $attributeName, string $localeCode): string
     {
         $this->clickTabIfItsNotActive();
 
-        return $this->getElement('attribute_select', ['%attribute_name%' => $attribute, '%locale_code%' => $localeCode])->getText();
+        return $this->getElement('attribute_select', ['%attribute_name%' => $attributeName, '%locale_code%' => $localeCode])->getText();
     }
 
     public function getValueNonTranslatableAttribute(string $attributeName): string

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
@@ -28,66 +28,6 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         parent::__construct($session, $minkParameters);
     }
 
-    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string
-    {
-        $this->clickTabIfItsNotActive();
-
-        $validationError = $this->getElement('attribute')->find('css', '.sylius-validation-error');
-
-        return $validationError->getText();
-    }
-
-    public function removeAttribute(string $attributeName, string $localeCode): void
-    {
-        $this->changeTab();
-
-        $this->getElement('product_attribute_delete_button', ['%attributeName%' => $attributeName])->press();
-
-        $this->waitForFormUpdate();
-    }
-
-    public function getAttributeSelectText(string $attribute, string $localeCode): string
-    {
-        $this->clickTabIfItsNotActive();
-
-        return $this->getElement('attribute_select', ['%attributeName%' => $attribute, '%localeCode%' => $localeCode])->getText();
-    }
-
-    public function getNonTranslatableAttributeValue(string $attribute): string
-    {
-        $this->clickTabIfItsNotActive();
-
-        return $this->getElement('non_translatable_attribute', ['%attributeName%' => $attribute])->getValue();
-    }
-
-    public function hasAttribute(string $attributeName): bool
-    {
-        return null !== $this->getDocument()->find('css', sprintf('.attribute .label:contains("%s")', $attributeName));
-    }
-
-    public function hasNonTranslatableAttributeWithValue(string $attributeName, string $value): bool
-    {
-        $attribute = $this->getDocument()->find('css', sprintf('.attribute .attribute-label:contains("%s")', $attributeName));
-
-        return
-            $attribute->getParent()->getParent()->find('css', '.attribute-input input')->getValue() === $value &&
-            $attribute->find('css', '.globe.icon') !== null
-        ;
-    }
-
-    public function addNonTranslatableAttribute(string $attributeName, string $value): void
-    {
-        $this->clickTabIfItsNotActive();
-
-        $attributeOption = $this->getElement('attributes_choice')->find('css', sprintf('option:contains("%s")', $attributeName));
-        $this->selectElementFromAttributesDropdown($attributeOption->getAttribute('value'));
-
-        $this->getDocument()->pressButton('Add attributes');
-        $this->waitForFormElement();
-
-        $this->getElement('non_translatable_attribute_value', ['%attributeName%' => $attributeName])->setValue($value);
-    }
-
     public function addAttribute(string $attributeName): void
     {
         $this->changeTab();
@@ -97,12 +37,19 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         $this->waitForFormUpdate();
     }
 
+    public function addSelectedAttributes(): void
+    {
+        $this->changeTab();
+        $this->clickButton('Add');
+        $this->waitForFormUpdate();
+    }
+
     public function updateAttribute(string $attributeName, string $value, string $localeCode): void
     {
         $this->changeTab();
         $this->changeAttributeTab($attributeName);
 
-        $attributeValue = $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode]);
+        $attributeValue = $this->getElement('attribute_value', ['%attribute_name%' => $attributeName, '%locale_code%' => $localeCode]);
 
         match ($attributeValue->getTagName()) {
             'input' => $attributeValue->setValue($value),
@@ -114,12 +61,33 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         $this->waitForFormUpdate();
     }
 
+    public function removeAttribute(string $attributeName): void
+    {
+        $this->changeTab();
+
+        $this->getElement('attribute_delete_button', ['%attribute_name%' => $attributeName])->press();
+
+        $this->waitForFormUpdate();
+    }
+
+    public function hasAttribute(string $attributeName): bool
+    {
+        $this->changeTab();
+
+        return $this->hasElement('attribute_tab', ['%name%' => $attributeName]);
+    }
+
+    public function getNumberOfAttributes(): int
+    {
+        return count($this->getDocument()->findAll('css', '[data-test-attribute-tab]'));
+    }
+
     public function getAttributeValue(string $attribute, string $localeCode): string
     {
         $this->changeTab();
         $this->changeAttributeTab($attribute);
 
-        $attributeValue = $this->getElement('attribute_value', ['%attributeName%' => $attribute, '%localeCode%' => $localeCode]);
+        $attributeValue = $this->getElement('attribute_value', ['%attribute_name%' => $attribute, '%locale_code%' => $localeCode]);
 
         return match ($attributeValue->getTagName()) {
             'input' => $attributeValue->getValue(),
@@ -128,16 +96,27 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         };
     }
 
-    public function addSelectedAttributes(): void
+    public function getAttributeSelectText(string $attribute, string $localeCode): string
     {
-        $this->changeTab();
-        $this->clickButton('Add');
-        $this->waitForFormUpdate();
+        $this->clickTabIfItsNotActive();
+
+        return $this->getElement('attribute_select', ['%attribute_name%' => $attribute, '%locale_code%' => $localeCode])->getText();
     }
 
-    public function getNumberOfAttributes(): int
+    public function getValueNonTranslatableAttribute(string $attributeName): string
     {
-        return count($this->getDocument()->findAll('css', '[data-test-product-attribute-tab]'));
+        $this->changeTab();
+        $this->changeAttributeTab($attributeName);
+
+        return $this->getElement('attribute_input', ['%name%' => $attributeName])->getValue();
+    }
+
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string
+    {
+        $this->changeTab();
+        $this->changeAttributeTab($attributeName);
+
+        return $this->getValidationMessage('attribute_value', ['%attribute_name%' => $attributeName, '%locale_code%' => $localeCode]);
     }
 
     public function hasAttributeError(string $attributeName, string $localeCode): bool
@@ -145,7 +124,7 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         $this->changeTab();
         $this->changeAttributeTab($attributeName);
 
-        $attributeValue = $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode]);
+        $attributeValue = $this->getElement('attribute_value', ['%attribute_name%' => $attributeName, '%locale_code%' => $localeCode]);
 
         return $attributeValue->hasClass('is-invalid');
     }
@@ -153,21 +132,22 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
     protected function getDefinedElements(): array
     {
         return [
-            'product_attribute_delete_button' => '[data-test-product-attribute-delete-button="%attributeName%"]',
-            'product_attribute_input' => 'input[name="product_attributes"]',
-            'product_attribute_tab' => '[data-test-product-attribute-tab="%name%"]',
-            'attribute_value' => '[data-test-attribute-value][data-test-locale-code="%localeCode%"][data-test-attribute-name="%attributeName%"]',
-            'side_navigation_tab' => '[data-test-side-navigation-tab="%name%"]',
+            'attribute_add_button' => '[data-test-attribute-add-button]',
+            'attribute_autocomplete' => '[data-test-attribute-autocomplete] input[name="product_attributes"]',
+            'attribute_delete_button' => '[data-test-attribute-delete-button="%attribute_name%"]',
+            'attribute_input' => '[data-test-attribute-name="%name%"]',
+            'attribute_tab' => '[data-test-attribute-tab="%name%"]',
+            'attribute_value' => '[data-test-attribute-value][data-test-locale-code="%locale_code%"][data-test-attribute-name="%attribute_name%"]',
             'form' => '[data-live-name-value="sylius_admin:product:form"]',
+            'side_navigation_tab' => '[data-test-side-navigation-tab="%name%"]',
         ];
     }
 
     private function selectAttributeToBeAdded(string $attributeName): void
     {
-        $driver = $this->getDriver();
         $this->autocompleteHelper->selectByName(
-            $driver,
-            $this->getElement('product_attribute_input')->getXpath(),
+            $this->getDriver(),
+            $this->getElement('attribute_autocomplete')->getXpath(),
             $attributeName,
         );
     }
@@ -180,20 +160,9 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         }
     }
 
-    private function changeAttributeTab(string $attributeName): void
-    {
-        if (DriverHelper::isNotJavascript($this->getDriver())) {
-            return;
-        }
-
-        $this->getElement('product_attribute_tab', ['%name%' => $attributeName])->click();
-    }
-
     private function clickButton(string $locator): void
     {
-        if (DriverHelper::isJavascript($this->getDriver())) {
-            $this->getDocument()->pressButton($locator);
-        }
+        $this->getElement('attribute_add_button')->click();
     }
 
     private function changeTab(): void
@@ -203,5 +172,14 @@ final class AttributesFormElement extends BaseFormElement implements AttributesF
         }
 
         $this->getElement('side_navigation_tab', ['%name%' => 'attributes'])->click();
+    }
+
+    private function changeAttributeTab(string $attributeName): void
+    {
+        if (DriverHelper::isNotJavascript($this->getDriver())) {
+            return;
+        }
+
+        $this->getElement('attribute_tab', ['%name%' => $attributeName])->click();
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
@@ -29,9 +29,9 @@ interface AttributesFormElementInterface extends FormElementInterface
 
     public function getNumberOfAttributes(): int;
 
-    public function getAttributeValue(string $attribute, string $localeCode): string;
+    public function getAttributeValue(string $attributeName, string $localeCode): string;
 
-    public function getAttributeSelectText(string $attribute, string $localeCode): string;
+    public function getAttributeSelectText(string $attributeName, string $localeCode): string;
 
     public function getValueNonTranslatableAttribute(string $attributeName): string;
 

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
@@ -38,4 +38,6 @@ interface AttributesFormElementInterface
     public function addSelectedAttributes(): void;
 
     public function getNumberOfAttributes(): int;
+
+    public function hasAttributeError(string $attributeName, string $localeCode): bool;
 }

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElementInterface.php
@@ -13,31 +13,29 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Product;
 
-interface AttributesFormElementInterface
+use Sylius\Behat\Element\Admin\Crud\FormElementInterface;
+
+interface AttributesFormElementInterface extends FormElementInterface
 {
-    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;
-
-    public function removeAttribute(string $attributeName, string $localeCode): void;
-
-    public function getAttributeSelectText(string $attribute, string $localeCode): string;
-
-    public function getNonTranslatableAttributeValue(string $attribute): string;
-
-    public function hasAttribute(string $attributeName): bool;
-
-    public function hasNonTranslatableAttributeWithValue(string $attributeName, string $value): bool;
-
-    public function addNonTranslatableAttribute(string $attributeName, string $value): void;
-
     public function addAttribute(string $attributeName): void;
-
-    public function updateAttribute(string $attributeName, string $value, string $localeCode): void;
-
-    public function getAttributeValue(string $attribute, string $localeCode): string;
 
     public function addSelectedAttributes(): void;
 
+    public function updateAttribute(string $attributeName, string $value, string $localeCode): void;
+
+    public function removeAttribute(string $attributeName): void;
+
+    public function hasAttribute(string $attributeName): bool;
+
     public function getNumberOfAttributes(): int;
+
+    public function getAttributeValue(string $attribute, string $localeCode): string;
+
+    public function getAttributeSelectText(string $attribute, string $localeCode): string;
+
+    public function getValueNonTranslatableAttribute(string $attributeName): string;
+
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;
 
     public function hasAttributeError(string $attributeName, string $localeCode): bool;
 }

--- a/src/Sylius/Behat/Service/DriverHelper.php
+++ b/src/Sylius/Behat/Service/DriverHelper.php
@@ -27,6 +27,6 @@ abstract class DriverHelper
 
     public static function isNotJavascript(DriverInterface $driver): bool
     {
-        return !$driver instanceof Selenium2Driver && !$driver instanceof ChromeDriver;
+        return !$driver instanceof Selenium2Driver && !$driver instanceof ChromeDriver && !$driver instanceof PantherDriver;
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
@@ -87,7 +87,7 @@ class FormComponent
     {
         $mappedAttributes = [];
 
-        $attributes = $this->getForm()->createView()->children['attributes'];
+        $attributes = $this->getFormView()->children['attributes'];
 
         foreach ($attributes->children as $attribute) {
             /** @var ProductAttributeValueInterface $productAttributeValue */

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes.html.twig
@@ -4,13 +4,13 @@
     <div class="card mb-3">
         <div class="card-header">
             <h2 id="product-attributes" class="card-title">
-                {{ 'sylius.ui.attributes'|trans }} <span class="badge">{{ 'sylius.ui.work_in_progress'|trans }}</span>
+                {{ 'sylius.ui.attributes'|trans }}
             </h2>
         </div>
         <div class="card-body py-4 border-bottom">
             <div class="sylius-admin-product-attribute-autocomplete">
                 <twig:sylius_admin:product:product_attribute_autocomplete data-model="attributesToBeAdded:selectedAttributeCodes" :excludedAttributeCodes="product_attributes|keys" />
-                <button type="button" class="btn btn-primary" data-action="live#action" data-live-action-param="prevent|addAttributes">
+                <button type="button" class="btn btn-primary" data-action="live#action" data-live-action-param="prevent|addAttributes" {{ sylius_test_html_attribute('attribute-add-button') }}>
                     {{ 'sylius.ui.add'|trans }}
                 </button>
             </div>
@@ -27,7 +27,7 @@
                                 data-bs-target="#{{ product_attribute_code }}"
                                 aria-selected="{{ loop.first ? 'true' : 'false' }}"
                                 role="tab"
-                                {{ sylius_test_html_attribute('product-attribute-tab', product_attribute_name) }}
+                                {{ sylius_test_html_attribute('attribute-tab', product_attribute_name) }}
                             >
                                 <div class="d-flex justify-content-between align-items-center">
                                     <div>{{ product_attribute_name }}</div>
@@ -38,7 +38,7 @@
                                             data-action="live#action:stop"
                                             data-live-action-param="prevent|removeAttribute"
                                             data-live-attribute-code-param="{{ product_attribute_code }}"
-                                            {{ sylius_test_html_attribute('product-attribute-delete-button', product_attribute_name) }}
+                                            {{ sylius_test_html_attribute('attribute-delete-button', product_attribute_name) }}
                                         >
                                             <svg xmlns="http://www.w3.org/2000/svg" class="text-muted" width="12" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                                                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -64,7 +64,7 @@
                             >
                                 {% for product_attribute_value in product_attribute_values %}
                                     {% set locale_code = product_attribute_value.vars.data.localeCode %}
-                                    <div class="d-flex gap-2 mb-3">
+                                    <div class="field d-flex gap-2 mb-3">
                                         <div>
                                             {% if locale_code is not null %}
                                                 <span class="flag flag-sm flag-country-{{ locale_code|lower|split('_')|last }} me-3"></span>
@@ -93,7 +93,7 @@
                                                     'locale-code': product_attribute_value.localeCode.vars.value,
                                                 })
                                             ) }}
-
+                                            {{ form_errors(product_attribute_value.value) }}
                                             <input type="hidden" name="{{ product_attribute_value.attribute.vars.full_name }}" value="{{ product_attribute_value.attribute.vars.value }}">
                                             <input type="hidden" name="{{ product_attribute_value.localeCode.vars.full_name }}" value="{{ product_attribute_value.localeCode.vars.value }}">
                                         </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/product_attribute_autocomplete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/product_attribute_autocomplete.html.twig
@@ -1,4 +1,4 @@
-<div {{ attributes }} class="d-grid" {{ sylius_test_html_attribute('product-attribute-autocomplete') }}>
+<div {{ attributes }} class="d-grid" {{ sylius_test_html_attribute('attribute-autocomplete') }}>
     <input
         name="product_attributes"
         data-model="selectedAttributeCodes"


### PR DESCRIPTION
Doing the following steps:

1. Create/Update a product
2. Add a new product attribute
3. Hit the `Save/update` button without providing any value

results in disappearing product attribute we've tried to add. This PR fixes it.

The cause of the invalid behavior was this method:

```diff
    /**
     * @return array<string, array<string, FormView>>
     */
    #[ExposeInTemplate]
    public function getMappedProductAttributes(): array
    {
        $mappedAttributes = [];

+       $attributes = $this->getFormView()->children['attributes'];
-       $attributes = $this->getForm()->createView()->children['attributes'];

        foreach ($attributes->children as $attribute) {
            /** @var ProductAttributeValueInterface $productAttributeValue */
            $productAttributeValue = $attribute->vars['value'];

            $mappedAttributes[$productAttributeValue->getAttribute()->getCode()][$productAttributeValue->getLocaleCode()] = $attribute;
        }

        return $mappedAttributes;
    }
```

`->getFormView()` from the `FormWithComponentTrait` does one more additional action:
```php
    public function getFormView(): FormView
    {
        if (null === $this->formView) {
            $this->formView = $this->getForm()->createView();
            $this->useNameAttributesAsModelName(); // here
        }

        return $this->formView;
    }
```

and probably this is the reason. I've added a behat scenario to cover this.
