### PR TITLE
Fixing configuration for customer order view

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/customer_order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/customer_order.yml
@@ -7,6 +7,7 @@ sylius_grid:
                     repository:
                         method: createByCustomerIdCriteriaAwareQueryBuilder
                         arguments:
+                            criteria: ~
                             customerId: $id
             fields:
                 customer:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #15132
| License         | MIT

In the Pull request linked above @jakubtobiasz configured repository method was changed to also require a criteria argument (of type array). Which resulted in this:
![image](https://github.com/user-attachments/assets/b4d24387-b0e4-478f-8e27-2d4dafba976b)

The reason for this is despite the fact that it looks like they're being passed as named arguments from the config, the grid bundle does an `array_values` on the array to throw away the keys. This PR fixes that and just passes a default value for the criteria.

## Steps to reproduce

* Create a customer
* Go to the customers details page in the admin
* Click on "Show orders"
* See creash
