### PR TITLE
Fix applying coupon codes with a "total price of items from taxon" rule

### DIFF
--- a/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_rules.feature
+++ b/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_rules.feature
@@ -1,0 +1,31 @@
+@applying_promotion_coupon
+Feature: Applying promotion coupon with rules
+    In order to pay proper amount after using the promotion coupon
+    As a Visitor
+    I want to have promotion coupon's discounts applied to my cart only if I meet the condition of a promotion coupon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has "Fashion" taxonomy
+        And the store has a product "PHP T-Shirt" in the "Fashion" taxon at 1st position priced at "$100.00"
+
+    @api @ui
+    Scenario: Receiving discount from promotion with total price of items from taxon rule
+        Given there is a promotion "Christmas sale" with "Total price of items from taxon" rule configured with "Fashion" taxon and "$90.00" amount for "United States" channel of coupon code "SANTA2024"
+        And this promotion gives "75%" discount to every order
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2024"
+        Then I should be notified that the cart has been updated
+        And my cart total should be "$25.00"
+        And my discount should be "-$75.00"
+
+    @api @ui
+    Scenario: Receiving discount from promotion with total price of items from taxon rule applied twice
+        Given there is a promotion "Christmas sale" with "Total price of items from taxon" rule configured with "Fashion" taxon and "$90.00" amount for "United States" channel of coupon code "SANTA2024"
+        And this promotion gives "75%" discount to every order
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2024"
+        And I use coupon with code "SANTA2024"
+        Then I should be notified that the cart has been updated
+        And my cart total should be "$25.00"
+        And my discount should be "-$75.00"

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -430,6 +430,18 @@ final class CartContext implements Context
     }
 
     /**
+     * @Then I should be notified that the cart has been updated
+     */
+    public function iShouldBeNotifiedThatTheCartHasBeenUpdated(): void
+    {
+        $response = $this->shopClient->getLastResponse();
+        Assert::true(
+            $this->responseChecker->isUpdateSuccessful($response),
+            SprintfResponseEscaper::provideMessageWithEscapedResponseContent('The cart cannot be updated with the given data.', $response),
+        );
+    }
+
+    /**
      * @Then /^I should see(?:| also) "([^"]+)" with unit price ("[^"]+") in my cart$/
      */
     public function iShouldSeeProductWithUnitPriceInMyCart(string $productName, int $unitPrice): void

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -116,13 +116,15 @@ final class ProductContext implements Context
 
     /**
      * @Given /^the store(?:| also) has a product "([^"]+)" in the ("[^"]+" taxon) at (\d+)(?:st|nd|rd|th) position$/
+     * @Given /^the store(?:| also) has a product "([^"]+)" in the ("[^"]+" taxon) at (\d+)(?:st|nd|rd|th) position priced at ("[^"]+")$/
      */
     public function theStoreHasAProductInTheTaxonAtPosition(
         string $productName,
         TaxonInterface $taxon,
         int $position,
+        int $price = 100,
     ): void {
-        $product = $this->createProduct($productName);
+        $product = $this->createProduct($productName, $price);
 
         $productTaxon = $this->createProductTaxon($taxon, $product, $position);
         $product->addProductTaxon($productTaxon);

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -538,6 +538,17 @@ final class CartContext implements Context
     }
 
     /**
+     * @Then I should be notified that the cart has been updated
+     */
+    public function iShouldBeNotifiedThatTheCartHasBeenUpdated(): void
+    {
+        $this->notificationChecker->checkNotification(
+            'The cart has been successfully updated',
+            NotificationType::success(),
+        );
+    }
+
+    /**
      * @Then total price of :productName item should be :productPrice
      */
     public function thisItemPriceShouldBe(string $productName, string $productPrice): void

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
@@ -38,12 +38,8 @@ final class TotalOfItemsFromTaxonRuleChecker implements RuleCheckerInterface
             throw new UnsupportedTypeException($subject, OrderInterface::class);
         }
 
-        $channelCode = $subject->getChannel()->getCode();
-        if (!isset($configuration[$channelCode])) {
-            return false;
-        }
-
-        $configuration = $configuration[$channelCode];
+        $channel = $subject->getChannel();
+        $configuration = $configuration[$channel->getCode()] ?? null;
 
         if (!isset($configuration['taxon']) || !isset($configuration['amount'])) {
             return false;
@@ -59,7 +55,9 @@ final class TotalOfItemsFromTaxonRuleChecker implements RuleCheckerInterface
         /** @var OrderItemInterface $item */
         foreach ($subject->getItems() as $item) {
             if ($item->getProduct()->hasTaxon($targetTaxon)) {
-                $itemsWithTaxonTotal += $item->getTotal();
+                $channelPricing = $item->getVariant()->getChannelPricingForChannel($channel);
+
+                $itemsWithTaxonTotal += $channelPricing->getPrice();
             }
         }
 

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerSpec.php
@@ -16,9 +16,11 @@ namespace spec\Sylius\Component\Core\Promotion\Checker\Rule;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
@@ -46,6 +48,12 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
         ProductInterface $compositeBow,
         ProductInterface $longsword,
         ProductInterface $reflexBow,
+        ProductVariantInterface $compositeBowVariant,
+        ProductVariantInterface $longswordVariant,
+        ProductVariantInterface $reflexBowVariant,
+        ChannelPricingInterface $compositeBowPricing,
+        ChannelPricingInterface $longswordPricing,
+        ChannelPricingInterface $reflexBowPricing,
         TaxonInterface $bows,
     ): void {
         $order->getChannel()->willReturn($channel);
@@ -61,15 +69,21 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
 
         $compositeBowItem->getProduct()->willReturn($compositeBow);
         $compositeBow->hasTaxon($bows)->willReturn(true);
-        $compositeBowItem->getTotal()->willReturn(5000);
+        $compositeBowItem->getVariant()->willReturn($compositeBowVariant);
+        $compositeBowVariant->getChannelPricingForChannel($channel)->willReturn($compositeBowPricing);
+        $compositeBowPricing->getPrice()->willReturn(5000);
 
         $longswordItem->getProduct()->willReturn($longsword);
         $longsword->hasTaxon($bows)->willReturn(false);
-        $longswordItem->getTotal()->willReturn(4000);
+        $longswordItem->getVariant()->willReturn($longswordVariant);
+        $longswordVariant->getChannelPricingForChannel($channel)->willReturn($longswordPricing);
+        $longswordPricing->getPrice()->willReturn(4000);
 
         $reflexBowItem->getProduct()->willReturn($reflexBow);
         $reflexBow->hasTaxon($bows)->willReturn(true);
-        $reflexBowItem->getTotal()->willReturn(9000);
+        $reflexBowItem->getVariant()->willReturn($reflexBowVariant);
+        $reflexBowVariant->getChannelPricingForChannel($channel)->willReturn($reflexBowPricing);
+        $reflexBowPricing->getPrice()->willReturn(9000);
 
         $this->isEligible($order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]])->shouldReturn(true);
     }
@@ -81,6 +95,10 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
         OrderItemInterface $reflexBowItem,
         ProductInterface $compositeBow,
         ProductInterface $reflexBow,
+        ProductVariantInterface $compositeBowVariant,
+        ProductVariantInterface $reflexBowVariant,
+        ChannelPricingInterface $compositeBowPricing,
+        ChannelPricingInterface $reflexBowPricing,
         TaxonInterface $bows,
         TaxonRepositoryInterface $taxonRepository,
     ): void {
@@ -93,11 +111,15 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
 
         $compositeBowItem->getProduct()->willReturn($compositeBow);
         $compositeBow->hasTaxon($bows)->willReturn(true);
-        $compositeBowItem->getTotal()->willReturn(5000);
+        $compositeBowItem->getVariant()->willReturn($compositeBowVariant);
+        $compositeBowVariant->getChannelPricingForChannel($channel)->willReturn($compositeBowPricing);
+        $compositeBowPricing->getPrice()->willReturn(5000);
 
         $reflexBowItem->getProduct()->willReturn($reflexBow);
         $reflexBow->hasTaxon($bows)->willReturn(true);
-        $reflexBowItem->getTotal()->willReturn(5000);
+        $reflexBowItem->getVariant()->willReturn($reflexBowVariant);
+        $reflexBowVariant->getChannelPricingForChannel($channel)->willReturn($reflexBowPricing);
+        $reflexBowPricing->getPrice()->willReturn(5000);
 
         $this->isEligible($order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]])->shouldReturn(true);
     }
@@ -109,6 +131,10 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
         OrderItemInterface $longswordItem,
         ProductInterface $compositeBow,
         ProductInterface $longsword,
+        ProductVariantInterface $compositeBowVariant,
+        ProductVariantInterface $longswordVariant,
+        ChannelPricingInterface $compositeBowPricing,
+        ChannelPricingInterface $longswordPricing,
         TaxonInterface $bows,
         TaxonRepositoryInterface $taxonRepository,
     ): void {
@@ -121,11 +147,15 @@ final class TotalOfItemsFromTaxonRuleCheckerSpec extends ObjectBehavior
 
         $compositeBowItem->getProduct()->willReturn($compositeBow);
         $compositeBow->hasTaxon($bows)->willReturn(true);
-        $compositeBowItem->getTotal()->willReturn(5000);
+        $compositeBowItem->getVariant()->willReturn($compositeBowVariant);
+        $compositeBowVariant->getChannelPricingForChannel($channel)->willReturn($compositeBowPricing);
+        $compositeBowPricing->getPrice()->willReturn(5000);
 
         $longswordItem->getProduct()->willReturn($longsword);
         $longsword->hasTaxon($bows)->willReturn(false);
-        $longswordItem->getTotal()->willReturn(4000);
+        $longswordItem->getVariant()->willReturn($longswordVariant);
+        $longswordVariant->getChannelPricingForChannel($channel)->willReturn($longswordPricing);
+        $longswordPricing->getPrice()->willReturn(4000);
 
         $this->isEligible($order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]])->shouldReturn(false);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/16303
| License         | MIT

As described in the related ticket. The fix is to calculate the sum of order items based on variant price rather than the order item total.