### PR TITLE
Remove leftovers of paypal express checkout in tests

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Tests/DependencyInjection/SyliusPayumExtensionTest.php
+++ b/src/Sylius/Bundle/PayumBundle/Tests/DependencyInjection/SyliusPayumExtensionTest.php
@@ -47,13 +47,13 @@ final class SyliusPayumExtensionTest extends AbstractExtensionTestCase
         $this->load([
             'gateway_config' => [
                 'validation_groups' => [
-                        'paypal_express_checkout' => ['sylius', 'paypal'],
+                        'paypal' => ['sylius', 'paypal'],
                         'offline' => ['sylius'],
                 ],
             ],
         ]);
 
-        $this->assertContainerBuilderHasParameter('sylius.payum.gateway_config.validation_groups', ['paypal_express_checkout' => ['sylius', 'paypal'], 'offline' => ['sylius']]);
+        $this->assertContainerBuilderHasParameter('sylius.payum.gateway_config.validation_groups', ['paypal' => ['sylius', 'paypal'], 'offline' => ['sylius']]);
     }
 
     protected function getContainerExtensions(): array

--- a/src/Sylius/Bundle/PayumBundle/spec/Validator/GatewayFactoryExistsValidatorSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Validator/GatewayFactoryExistsValidatorSpec.php
@@ -28,7 +28,7 @@ final class GatewayFactoryExistsValidatorSpec extends ObjectBehavior
         ExecutionContextInterface $executionContext,
     ): void {
         $this->beConstructedWith(
-            ['paypal_express_checkout' => 'sylius.payum_gateway_factory.paypal_express_checkout', 'stripe_checkout' => 'sylius.payum_gateway_factory.stripe_checkout'],
+            ['paypal' => 'sylius.payum_gateway_factory.paypal', 'stripe_checkout' => 'sylius.payum_gateway_factory.stripe_checkout'],
         );
 
         $this->initialize($executionContext);
@@ -60,6 +60,6 @@ final class GatewayFactoryExistsValidatorSpec extends ObjectBehavior
     ): void {
         $executionContext->buildViolation(Argument::cetera())->shouldNotBeCalled();
 
-        $this->validate('paypal_express_checkout', new GatewayFactoryExists());
+        $this->validate('paypal', new GatewayFactoryExists());
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/spec/Validator/GroupsGenerator/GatewayConfigGroupsGeneratorSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Validator/GroupsGenerator/GatewayConfigGroupsGeneratorSpec.php
@@ -23,7 +23,7 @@ final class GatewayConfigGroupsGeneratorSpec extends ObjectBehavior
     function let(): void
     {
         $this->beConstructedWith([
-            'paypal_express_checkout' => ['paypal_express_checkout', 'sylius'],
+            'paypal' => ['paypal', 'sylius'],
             'stripe_checkout' => ['stripe_checkout', 'sylius'],
         ]);
     }
@@ -41,9 +41,9 @@ final class GatewayConfigGroupsGeneratorSpec extends ObjectBehavior
         PaymentMethodInterface $paymentMethod,
     ): void {
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getFactoryName()->willReturn('paypal_express_checkout');
+        $gatewayConfig->getFactoryName()->willReturn('paypal');
 
-        $this($paymentMethod)->shouldReturn(['paypal_express_checkout', 'sylius']);
+        $this($paymentMethod)->shouldReturn(['paypal', 'sylius']);
     }
 
     function it_returns_default_validation_groups_if_gateway_config_is_null(
@@ -61,8 +61,8 @@ final class GatewayConfigGroupsGeneratorSpec extends ObjectBehavior
     ): void {
         $form->getData()->willReturn($paymentMethod);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getFactoryName()->willReturn('paypal_express_checkout');
+        $gatewayConfig->getFactoryName()->willReturn('paypal');
 
-        $this($form)->shouldReturn(['paypal_express_checkout', 'sylius']);
+        $this($form)->shouldReturn(['paypal', 'sylius']);
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
continuation of https://github.com/Sylius/Sylius/pull/16946
