### PR TITLE
[Docs] Add a link to the database schema

### DIFF
--- a/docs/book/installation/requirements.rst
+++ b/docs/book/installation/requirements.rst
@@ -67,7 +67,9 @@ By default, the database connection is pre-configured to work with a following M
 
 .. note::
 
-    You might also use any other RDBMS (like PostgreSQL), but our database migrations support MySQL only.
+    You might also use any other RDBMS (like PostgreSQL).
+
+The Sylius Database Schema is available `here <https://drawsql.app/templates/sylius>`_.
 
 NPM Package Manager
 -------------------

--- a/docs/cookbook/configuration/installation-commands.rst
+++ b/docs/cookbook/configuration/installation-commands.rst
@@ -25,6 +25,7 @@ Sylius can create or even reset the database/schema for you, simply call:
 
 The command will check if your database schema exists. If yes, you may decide to recreate it from scratch, otherwise Sylius will take care of this automatically.
 It also allows you to load sample data.
+You can review the Sylius Database Schema `here <https://drawsql.app/templates/sylius>`_.
 
 Loading sample data
 -------------------

--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -406,3 +406,8 @@ Which we strongly recommend over updating the schema.
 you'll need to update its form type. Check how to do it :doc:`here </customization/form>`.
 
 .. include:: /customization/plugins.rst
+
+Learn more
+----------
+
+* `Sylius Database Schema <https://drawsql.app/templates/sylius>`_


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13

https://drawsql.app/templates/sylius

There is a place where you can view a visual representation of Sylius' database schema. I believe adding a link to it in a few places in the docs might be handy.

Please wait for @GSadee to update the schema before merging 🙏🏻 

*Additionally I've removed the information on the unsupported database migrations for DBs other than MySQL. *[ref](https://sylius-community.slack.com/archives/C3EGDG9LY/p1718651913317339)*