### PR TITLE
Fix PaymentMethod translations order filter

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TranslationOrderNameAndLocaleFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Filter/Doctrine/TranslationOrderNameAndLocaleFilter.php
@@ -23,7 +23,7 @@ final class TranslationOrderNameAndLocaleFilter extends AbstractFilter
 {
     protected function filterProperty(
         string $property,
-               $value,
+        $value,
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         string $resourceClass,

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -22,6 +22,7 @@
         </service>
 
         <service id="sylius_api.doctrine.orm.query_extension.common.translation_order_locale" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Common\TranslationOrderLocaleExtension">
+            <argument type="service" id="sylius.section_resolver.uri_based_section_resolver" />
             <tag name="api_platform.doctrine.orm.query_extension.collection" />
         </service>
 


### PR DESCRIPTION
…

| Q               | A
|-----------------|-----
| Branch?         | api-platform-3 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Fixing the error, when no localeCode passed:
![Screenshot 2024-08-13 at 11 48 24](https://github.com/user-attachments/assets/d2792fc0-fe1d-47fc-aa08-c8173ef6b136)

