### PR TITLE
[Maintenance] Deprecate leftover legacy custom promotion validation

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -42,6 +42,20 @@
    Starting with this version, form types will be extended using the parent form instead of through form extensions,
    like it's done in the `Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionScopeType` and `Sylius\Bundle\AdminBundle\Form\Type\CatalogPromotionActionType` classes.
 
+1. Classes related to legacy validation of CatalogPromotions' configuration have been deprecated and will be remove in Sylius 2.0:
+    - `Sylius\Bundle\ApiBundle\Validator\CatalogPromotion\FixedDiscountActionValidator`
+    - `Sylius\Bundle\ApiBundle\Validator\CatalogPromotion\ForProductsScopeValidator`
+    - `Sylius\Bundle\ApiBundle\Validator\CatalogPromotion\ForTaxonsScopeValidator`
+    - `Sylius\Bundle\ApiBundle\Validator\CatalogPromotion\ForVariantsScopeValidator`
+    - `Sylius\Bundle\ApiBundle\Validator\CatalogPromotion\PercentageDiscountActionValidator`
+    - `Sylius\Bundle\CoreBundle\CatalogPromotion\Validator\CatalogPromotionAction\FixedDiscountActionValidator`
+    - `Sylius\Bundle\CoreBundle\CatalogPromotion\Validator\CatalogPromotionScope\ForProductsScopeValidator`
+    - `Sylius\Bundle\CoreBundle\CatalogPromotion\Validator\CatalogPromotionScope\ForTaxonsScopeValidator`
+    - `Sylius\Bundle\CoreBundle\CatalogPromotion\Validator\CatalogPromotionScope\ForVariantsScopeValidator`
+    - `Sylius\Bundle\PromotionBundle\Validator\Constraints\CatalogPromotionAction` 
+    - `Sylius\Bundle\PromotionBundle\Validator\Constraints\CatalogPromotionScope` 
+   Use the regular Symfony validation constraints instead.
+
 1. The class `Sylius\Bundle\CoreBundle\Twig\StateMachineExtension` has been deprecated and will be removed in Sylius 2.0. Use `Sylius\Abstraction\StateMachine\Twig\StateMachineExtension` instead.
 
 1. The class `Sylius\Bundle\CoreBundle\Console\Command\ShowAvailablePluginsCommand` has been deprecated and will be removed in Sylius 2.0.

--- a/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/FixedDiscountActionValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/FixedDiscountActionValidator.php
@@ -21,6 +21,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/api-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    FixedDiscountActionValidator::class,
+);
 final class FixedDiscountActionValidator implements ActionValidatorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForProductsScopeValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForProductsScopeValidator.php
@@ -21,6 +21,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/api-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForProductsScopeValidator::class,
+);
 final class ForProductsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForTaxonsScopeValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForTaxonsScopeValidator.php
@@ -21,6 +21,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/api-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForTaxonsScopeValidator::class,
+);
 final class ForTaxonsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForVariantsScopeValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/ForVariantsScopeValidator.php
@@ -21,6 +21,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/api-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForVariantsScopeValidator::class,
+);
 final class ForVariantsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/PercentageDiscountActionValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/CatalogPromotion/PercentageDiscountActionValidator.php
@@ -21,6 +21,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/api-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    PercentageDiscountActionValidator::class,
+);
 final class PercentageDiscountActionValidator implements ActionValidatorInterface
 {
     public function __construct(private SectionProviderInterface $sectionProvider)

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionAction/FixedDiscountActionValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionAction/FixedDiscountActionValidator.php
@@ -22,6 +22,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    FixedDiscountActionValidator::class,
+);
 final class FixedDiscountActionValidator implements ActionValidatorInterface
 {
     public function __construct(private ChannelRepositoryInterface $channelRepository)

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForProductsScopeValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForProductsScopeValidator.php
@@ -20,6 +20,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForProductsScopeValidator::class,
+);
 final class ForProductsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(private ProductRepositoryInterface $productRepository)

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForTaxonsScopeValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForTaxonsScopeValidator.php
@@ -20,6 +20,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForTaxonsScopeValidator::class,
+);
 final class ForTaxonsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(private TaxonRepositoryInterface $taxonRepository)

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForVariantsScopeValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Validator/CatalogPromotionScope/ForVariantsScopeValidator.php
@@ -20,6 +20,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    ForVariantsScopeValidator::class,
+);
 final class ForVariantsScopeValidator implements ScopeValidatorInterface
 {
     public function __construct(private ProductVariantRepositoryInterface $variantRepository)

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionAction.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionAction.php
@@ -15,6 +15,12 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+trigger_deprecation(
+    'sylius/promotion-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    CatalogPromotionAction::class,
+);
 final class CatalogPromotionAction extends Constraint
 {
     public string $invalidType = 'sylius.catalog_promotion_action.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScope.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScope.php
@@ -15,6 +15,12 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+trigger_deprecation(
+    'sylius/promotion-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0, use the usual symfony logic for validation.',
+    CatalogPromotionScope::class,
+);
 final class CatalogPromotionScope extends Constraint
 {
     public string $invalidType = 'sylius.catalog_promotion_scope.invalid_type';


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | related #15797 #15708
| License         | MIT
