### PR TITLE
Filter 'cancel unpaid orders' command by channel (optional)

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Console/Command/CancelUnpaidOrdersCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/CancelUnpaidOrdersCommand.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Console\Command;
 
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use SyliusLabs\Polyfill\Symfony\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,27 +24,44 @@ final class CancelUnpaidOrdersCommand extends ContainerAwareCommand
 {
     protected static $defaultName = 'sylius:cancel-unpaid-orders';
 
+    public function __construct(
+        private ChannelRepositoryInterface $channelRepository
+    ) {}
+
     protected function configure(): void
     {
         $this
             ->setDescription(
                 'Removes order that have been unpaid for a configured period. Configuration parameter - sylius_order.order_expiration_period.',
             )
+            ->addArgument(
+                'channel',
+                InputArgument::IS_ARRAY | InputArgument::OPTIONAL,
+                'Channel filter (optional), supply channel codes'
+            )
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $channelInput = $input->getArgument('channel', []);
+        $channels = !empty($channelInput)
+            ? $this->channelRepository->findBy(['code' => $channelInput])
+            : $this->channelRepository->findAll();
+
         $expirationTime = $this->getContainer()->getParameter('sylius_order.order_expiration_period');
         $output->writeln(sprintf(
-            'Command will cancel orders that have been unpaid for <info>%s</info>.',
+            'Command will cancel orders that have been unpaid for <info>%s</info>, channels <info>%s</info>.',
             (string) $expirationTime,
+            join(', ', array_map(fn (ChannelInterface $channel) => $channel->getCode(), $channels)),
         ));
 
         $unpaidCartsStateUpdater = $this->getContainer()->get('sylius.unpaid_orders_state_updater');
-        $unpaidCartsStateUpdater->cancel();
+        foreach ($channels as $channel) {
+            $unpaidCartsStateUpdater->cancel($channel);
 
-        $this->getContainer()->get('sylius.manager.order')->flush();
+            $this->getContainer()->get('sylius.manager.order')->flush();
+        }
 
         $output->writeln('<info>Unpaid orders have been canceled</info>');
 

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -398,7 +398,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         ;
     }
 
-    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate, ?int $limit = null): array
+    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate, ?int $limit = null, ?ChannelInterface $channel = null): array
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->where('o.checkoutState = :checkoutState')
@@ -414,6 +414,10 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         if (null !== $limit) {
             Assert::positiveInteger($limit);
             $queryBuilder->setMaxResults($limit);
+        }
+
+        if (null !== $channel) {
+            $queryBuilder->andWhere('o.channel = :channel')->setParameter('channel', $channel);
         }
 
         return $queryBuilder->getQuery()->getResult();

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/console_command.xml
@@ -16,6 +16,7 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\CoreBundle\Console\Command\CancelUnpaidOrdersCommand">
+            <argument type="service" id="sylius.repository.channel" />
             <tag name="console.command" />
         </service>
 

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -98,7 +98,7 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
     /**
      * @return array|OrderInterface[]
      */
-    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate, ?int $limit = null): array;
+    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate, ?int $limit = null, ?ChannelInterface $channel = null): array;
 
     public function findCartForSummary($id): ?OrderInterface;
 

--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -20,6 +20,7 @@ use SM\Factory\FactoryInterface;
 use Sylius\Abstraction\StateMachine\Exception\StateMachineExecutionException;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Abstraction\StateMachine\WinzouStateMachineAdapter;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\OrderTransitions;
@@ -65,11 +66,11 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
         $this->logger = $logger;
     }
 
-    public function cancel(): void
+    public function cancel(?ChannelInterface $channel = null): void
     {
         $batchSize = null === $this->orderManager ? null : $this->batchSize;
 
-        while ([] !== $expiredUnpaidOrders = $this->findExpiredUnpaidOrders($batchSize)) {
+        while ([] !== $expiredUnpaidOrders = $this->findExpiredUnpaidOrders($batchSize, $channel)) {
             foreach ($expiredUnpaidOrders as $expiredUnpaidOrder) {
                 $this->cancelOrder($expiredUnpaidOrder);
             }
@@ -83,11 +84,12 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
         }
     }
 
-    private function findExpiredUnpaidOrders(?int $batchSize): array
+    private function findExpiredUnpaidOrders(?int $batchSize, ?ChannelInterface $channel = null): array
     {
         return $this->orderRepository->findOrdersUnpaidSince(
             new \DateTime('-' . $this->expirationPeriod),
             $batchSize,
+            $channel,
         );
     }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | depends
| BC breaks?      | depends
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I need to filter this command against certain channels in our project. For some channels, we do not want to cancel them automatically, while for other we would like to keep doing that.

I'm happy to contribute it here as well. I was hoping to get some first feedback whether this is the right approach, and whether we are open to merge this (once it passes quality checks). 