### PR TITLE
Use callback wrapper for LocaleChoiceType choices

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -41,7 +41,7 @@ final class LocaleChoiceType extends AbstractType
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'choices' => fn (Options $options): array => $this->localeRepository->findAll(),
+            'choices' => fn (): array => $this->localeRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -41,7 +41,7 @@ final class LocaleChoiceType extends AbstractType
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'choices' => fn (): array => $this->localeRepository->findAll(),
+            'choices' => fn (Options $options): array => $this->localeRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -18,6 +18,7 @@ use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class LocaleChoiceType extends AbstractType
@@ -40,7 +41,7 @@ final class LocaleChoiceType extends AbstractType
         parent::configureOptions($resolver);
 
         $resolver->setDefaults([
-            'choices' => $this->localeRepository->findAll(),
+            'choices' => fn (Options $options): array => $this->localeRepository->findAll(),
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,


### PR DESCRIPTION
Using the callback wrapper to resolve the LocaleChoiceType keeping old entity objects during tests where both the form is build and submit through the Symfony PhpUnit WebTestCase.

Also see https://github.com/Sylius/Sylius/issues/16572

| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #https://github.com/Sylius/Sylius/issues/16572
| License         | MIT
