### PR TITLE
[Inventory] Extract service for checking reserved stock availability for given order item

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -5,10 +5,12 @@
 
    ```diff
     public function __construct(
-    +   private OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker,
+    +   private OrderItemAvailabilityCheckerInterface|AvailabilityCheckerInterface $availabilityChecker,
     -   private AvailabilityCheckerInterface $availabilityChecker,
     )
     ```
+
+   If you have overwritten the service or its argument, check the correct functioning.
 
 # UPGRADING FROM `v1.12.13` TO `v1.12.14`
 

--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -1,3 +1,15 @@
+# UPGRADING FROM `v1.12.16` TO `v1.12.17`
+
+1. Due to a bug that was causing wrong calculation of available stock during completing a payment [REF](https://github.com/Sylius/Sylius/issues/16160),
+   The constructor of `Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener` has been modified as follows:
+
+   ```diff
+    public function __construct(
+    +   private OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker,
+    -   private AvailabilityCheckerInterface $availabilityChecker,
+    )
+    ```
+
 # UPGRADING FROM `v1.12.13` TO `v1.12.14`
 
 1. The `Accept-Language` header should now correctly resolve locale codes based on RFC 4647 using Symfony's request language negotiation,

--- a/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PaymentPreCompleteListener.php
@@ -16,11 +16,13 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 
 final class PaymentPreCompleteListener
 {
     public function __construct(
-        private OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker,
+        private OrderItemAvailabilityCheckerInterface|AvailabilityCheckerInterface $availabilityChecker,
     ) {
     }
 
@@ -31,16 +33,43 @@ final class PaymentPreCompleteListener
         $orderItems = $payment->getOrder()->getItems();
 
         foreach ($orderItems as $orderItem) {
-            if (!$this->orderItemAvailabilityChecker->isReservedStockSufficient($orderItem)) {
-                $variant = $orderItem->getVariant();
+            $variant = $orderItem->getVariant();
 
-                $event->setMessageType('error');
-                $event->setMessage('sylius.resource.payment.cannot_be_completed');
-                $event->setMessageParameters(['%productVariantCode%' => $variant->getCode()]);
-                $event->stopPropagation();
+            if ($this->availabilityChecker instanceof OrderItemAvailabilityCheckerInterface) {
+                if (!$this->availabilityChecker->isReservedStockSufficient($orderItem)) {
+                    $this->stopEvent($event, $variant->getCode());
+
+                    break;
+                }
+
+                continue;
+            }
+
+            if (!$this->isStockSufficient($variant, $orderItem->getQuantity())) {
+                $this->stopEvent($event, $variant->getCode());
 
                 break;
             }
         }
+    }
+
+    private function isStockSufficient(ProductVariantInterface $variant, int $quantity): bool
+    {
+        if (!$variant->isTracked()) {
+            return true;
+        }
+
+        return
+            $variant->getOnHold() - $quantity >= 0 &&
+            $variant->getOnHand() - $quantity >= 0
+        ;
+    }
+
+    private function stopEvent(ResourceControllerEvent $event, string $variantCode): void
+    {
+        $event->setMessageType('error');
+        $event->setMessage('sylius.resource.payment.cannot_be_completed');
+        $event->setMessageParameters(['%productVariantCode%' => $variantCode]);
+        $event->stopPropagation();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -132,6 +132,9 @@
         </service>
         <service id="Sylius\Component\Customer\Context\CustomerContextInterface" alias="sylius.context.customer" />
 
+        <service id="sylius.inventory.order_item_availability_checker" class="Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityChecker"/>
+        <service id="Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface" alias="sylius.inventory.order_item_availability_checker" />
+
         <service id="sylius.inventory.order_inventory_operator" class="Sylius\Component\Core\Inventory\Operator\OrderInventoryOperator"/>
         <service id="Sylius\Component\Core\Inventory\Operator\OrderInventoryOperatorInterface" alias="sylius.inventory.order_inventory_operator" />
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -99,6 +99,7 @@
         </service>
 
         <service id="Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener">
+            <argument type="service" id="sylius.inventory.order_item_availability_checker" />
             <tag name="kernel.event_listener" event="sylius.payment.pre_complete" method="checkStockAvailability" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/PaymentPreCompleteListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/PaymentPreCompleteListenerSpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -23,21 +24,23 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 
 final class PaymentPreCompleteListenerSpec extends ObjectBehavior
 {
-    function it_does_nothing_if_no_item_is_tracked(
+    function let(OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker)
+    {
+        $this->beConstructedWith($orderItemAvailabilityChecker);
+    }
+
+    function it_does_nothing_if_reserved_stock_is_sufficient(
+        OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker,
         ResourceControllerEvent $event,
         PaymentInterface $payment,
         OrderInterface $order,
         OrderItemInterface $orderItem,
-        ProductVariantInterface $variant,
     ): void {
         $event->getSubject()->willReturn($payment);
         $payment->getOrder()->willReturn($order);
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
-        $orderItem->getVariant()->willReturn($variant);
-        $orderItem->getQuantity()->willReturn(2);
-
-        $variant->isTracked()->willReturn(false);
+        $orderItemAvailabilityChecker->isReservedStockSufficient($orderItem)->willReturn(true);
 
         $event->setMessageType('error')->shouldNotBeCalled();
         $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldNotBeCalled();
@@ -46,7 +49,8 @@ final class PaymentPreCompleteListenerSpec extends ObjectBehavior
         $this->checkStockAvailability($event);
     }
 
-    function it_does_nothing_if_stock_is_sufficient_for_items(
+    function it_prevents_completing_the_payment_if_reserved_stock_is_not_sufficient(
+        OrderItemAvailabilityCheckerInterface $orderItemAvailabilityChecker,
         ResourceControllerEvent $event,
         PaymentInterface $payment,
         OrderInterface $order,
@@ -57,64 +61,9 @@ final class PaymentPreCompleteListenerSpec extends ObjectBehavior
         $payment->getOrder()->willReturn($order);
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
-        $orderItem->getVariant()->willReturn($variant);
-        $orderItem->getQuantity()->willReturn(2);
-
-        $variant->isTracked()->willReturn(true);
-        $variant->getOnHold()->willReturn(2);
-        $variant->getOnHand()->willReturn(3);
-
-        $event->setMessageType('error')->shouldNotBeCalled();
-        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldNotBeCalled();
-        $event->stopPropagation()->shouldNotBeCalled();
-
-        $this->checkStockAvailability($event);
-    }
-
-    function it_prevents_completing_the_payment_if_on_hold_amount_is_not_sufficient_for_item(
-        ResourceControllerEvent $event,
-        PaymentInterface $payment,
-        OrderInterface $order,
-        OrderItemInterface $orderItem,
-        ProductVariantInterface $variant,
-    ): void {
-        $event->getSubject()->willReturn($payment);
-        $payment->getOrder()->willReturn($order);
-        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
+        $orderItemAvailabilityChecker->isReservedStockSufficient($orderItem)->willReturn(false);
 
         $orderItem->getVariant()->willReturn($variant);
-        $orderItem->getQuantity()->willReturn(2);
-
-        $variant->isTracked()->willReturn(true);
-        $variant->getOnHold()->willReturn(1);
-        $variant->getOnHand()->willReturn(3);
-        $variant->getCode()->willReturn('CODE');
-
-        $event->setMessageType('error')->shouldBeCalled();
-        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldBeCalled();
-        $event->setMessageParameters(['%productVariantCode%' => 'CODE'])->shouldBeCalled();
-        $event->stopPropagation()->shouldBeCalled();
-
-        $this->checkStockAvailability($event);
-    }
-
-    function it_prevents_completing_the_payment_if_on_hand_amount_is_not_sufficient_for_item(
-        ResourceControllerEvent $event,
-        PaymentInterface $payment,
-        OrderInterface $order,
-        OrderItemInterface $orderItem,
-        ProductVariantInterface $variant,
-    ): void {
-        $event->getSubject()->willReturn($payment);
-        $payment->getOrder()->willReturn($order);
-        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
-
-        $orderItem->getVariant()->willReturn($variant);
-        $orderItem->getQuantity()->willReturn(2);
-
-        $variant->isTracked()->willReturn(true);
-        $variant->getOnHold()->willReturn(3);
-        $variant->getOnHand()->willReturn(1);
         $variant->getCode()->willReturn('CODE');
 
         $event->setMessageType('error')->shouldBeCalled();

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/PaymentPreCompleteListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/PaymentPreCompleteListenerSpec.php
@@ -21,6 +21,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 
 final class PaymentPreCompleteListenerSpec extends ObjectBehavior
 {
@@ -64,6 +65,119 @@ final class PaymentPreCompleteListenerSpec extends ObjectBehavior
         $orderItemAvailabilityChecker->isReservedStockSufficient($orderItem)->willReturn(false);
 
         $orderItem->getVariant()->willReturn($variant);
+        $variant->getCode()->willReturn('CODE');
+
+        $event->setMessageType('error')->shouldBeCalled();
+        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldBeCalled();
+        $event->setMessageParameters(['%productVariantCode%' => 'CODE'])->shouldBeCalled();
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->checkStockAvailability($event);
+    }
+    function it_does_nothing_if_no_item_is_tracked_when_order_item_availability_checker_is_not_passed(
+        AvailabilityCheckerInterface $availabilityChecker,
+        ResourceControllerEvent $event,
+        PaymentInterface $payment,
+        OrderInterface $order,
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->beConstructedWith($availabilityChecker);
+
+        $event->getSubject()->willReturn($payment);
+        $payment->getOrder()->willReturn($order);
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
+
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(false);
+
+        $event->setMessageType('error')->shouldNotBeCalled();
+        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldNotBeCalled();
+        $event->stopPropagation()->shouldNotBeCalled();
+
+        $this->checkStockAvailability($event);
+    }
+
+    function it_does_nothing_if_stock_is_sufficient_for_items_when_order_item_availability_checker_is_not_passed(
+        AvailabilityCheckerInterface $availabilityChecker,
+        ResourceControllerEvent $event,
+        PaymentInterface $payment,
+        OrderInterface $order,
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->beConstructedWith($availabilityChecker);
+
+        $event->getSubject()->willReturn($payment);
+        $payment->getOrder()->willReturn($order);
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
+
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(2);
+        $variant->getOnHand()->willReturn(3);
+
+        $event->setMessageType('error')->shouldNotBeCalled();
+        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldNotBeCalled();
+        $event->stopPropagation()->shouldNotBeCalled();
+
+        $this->checkStockAvailability($event);
+    }
+
+    function it_prevents_completing_the_payment_if_on_hold_amount_is_not_sufficient_for_item_when_order_item_availability_checker_is_not_passed(
+        AvailabilityCheckerInterface $availabilityChecker,
+        ResourceControllerEvent $event,
+        PaymentInterface $payment,
+        OrderInterface $order,
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->beConstructedWith($availabilityChecker);
+
+        $event->getSubject()->willReturn($payment);
+        $payment->getOrder()->willReturn($order);
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
+
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(1);
+        $variant->getOnHand()->willReturn(3);
+        $variant->getCode()->willReturn('CODE');
+
+        $event->setMessageType('error')->shouldBeCalled();
+        $event->setMessage('sylius.resource.payment.cannot_be_completed')->shouldBeCalled();
+        $event->setMessageParameters(['%productVariantCode%' => 'CODE'])->shouldBeCalled();
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->checkStockAvailability($event);
+    }
+
+    function it_prevents_completing_the_payment_if_on_hand_amount_is_not_sufficient_for_item_when_order_item_availability_checker_is_not_passed(
+        AvailabilityCheckerInterface $availabilityChecker,
+        ResourceControllerEvent $event,
+        PaymentInterface $payment,
+        OrderInterface $order,
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $this->beConstructedWith($availabilityChecker);
+
+        $event->getSubject()->willReturn($payment);
+        $payment->getOrder()->willReturn($order);
+        $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
+
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(3);
+        $variant->getOnHand()->willReturn(1);
         $variant->getCode()->willReturn('CODE');
 
         $event->setMessageType('error')->shouldBeCalled();

--- a/src/Sylius/Component/Core/Inventory/Checker/OrderItemAvailabilityChecker.php
+++ b/src/Sylius/Component/Core/Inventory/Checker/OrderItemAvailabilityChecker.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Inventory\Checker;
+
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+final class OrderItemAvailabilityChecker implements OrderItemAvailabilityCheckerInterface
+{
+    public function isReservedStockSufficient(OrderItemInterface $orderItem): bool
+    {
+        $variant = $orderItem->getVariant();
+        if (!$variant->isTracked()) {
+            return true;
+        }
+
+        $quantity = $orderItem->getQuantity();
+
+        return
+            $variant->getOnHold() - $quantity >= 0 &&
+            $variant->getOnHand() - $quantity >= 0
+        ;
+    }
+}

--- a/src/Sylius/Component/Core/Inventory/Checker/OrderItemAvailabilityCheckerInterface.php
+++ b/src/Sylius/Component/Core/Inventory/Checker/OrderItemAvailabilityCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Inventory\Checker;
+
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+interface OrderItemAvailabilityCheckerInterface
+{
+    public function isReservedStockSufficient(OrderItemInterface $orderItem): bool;
+}

--- a/src/Sylius/Component/Core/spec/Inventory/Checker/OrderItemAvailabilityCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Inventory/Checker/OrderItemAvailabilityCheckerSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Core\Inventory\Checker;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+final class OrderItemAvailabilityCheckerSpec extends ObjectBehavior
+{
+    function it_implements_an_order_item_availability_checker_interface(): void
+    {
+        $this->shouldImplement(OrderItemAvailabilityCheckerInterface::class);
+    }
+
+    function it_returns_true_if_variant_is_untracked(
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $orderItem->getVariant()->willReturn($variant);
+        $variant->isTracked()->willReturn(false);
+
+        $this->isReservedStockSufficient($orderItem)->shouldReturn(true);
+    }
+
+    function it_returns_true_if_stock_is_sufficient(
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(2);
+        $variant->getOnHand()->willReturn(2);
+
+        $this->isReservedStockSufficient($orderItem)->shouldReturn(true);
+    }
+
+    function it_returns_false_if_on_hold_value_is_not_sufficient(
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(1);
+        $variant->getOnHand()->willReturn(2);
+
+        $this->isReservedStockSufficient($orderItem)->shouldReturn(false);
+    }
+
+    function it_returns_false_if_on_hand_value_is_not_sufficient(
+        OrderItemInterface $orderItem,
+        ProductVariantInterface $variant,
+    ): void {
+        $orderItem->getVariant()->willReturn($variant);
+        $orderItem->getQuantity()->willReturn(2);
+
+        $variant->isTracked()->willReturn(true);
+        $variant->getOnHold()->willReturn(2);
+        $variant->getOnHand()->willReturn(1);
+
+        $this->isReservedStockSufficient($orderItem)->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | after #16307
| License         | MIT

In order to make it easier to customise the logic for checking the available stock, I would like to extract it from the listener into a separate service.

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
