### PR TITLE
[2.0] Fix data grid sorting when there are no defaults

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/sorting.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/sorting.html.twig
@@ -1,5 +1,5 @@
 {% macro table_header(grid, field, attributes) %}
-    {% set sorting_order = grid.getSortingOrder(field.name) %}
+    {% set sorting_order = grid.getSortingOrder(field.name)|default('asc') %}
 
     {% if grid.isSortedBy(field.name) %}
         <th class="sortable sorted {{ sorting_order == 'desc' ? 'descending' : 'ascending' }} sylius-table-column-{{ field.name }} {{ field.options.vars.th_class|default('') }}">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes (on 2.0, but I think we also have this issue in 1.x)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

When there is no default sorting (see below), the sorting link doesn't work.

```yaml
sylius_grid:
    grids:
        sylius_admin_product:
            driver:
                name: doctrine/orm
                options:
                    class: "%sylius.model.product.class%"
                    repository:
                        method: createListQueryBuilder
                        arguments: ["expr:service('sylius.context.locale').getLocaleCode()"]
#            sorting:
#                code: asc
```

Before
[Capture vidéo du 2024-09-03 10-43-21.webm](https://github.com/user-attachments/assets/7e1ce802-011d-4818-a1dc-c32d06d8453f)

After
[Capture vidéo du 2024-09-03 10-44-41.webm](https://github.com/user-attachments/assets/bfa835e7-7259-44a6-8443-4ef8be00de52)

