### PR TITLE
Filter product variants ASC by position by default, fix order of tags in variant scenarios

### DIFF
--- a/features/admin/product/managing_product_variants/browsing_product_variants_in_different_locales.feature
+++ b/features/admin/product/managing_product_variants/browsing_product_variants_in_different_locales.feature
@@ -15,7 +15,7 @@ Feature: Browsing product variants in different locales
         And this variant has no translation in "English (United States)" locale
         And I am logged in as an administrator
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Seeing all variants when some don't have translations in my locale which is also the base
         When I want to view all variants of this product
         Then I should see 3 variants in the list
@@ -23,7 +23,7 @@ Feature: Browsing product variants in different locales
         And I should also see a variant named "Berserk Pug with Morning Star"
         And I should also see 1 variant with no name
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Seeing all variants when some don't have translations in my locale which is not the base
         Given I change my locale to "Polish (Poland)"
         When I want to view all variants of this product
@@ -32,7 +32,7 @@ Feature: Browsing product variants in different locales
         And I should also see a variant named "Szałowy Mops z Mieczem"
         And I should also see 1 variant with no name
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Seeing all variants when none have names in my locale
         Given I change my locale to "Irish (Ireland)"
         When I want to view all variants of this product

--- a/features/admin/product/managing_product_variants/generating_product_variant.feature
+++ b/features/admin/product/managing_product_variants/generating_product_variant.feature
@@ -10,7 +10,7 @@ Feature: Generating product variants
         And this product has option "Taste" with values "Orange" and "Melon"
         And I am logged in as an administrator
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating a product variant for product without variants
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90.00" in "United States" channel
@@ -19,7 +19,7 @@ Feature: Generating product variants
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating the rest of product variants for product with at least one
         Given this product is available in "Melon" taste priced at "$95.00"
         When I want to generate new variants for this product
@@ -28,7 +28,7 @@ Feature: Generating product variants
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating the rest of product variants for product with at least one
         Given this product is available in "Orange" taste priced at "$90.00"
         When I want to generate new variants for this product
@@ -37,7 +37,7 @@ Feature: Generating product variants
         Then I should be notified that it has been successfully generated
         And I should see 2 variants in the list
 
-    @ui @mink:chromedriver @no-api
+    @no-api @ui @mink:chromedriver
     Scenario: Generating only a part of product variants
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code and costs "$90.00" in "United States" channel

--- a/features/admin/product/managing_product_variants/generating_product_variant_validation.feature
+++ b/features/admin/product/managing_product_variants/generating_product_variant_validation.feature
@@ -10,7 +10,7 @@ Feature: Generating product variant generation
         And this product has option "Taste" with values "Orange" and "Melon"
         And I am logged in as an administrator
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating a product's variant without price
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code
@@ -18,7 +18,7 @@ Feature: Generating product variant generation
         Then I should be notified that price for the 1st variant in "United States" channel must be defined
         And I should not see any variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating a product's variant without code
         When I want to generate new variants for this product
         And I specify that the 1st variant costs "$90.00" in "United States" channel
@@ -26,7 +26,7 @@ Feature: Generating product variant generation
         Then I should be notified that code is required for the 1st variant
         And I should not see any variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating product's variants without specific required fields for second variant
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_ORANGE" code
@@ -36,7 +36,7 @@ Feature: Generating product variant generation
         And I should be notified that price for the 2nd variant in "United States" channel must be defined
         And I should not see any variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating product's variants with the same code
         When I want to generate new variants for this product
         And I specify that the 1st variant is identified by "WYBOROWA_TASTE" code
@@ -48,7 +48,7 @@ Feature: Generating product variant generation
         And I should be notified that variant code must be unique within this product for the 2nd variant
         And I should not see any variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Generating product's variants without specific required fields for second variant
         When I want to generate new variants for this product
         And I do not specify any information about variants
@@ -59,7 +59,7 @@ Feature: Generating product variant generation
         And I should be notified that price for the 2nd variant in "United States" channel must be defined
         And I should not see any variants in the list
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Trying to remove an existing product variant during generation
         Given the product "Wyborowa Vodka" has "Wyborowa Vodka Orange" variant priced at "$40.00" configured with "Orange" option value
         When I want to generate new variants for this product

--- a/features/admin/product/managing_product_variants/preventing_generation_of_products_variants_from_options_without_any_values.feature
+++ b/features/admin/product/managing_product_variants/preventing_generation_of_products_variants_from_options_without_any_values.feature
@@ -10,7 +10,7 @@ Feature: Preventing the generation of product variants from options without any 
         And this product has an option "Taste" without any values
         And I am logged in as an administrator
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Trying to generate a product variant for a product without options values
         When I try to generate new variants for this product
         Then I should be notified that variants cannot be generated from options without any values

--- a/features/admin/product/managing_product_variants/product_variant_validation.feature
+++ b/features/admin/product/managing_product_variants/product_variant_validation.feature
@@ -18,7 +18,7 @@ Feature: Product variant validation
         Then I should be notified that prices in "United States" channel must be defined
         And the "VODKA_WYBOROWA_PREMIUM" variant of the "Wyborowa Vodka" product should not appear in the store
 
-    @no-ui @api
+    @api @no-ui
     Scenario: Trying to add product variant translation in unexisting locale
         When I want to create a new variant of this product
         And I specify its code as "lemon"

--- a/features/admin/product/managing_product_variants/seeing_correct_option_values_while_editing_product_variant.feature
+++ b/features/admin/product/managing_product_variants/seeing_correct_option_values_while_editing_product_variant.feature
@@ -12,13 +12,13 @@ Feature: Seeing correct option values while editing product variant
         And this product has option "Type" with values "Clear" and "Color"
         And I am logged in as an administrator
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Seeing default option values while editing product variant in store
         When I want to modify the "Wyborowa Vodka Exquisite" product variant
         And I should see the "Type" option as "Clear"
         And I should see the "Taste" option as "Orange"
 
-    @ui @no-api
+    @no-api @ui
     Scenario: Seeing changed option values while editing product variant in store
         When I want to modify the "Wyborowa Vodka Exquisite" product variant
         And I change its "Taste" option to "Melon"

--- a/features/admin/product/managing_product_variants/sorting_product_variants_within_product_by_position.feature
+++ b/features/admin/product/managing_product_variants/sorting_product_variants_within_product_by_position.feature
@@ -12,35 +12,35 @@ Feature: Sorting listed product variants from a product by position
         And this product has also an "Opel Insignia Sedan" variant at position 1
         And I am logged in as an administrator
 
-    @ui @api
+    @api @api
     Scenario: Product variants are sorted by position in ascending order by default
         When I view all variants of the product "Opel Insignia"
         Then I should see 3 variants in the list
         And the first variant in the list should have name "Opel Insignia Hatchback"
         And the last variant in the list should have name "Opel Insignia Sports Tourer"
 
-    @ui @api
+    @api @api
     Scenario: Sorting product variants in descending order
         When I view all variants of the product "Opel Insignia"
         And I start sorting variants by position
         Then the first variant in the list should have name "Opel Insignia Sports Tourer"
         And the last variant in the list should have name "Opel Insignia Hatchback"
 
-    @ui @api
+    @api @api
     Scenario: New product variant with no position is added as the last one
         Given the product "Opel Insignia" has also an "Opel Insignia Country Tourer" variant
         When I view all variants of the product "Opel Insignia"
         Then I should see 4 variants in the list
         And the last variant in the list should have name "Opel Insignia Country Tourer"
 
-    @ui @api
+    @api @api
     Scenario: New product variant with position 0 is added as the first one
         Given the product "Opel Insignia" has also an "Opel Insignia Country Tourer" variant at position 0
         When I view all variants of the product "Opel Insignia"
         Then I should see 4 variants in the list
         And the first variant in the list should have name "Opel Insignia Country Tourer"
 
-    @ui @mink:chromedriver @api
+    @api @ui @mink:chromedriver
     Scenario: Setting product variant as the first one in the list
         When I view all variants of the product "Opel Insignia"
         And I set the position of "Opel Insignia Sedan" to 0
@@ -48,7 +48,7 @@ Feature: Sorting listed product variants from a product by position
         And I view all variants of the product "Opel Insignia" again
         Then the first variant in the list should have name "Opel Insignia Sedan"
 
-    @ui @mink:chromedriver @api
+    @api @ui @mink:chromedriver
     Scenario: Setting product variant as the last one in the list
         When I view all variants of the product "Opel Insignia"
         And I set the position of "Opel Insignia Sedan" to 7

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/ProductVariant.xml
@@ -21,6 +21,11 @@
 
         <operations>
             <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-variants">
+                <order>
+                    <values>
+                        <value name="position">ASC</value>
+                    </values>
+                </order>
                 <normalizationContext>
                     <values>
                         <value name="groups">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | api-platform-3 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
