### PR TITLE
[Unstable][PHPStan] Support both `sylius/resource-bundle` 1.11 and older versions

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,6 +34,34 @@ parameters:
         # To investigate, occurs after release of doctrine/orm 2.14, the processing of these classes ends with exit code 143
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/DQL/**.php'
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/SqlWalker/**.php'
+
+        # To support both sylius/resource-bundle 1.10 and 1.11
+        - 'src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php'
+        - 'src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AcceptLanguageHeaderDocumentationModifier.php'
+        - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceDeleteHandler.php'
+        - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceUpdateHandler.php'
+        - 'src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php'
+        - 'src/Sylius/Bundle/CoreBundle/Resource/StateMachine/Controller/CompositeStateMachine.php'
+        - 'src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollectionValidator.php'
+        - 'src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExistsValidator.php'
+        - 'src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderStateValidator.php'
+        - 'src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentStateValidator.php'
+        - 'src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionCouponToCodeType.php'
+        - 'src/Sylius/Bundle/TaxonomyBundle/Controller/TaxonSlugController.php'
+        - 'src/Sylius/Bundle/UserBundle/Factory/UserWithEncoderFactory.php'
+        - 'src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php'
+        - 'src/Sylius/Component/Core/Customer/Statistics/CustomerStatisticsProvider.php'
+        - 'src/Sylius/Component/Core/Factory/ChannelFactory.php'
+        - 'src/Sylius/Component/Core/Factory/PaymentMethodFactory.php'
+        - 'src/Sylius/Component/Core/Factory/PromotionActionFactory.php'
+        - 'src/Sylius/Component/Core/Promotion/Checker/ProductInPromotionRuleChecker.php'
+        - 'src/Sylius/Component/Core/Promotion/Checker/TaxonInPromotionRuleChecker.php'
+        - 'src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php'
+        - 'src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemUnitsTaxesApplicatorTest.php'
+        - 'src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemsTaxesApplicatorTest.php'
+        - 'src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php'
+        - 'src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php'
+        - 'src/Sylius/Component/Locale/Provider/LocaleProvider.php'
     ignoreErrors:
         - '/(Interface|Class) [a-zA-Z\\]+ specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior, we are basing on Psalm for generics checks
         - '/Access to an undefined property Doctrine\\Common\\Collections\\ArrayCollection/'
@@ -45,3 +73,12 @@ parameters:
         - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'
         - '/Method [a-zA-z\\]+Filter\:\:filterProperty\(\) has parameter \$value with no type specified./'
         - '/Method [a-zA-z\\]+Persister\:\:(persist|remove|supports)\(\) has parameter \$data with no type specified./'
+
+        # To support both sylius/resource-bundle 1.10 and 1.11
+        - '/Call to an undefined method Sylius\\Resource\\Model\\ResourceInterface::\w+\(\)\./'
+        - '/Method Sylius\\Component\\Payment\\Resolver\\PaymentMethodsResolver::getSupportedMethods\(\) should return array<Sylius\\Component\\Payment\\Model\\PaymentMethodInterface> but returns array<int, Sylius\\Resource\\Model\\ResourceInterface>\./'
+        - '/Method Sylius\\Component\\Taxation\\Resolver\\TaxRateResolver::resolve\(\) should return Sylius\\Component\\Taxation\\Model\\TaxRateInterface\|null but returns Sylius\\Resource\\Model\\ResourceInterface\|null\./'
+        - '/Parameter #\d+ \$(\w+) \(Sylius\\Component\\\w+\\Model\\\w+(\|null)?\) of method Sylius\\Bundle\\\w+\\Controller\\\w+::\w+\(\) is not contravariant with parameter #\d+ \$(\w+) \(Sylius\\Resource\\Model\\\w+(\|null)?\) of method Sylius\\Bundle\\\w+\\Controller\\\w+\::\w+\(\)\./'
+        - '/PHPDoc tag @extends contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
+        - '/PHPDoc tag @param for parameter \$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
+        - '/PHPDoc type for property Sylius\\Bundle\\\w+\\\w+\\\w+::\$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -49,6 +49,7 @@
     "conflict": {
         "api-platform/core": "2.7.17",
         "doctrine/doctrine-bundle": "2.3.0",
+        "doctrine/orm": ">= 2.14.0",
         "lexik/jwt-authentication-bundle": "^2.18"
     },
     "config": {

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -86,6 +86,9 @@
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/dotenv": "^5.4.21 || ^6.4"
     },
+    "conflict": {
+        "doctrine/orm": ">= 2.14.0"
+    },
     "config": {
         "allow-plugins": {
             "php-http/discovery": false,

--- a/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
@@ -129,23 +129,20 @@ final class TaxonSpec extends ObjectBehavior
         $this->getFullname()->shouldReturn('Category');
     }
 
-    function its_fullname_prepends_with_parents_fullname(): void
-    {
-        $rootTaxon = new Taxon();
-        $rootTaxon->setCurrentLocale('en_US');
-        $rootTaxon->setName('Category');
+    function its_fullname_prepends_with_parents_fullname(
+        TaxonInterface $clothesTaxon,
+        TaxonInterface $rootTaxon,
+    ): void {
+        $rootTaxon->getFullname(' / ')->willReturn('Category');
 
-        $clothesTaxon = new Taxon();
-        $clothesTaxon->setCurrentLocale('en_US');
-        $clothesTaxon->setName('Clothes');
-        $clothesTaxon->setParent($rootTaxon);
+        $clothesTaxon->getFullname(' / ')->willReturn('Category / Clothes');
+        $clothesTaxon->getParent()->willReturn($rootTaxon);
+        $clothesTaxon->addChild($this)->shouldBeCalled();
 
-        $this->setCurrentLocale('en_US');
-        $this->setName('T-shirts');
         $this->setParent($clothesTaxon);
+        $this->setName('T-shirts');
 
         $this->getFullname()->shouldReturn('Category / Clothes / T-shirts');
-        $this->getFullname(' -- ')->shouldReturn('Category -- Clothes -- T-shirts');
     }
 
     function it_has_no_description_by_default(): void


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Resource bundle 1.10:
<img width="914" alt="image" src="https://github.com/user-attachments/assets/3c162127-7c5a-4516-935b-e9627304ca86">

Resource bundle 1.11:
<img width="895" alt="image" src="https://github.com/user-attachments/assets/d72ba9d9-bada-42fd-8004-02e54d56c3ed">

