### PR TITLE
[BC-Break Fix][1.13] Do not enforce soft method requirement on ProductVar…

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
@@ -61,12 +61,22 @@ final class ProductVariantNormalizer implements ContextAwareNormalizerInterface,
         try {
             $data['price'] = $this->priceCalculator->calculate($object, ['channel' => $channel]);
             $data['originalPrice'] = $this->priceCalculator->calculateOriginal($object, ['channel' => $channel]);
-            $data['lowestPriceBeforeDiscount'] = $this->priceCalculator->calculateLowestPriceBeforeDiscount(
-                $object,
-                ['channel' => $channel],
-            );
+
+            if (\method_exists($this->priceCalculator, 'calculateLowestPriceBeforeDiscount')) {
+                $data['lowestPriceBeforeDiscount'] = $this->priceCalculator->calculateLowestPriceBeforeDiscount(
+                    $object,
+                    ['channel' => $channel],
+                );
+            } else {
+                trigger_deprecation(
+                    'sylius/sylius',
+                    '1.13',
+                    'Not having `calculateLowestPriceBeforeDiscount` method on %s is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                    $this->priceCalculator::class,
+                );
+            }
         } catch (MissingChannelConfigurationException) {
-            unset($data['price'], $data['originalPrice']);
+            unset($data['price'], $data['originalPrice'], $data['lowestPriceBeforeDiscount']);
         }
 
         /** @var ArrayCollection $appliedPromotions */

--- a/src/Sylius/Bundle/ApiBundle/Tests/Serializer/ProductVariantNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Serializer/ProductVariantNormalizerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Tests\Serializer;
+
+use ApiPlatform\Api\IriConverterInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Bundle\ApiBundle\Serializer\ProductVariantNormalizer;
+use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. */
+final class ProductVariantNormalizerTest extends TestCase
+{
+    private ProductVariantPricesCalculatorInterface&MockObject $pricesCalculator;
+    private AvailabilityCheckerInterface&MockObject $availabilityChecker;
+    private SectionProviderInterface&MockObject $sectionProvider;
+    private IriConverterInterface&MockObject $iriConverter;
+    private NormalizerInterface&MockObject $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->pricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->availabilityChecker = $this->createMock(AvailabilityCheckerInterface::class);
+        $this->sectionProvider = $this->createMock(SectionProviderInterface::class);
+        $this->iriConverter = $this->createMock(IriConverterInterface::class);
+        $this->normalizer = $this->createMock(NormalizerInterface::class);
+    }
+
+    public function testSerializesProductVariantIfItemOperationNameIsDifferentThanAdminGetWithoutLowestPrice(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $variant = $this->createMock(ProductVariantInterface::class);
+
+        $this->normalizer->method('normalize')->willReturn([]);
+        $this->pricesCalculator->method('calculate')->willReturn(1000);
+        $this->pricesCalculator->method('calculateOriginal')->willReturn(1000);
+        $variant->method('getAppliedPromotionsForChannel')->willReturn(new ArrayCollection());
+        $this->availabilityChecker->method('isStockAvailable')->willReturn(true);
+
+        $normalizer = new ProductVariantNormalizer($this->pricesCalculator, $this->availabilityChecker, $this->sectionProvider, $this->iriConverter);
+        $normalizer->setNormalizer($this->normalizer);
+
+        $result = $normalizer->normalize($variant, null, [ContextKeys::CHANNEL => $channel]);
+
+        $this->assertEquals(['price' => 1000, 'originalPrice' => 1000, 'inStock' => true], $result);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/PriceHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/PriceHelper.php
@@ -57,10 +57,21 @@ class PriceHelper extends Helper
         Assert::keyExists($context, 'channel');
         Assert::isInstanceOf($this->productVariantPriceCalculator, ProductVariantPricesCalculatorInterface::class);
 
-        return $this
-            ->productVariantPriceCalculator
-            ->calculateLowestPriceBeforeDiscount($productVariant, $context)
-        ;
+        if (\method_exists($this->productVariantPriceCalculator, 'calculateLowestPriceBeforeDiscount')) {
+            return $this
+                ->productVariantPriceCalculator
+                ->calculateLowestPriceBeforeDiscount($productVariant, $context)
+            ;
+        }
+
+        trigger_deprecation(
+            'sylius/sylius',
+            '1.13',
+            'Not having `calculateLowestPriceBeforeDiscount` method on %s is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+            $this->productVariantPriceCalculator::class,
+        );
+
+        return $this->getPrice($productVariant, $context);
     }
 
     public function hasLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): bool

--- a/src/Sylius/Bundle/CoreBundle/Tests/Helper/PriceHelperTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Helper/PriceHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Helper;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper;
+
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. */
+final class PriceHelperTest extends TestCase
+{
+    private ProductVariantPricesCalculatorInterface&MockObject $productVariantPricesCalculator;
+
+    protected function setUp(): void
+    {
+        $this->productVariantPricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+    }
+
+    public function testReturnsRegularPriceIfCalculateLowestPriceBeforeDiscountIsNotPresentOnObject(): void
+    {
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantPricesCalculator
+            ->method('calculate')
+            ->with($productVariant, ['channel' => $channel])
+            ->willReturn(1000)
+        ;
+
+        $helper = new PriceHelper($this->productVariantPricesCalculator);
+
+        $this->assertEquals(1000, $helper->getLowestPriceBeforeDiscount($productVariant, ['channel' => $channel]));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Provider/ProductVariantLowestPriceMapProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Provider/ProductVariantLowestPriceMapProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Provider;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Provider\ProductVariantMap\ProductVariantLowestPriceMapProvider;
+
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. */
+final class ProductVariantLowestPriceMapProviderTest extends TestCase
+{
+    private ProductVariantPricesCalculatorInterface&MockObject $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+    }
+
+    public function testDoesNotSupportVariantsWithNoLowestPriceInChannel(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $channelPricing = $this->createMock(ChannelPricingInterface::class);
+
+        $variant->method('getChannelPricingForChannel')->willReturn($channelPricing);
+
+        $provider = new ProductVariantLowestPriceMapProvider($this->calculator);
+
+        $this->assertFalse($provider->supports($variant, ['channel' => $channel]));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Provider/ProductVariantsPricesProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Provider/ProductVariantsPricesProviderTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Provider;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Provider\ProductVariantsPricesProvider;
+use Sylius\Component\Product\Model\ProductOptionValueInterface;
+
+/** @deprecated since Sylius 1.13 and will be removed in Sylius 2.0. */
+final class ProductVariantsPricesProviderTest extends TestCase
+{
+    private ProductVariantPricesCalculatorInterface&MockObject $productVariantPriceCalculator;
+
+    protected function setUp(): void
+    {
+        $this->productVariantPriceCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+    }
+
+    public function testProvidesArrayContainingProductVariantOptionsMapWithCorrespondingPriceAndAppliedPromotionsButWithoutLowestPrice(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $tShirt = $this->createMock(ProductInterface::class);
+        $black = $this->createMock(ProductOptionValueInterface::class);
+        $large = $this->createMock(ProductOptionValueInterface::class);
+        $small = $this->createMock(ProductOptionValueInterface::class);
+        $white = $this->createMock(ProductOptionValueInterface::class);
+        $blackLargeTShirt = $this->createMock(ProductVariantInterface::class);
+        $blackSmallTShirt = $this->createMock(ProductVariantInterface::class);
+        $whiteLargeTShirt = $this->createMock(ProductVariantInterface::class);
+        $whiteSmallTShirt = $this->createMock(ProductVariantInterface::class);
+        $winterCatalogPromotion = $this->createMock(CatalogPromotionInterface::class);
+        $summerCatalogPromotion = $this->createMock(CatalogPromotionInterface::class);
+
+        $tShirt->method('getEnabledVariants')->willReturn(new ArrayCollection([
+            $blackSmallTShirt,
+            $whiteSmallTShirt,
+            $blackLargeTShirt,
+            $whiteLargeTShirt,
+        ]));
+
+        $blackSmallTShirt->method('getAppliedPromotionsForChannel')->willReturn(new ArrayCollection([$winterCatalogPromotion]));
+        $whiteSmallTShirt->method('getAppliedPromotionsForChannel')->willReturn(new ArrayCollection());
+        $blackLargeTShirt->method('getAppliedPromotionsForChannel')->willReturn(new ArrayCollection([$summerCatalogPromotion]));
+        $whiteLargeTShirt->method('getAppliedPromotionsForChannel')->willReturn(new ArrayCollection());
+
+        $blackSmallTShirt->method('getOptionValues')->willReturn(new ArrayCollection([$black, $small]));
+        $whiteSmallTShirt->method('getOptionValues')->willReturn(new ArrayCollection([$white, $small]));
+        $blackLargeTShirt->method('getOptionValues')->willReturn(new ArrayCollection([$black, $large]));
+        $whiteLargeTShirt->method('getOptionValues')->willReturn(new ArrayCollection([$white, $large]));
+
+        $this->productVariantPriceCalculator->method('calculate')->will($this->returnValueMap([
+            [$blackSmallTShirt, ['channel' => $channel], 1000],
+            [$whiteSmallTShirt, ['channel' => $channel], 1500],
+            [$blackLargeTShirt, ['channel' => $channel], 2000],
+            [$whiteLargeTShirt, ['channel' => $channel], 2500],
+        ]));
+        $this->productVariantPriceCalculator->method('calculateOriginal')->will($this->returnValueMap([
+            [$blackSmallTShirt, ['channel' => $channel], 1000],
+            [$whiteSmallTShirt, ['channel' => $channel], 2000],
+            [$blackLargeTShirt, ['channel' => $channel], 2000],
+            [$whiteLargeTShirt, ['channel' => $channel], 3000],
+        ]));
+
+        $black->method('getOptionCode')->willReturn('t_shirt_color');
+        $white->method('getOptionCode')->willReturn('t_shirt_color');
+        $small->method('getOptionCode')->willReturn('t_shirt_size');
+        $large->method('getOptionCode')->willReturn('t_shirt_size');
+
+        $black->method('getCode')->willReturn('black');
+        $white->method('getCode')->willReturn('white');
+        $small->method('getCode')->willReturn('small');
+        $large->method('getCode')->willReturn('large');
+
+        $provider = new ProductVariantsPricesProvider($this->productVariantPriceCalculator);
+
+        $result = $provider->provideVariantsPrices($tShirt, $channel);
+
+        $this->assertEquals([
+            [
+                't_shirt_color' => 'black',
+                't_shirt_size' => 'small',
+                'value' => 1000,
+                'applied_promotions' => [$winterCatalogPromotion],
+            ],
+            [
+                't_shirt_color' => 'white',
+                't_shirt_size' => 'small',
+                'value' => 1500,
+                'original-price' => 2000,
+            ],
+            [
+                't_shirt_color' => 'black',
+                't_shirt_size' => 'large',
+                'value' => 2000,
+                'applied_promotions' => [$summerCatalogPromotion],
+            ],
+            [
+                't_shirt_color' => 'white',
+                't_shirt_size' => 'large',
+                'value' => 2500,
+                'original-price' => 3000,
+            ],
+        ], $result);
+    }
+}

--- a/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantLowestPriceMapProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantMap/ProductVariantLowestPriceMapProvider.php
@@ -16,6 +16,7 @@ namespace Sylius\Component\Core\Provider\ProductVariantMap;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Webmozart\Assert\Assert;
 
 final class ProductVariantLowestPriceMapProvider implements ProductVariantMapProviderInterface
 {
@@ -25,6 +26,8 @@ final class ProductVariantLowestPriceMapProvider implements ProductVariantMapPro
 
     public function provide(ProductVariantInterface $variant, array $context): array
     {
+        Assert::methodExists($this->calculator, 'calculateLowestPriceBeforeDiscount');
+
         return [
             'lowest-price-before-discount' => $this->calculator->calculateLowestPriceBeforeDiscount($variant, $context),
         ];
@@ -32,6 +35,17 @@ final class ProductVariantLowestPriceMapProvider implements ProductVariantMapPro
 
     public function supports(ProductVariantInterface $variant, array $context): bool
     {
+        if (!\method_exists($this->calculator, 'calculateLowestPriceBeforeDiscount')) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '1.13',
+                'Not having `calculateLowestPriceBeforeDiscount` method on %s is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                $this->calculator::class,
+            );
+
+            return false;
+        }
+
         return
             isset($context['channel']) &&
             $context['channel'] instanceof ChannelInterface &&

--- a/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
+++ b/src/Sylius/Component/Core/Provider/ProductVariantsPricesProvider.php
@@ -72,10 +72,20 @@ final class ProductVariantsPricesProvider implements ProductVariantsPricesProvid
             return $optionMap;
         }
 
-        $lowestPriceBeforeDiscount = $this->productVariantPriceCalculator->calculateLowestPriceBeforeDiscount($variant, ['channel' => $channel]);
 
-        if ($lowestPriceBeforeDiscount !== null) {
-            $optionMap['lowest-price-before-discount'] = $lowestPriceBeforeDiscount;
+        if (\method_exists($this->productVariantPriceCalculator, 'calculateLowestPriceBeforeDiscount')) {
+            $lowestPriceBeforeDiscount = $this->productVariantPriceCalculator->calculateLowestPriceBeforeDiscount($variant, ['channel' => $channel]);
+
+            if ($lowestPriceBeforeDiscount !== null) {
+                $optionMap['lowest-price-before-discount'] = $lowestPriceBeforeDiscount;
+            }
+        } else {
+            trigger_deprecation(
+                'sylius/sylius',
+                '1.13',
+                'Not having `calculateLowestPriceBeforeDiscount` method on %s is deprecated since Sylius 1.13 and will be required in Sylius 2.0.',
+                $this->productVariantPriceCalculator::class,
+            );
         }
 
         $originalPrice = $this->productVariantPriceCalculator->calculateOriginal($variant, ['channel' => $channel]);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

While testing out https://github.com/Brille24/SyliusTierpricePlugin, I've encountered 500 errors when trying to access the product detail page. This is because even tho the `calculateLowestPriceBeforeDiscount` method has a soft requirement on `Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface`, it is used in several classes and therefore enforced. This PR fixes that with checks if the method exists.

I had to use PHPUnit tests to ensure the correctness of this fix, as PHPSpec, by default, treats methods declared in doc block as defined on the class. 