### PR TITLE
[User] Reflect New Default Token Length in the Packages Tests

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/UserBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -33,7 +33,7 @@ final class ConfigurationTest extends TestCase
                         'resetting' => [
                             'token' => [
                                 'ttl' => 'P1D',
-                                'length' => 16,
+                                'length' => 64,
                                 'field_name' => 'passwordResetToken',
                             ],
                             'pin' => [


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | https://github.com/Sylius/Sylius/pull/16393 https://github.com/Sylius/Sylius/pull/16393/files#diff-2457b8aae3ac4bde24b495649d257987a0d616a1b6aa945c94f7764ab7387c40R69
| License         | MIT

The aforementioned PR has been merged into version `1.12`. In `1.13`, we added a package test to verify the token length. This PR reflects that updated default value.