### PR TITLE
[Composer] Upgrade Webpack to ^2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         "symfony/ux-live-component": "^2.17",
         "symfony/ux-twig-component": "^2.17",
         "symfony/validator": "^6.4.0 || ^7.0",
-        "symfony/webpack-encore-bundle": "^1.17.1",
+        "symfony/webpack-encore-bundle": "^2.1",
         "symfony/workflow": "^6.4.0 || ^7.0",
         "symfony/yaml": "^6.4.0 || ^7.0",
         "symfonycasts/dynamic-forms": "v0.1.1",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -43,7 +43,7 @@
         "symfony/browser-kit": "^6.4.0 || ^7.0",
         "symfony/debug-bundle": "^6.4.0 || ^7.0",
         "symfony/dotenv": "^6.4.0 || ^7.0",
-        "symfony/webpack-encore-bundle": "^1.17.1",
+        "symfony/webpack-encore-bundle": "^2.1",
         "theofidry/alice-data-fixtures": "^1.4"
     },
     "conflict": {

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -31,7 +31,7 @@
         "sylius/ui-bundle": "^2.0",
         "symfony/framework-bundle": "^6.4.1 || ^7.0",
         "symfony/security-bundle": "^6.4.0 || ^7.0",
-        "symfony/webpack-encore-bundle": "^1.17.1",
+        "symfony/webpack-encore-bundle": "^2.1",
         "twig/intl-extra": "~3.8.0",
         "twig/twig": "~3.8.0"
     },


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | symfony-7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

Upgrade Webpack to ^2.1 so that its version is consistent across all packages
<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
