### PR TITLE
[CI] Correct Branches Comparision in Upmerge Workflow

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -40,7 +40,19 @@ jobs:
                     git reset --hard ${{ matrix.base_branch }}
 
             -
+                name: Check if there are differences
+                id: check_diff
+                run: |
+                    git fetch origin ${{ matrix.target_branch }}
+                    if git diff --quiet ${{ matrix.base_branch }} origin/${{ matrix.target_branch }}; then
+                        echo "has_diff=false" >> $GITHUB_OUTPUT
+                    else
+                        echo "has_diff=true" >> $GITHUB_OUTPUT
+                    fi
+
+            -
                 name: Create Pull Request
+                if: steps.check_diff.outputs.has_diff == 'true'
                 uses: peter-evans/create-pull-request@v4
                 with:
                     token: ${{ secrets.SYLIUS_BOT_PAT }}


### PR DESCRIPTION
 ## Summary

  This PR fixes the upmerge workflow failing when there are no commits between branches by adding `continue-on-error: true` to the Create Pull Request step.

  When branches are already in sync (no commits to upmerge), the workflow will now complete successfully instead of failing with "No commits between X and Y" error:
<img width="1358" height="232" alt="image" src="https://github.com/user-attachments/assets/d0c3c140-c8e8-491d-a958-d5707e281889" />

  ## Changes

  - Added `continue-on-error: true` flag to the "Create Pull Request" step in the upmerge workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now checks for repository differences and only creates pull requests when changes are detected, reducing empty/ unnecessary PRs.
  * No other user-facing behavior changes in this release; improvements are limited to internal release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->