### PR TITLE
[Shop] Change password form submit revert

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/change_password.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/change_password.yaml
@@ -2,7 +2,9 @@ twig_hooks:
     hooks:
         'sylius_shop.account.change_password':
             form:
-                component: 'sylius_shop:account:change_password:form'    
+                component: 'sylius_shop:account:change_password:form'
+                props:
+                    form: '@=_context.form'
                 
         'sylius_shop.account.change_password.form':
             fields:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account.yml
@@ -47,8 +47,10 @@ sylius_shop_account_profile_update:
 
 sylius_shop_account_change_password:
     path: /change-password
-    methods: [GET]
+    methods: [GET, POST]
     defaults:
         _controller: sylius.controller.shop_user::changePasswordAction
         _sylius:
+            form: Sylius\Bundle\ShopBundle\Form\Type\UserChangePasswordType
             template: "@SyliusShop/account/change_password.html.twig"
+            redirect: sylius_shop_account_dashboard

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component.xml
@@ -292,13 +292,7 @@
             class="Sylius\Bundle\ShopBundle\Twig\Component\Account\ChangePassword\FormComponent"
         >
             <argument type="service" id="form.factory" />
-            <argument type="service" id="router.default" />
-            <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="event_dispatcher" />
-            <argument type="service" id="security.token_storage" />
-            <argument type="service" id="request_stack" />
             <argument>Sylius\Bundle\ShopBundle\Form\Type\UserChangePasswordType</argument>
-            <argument>sylius_shop_account_dashboard</argument>
 
             <tag
                 name="sylius.live_component"

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/ChangePassword/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/ChangePassword/FormComponent.php
@@ -13,22 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig\Component\Account\ChangePassword;
 
-use Doctrine\Persistence\ObjectManager;
-use Sylius\Bundle\CoreBundle\Provider\FlashBagProvider;
 use Sylius\Bundle\UserBundle\Form\Model\ChangePassword;
-use Sylius\Bundle\UserBundle\UserEvents;
-use Sylius\Component\User\Model\UserInterface;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\RouterInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
-use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
@@ -46,37 +35,8 @@ class FormComponent
     /** @param class-string $formClass */
     public function __construct(
         private readonly FormFactoryInterface $formFactory,
-        private readonly RouterInterface $router,
-        private readonly ObjectManager $manager,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly TokenStorageInterface $tokenStorage,
-        private readonly RequestStack $requestStack,
         private readonly string $formClass,
-        private readonly string $redirectRouteName,
     ) {
-    }
-
-    #[LiveAction]
-    public function save(): RedirectResponse
-    {
-        $this->submitForm();
-
-        /** @var UserInterface $user */
-        $user = $this->tokenStorage->getToken()->getUser();
-        $request = $this->requestStack->getCurrentRequest();
-
-        $user->setPlainPassword($this->formValues['newPassword']['first']);
-
-        $this->eventDispatcher->dispatch(new GenericEvent($user), UserEvents::PRE_PASSWORD_CHANGE);
-
-        $this->manager->flush();
-        FlashBagProvider::getFlashBag($this->requestStack)
-            ->add('success', 'sylius.user.change_password')
-        ;
-
-        $this->eventDispatcher->dispatch(new GenericEvent($user), UserEvents::POST_PASSWORD_CHANGE);
-
-        return new RedirectResponse($this->router->generate($this->redirectRouteName));
     }
 
     protected function instantiateForm(): FormInterface

--- a/src/Sylius/Bundle/ShopBundle/templates/account/change_password.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/change_password.html.twig
@@ -18,5 +18,5 @@
 {% endblock %}
 
 {% block account_content %}
-    {% hook 'sylius_shop.account.change_password' %}
+    {% hook 'sylius_shop.account.change_password' with { form } %}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/change_password/form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/change_password/form.html.twig
@@ -7,7 +7,7 @@
             <img src="{{ asset('build/shop/images/loader.gif', 'shop') }}" alt="{{ 'sylius.ui.loading'|trans }}"/>
         </div>
     </div>
-    {{ form_start(form, {'attr': {'novalidate': 'novalidate', 'data-action': 'live#action:prevent', 'data-live-action-param': 'save'}}) }}
+    {{ form_start(form, {'action': path('sylius_shop_account_change_password'), 'attr': {'novalidate': 'novalidate'}}) }}
 
     {% hook 'form' with { form } %}
 

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -16,8 +16,10 @@ namespace Sylius\Bundle\UserBundle\Controller;
 use FOS\RestBundle\View\View;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Bundle\UserBundle\Form\Model\ChangePassword;
 use Sylius\Bundle\UserBundle\Form\Model\PasswordReset;
 use Sylius\Bundle\UserBundle\Form\Model\PasswordResetRequest;
+use Sylius\Bundle\UserBundle\Form\Type\UserChangePasswordType;
 use Sylius\Bundle\UserBundle\Form\Type\UserRequestPasswordResetType;
 use Sylius\Bundle\UserBundle\Form\Type\UserResetPasswordType;
 use Sylius\Bundle\UserBundle\UserEvents;
@@ -43,8 +45,23 @@ class UserController extends ResourceController
             throw new AccessDeniedException('You have to be registered user to access this section.');
         }
 
+        $user = $this->container->get('security.token_storage')->getToken()->getUser();
+
+        $changePassword = new ChangePassword();
+        $formType = $this->getSyliusAttribute($request, 'form', UserChangePasswordType::class);
+        $form = $this->createResourceForm($configuration, $formType, $changePassword);
+
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
+            return $this->handleChangePassword($request, $configuration, $user, $changePassword->getNewPassword());
+        }
+
+        if (!$configuration->isHtmlRequest()) {
+            return $this->viewHandler->handle($configuration, View::create($form, Response::HTTP_BAD_REQUEST));
+        }
+
         return new Response($this->container->get('twig')->render(
             $configuration->getTemplate('changePassword.html'),
+            ['form' => $form->createView()],
         ));
     }
 
@@ -312,6 +329,32 @@ class UserController extends ResourceController
         $this->addTranslatedFlash('success', 'sylius.user.reset_password');
 
         $dispatcher->dispatch(new GenericEvent($user), UserEvents::POST_PASSWORD_RESET);
+
+        if (!$configuration->isHtmlRequest()) {
+            return $this->viewHandler->handle($configuration, View::create(null, Response::HTTP_NO_CONTENT));
+        }
+
+        $redirectRouteName = $this->getSyliusAttribute($request, 'redirect', null);
+        Assert::notNull($redirectRouteName, 'Redirect is not configured.');
+
+        return new RedirectResponse($this->container->get('router')->generate($redirectRouteName));
+    }
+
+    protected function handleChangePassword(
+        Request $request,
+        RequestConfiguration $configuration,
+        UserInterface $user,
+        string $newPassword,
+    ): Response {
+        $user->setPlainPassword($newPassword);
+
+        $dispatcher = $this->container->get('event_dispatcher');
+        $dispatcher->dispatch(new GenericEvent($user), UserEvents::PRE_PASSWORD_CHANGE);
+
+        $this->manager->flush();
+        $this->addTranslatedFlash('success', 'sylius.user.change_password');
+
+        $dispatcher->dispatch(new GenericEvent($user), UserEvents::POST_PASSWORD_CHANGE);
 
         if (!$configuration->isHtmlRequest()) {
             return $this->viewHandler->handle($configuration, View::create(null, Response::HTTP_NO_CONTENT));


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | bootstrap-shop
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Reverted change password form to be submitted via controller
