### PR TITLE
[Inventory] Extend \RuntimeException by inventory exceptions

### DIFF
--- a/src/Sylius/Component/Core/Inventory/Exception/NotEnoughUnitsOnHandException.php
+++ b/src/Sylius/Component/Core/Inventory/Exception/NotEnoughUnitsOnHandException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Inventory\Exception;
 
-final class NotEnoughUnitsOnHandException extends \InvalidArgumentException
+final class NotEnoughUnitsOnHandException extends \RuntimeException
 {
     public function __construct(string $variantName)
     {

--- a/src/Sylius/Component/Core/Inventory/Exception/NotEnoughUnitsOnHoldException.php
+++ b/src/Sylius/Component/Core/Inventory/Exception/NotEnoughUnitsOnHoldException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Inventory\Exception;
 
-final class NotEnoughUnitsOnHoldException extends \InvalidArgumentException
+final class NotEnoughUnitsOnHoldException extends \RuntimeException
 {
     public function __construct(string $variantName)
     {

--- a/src/Sylius/Component/Core/spec/Inventory/Operator/OrderInventoryOperatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Inventory/Operator/OrderInventoryOperatorSpec.php
@@ -16,6 +16,8 @@ namespace spec\Sylius\Component\Core\Inventory\Operator;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\Core\Inventory\Exception\NotEnoughUnitsOnHandException;
+use Sylius\Component\Core\Inventory\Exception\NotEnoughUnitsOnHoldException;
 use Sylius\Component\Core\Inventory\Operator\OrderInventoryOperatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
@@ -123,7 +125,7 @@ final class OrderInventoryOperatorSpec extends ObjectBehavior
         $this->cancel($order);
     }
 
-    function it_throws_an_invalid_argument_exception_if_difference_between_on_hold_and_item_quantity_is_smaller_than_zero_during_cancelling(
+    function it_throws_a_not_enough_units_on_hold_exception_if_difference_between_on_hold_and_item_quantity_is_smaller_than_zero_during_cancelling(
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $variant,
@@ -139,10 +141,10 @@ final class OrderInventoryOperatorSpec extends ObjectBehavior
 
         $variant->getName()->willReturn('Red Skirt');
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('cancel', [$order]);
+        $this->shouldThrow(NotEnoughUnitsOnHoldException::class)->during('cancel', [$order]);
     }
 
-    function it_throws_an_invalid_argument_exception_if_difference_between_on_hold_and_item_quantity_is_smaller_than_zero_during_selling(
+    function it_throws_a_not_enough_units_on_hold_exception_if_difference_between_on_hold_and_item_quantity_is_smaller_than_zero_during_selling(
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $variant,
@@ -156,10 +158,10 @@ final class OrderInventoryOperatorSpec extends ObjectBehavior
 
         $variant->getName()->willReturn('Red Skirt');
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('sell', [$order]);
+        $this->shouldThrow(NotEnoughUnitsOnHoldException::class)->during('sell', [$order]);
     }
 
-    function it_throws_an_invalid_argument_exception_if_difference_between_on_hand_and_item_quantity_is_smaller_than_zero_during_selling(
+    function it_throws_a_not_enough_units_on_hand_exception_if_difference_between_on_hand_and_item_quantity_is_smaller_than_zero_during_selling(
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $variant,
@@ -174,7 +176,7 @@ final class OrderInventoryOperatorSpec extends ObjectBehavior
 
         $variant->getName()->willReturn('Red Skirt');
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('sell', [$order]);
+        $this->shouldThrow(NotEnoughUnitsOnHandException::class)->during('sell', [$order]);
     }
 
     function it_does_nothing_if_variant_is_not_tracked_during_cancelling(


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | after #16307, related to https://github.com/Sylius/Sylius/pull/16333
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
