### PR TITLE
[API] Fix GET endpoint for Shipping Method Translation resource

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ShippingMethodTranslation.xml
@@ -18,12 +18,22 @@
 >
     <resource class="Sylius\Component\Shipping\Model\ShippingMethodTranslation" uriTemplate="/admin/shipping-methods/{code}/translations/{localeCode}">
         <uriVariables>
-            <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ShippingMethod" fromProperty="translatable" />
-            <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Shipping\Model\ShippingMethodTranslation" fromProperty="locale" />
+            <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ShippingMethod" fromProperty="translations" />
+            <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Shipping\Model\ShippingMethodTranslation" />
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" />
+            <operation class="ApiPlatform\Metadata\Get">
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:admin:shipping_method_translation:show</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+            </operation>
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShippingMethodTranslation.xml
@@ -17,11 +17,13 @@
 >
     <class name="Sylius\Component\Shipping\Model\ShippingMethodTranslation">
         <attribute name="id">
+            <group>sylius:admin:shipping_method_translation:show</group>
             <group>sylius:admin:shipping_method:index</group>
             <group>sylius:admin:shipping_method:show</group>
         </attribute>
 
         <attribute name="name">
+            <group>sylius:admin:shipping_method_translation:show</group>
             <group>sylius:admin:shipping_method:create</group>
             <group>sylius:admin:shipping_method:index</group>
             <group>sylius:admin:shipping_method:show</group>
@@ -29,6 +31,7 @@
         </attribute>
 
         <attribute name="description">
+            <group>sylius:admin:shipping_method_translation:show</group>
             <group>sylius:admin:shipping_method:create</group>
             <group>sylius:admin:shipping_method:index</group>
             <group>sylius:admin:shipping_method:show</group>
@@ -36,8 +39,13 @@
         </attribute>
 
         <attribute name="locale">
+            <group>sylius:admin:shipping_method_translation:show</group>
             <group>sylius:admin:shipping_method:create</group>
             <group>sylius:admin:shipping_method:update</group>
+        </attribute>
+
+        <attribute name="translatable" serialized-name="shippingMethod">
+            <group>sylius:admin:shipping_method_translation:show</group>
         </attribute>
     </class>
 </serializer>

--- a/tests/Api/Admin/ShippingMethodTranslationsTest.php
+++ b/tests/Api/Admin/ShippingMethodTranslationsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Api\Admin;
+
+use Sylius\Tests\Api\JsonApiTestCase;
+
+final class ShippingMethodTranslationsTest extends JsonApiTestCase
+{
+    protected function setUp(): void
+    {
+        $this->setUpAdminContext();
+        $this->setUpDefaultGetHeaders();
+
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_gets_shipping_method_translation(): void
+    {
+        $this->loadFixturesFromFiles([
+            'authentication/api_administrator.yaml',
+            'channel.yaml',
+            'country.yaml',
+            'shipping_method.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/admin/shipping-methods/UPS/translations/en_US');
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/shipping_method_translation/get_shipping_method_translation_response',
+        );
+    }
+}

--- a/tests/Api/Responses/admin/shipping_method_translation/get_shipping_method_translation_response.json
+++ b/tests/Api/Responses/admin/shipping_method_translation/get_shipping_method_translation_response.json
@@ -1,0 +1,10 @@
+{
+    "@context": "\/api\/v2\/contexts\/ShippingMethodTranslation",
+    "@id": "\/api\/v2\/admin\/shipping-methods\/UPS\/translations\/en_US",
+    "@type": "ShippingMethodTranslation",
+    "id": @integer@,
+    "name": "UPS",
+    "description": "@string@",
+    "locale": "en_US",
+    "shippingMethod": "\/api\/v2\/admin\/shipping-methods\/UPS"
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         |api-platform-3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | replaces #16588 
| License         | MIT

Alternative to #16588, which fixes the endpoint `/api/v2/admin/shipping-methods/{code}/translations/{localeCode}`

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
