### PR TITLE
[Admin] Make Marketing and Configuration Menu Elements Always Open

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/menu.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/menu.html.twig
@@ -29,7 +29,7 @@
         {%- set classes = classes|merge([options.lastClass]) %}
     {%- endif %}
 
-    {% set always_open = ['catalog', 'sales', 'customers'] %}
+    {% set always_open = ['catalog', 'sales', 'customers', 'marketing', 'configuration'] %}
     {% set is_active = matcher.isCurrent(item) or matcher.isAncestor(item, options.matchingDepth)  or item.name in always_open %}
 
     {# Mark item as "leaf" (no children) or as "branch" (has children that are displayed) #}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

From my perspective, it's quite common to click on these menu elements, so having to expand these sections every time is a bit annoying. My proposal is to keep them always open 💃 