### PR TITLE
Update state_machine.rst

### DIFF
--- a/docs/customization/state_machine.rst
+++ b/docs/customization/state_machine.rst
@@ -127,7 +127,7 @@ so that it does not count the average rating but does something else - you need 
 
     # config/packages/_sylius.yaml
     winzou_state_machine:
-        sylius_review:
+        sylius_product_review:
             callbacks:
                 after:
                     update_price:
@@ -147,7 +147,7 @@ On the example of the state machine of ProductReview, we can turn off the ``upda
 
     # config/packages/_sylius.yaml
     winzou_state_machine:
-        sylius_review:
+        sylius_product_review:
             callbacks:
                 after:
                     update_price:


### PR DESCRIPTION
Update of ProductReviews state machine name that is used in example. Currently not existing name (sylius_review) is used to show on how to modify existing callback with existing state machine Should be sylius_product_review
