### PR TITLE
[PHPStan] Temporarily ignore errors with ResourceBundle 1.11 to fix static analysis

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,6 +39,11 @@ parameters:
 
         # To support both sylius/resource-bundle 1.11 and older versions
         - 'src/Sylius/Bundle/AdminBundle/Controller/RedirectHandler.php'
+        - 'src/Sylius/Bundle/AdminBundle/Form/DataTransformer/ProductsToProductAssociationsTransformer.php'
+        - 'src/Sylius/Bundle/AdminBundle/Provider/LoggedInAdminUserProvider.php'
+        - 'src/Sylius/Bundle/AdminBundle/Twig/Component/Customer/OrderStatisticsComponent.php'
+        - 'src/Sylius/Bundle/AdminBundle/Twig/Component/Order/AddressHistoryComponent.php'
+        - 'src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/FormComponent.php'
         - 'src/Sylius/Bundle/ApiBundle/OpenApi/Documentation/AcceptLanguageHeaderDocumentationModifier.php'
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceDeleteHandler.php'
         - 'src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceUpdateHandler.php'
@@ -64,6 +69,7 @@ parameters:
         - 'src/Sylius/Component/Core/Translation/TranslatableEntityLocaleAssigner.php'
         - 'src/Sylius/Component/Locale/Provider/LocaleCollectionProvider.php'
         - 'src/Sylius/Component/Locale/Provider/LocaleProvider.php'
+        - 'src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php'
 
     ignoreErrors:
         - '/(Interface|Class) [a-zA-Z\\]+ specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior, we are basing on Psalm for generics checks
@@ -86,3 +92,5 @@ parameters:
         - '/PHPDoc tag @extends contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
         - '/PHPDoc tag @param for parameter \$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
         - '/PHPDoc type for property Sylius\\Bundle\\\w+\\\w+\\\w+::\$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
+        - '/PHPDoc type for property Sylius\\Bundle\\\w+\\\w+\\\w+\\\w+::\$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'
+        - '/PHPDoc type for property Sylius\\Bundle\\\w+\\\w+\\\w+\\\w+\\\w+::\$(\w+) contains generic type Sylius\\Component\\Resource\\\w+\\\w+<Sylius\\Component\\\w+\\Model\\\w+> but interface Sylius\\Component\\Resource\\\w+\\\w+ is not generic\./'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | continuation of #16819 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
