### PR TITLE
[Unit] Add PHPUnit-Like Array Difference Visualization

### DIFF
--- a/tests/Api/Admin/AddressesTest.php
+++ b/tests/Api/Admin/AddressesTest.php
@@ -98,8 +98,7 @@ final class AddressesTest extends JsonApiTestCase
             ], \JSON_THROW_ON_ERROR),
         );
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonResponseViolations($this->client->getResponse(), [
+        $this->assertResponseContainsViolations([
             [
                 'propertyPath' => 'countryCode',
                 'message' => 'This value is not a valid country.',

--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -277,7 +277,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
             ],
         );
 
-        $this->assertJsonResponseViolations($this->client->getResponse(), [
+        $this->assertResponseContainsViolations([
             [
                 'propertyPath' => 'scopes[0].type',
                 'message' => 'Catalog promotion scope type is invalid. Available types are for_products, for_taxons, for_variants.',
@@ -453,7 +453,7 @@ final class CatalogPromotionsTest extends JsonApiTestCase
             ],
         );
 
-        $this->assertJsonResponseViolations($this->client->getResponse(), [
+        $this->assertResponseContainsViolations([
             [
                 'propertyPath' => 'actions[0].type',
                 'message' => 'Please choose an action type.',

--- a/tests/Api/Admin/ChannelsTest.php
+++ b/tests/Api/Admin/ChannelsTest.php
@@ -123,8 +123,7 @@ final class ChannelsTest extends JsonApiTestCase
 
         $this->requestPost('/api/v2/admin/channels', $inputData);
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonResponseViolations($this->client->getResponse(), [$validation], false);
+        $this->assertResponseContainsViolations([$validation]);
     }
 
     #[Test]

--- a/tests/Api/Admin/ProductOptionsTest.php
+++ b/tests/Api/Admin/ProductOptionsTest.php
@@ -118,27 +118,24 @@ final class ProductOptionsTest extends JsonApiTestCase
             ],
         );
 
-        $this->assertResponseViolations(
-            $this->client->getResponse(),
+        $this->assertResponseContainsViolations([
             [
-                [
-                    'propertyPath' => 'code',
-                    'message' => 'Please enter option code.',
-                ],
-                [
-                    'propertyPath' => 'values[0].code',
-                    'message' => 'Please enter option value code.',
-                ],
-                [
-                    'propertyPath' => 'values[0].translations[en_US].value',
-                    'message' => 'Please enter option value.',
-                ],
-                [
-                    'propertyPath' => 'translations[en_US].name',
-                    'message' => 'Please enter option name.',
-                ],
+                'propertyPath' => 'code',
+                'message' => 'Please enter option code.',
             ],
-        );
+            [
+                'propertyPath' => 'values[0].code',
+                'message' => 'Please enter option value code.',
+            ],
+            [
+                'propertyPath' => 'values[0].translations[en_US].value',
+                'message' => 'Please enter option value.',
+            ],
+            [
+                'propertyPath' => 'translations[en_US].name',
+                'message' => 'Please enter option name.',
+            ],
+        ]);
     }
 
     #[Test]

--- a/tests/Api/Admin/ProductReviewsTest.php
+++ b/tests/Api/Admin/ProductReviewsTest.php
@@ -153,7 +153,6 @@ final class ProductReviewsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'rating',

--- a/tests/Api/Admin/ProductVariantsTest.php
+++ b/tests/Api/Admin/ProductVariantsTest.php
@@ -230,7 +230,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'channelPricings[NON-EXISTING-CHANNEL].channelCode',
@@ -268,7 +267,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'channelPricings[].channelCode',
@@ -340,7 +338,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'product',
@@ -385,7 +382,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'translations[NON-EXISTING-LOCALE-CODE]',
@@ -495,7 +491,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'translations[NON-EXISTING-LOCALE-CODE]',
@@ -538,7 +533,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'translations[en_US].locale',
@@ -579,7 +573,6 @@ final class ProductVariantsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'channelPricings[WEB].channelCode',

--- a/tests/Api/Admin/ShippingMethodsTest.php
+++ b/tests/Api/Admin/ShippingMethodsTest.php
@@ -181,7 +181,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'configuration[WEB][amount]',
@@ -269,7 +268,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'rules[0].configuration[weight]',
@@ -280,19 +278,19 @@ final class ShippingMethodsTest extends JsonApiTestCase
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
-                    'propertyPath' => 'rules[2].configuration[MOBILE][amount]',
-                    'message' => 'This value should be of type numeric.',
-                ],
-                [
                     'propertyPath' => 'rules[2].configuration[WEB][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
-                    'propertyPath' => 'rules[3].configuration[MOBILE][amount]',
+                    'propertyPath' => 'rules[2].configuration[MOBILE][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
                     'propertyPath' => 'rules[3].configuration[WEB][amount]',
+                    'message' => 'This value should be of type numeric.',
+                ],
+                [
+                    'propertyPath' => 'rules[3].configuration[MOBILE][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
             ],
@@ -423,7 +421,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'configuration[WEB][amount]',
@@ -470,7 +467,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'translations[en_US].locale',
@@ -536,7 +532,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'rules[0].configuration[weight]',
@@ -547,19 +542,19 @@ final class ShippingMethodsTest extends JsonApiTestCase
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
-                    'propertyPath' => 'rules[2].configuration[MOBILE][amount]',
-                    'message' => 'This value should be of type numeric.',
-                ],
-                [
                     'propertyPath' => 'rules[2].configuration[WEB][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
-                    'propertyPath' => 'rules[3].configuration[MOBILE][amount]',
+                    'propertyPath' => 'rules[2].configuration[MOBILE][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
                 [
                     'propertyPath' => 'rules[3].configuration[WEB][amount]',
+                    'message' => 'This value should be of type numeric.',
+                ],
+                [
+                    'propertyPath' => 'rules[3].configuration[MOBILE][amount]',
                     'message' => 'This value should be of type numeric.',
                 ],
             ],
@@ -594,7 +589,6 @@ final class ShippingMethodsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'rules[0].type',

--- a/tests/Api/Admin/StatisticsTest.php
+++ b/tests/Api/Admin/StatisticsTest.php
@@ -169,15 +169,12 @@ final class StatisticsTest extends JsonApiTestCase
             server: $this->headerBuilder()->withAdminUserAuthorization('api@example.com')->build(),
         );
 
-        $this->assertResponseViolations(
-            $this->client->getResponse(),
+        $this->assertResponseContainsViolations([
             [
-                [
-                    'propertyPath' => '',
-                    'message' => 'The start date must be earlier than the end date.',
-                ],
+                'propertyPath' => '',
+                'message' => 'The start date must be earlier than the end date.',
             ],
-        );
+        ]);
     }
 
     #[DataProvider('missingQueryParameters')]
@@ -197,7 +194,7 @@ final class StatisticsTest extends JsonApiTestCase
             server: $this->headerBuilder()->withAdminUserAuthorization('api@example.com')->build(),
         );
 
-        $this->assertResponseViolations($this->client->getResponse(), $expectedViolations);
+        $this->assertResponseContainsViolations($expectedViolations);
     }
 
     public static function missingQueryParameters(): iterable

--- a/tests/Api/JsonApiTestCase.php
+++ b/tests/Api/JsonApiTestCase.php
@@ -222,6 +222,92 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
         return $this->request('DELETE', $uri, $queryParameters, $headers);
     }
 
+    protected function assertJsonResponseContent(Response $response, string $filename): void
+    {
+        $responseSource = $this->expectedResponsesPath;
+        $filepath = sprintf('%s/%s.json', $responseSource, $filename);
+        $contents = file_get_contents($filepath);
+
+        if ($contents === false) {
+            throw new \RuntimeException(sprintf('File %s does not exist', $filepath));
+        }
+
+        $expectedResponse = trim($contents);
+        $actualResponse = trim($this->prettifyJson($response->getContent()));
+
+        $matcher = $this->buildMatcher();
+        $result = $matcher->match($actualResponse, $expectedResponse);
+
+        if (!$result) {
+            $this->failWithJsonDiff($expectedResponse, $actualResponse, $filepath, $matcher->getError());
+        }
+    }
+
+    private function failWithJsonDiff(
+        string $expectedJson,
+        string $actualJson,
+        string $filepath,
+        ?string $matcherError = null,
+    ): void {
+        $expected = json_decode($expectedJson, true);
+        $actual = json_decode($actualJson, true);
+
+        $actualNormalized = $this->normalizeDynamicValues($actual, $expected);
+
+        $reset = "\033[0m";
+        self::assertSame($expected, $actualNormalized, $reset . "\nExpected response file: " . $filepath . ':1');
+    }
+
+    private function normalizeDynamicValues(mixed $actual, mixed $expected): mixed
+    {
+        if (!is_array($actual) || !is_array($expected)) {
+            return $actual;
+        }
+
+        $result = [];
+
+        foreach ($expected as $key => $expectedValue) {
+            if (!array_key_exists($key, $actual)) {
+                continue;
+            }
+
+            $actualValue = $actual[$key];
+
+            if (is_string($expectedValue) && $this->isPattern($expectedValue)) {
+                $result[$key] = $expectedValue;
+            } elseif (is_array($actualValue) && is_array($expectedValue)) {
+                $result[$key] = $this->normalizeDynamicValues($actualValue, $expectedValue);
+            } else {
+                $result[$key] = $actualValue;
+            }
+        }
+
+        foreach ($actual as $key => $value) {
+            if (!array_key_exists($key, $result)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    private function isPattern(string $value): bool
+    {
+        // Patterns like @integer@, @string@, @uuid@, etc.
+        if (preg_match('/^@\w+@/', $value)) {
+            return true;
+        }
+        // Patterns embedded in strings like "/api/v2/shop/orders/@integer@"
+        if (str_contains($value, '@integer@') || str_contains($value, '@string@') || str_contains($value, '@uuid@')) {
+            return true;
+        }
+        // Patterns with methods like @string@.contains('...')
+        if (preg_match('/@\w+@\./', $value)) {
+            return true;
+        }
+        return false;
+    }
+
     /** @throws \Exception */
     protected function assertResponseSuccessful(string $filename): void
     {
@@ -295,38 +381,74 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
     }
 
     /**
-     * @throws \Exception
+     * Asserts that response contains exactly the expected violations (exact match).
      *
      * @param array<array-key, mixed> $expectedViolations
+     *
+     * @throws \Exception
      */
-    protected function assertResponseViolations(Response $response, array $expectedViolations): void
+    protected function assertResponseViolations(array $expectedViolations): void
     {
-        if (isset($_SERVER['OPEN_ERROR_IN_BROWSER']) && true === $_SERVER['OPEN_ERROR_IN_BROWSER']) {
-            $this->showErrorInBrowserIfOccurred($response);
-        }
+        $this->assertViolationResponseHeaders();
 
-        $this->assertResponseCode($response, Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonHeader($response);
-        $this->assertJsonResponseViolations($response, $expectedViolations);
+        $response = $this->client->getResponse();
+        $responseContent = $response->getContent() ?: '';
+        $this->assertNotEmpty($responseContent);
+
+        $decoded = json_decode($responseContent, true);
+        $actualViolations = $decoded['violations'];
+        $actualDescription = $decoded['hydra:description'];
+
+        array_walk($actualViolations, function (&$item): void {
+            unset($item['code']);
+        });
+
+        $mappedViolations = array_map(function (array $violation): string {
+            if (empty($violation['propertyPath'])) {
+                return $violation['message'];
+            }
+
+            return $violation['propertyPath'] . ': ' . $violation['message'];
+        }, $expectedViolations);
+
+        $expectedDescription = implode("\n", $mappedViolations);
+
+        $expected = [
+            '@context' => '/api/v2/contexts/ConstraintViolationList',
+            '@type' => 'ConstraintViolationList',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => $expectedDescription,
+            'violations' => $expectedViolations,
+        ];
+
+        $actual = [
+            '@context' => '/api/v2/contexts/ConstraintViolationList',
+            '@type' => 'ConstraintViolationList',
+            'hydra:title' => 'An error occurred',
+            'hydra:description' => $actualDescription,
+            'violations' => $actualViolations,
+        ];
+
+        $this->assertSame($expected, $actual);
     }
 
     /**
-     * @throws \Exception
+     * Asserts that response contains at least the expected violations (contains mode).
+     * Use this when the response may contain additional violations beyond those specified.
      *
      * @param array<array-key, mixed> $expectedViolations
+     *
+     * @throws \Exception
      */
-    protected function assertJsonResponseViolations(
-        Response $response,
-        array $expectedViolations,
-        bool $assertViolationsCount = true,
-    ): void {
+    protected function assertResponseContainsViolations(array $expectedViolations): void
+    {
+        $this->assertViolationResponseHeaders();
+
+        $response = $this->client->getResponse();
         $responseContent = $response->getContent() ?: '';
         $this->assertNotEmpty($responseContent);
-        $violations = json_decode($responseContent, true)['violations'] ?? [];
 
-        if ($assertViolationsCount) {
-            $this->assertCount(count($expectedViolations), $violations, $responseContent);
-        }
+        $violations = json_decode($responseContent, true)['violations'] ?? [];
 
         $violationMap = [];
         foreach ($violations as $violation) {
@@ -338,6 +460,18 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
             $this->assertArrayHasKey($propertyPath, $violationMap, $responseContent);
             $this->assertContains($expectedViolation['message'], $violationMap[$propertyPath], $responseContent);
         }
+    }
+
+    private function assertViolationResponseHeaders(): void
+    {
+        $response = $this->client->getResponse();
+
+        if (isset($_SERVER['OPEN_ERROR_IN_BROWSER']) && true === $_SERVER['OPEN_ERROR_IN_BROWSER']) {
+            $this->showErrorInBrowserIfOccurred($response);
+        }
+
+        $this->assertResponseCode($response, Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertJsonHeader($response);
     }
 
     /**

--- a/tests/Api/Shop/AddressesTest.php
+++ b/tests/Api/Shop/AddressesTest.php
@@ -252,8 +252,7 @@ final class AddressesTest extends JsonApiTestCase
             ], \JSON_THROW_ON_ERROR),
         );
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $this->assertJsonResponseViolations($this->client->getResponse(), [
+        $this->assertResponseViolations([
             [
                 'propertyPath' => 'countryCode',
                 'message' => 'This value is not a valid country.',

--- a/tests/Api/Shop/Checkout/CartTest.php
+++ b/tests/Api/Shop/Checkout/CartTest.php
@@ -447,7 +447,6 @@ final class CartTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Email can be changed only for guest customers. Once the customer logs in and the cart is assigned, the email can\'t be changed.'],
             ],
@@ -471,7 +470,6 @@ final class CartTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'An empty order cannot be processed.'],
             ],
@@ -510,7 +508,6 @@ final class CartTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Please provide a billing address.'],
             ],
@@ -549,7 +546,6 @@ final class CartTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Please provide a shipping address.'],
             ],
@@ -582,7 +578,6 @@ final class CartTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'The country invalid-code does not exist.'],
                 ['propertyPath' => '', 'message' => 'The address without country cannot exist'],

--- a/tests/Api/Shop/Checkout/CompletionTest.php
+++ b/tests/Api/Shop/Checkout/CompletionTest.php
@@ -47,7 +47,6 @@ final class CompletionTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Cannot complete as order is in a wrong state. Current: cart. Possible transitions: address.'],
             ],
@@ -75,7 +74,6 @@ final class CompletionTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Cannot complete as order is in a wrong state. Current: addressed. Possible transitions: address, skip_shipping, select_shipping.'],
             ],
@@ -105,7 +103,6 @@ final class CompletionTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Cannot complete as order is in a wrong state. Current: shipping_selected. Possible transitions: address, select_shipping, skip_payment, select_payment.'],
             ],
@@ -134,7 +131,6 @@ final class CompletionTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'Cannot complete as order is in a wrong state. Current: shipping_skipped. Possible transitions: address, skip_payment, select_payment.'],
             ],

--- a/tests/Api/Shop/Checkout/PaymentMethodTest.php
+++ b/tests/Api/Shop/Checkout/PaymentMethodTest.php
@@ -287,7 +287,6 @@ final class PaymentMethodTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'The payment method with invalid code does not exist.'],
             ],

--- a/tests/Api/Shop/Checkout/ShippingMethodTest.php
+++ b/tests/Api/Shop/Checkout/ShippingMethodTest.php
@@ -147,7 +147,6 @@ final class ShippingMethodTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'The shipping method with invalid code does not exist.'],
             ],

--- a/tests/Api/Shop/OrdersTest.php
+++ b/tests/Api/Shop/OrdersTest.php
@@ -51,7 +51,7 @@ final class OrdersTest extends JsonApiTestCase
         $this->placeOrder('nAWw2jewpB', 'oliver@doe.com');
         $this->placeOrder('nAWw2jewpC', 'dave@doe.com');
         $this->pickUpCart('nAWw2jewpD');
-        $this->updateCartWithAddressAndCouponCode('nAWw2jewpD', 'oliver@doe.com');
+        $this->updateCartWithAddress('nAWw2jewpD', 'oliver@doe.com');
         $this->pickUpCart('nAWw2jewpE');
 
         $this->requestGet(
@@ -461,7 +461,6 @@ final class OrdersTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 ['propertyPath' => '', 'message' => 'You cannot change the payment method for a cancelled order.'],
             ],

--- a/tests/Api/Shop/PaymentRequestsTest.php
+++ b/tests/Api/Shop/PaymentRequestsTest.php
@@ -185,12 +185,9 @@ final class PaymentRequestsTest extends JsonApiTestCase
             ], \JSON_THROW_ON_ERROR),
         );
 
-        $this->assertResponseViolations(
-            $this->client->getResponse(),
-            [
-                ['propertyPath' => '', 'message' => sprintf('The payment request (method code: %s and payment id: %d) has no handler. Please choose another payment method.', $payment->getMethod()->getCode(), $payment->getId())],
-            ],
-        );
+        $this->assertResponseContainsViolations([
+            ['propertyPath' => '', 'message' => sprintf('The payment request (method code: %s and payment id: %d) has no handler. Please choose another payment method.', $payment->getMethod()->getCode(), $payment->getId())],
+        ]);
     }
 
     /**

--- a/tests/Api/Shop/ProductReviewsTest.php
+++ b/tests/Api/Shop/ProductReviewsTest.php
@@ -135,7 +135,6 @@ final class ProductReviewsTest extends JsonApiTestCase
         );
 
         $this->assertResponseViolations(
-            $this->client->getResponse(),
             [
                 [
                     'propertyPath' => 'email',


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Here's an example of a failing test:

Before:
<img width="1323" alt="image" src="https://github.com/user-attachments/assets/e501e05c-5beb-4d46-bb3c-d36a82b4f2a6">
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/cf990b15-e55b-411b-8255-5656356bb473">
<img width="1328" alt="image" src="https://github.com/user-attachments/assets/448ccdbd-e98d-43ed-a1a5-a32e4476d7c4">

After: (it also provides a direct way to jump right into the expected response file):
<img width="967" alt="image" src="https://github.com/user-attachments/assets/9d0e55a9-65c3-4282-9f93-09508652cd11">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Standardized validation assertions across API suites, simplifying calls and using the latest response implicitly.
  - Introduced exact vs. contains-style violation checks for clearer failures.
  - Added robust JSON response comparison with dynamic value normalization and helpful diffs.
  - Corrected expected validation paths in shipping method rule scenarios for accuracy.
  - Harmonized negative-case tests in admin and shop flows (addresses, catalog promotions, channels, product options/variants/reviews, checkout, orders).
  - Minor scenario adjustments in order-related tests to reflect current behavior without altering outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->