### PR TITLE
[API] Fix parameter name in ProductOptionValue endpoints

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ProductOptionValue.xml
@@ -18,16 +18,16 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOptionValue">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-options/{product_option_code}/values/{code}">
+            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-options/{optionCode}/values/{code}">
                 <uriVariables>
-                    <uriVariable parameterName="product_option_code" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
+                    <uriVariable parameterName="optionCode" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOptionValue" />
                 </uriVariables>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/shop/product-options/{product_option_code}/values/{code}">
+            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/shop/product-options/{optionCode}/values/{code}">
                 <uriVariables>
-                    <uriVariable parameterName="product_option_code" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
+                    <uriVariable parameterName="optionCode" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOptionValue" />
                 </uriVariables>
             </operation>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | api-platform-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/16684#pullrequestreview-2237189977
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
