### PR TITLE
[CI] Run 1.14 full build instead of unsupported 1.12

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration 1.12 (Full)
+name: Continuous Integration 1.14 (Full)
 
 on:
     schedule:
@@ -17,7 +17,7 @@ jobs:
     static-checks:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] Static checks"
         uses: ./.github/workflows/ci_static-checks.yaml
         with:
@@ -26,7 +26,7 @@ jobs:
     e2e-mariadb:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] End-to-end tests (MariaDB)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mariadb.yaml
@@ -36,7 +36,7 @@ jobs:
     e2e-mysql:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] End-to-end tests (MySQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mysql.yaml
@@ -46,7 +46,7 @@ jobs:
     e2e-pgsql:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] End-to-end tests (PostgreSQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-pgsql.yaml
@@ -56,7 +56,7 @@ jobs:
     e2e-custom:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] End-to-end tests (Custom)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-custom.yaml
@@ -72,7 +72,7 @@ jobs:
     packages:
         strategy:
             matrix:
-                branch: [ "1.12" ]
+                branch: [ "1.14" ]
         name: "[${{ matrix.branch }}] Packages"
         needs: static-checks
         uses: ./.github/workflows/ci_packages.yaml


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
