### PR TITLE
Add missing required field mark and error messages to product option value field

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/product_option/form/sections/values/value/translations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_option/form/sections/values/value/translations.html.twig
@@ -1,14 +1,14 @@
 {% for translation_form in hookable_metadata.context.value_form.translations %}
     <div class="row">
         <div class="col">
-            <div class="mt-3">
                 {% if translation_form.vars.name is not null %}
-                    <span class="flag flag-sm flag-country-{{ translation_form.vars.name|lower|split('_')|last }} me-3"></span>
-                    {{ translation_form.vars.name|sylius_locale_name }}
+                <div class="d-flex">
+                    <span class="flag flag-sm flag-country-{{ translation_form.vars.name|lower|split('_')|last }} me-2 mt-3"></span>
+                    <div class="me-3 mt-1">{{ form_label(translation_form, translation_form.vars.name|sylius_locale_name) }}</div>
+                </div>
                 {% else %}
                     <span class="flag flag-sm flag-country-eu me-3"></span>
                 {% endif %}
-            </div>
         </div>
         <div class="col-9">
             <div class="d-flex">
@@ -17,6 +17,8 @@
                         translation_form.value,
                         sylius_test_form_attribute('option-value-translation')
                     ) }}
+
+                    {{ form_errors(translation_form.value) }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | a bit
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
![Screenshot 2024-06-17 at 11 12 01](https://github.com/Sylius/Sylius/assets/53942444/ef1ad456-8ec1-463a-ae42-fbc32a5e0ea0)


