### PR TITLE
Add a note to UPGRADE file about changing PaymentPreCompleteListener's constructor

### DIFF
--- a/UPGRADE-1.13.md
+++ b/UPGRADE-1.13.md
@@ -1,3 +1,17 @@
+# UPGRADING FROM `v1.13.1` TO `v1.13.2`
+
+1. Due to a bug that was causing wrong calculation of available stock during completing a payment [REF](https://github.com/Sylius/Sylius/issues/16160),
+   The constructor of `Sylius\Bundle\CoreBundle\EventListener\PaymentPreCompleteListener` has been modified as follows:
+
+   ```diff
+    public function __construct(
+    +   private OrderItemAvailabilityCheckerInterface|AvailabilityCheckerInterface $availabilityChecker,
+    -   private AvailabilityCheckerInterface $availabilityChecker,
+    )
+    ```
+
+   If you have overwritten the service or its argument, check the correct functioning.
+
 # UPGRADE FROM `v1.12.X` TO `v1.13.0`
 
 ## Preconditions


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | after #16344
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
