### PR TITLE
[API] Hide GET endpoint for Shipping Method Translation resource

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ShippingMethodTranslation.xml
@@ -18,12 +18,17 @@
 >
     <resource class="Sylius\Component\Shipping\Model\ShippingMethodTranslation" uriTemplate="/admin/shipping-methods/{code}/translations/{localeCode}">
         <uriVariables>
-            <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ShippingMethod" fromProperty="translatable" />
+            <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ShippingMethod" fromProperty="translations" />
             <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Shipping\Model\ShippingMethodTranslation" fromProperty="locale" />
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" />
+            <operation
+                class="ApiPlatform\Metadata\Get"
+                controller="ApiPlatform\Action\NotFoundAction"
+                read="false"
+                output="false"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -17,6 +17,7 @@ parameters:
         - "%sylius.security.new_api_route%/admin/promotion-actions/{id}"
         - "%sylius.security.new_api_route%/admin/promotion-rules/{id}"
         - "%sylius.security.new_api_route%/admin/shipping-method-rules/{id}"
+        - "%sylius.security.new_api_route%/admin/shipping-methods/{code}/translations/{localeCode}"
         - "%sylius.security.new_api_route%/admin/shop-users/{id}"
         - "%sylius.security.new_api_route%/shop/adjustments/{id}"
     sylius.security.new_api_route: "/api/v2"

--- a/tests/Api/Admin/ShippingMethodTranslationsTest.php
+++ b/tests/Api/Admin/ShippingMethodTranslationsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Api\Admin;
+
+use Sylius\Tests\Api\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ShippingMethodTranslationsTest extends JsonApiTestCase
+{
+    protected function setUp(): void
+    {
+        $this->setUpAdminContext();
+        $this->setUpDefaultGetHeaders();
+
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_returns_not_found_on_get_shipping_method_translation(): void
+    {
+        $this->loadFixturesFromFiles([
+            'authentication/api_administrator.yaml',
+            'channel.yaml',
+            'country.yaml',
+            'shipping_method.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/admin/shipping-methods/UPS/translations/en_US');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | api-platform-3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | after #16582 
| License         | MIT

As the endpoint `/api/v2/admin/shipping-methods/{code}/translations/{localeCode}` is not working at the moment and, above all, because the management of translations is done via the parent entity, I guess that the best thing to do at the moment is to hide it.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
