### PR TITLE
Fix ProductTaxons' positioning logic

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -72,7 +72,7 @@ class ProductTaxonController extends ResourceController
             return $this->redirectHandler->redirectToReferer($configuration);
         }
 
-        $maxPosition = $this->getMaxPosition($configuration);
+        $maxPosition = $this->getMaxPosition($productTaxonsPositions);
 
         try {
             $this->updatePositions($productTaxonsPositions, $maxPosition);
@@ -120,13 +120,16 @@ class ProductTaxonController extends ResourceController
         }
     }
 
-    private function getMaxPosition(RequestConfiguration $configuration): int
+    /** @param array<int, string> $productTaxonsPositions */
+    private function getMaxPosition(array $productTaxonsPositions): int
     {
-        /** @var ProductTaxonInterface $productTaxon */
-        $productTaxon = $this->findOr404($configuration);
+        $firstProductTaxonId = array_keys($productTaxonsPositions)[0];
 
         /** @var EntityRepository&RepositoryInterface $repository */
         $repository = $this->repository;
+
+        /** @var ProductTaxonInterface $productTaxon */
+        $productTaxon = $repository->find($firstProductTaxonId);
 
         return $repository->count(['taxon' => $productTaxon->getTaxon()]) - 1;
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | outlined in https://github.com/Sylius/Sylius/pull/15225#issuecomment-1790825230
| License         | MIT

The second issue:
>The other error is smaller, the count should not be reduced by 1 because the positioner will check for $newPosition >= $maxPosition. If you move a product to the last one in the taxon it will change it to the second-last position.

does not occur since when the `$newPosition >= $maxPosition` check is true, the position is set to `-1` instead of being reduced by 1. After that, the default Gedmo logic kicks in and `-1` gets converted into the last position.