### PR TITLE
[PHPStan] `Negated Boolean Expression Is Always True` Issue Fix

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
@@ -48,7 +48,9 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
             }
         }
 
-        if (!$input->getArgument('email')) {
+        $email = $input->getArgument('email');
+
+        if ($email === null) {
             $question = new Question('Please enter an email:');
             $question->setValidator(function (?string $email) {
                 if (!filter_var($email, \FILTER_VALIDATE_EMAIL)) {
@@ -61,7 +63,9 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
             $input->setArgument('email', $email);
         }
 
-        if (!$input->getArgument('roles')) {
+        $roles = $input->getArgument('roles');
+
+        if ($roles === null) {
             $question = new Question('Please enter user\'s roles (separated by space):');
             $question->setValidator(function (?string $roles) {
                 if ('' === $roles) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

There was a PHPStan update that apparently introduced a new check:
<img width="717" alt="image" src="https://github.com/Sylius/Sylius/assets/40125720/8c63b34e-a931-4f13-a949-b78514d65462">
