### PR TITLE
Deprecate CustomerTypeExtension and AddUserFormSubscriber

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/AddUserFormSubscriber.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/AddUserFormSubscriber.php
@@ -21,6 +21,14 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints\Valid;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0.',
+    AddUserFormSubscriber::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 final class AddUserFormSubscriber implements EventSubscriberInterface
 {
     public function __construct(private string $entryType)

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
@@ -19,6 +19,14 @@ use Sylius\Bundle\CustomerBundle\Form\Type\CustomerType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0.',
+    CustomerTypeExtension::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 final class CustomerTypeExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/src/Sylius/UPGRADE-1.14.md
+++ b/src/Sylius/UPGRADE-1.14.md
@@ -2,5 +2,11 @@
 
 ### Deprecations
 
-1. The `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionScopeTypeExtension` and `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionActionTypeExtension` have been deprecated and will be removed in Sylius 2.0.
+1. The following form extensions have been deprecated and will be removed in Sylius 2.0:
+    - `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionScopeTypeExtension`
+    - `Sylius\Bundle\AdminBundle\Form\Extension\CatalogPromotionActionTypeExtension`
+    - `Sylius\Bundle\CoreBundle\Form\Extension\CustomerTypeExtension`
+
    Starting with this version, form types will be extended using the parent form instead of through form extensions.
+
+1. The `Sylius\Bundle\CoreBundle\Form\EventSubscriber\AddUserFormSubscriber` has been deprecated and will be removed in Sylius 2.0.


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14  <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.12 or 1.13 branches
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
[REF](https://github.com/Sylius/Sylius/pull/16458)
