### PR TITLE
Fix typo in called assert method

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -98,7 +98,7 @@ class Order extends BaseOrder implements OrderInterface
 
     public function setCustomer(?BaseCustomerInterface $customer): void
     {
-        Assert::nullOrisInstanceOf($customer, CustomerInterface::class);
+        Assert::nullOrIsInstanceOf($customer, CustomerInterface::class);
 
         $this->customer = $customer;
     }


### PR DESCRIPTION
Fix harmless but visually ugly typo in called assert method.

| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Beautify | yes ✨
| Related tickets | -
| License         | MIT