### PR TITLE
[Core] Fix #16603 SyliusCollector do not display API tag properly

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
@@ -37,7 +37,7 @@ final class SyliusCollector extends DataCollector
             'default_locale_code' => $defaultLocaleCode,
             'locale_code' => null,
             'extensions' => [
-                'SyliusAdminApiBundle' => ['name' => 'API', 'enabled' => false],
+                'SyliusApiBundle' => ['name' => 'API', 'enabled' => false],
                 'SyliusAdminBundle' => ['name' => 'Admin', 'enabled' => false],
                 'SyliusShopBundle' => ['name' => 'Shop', 'enabled' => false],
             ],


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16603
| License         | MIT

