### PR TITLE
Fix typos in the product options twig hooks

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
@@ -4,7 +4,7 @@ twig_hooks:
             form:
                 component: 'sylius_admin:product_option:form'
                 props:
-                    productOption: '@=_context.resource'
+                    resource: '@=_context.resource'
                     form: '@=_context.form'
 
         'sylius_admin.product_option.create.content.form':

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
@@ -4,7 +4,7 @@ twig_hooks:
             form:
                 component: 'sylius_admin:product_option:form'
                 props:
-                    country: '@=_context.resource'
+                    resource: '@=_context.resource'
                     form: '@=_context.form'
                 configuration:
                     method: 'PUT'

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductOption/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductOption/FormComponent.php
@@ -30,7 +30,7 @@ class FormComponent
     use LiveCollectionTrait;
 
     #[LiveProp(fieldName: 'resource')]
-    public ?ProductOption $productOption = null;
+    public ?ProductOption $resource = null;
 
     /** @param class-string $formClass */
     public function __construct(
@@ -41,6 +41,6 @@ class FormComponent
 
     protected function instantiateForm(): FormInterface
     {
-        return $this->formFactory->create($this->formClass, $this->productOption);
+        return $this->formFactory->create($this->formClass, $this->resource);
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
we had some issue with "disappearing" disabled attribute from the `code` fields due to inconsistency in the props configuration
