### PR TITLE
[API] Introduce operations' names for all endpoints

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resolver/PathPrefixBasedOperationResolver.php
+++ b/src/Sylius/Bundle/ApiBundle/Resolver/PathPrefixBasedOperationResolver.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Resolver;
 
-use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\NotExposed;
 use ApiPlatform\Metadata\Operation;
@@ -42,15 +41,14 @@ final readonly class PathPrefixBasedOperationResolver implements OperationResolv
         $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
         foreach ($resourceMetadataCollection as $resourceMetadata) {
             foreach ($resourceMetadata->getOperations() as $operationName => $resourceOperation) {
-                if ($resourceOperation instanceof CollectionOperationInterface) {
-                    continue;
-                }
-
                 if ((!$resourceOperation instanceof Get) && (!$resourceOperation instanceof NotExposed)) {
                     continue;
                 }
 
-                if (str_starts_with($operationName, '_api_/' . $pathPrefix)) {
+                if (
+                    str_starts_with($operationName, '_api_/' . $pathPrefix) ||
+                    str_starts_with($operationName, 'sylius_api_' . $pathPrefix)
+                ) {
                     return $resourceOperation;
                 }
             }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Address.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Address">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/addresses/{id}">
+            <operation name="sylius_api_admin_address_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/addresses/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/addresses/{id}">
+            <operation name="sylius_api_admin_address_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/addresses/{id}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AddressLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AddressLogEntry.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Addressing\Model\AddressLogEntry">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" routePrefix="admin" />
+            <operation name="sylius_api_admin_address_log_entry_get" class="ApiPlatform\Metadata\NotExposed" routePrefix="admin" />
         </operations>
     </resource>
 
@@ -34,7 +34,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_address_address_log_entry_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Adjustment.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Adjustment">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/adjustments/{id}">
+            <operation name="sylius_api_admin_adjustment_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/adjustments/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -38,7 +38,11 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.admin.order.adjustment.collection">
+            <operation
+                name="sylius_api_admin_order_adjustment_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.admin.order.adjustment.collection"
+            >
                 <parameters>
                     <parameter key="type" />
                 </parameters>
@@ -61,7 +65,11 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.admin.order_item.adjustment.collection">
+            <operation
+                name="sylius_api_admin_order_item_adjustment_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.admin.order_item.adjustment.collection"
+            >
                 <parameters>
                     <parameter key="type" />
                 </parameters>
@@ -84,7 +92,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_order_item_unit_adjustment_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -104,7 +112,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_shipment_adjustment_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUser.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\AdminUser" shortName="Administrator" routePrefix="admin">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_admin_user_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get">
+            <operation name="sylius_api_admin_admin_user_get" class="ApiPlatform\Metadata\Get">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +42,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post">
+            <operation name="sylius_api_admin_admin_user_post" class="ApiPlatform\Metadata\Post">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -73,7 +73,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" processor="sylius_api.state_processor.admin.admin_user.persist">
+            <operation
+                name="sylius_api_admin_admin_user_put"
+                class="ApiPlatform\Metadata\Put"
+                processor="sylius_api.state_processor.admin.admin_user.persist"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -103,7 +107,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" processor="sylius_api.state_processor.admin.admin_user.remove"/>
+            <operation
+                name="sylius_api_admin_admin_user_delete"
+                class="ApiPlatform\Metadata\Delete"
+                processor="sylius_api.state_processor.admin.admin_user.remove"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUserPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUserPassword.xml
@@ -25,6 +25,7 @@
     >
         <operations>
             <operation
+                name="sylius_api_admin_reset_password_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/administrators/reset-password"
                 input="Sylius\Bundle\CoreBundle\Command\Admin\Account\RequestResetPasswordEmail"
@@ -55,6 +56,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_reset_password_patch"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/administrators/reset-password/{token}"
                 input="Sylius\Bundle\CoreBundle\Command\Admin\Account\ResetPassword"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AvatarImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AvatarImage.xml
@@ -22,7 +22,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\Get">
+            <operation name="sylius_api_admin_admin_user_avatar_image_get" class="ApiPlatform\Metadata\Get">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -35,6 +35,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_admin_user_avatar_image_post"
                 class="ApiPlatform\Metadata\Post"
                 processor="sylius_api.state_processor.admin.avatar_image.persist"
                 deserialize="false"
@@ -89,7 +90,7 @@
                 </openapi>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete"/>
+            <operation name="sylius_api_admin_admin_user_avatar_image_delete" class="ApiPlatform\Metadata\Delete" />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotion.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\CatalogPromotion">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/catalog-promotions">
+            <operation
+                name="sylius_api_admin_catalog_promotion_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/catalog-promotions"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -37,7 +41,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get"  uriTemplate="/admin/catalog-promotions/{code}">
+            <operation
+                name="sylius_api_admin_catalog_promotion_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/catalog-promotions/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -49,7 +57,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/catalog-promotions" >
+            <operation
+                name="sylius_api_admin_catalog_promotion_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/catalog-promotions"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -108,7 +120,11 @@ Example configuration for `percentage_discount` action type:
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/catalog-promotions/{code}">
+            <operation
+                name="sylius_api_admin_catalog_promotion_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/catalog-promotions/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -168,6 +184,7 @@ Example configuration for `percentage_discount` action type:
             </operation>
 
             <operation
+                name="sylius_api_admin_catalog_promotion_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/catalog-promotions/{code}"
                 controller="Sylius\Bundle\ApiBundle\Controller\RemoveCatalogPromotionAction"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionAction.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Promotion\Model\CatalogPromotionAction">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/catalog-promotions/{code}/actions/{id}">
+            <operation
+                name="sylius_api_admin_catalog_promotion_action_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/catalog-promotions/{code}/actions/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\CatalogPromotion" fromProperty="actions" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Promotion\Model\CatalogPromotionAction"/>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionAction.xml
@@ -19,7 +19,7 @@
     <resource class="Sylius\Component\Promotion\Model\CatalogPromotionAction">
         <operations>
             <operation
-                name="sylius_api_admin_catalog_promotion_action_get"
+                name="sylius_api_admin_catalog_promotion_catalog_promotion_action_get"
                 class="ApiPlatform\Metadata\NotExposed"
                 uriTemplate="/admin/catalog-promotions/{code}/actions/{id}"
             >

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionScope.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionScope.xml
@@ -19,7 +19,7 @@
     <resource class="Sylius\Component\Core\Model\CatalogPromotionScope">
         <operations>
             <operation
-                name="sylius_api_admin_catalog_promotion_scope_get"
+                name="sylius_api_admin_catalog_promotion_catalog_promotion_scope_get"
                 class="ApiPlatform\Metadata\NotExposed"
                 uriTemplate="/admin/catalog-promotions/{code}/scopes/{id}"
             >

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionScope.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionScope.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\CatalogPromotionScope">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/catalog-promotions/{code}/scopes/{id}">
+            <operation
+                name="sylius_api_admin_catalog_promotion_scope_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/catalog-promotions/{code}/scopes/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\CatalogPromotion" fromProperty="scopes" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\CatalogPromotionScope" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CatalogPromotionTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Promotion\Model\CatalogPromotionTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/catalog-promotions/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_catalog_promotion_catalog_promotion_translation_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/catalog-promotions/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\CatalogPromotion" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Promotion\Model\CatalogPromotionTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Channel.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\Channel">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/channels">
+            <operation
+                name="sylius_api_admin_channel_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/channels"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/channels/{code}">
+            <operation name="sylius_api_admin_channel_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/channels/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +46,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/channels">
+            <operation name="sylius_api_admin_channel_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/channels">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -72,7 +76,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/channels/{code}">
+            <operation name="sylius_api_admin_channel_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/channels/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -103,6 +107,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_channel_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/channels/{code}"
                 processor="sylius_api.state_processor.admin.channel.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ChannelPricing.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ChannelPricing.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ChannelPricing">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-variants/{code}/channel-pricings/{channelCode}">
+            <operation
+                name="sylius_api_admin_product_variant_channel_pricing_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-variants/{code}/channel-pricings/{channelCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ProductVariant" fromProperty="channelPricings" />
                     <uriVariable parameterName="channelCode" fromClass="Sylius\Component\Core\Model\ChannelPricing" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ChannelPricingLogEntry.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ChannelPricingLogEntry.xml
@@ -18,12 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ChannelPricingLogEntry">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/channel-pricing-log-entries">
-                <order>
-                    <values>
-                        <value name="id">DESC</value>
-                    </values>
-                </order>
+            <operation
+                name="sylius_api_admin_channel_pricing_log_entry_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/channel-pricing-log-entries"
+            >
                 <normalizationContext>
                     <values>
                         <value>sylius:admin:channel_pricing_log_entry:index</value>
@@ -32,9 +31,18 @@
                 <filters>
                     <filter>sylius_api.search_filter.admin.channel_pricing_log_entry</filter>
                 </filters>
+                <order>
+                    <values>
+                        <value name="id">DESC</value>
+                    </values>
+                </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/channel-pricing-log-entries/{id}">
+            <operation
+                name="sylius_api_admin_channel_pricing_log_entry_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/channel-pricing-log-entries/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value>sylius:admin:channel_pricing_log_entry:show</value>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Country.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Addressing\Model\Country">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/countries">
+            <operation
+                name="sylius_api_admin_country_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/countries"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/countries/{code}">
+            <operation name="sylius_api_admin_country_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/countries/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -43,6 +47,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_country_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/countries"
                 processor="sylius_api.state_processor.admin.country.persist"
@@ -77,6 +82,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_country_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/admin/countries/{code}"
                 processor="sylius_api.state_processor.admin.country.persist"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Currency.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Currency\Model\Currency">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/currencies">
+            <operation
+                name="sylius_api_admin_currency_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/currencies"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get"  uriTemplate="/admin/currencies/{code}">
+            <operation name="sylius_api_admin_currency_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/currencies/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +46,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/currencies" >
+            <operation name="sylius_api_admin_currency_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/currencies">
                 <denormalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Customer.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\Customer">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/customers">
+            <operation
+                name="sylius_api_admin_customer_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/customers"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,7 +43,7 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/customers/{id}">
+            <operation name="sylius_api_admin_customer_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/customers/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,6 +56,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_customer_get_statistics"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/admin/customers/{id}/statistics"
                 controller="Sylius\Bundle\ApiBundle\Controller\GetCustomerStatisticsAction"
@@ -67,7 +72,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/customers" >
+            <operation name="sylius_api_admin_customer_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/customers" >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -99,7 +104,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/customers/{id}" >
+            <operation name="sylius_api_admin_customer_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/customers/{id}" >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -131,6 +136,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_customer_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/customers/{id}/user"
                 controller="Sylius\Bundle\ApiBundle\Controller\RemoveCustomerShopUserAction"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CustomerGroup.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/CustomerGroup.xml
@@ -14,7 +14,11 @@
 >
     <resource class="Sylius\Component\Customer\Model\CustomerGroup">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/customer-groups">
+            <operation
+                name="sylius_api_admin_customer_group_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/customer-groups"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/customer-groups/{code}">
+            <operation
+                name="sylius_api_admin_customer_group_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/customer-groups/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +50,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/customer-groups" >
+            <operation
+                name="sylius_api_admin_customer_group_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/customer-groups"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -72,7 +84,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/customer-groups/{code}" >
+            <operation
+                name="sylius_api_admin_customer_group_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/customer-groups/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -102,7 +118,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/customer-groups/{code}" />
+            <operation
+                name="sylius_api_admin_customer_group_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/customer-groups/{code}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ExchangeRate.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Currency\Model\ExchangeRate">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/exchange-rates">
+            <operation
+                name="sylius_api_admin_exchange_rate_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/exchange-rates"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -33,7 +37,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/exchange-rates/{id}">
+            <operation
+                name="sylius_api_admin_exchange_rate_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/exchange-rates/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -45,7 +53,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/exchange-rates" >
+            <operation
+                name="sylius_api_admin_exchange_rate_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/exchange-rates"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -75,7 +87,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/exchange-rates/{id}" >
+            <operation
+                name="sylius_api_admin_exchange_rate_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/exchange-rates/{id}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -105,7 +121,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/exchange-rates/{id}" />
+            <operation
+                name="sylius_api_admin_exchange_rate_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/exchange-rates/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/GatewayConfig.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/GatewayConfig.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Bundle\PayumBundle\Model\GatewayConfig">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/gateway-configs/{id}" />
+            <operation
+                name="sylius_api_admin_gateway_config_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/gateway-configs/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Locale.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Locale\Model\Locale">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/locales">
+            <operation
+                name="sylius_api_admin_locale_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/locales"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -33,7 +37,7 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/locales/{code}">
+            <operation name="sylius_api_admin_locale_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/locales/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -45,7 +49,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/locales">
+            <operation name="sylius_api_admin_locale_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/locales">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -76,6 +80,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_locale_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/locales/{code}"
                 processor="sylius_api.state_processor.admin.locale.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Order.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Order">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/orders">
+            <operation name="sylius_api_admin_order_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/orders">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -41,7 +41,7 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/orders/{tokenValue}">
+            <operation name="sylius_api_admin_order_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/orders/{tokenValue}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -54,6 +54,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_order_post_resend_confirmation_email"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/orders/{tokenValue}/resend-confirmation-email"
                 messenger="input"
@@ -78,6 +79,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_order_patch_cancel"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/orders/{tokenValue}/cancel"
                 input="false"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/OrderItem.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\OrderItem">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/order-items/{id}">
+            <operation name="sylius_api_admin_order_item_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/order-items/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/OrderItemUnit.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\OrderItemUnit">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/order-item-units/{id}">
+            <operation
+                name="sylius_api_admin_order_item_unit_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/order-item-units/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Payment.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Payment">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/payments">
+            <operation name="sylius_api_admin_payment_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/payments">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,7 +39,7 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/payments/{id}">
+            <operation name="sylius_api_admin_payment_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/payments/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,6 +52,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_payment_patch_complete"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/payments/{id}/complete"
                 input="false"
@@ -83,6 +84,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_payment_patch_refund"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/payments/{id}/refund"
                 input="false"
@@ -120,7 +122,7 @@
             <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order" fromProperty="payments"/>
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_order_payment_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PaymentMethod.xml
@@ -18,12 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\PaymentMethod">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/payment-methods">
-                <order>
-                    <values>
-                        <value name="position">ASC</value>
-                    </values>
-                </order>
+            <operation
+                name="sylius_api_admin_payment_method_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/payment-methods"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,9 +38,18 @@
                     <filter>sylius_api.search_filter.admin.payment_method</filter>
                     <filter>sylius_api.boolean_filter.admin.payment_method</filter>
                 </filters>
+                <order>
+                    <values>
+                        <value name="position">ASC</value>
+                    </values>
+                </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/payment-methods/{code}">
+            <operation
+                name="sylius_api_admin_payment_method_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/payment-methods/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -53,7 +61,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/payment-methods">
+            <operation
+                name="sylius_api_admin_payment_method_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/payment-methods"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -79,7 +91,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/payment-methods/{code}">
+            <operation
+                name="sylius_api_admin_payment_method_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/payment-methods/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -106,6 +122,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_payment_method_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/payment-methods/{code}"
                 processor="sylius_api.state_processor.admin.payment_method.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PaymentMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PaymentMethodTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Payment\Model\PaymentMethodTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/payment-methods/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_payment_method_payment_method_translation_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/payment-methods/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\PaymentMethod" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Payment\Model\PaymentMethodTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Product.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Product">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/products">
+            <operation name="sylius_api_admin_product_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/products">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -61,7 +61,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/products/{code}">
+            <operation name="sylius_api_admin_product_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/products/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -94,7 +94,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/products">
+            <operation name="sylius_api_admin_product_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/products">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -124,7 +124,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/products/{code}">
+            <operation name="sylius_api_admin_product_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/products/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -155,6 +155,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_product_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/products/{code}"
                 processor="sylius_api.state_processor.admin.product.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAssociation">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-associations">
+            <operation
+                name="sylius_api_admin_product_association_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-associations"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -33,7 +37,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-associations/{id}">
+            <operation
+                name="sylius_api_admin_product_association_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-associations/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -45,7 +53,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-associations">
+            <operation
+                name="sylius_api_admin_product_association_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-associations"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -75,7 +87,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-associations/{id}">
+            <operation
+                name="sylius_api_admin_product_association_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-associations/{id}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -105,7 +121,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/product-associations/{id}" />
+            <operation
+                name="sylius_api_admin_product_association_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/product-associations/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociationType.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAssociationType">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-association-types">
+            <operation
+                name="sylius_api_admin_product_association_type_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-association-types"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -34,7 +38,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-association-types/{code}">
+            <operation
+                name="sylius_api_admin_product_association_type_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-association-types/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -46,7 +54,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-association-types">
+            <operation
+                name="sylius_api_admin_product_association_type_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-association-types"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -76,7 +88,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-association-types/{code}">
+            <operation
+                name="sylius_api_admin_product_association_type_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-association-types/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -106,7 +122,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/product-association-types/{code}" />
+            <operation
+                name="sylius_api_admin_product_association_type_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/product-association-types/{code}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociationTypeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAssociationTypeTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAssociationTypeTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-association-types/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_association_type_product_association_type_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-association-types/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductAssociationType" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Product\Model\ProductAssociationTypeTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttribute.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAttribute">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-attributes">
+            <operation
+                name="sylius_api_admin_product_attribute_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-attributes"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -40,7 +44,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-attributes/{code}">
+            <operation
+                name="sylius_api_admin_product_attribute_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-attributes/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,7 +60,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-attributes">
+            <operation
+                name="sylius_api_admin_product_attribute_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-attributes"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -144,7 +156,11 @@ Example configuration for a `select` type attribute:
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-attributes/{code}">
+            <operation
+                name="sylius_api_admin_product_attribute_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-attributes/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -237,6 +253,7 @@ Example configuration for a `select` type attribute:
             </operation>
 
             <operation
+                name="sylius_api_admin_product_attribute_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/product-attributes/{code}"
                 processor="sylius_api.state_processor.admin.product_attribute.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttributeTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttributeTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAttributeTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-attributes/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_attribute_product_attribute_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-attributes/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductAttribute" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Product\Model\ProductAttributeTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductAttributeValue.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAttributeValue">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-attribute-values/{id}">
+            <operation
+                name="sylius_api_admin_product_attribute_value_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-attribute-values/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductImage.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductImage">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/products/{code}/images">
+            <operation
+                name="sylius_api_admin_product_product_image_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/products/{code}/images"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="images" />
                 </uriVariables>
@@ -56,7 +60,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/products/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_product_product_image_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/products/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="images" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\ProductImage" />
@@ -92,7 +100,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/products/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_product_product_image_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/products/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="images" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\ProductImage" />
@@ -126,7 +138,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/products/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_product_product_image_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/products/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="images" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\ProductImage" />
@@ -138,6 +154,7 @@
     <resource class="Sylius\Component\Core\Model\Product">
         <operations>
             <operation
+                name="sylius_api_admin_product_product_image_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/products/{code}/images"
                 processor="sylius_api.state_processor.admin.product_image.persist"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOption.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOption">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-options">
+            <operation
+                name="sylius_api_admin_product_option_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-options"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -38,7 +42,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-options/{code}">
+            <operation
+                name="sylius_api_admin_product_option_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-options/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -50,7 +58,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-options">
+            <operation
+                name="sylius_api_admin_product_option_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-options"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -80,7 +92,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-options/{code}">
+            <operation
+                name="sylius_api_admin_product_option_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-options/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -110,7 +126,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/product-options/{code}"/>
+            <operation
+                name="sylius_api_admin_product_option_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/product-options/{code}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOptionTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-options/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_option_product_option_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-options/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Product\Model\ProductOptionTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValue.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOptionValue">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-options/{optionCode}/values/{code}">
+            <operation
+                name="sylius_api_admin_product_option_product_option_value_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-options/{optionCode}/values/{code}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="optionCode" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOptionValue" />
@@ -42,7 +46,10 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation
+                name="sylius_api_admin_product_option_product_option_value_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductOptionValueTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOptionValueTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-option-values/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_option_value_product_option_value_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-option-values/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOptionValue" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Product\Model\ProductOptionValueTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductReview.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductReview">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-reviews">
+            <operation
+                name="sylius_api_admin_product_review_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-reviews"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,7 +43,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-reviews/{id}">
+            <operation
+                name="sylius_api_admin_product_review_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-reviews/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -51,7 +59,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-reviews/{id}">
+            <operation
+                name="sylius_api_admin_product_review_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-reviews/{id}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -82,6 +94,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_product_review_patch_accept"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/product-reviews/{id}/accept"
                 input="false"
@@ -104,6 +117,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_product_review_patch_reject"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/product-reviews/{id}/reject"
                 input="false"
@@ -125,7 +139,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/product-reviews/{id}" />
+            <operation
+                name="sylius_api_admin_product_review_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/product-reviews/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductTaxon.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductTaxon">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-taxons">
+            <operation
+                name="sylius_api_admin_product_taxon_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-taxons"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,7 +43,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-taxons/{id}">
+            <operation
+                name="sylius_api_admin_product_taxon_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-taxons/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -51,7 +59,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-taxons">
+            <operation
+                name="sylius_api_admin_product_taxon_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-taxons"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -81,7 +93,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-taxons/{id}">
+            <operation
+                name="sylius_api_admin_product_taxon_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-taxons/{id}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -111,7 +127,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/product-taxons/{id}"/>
+            <operation
+                name="sylius_api_admin_product_taxon_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/product-taxons/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/products/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_product_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/products/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Core\Model\ProductTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductVariant.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductVariant">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/product-variants">
+            <operation
+                name="sylius_api_admin_product_variant_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/product-variants"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -40,7 +44,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/product-variants/{code}">
+            <operation
+                name="sylius_api_admin_product_variant_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/product-variants/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,7 +60,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/product-variants">
+            <operation
+                name="sylius_api_admin_product_variant_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/product-variants"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -82,7 +94,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/product-variants/{code}">
+            <operation
+                name="sylius_api_admin_product_variant_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/product-variants/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -113,6 +129,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_product_variant_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/product-variants/{code}"
                 processor="sylius_api.state_processor.admin.product_variant.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ProductVariantTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductVariantTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/product-variants/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_product_variant_product_variant_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/product-variants/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ProductVariant" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Product\Model\ProductVariantTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Promotion.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\Promotion">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/promotions">
+            <operation
+                name="sylius_api_admin_promotion_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/promotions"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -40,7 +44,7 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/promotions/{code}">
+            <operation name="sylius_api_admin_promotion_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/promotions/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,7 +56,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/promotions">
+            <operation name="sylius_api_admin_promotion_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/promotions">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -115,7 +119,7 @@ Example configuration for `order_fixed_discount` action type:
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/promotions/{code}">
+            <operation name="sylius_api_admin_promotion_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/promotions/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -179,6 +183,7 @@ Example configuration for `order_fixed_discount` action type:
             </operation>
 
             <operation
+                name="sylius_api_admin_promotion_patch_archive"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/promotions/{code}/archive"
                 input="false"
@@ -212,6 +217,7 @@ Example configuration for `order_fixed_discount` action type:
             </operation>
 
             <operation
+                name="sylius_api_admin_promotion_patch_restore"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/promotions/{code}/restore"
                 input="false"
@@ -245,6 +251,7 @@ Example configuration for `order_fixed_discount` action type:
             </operation>
 
             <operation
+                name="sylius_api_admin_promotion_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/promotions/{code}"
                 processor="sylius_api.state_processor.admin.promotion.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionAction.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionAction.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Promotion\Model\PromotionAction">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/promotions/{code}/actions/{id}">
+            <operation
+                name="sylius_api_admin_promotion_promotion_action_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/promotions/{code}/actions/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Promotion" fromProperty="actions" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Promotion\Model\PromotionAction" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionCoupon.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\PromotionCoupon">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/promotion-coupons">
+            <operation
+                name="sylius_api_admin_promotion_coupon_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/promotion-coupons"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -39,7 +43,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/promotion-coupons/{code}">
+            <operation
+                name="sylius_api_admin_promotion_coupon_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/promotion-coupons/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -51,7 +59,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/promotion-coupons">
+            <operation
+                name="sylius_api_admin_promotion_coupon_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/promotion-coupons"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -82,6 +94,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_promotion_coupon_post_generate"
                 class="ApiPlatform\Metadata\Post"
                 messenger="input"
                 uriTemplate="/admin/promotion-coupons/generate"
@@ -123,7 +136,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/promotion-coupons/{code}">
+            <operation
+                name="sylius_api_admin_promotion_coupon_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/promotion-coupons/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -154,6 +171,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_promotion_coupon_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/promotion-coupons/{code}"
                 processor="sylius_api.state_processor.admin.promotion_coupon.remove"
@@ -167,7 +185,11 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/promotions/{code}/coupons">
+            <operation
+                name="sylius_api_admin_promotion_promotion_coupon_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/promotions/{code}/coupons"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionRule.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Promotion\Model\PromotionRule">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/promotions/{code}/rules/{id}">
+            <operation
+                name="sylius_api_admin_promotion_promotion_rule_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/promotions/{code}/rules/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Promotion" fromProperty="rules" />
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Promotion\Model\PromotionRule" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Promotion\Model\PromotionTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/promotions/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_promotion_promotion_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/promotions/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Promotion" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Promotion\Model\PromotionTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Addressing\Model\Province">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/provinces/{code}">
+            <operation name="sylius_api_admin_province_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/provinces/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/provinces/{code}">
+            <operation name="sylius_api_admin_province_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/provinces/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -68,7 +68,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_country_province_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Shipment.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\Shipment">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/shipments">
+            <operation
+                name="sylius_api_admin_shipment_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/shipments"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -38,7 +42,7 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/shipments/{id}">
+            <operation name="sylius_api_admin_shipment_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/shipments/{id}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -51,6 +55,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_shipment_post_resend_confirmation_email"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/shipments/{id}/resend-confirmation-email"
                 messenger="input"
@@ -75,6 +80,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_shipment_patch_ship"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/shipments/{id}/ship"
                 messenger="input"
@@ -115,7 +121,7 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_admin_order_shipment_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingCategory.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Shipping\Model\ShippingCategory">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/shipping-categories">
+            <operation
+                name="sylius_api_admin_shipping_category_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/shipping-categories"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/shipping-categories/{code}">
+            <operation
+                name="sylius_api_admin_shipping_category_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/shipping-categories/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +50,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/shipping-categories" >
+            <operation
+                name="sylius_api_admin_shipping_category_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/shipping-categories"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -72,7 +84,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/shipping-categories/{code}" >
+            <operation
+                name="sylius_api_admin_shipping_category_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/shipping-categories/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -102,7 +118,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/shipping-categories/{code}" />
+            <operation
+                name="sylius_api_admin_shipping_category_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/shipping-categories/{code}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethod.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ShippingMethod">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/shipping-methods">
+            <operation
+                name="sylius_api_admin_shipping_method_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/shipping-methods"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -40,7 +44,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/shipping-methods/{code}">
+            <operation
+                name="sylius_api_admin_shipping_method_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/shipping-methods/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -52,7 +60,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/shipping-methods">
+            <operation
+                name="sylius_api_admin_shipping_method_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/shipping-methods"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -118,7 +130,11 @@ Example configuration for `flat_rate` shipping charges calculator:
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/shipping-methods/{code}">
+            <operation
+                name="sylius_api_admin_shipping_method_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/shipping-methods/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -185,6 +201,7 @@ Example configuration for `flat_rate` shipping charges calculator:
             </operation>
 
             <operation
+                name="sylius_api_admin_shipping_method_patch_archive"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/shipping-methods/{code}/archive"
                 input="false"
@@ -207,6 +224,7 @@ Example configuration for `flat_rate` shipping charges calculator:
             </operation>
 
             <operation
+                name="sylius_api_admin_shipping_method_patch_restore"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/admin/shipping-methods/{code}/restore"
                 input="false"
@@ -229,6 +247,7 @@ Example configuration for `flat_rate` shipping charges calculator:
             </operation>
 
             <operation
+                name="sylius_api_admin_shipping_method_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/shipping-methods/{code}"
                 processor="sylius_api.state_processor.admin.shipping_method.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethodRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethodRule.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Shipping\Model\ShippingMethodRule">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" routePrefix="admin" />
+            <operation
+                name="sylius_api_admin_shipping_method_rule_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                routePrefix="admin"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShippingMethodTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Shipping\Model\ShippingMethodTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/shipping-methods/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_shipping_method_shipping_method_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/shipping-methods/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\ShippingMethod" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Shipping\Model\ShippingMethodTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/ShopUser.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ShopUser">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/shop-users/{id}" />
+            <operation
+                name="sylius_api_admin_shop_user_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/shop-users/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxCategory.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Taxation\Model\TaxCategory">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/tax-categories">
+            <operation
+                name="sylius_api_admin_tax_category_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/tax-categories"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -33,7 +37,27 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/tax-categories">
+            <operation
+                name="sylius_api_admin_tax_category_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/tax-categories/{code}"
+            >
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:admin:tax_category:show</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+            </operation>
+
+            <operation
+                name="sylius_api_admin_tax_category_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/admin/tax-categories"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -63,19 +87,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/tax-categories/{code}">
-                <normalizationContext>
-                    <values>
-                        <value name="groups">
-                            <values>
-                                <value>sylius:admin:tax_category:show</value>
-                            </values>
-                        </value>
-                    </values>
-                </normalizationContext>
-            </operation>
-
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/tax-categories/{code}">
+            <operation
+                name="sylius_api_admin_tax_category_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/tax-categories/{code}"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -105,7 +121,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/tax-categories/{code}" />
+            <operation
+                name="sylius_api_admin_tax_category_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/tax-categories/{code}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxRate.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\TaxRate">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/tax-rates">
+            <operation
+                name="sylius_api_admin_tax_rate_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/tax-rates"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -33,7 +37,7 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/tax-rates/{code}">
+            <operation name="sylius_api_admin_tax_rate_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/tax-rates/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -45,7 +49,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/tax-rates">
+            <operation name="sylius_api_admin_tax_rate_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/tax-rates">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -75,7 +79,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/tax-rates/{code}">
+            <operation name="sylius_api_admin_tax_rate_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/tax-rates/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -105,7 +109,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/tax-rates/{code}" />
+            <operation name="sylius_api_admin_tax_rate_delete" class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/tax-rates/{code}" />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Taxon.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Taxon">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/taxons">
+            <operation name="sylius_api_admin_taxon_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/taxons">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -50,7 +50,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/taxons/{code}">
+            <operation name="sylius_api_admin_taxon_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/taxons/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -82,7 +82,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/taxons">
+            <operation name="sylius_api_admin_taxon_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/taxons">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -112,7 +112,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/taxons/{code}">
+            <operation name="sylius_api_admin_taxon_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/taxons/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -142,7 +142,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/taxons/{code}" />
+            <operation name="sylius_api_admin_taxon_delete" class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/taxons/{code}" />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxonImage.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\TaxonImage">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/taxons/{code}/images">
+            <operation
+                name="sylius_api_admin_taxon_taxon_image_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/admin/taxons/{code}/images"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="images"/>
                 </uriVariables>
@@ -53,7 +57,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/taxons/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_taxon_taxon_image_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/taxons/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="images"/>
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\TaxonImage"/>
@@ -89,7 +97,11 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/taxons/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_taxon_taxon_image_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/taxons/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="images"/>
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\TaxonImage"/>
@@ -123,7 +135,11 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Delete" uriTemplate="/admin/taxons/{code}/images/{id}">
+            <operation
+                name="sylius_api_admin_taxon_taxon_image_delete"
+                class="ApiPlatform\Metadata\Delete"
+                uriTemplate="/admin/taxons/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="images"/>
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\TaxonImage"/>
@@ -135,6 +151,7 @@
     <resource class="Sylius\Component\Core\Model\Taxon">
         <operations>
             <operation
+                name="sylius_api_admin_taxon_taxon_image_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/taxons/{code}/images"
                 processor="sylius_api.state_processor.admin.taxon_image.persist"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/TaxonTranslation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Taxonomy\Model\TaxonTranslation">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/admin/taxon/{code}/translations/{localeCode}">
+            <operation
+                name="sylius_api_admin_taxon_taxon_translation_get_collection"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/admin/taxon/{code}/translations/{localeCode}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="translations" />
                     <uriVariable parameterName="localeCode" fromClass="Sylius\Component\Taxonomy\Model\TaxonTranslation" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Zone.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Zone.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Addressing\Model\Zone">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/zones">
+            <operation name="sylius_api_admin_zone_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/zones">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/admin/zones/{code}">
+            <operation name="sylius_api_admin_zone_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/zones/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -42,7 +42,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/admin/zones">
+            <operation name="sylius_api_admin_zone_post" class="ApiPlatform\Metadata\Post" uriTemplate="/admin/zones">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -72,7 +72,7 @@
                 </validationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Put" uriTemplate="/admin/zones/{code}">
+            <operation name="sylius_api_admin_zone_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/zones/{code}">
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -103,6 +103,7 @@
             </operation>
 
             <operation
+                name="sylius_api_admin_zone_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/zones/{code}"
                 processor="sylius_api.state_processor.admin.zone.remove"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Address.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Address">
         <operations>
             <operation
+                name="sylius_api_shop_address_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/addresses"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -35,6 +36,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_address_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/addresses/{id}"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -51,6 +53,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_address_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/shop/addresses"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -87,6 +90,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_address_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/shop/addresses/{id}"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -121,6 +125,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_address_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/shop/addresses/{id}"
                 security="is_granted('SYLIUS_SHOP_USER')"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Adjustment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Adjustment.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\Adjustment">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/shop/adjustments/{id}" />
+            <operation
+                name="sylius_api_shop_adjustment_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/shop/adjustments/{id}"
+            />
         </operations>
     </resource>
 
@@ -31,7 +35,11 @@
             <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order" fromProperty="adjustments" />
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.shop.order.adjustment.collection">
+            <operation
+                name="sylius_api_shop_order_adjustment_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.shop.order.adjustment.collection"
+            >
                 <parameters>
                     <parameter key="type" />
                 </parameters>
@@ -58,7 +66,11 @@
             <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order" fromProperty="items" />
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.shop.order.order_item.adjustment.collection">
+            <operation
+                name="sylius_api_shop_order_order_item_adjustment_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.shop.order.order_item.adjustment.collection"
+            >
                 <parameters>
                     <parameter key="type" />
                 </parameters>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CatalogPromotion.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\CatalogPromotion">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get"  uriTemplate="/shop/catalog-promotions/{code}">
+            <operation
+                name="sylius_api_shop_catalog_promotion_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/catalog-promotions/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Channel.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Channel">
         <operations>
             <operation
+                name="sylius_api_shop_channel_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/channels"
                 provider="sylius_api.state_provider.shop.channel.collection"
@@ -34,7 +35,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/channels/{code}">
+            <operation name="sylius_api_shop_channel_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/channels/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Contact.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Contact.xml
@@ -26,7 +26,7 @@
         status="202"
     >
         <operations>
-            <operation class="ApiPlatform\Metadata\Post" uriTemplate="/contact">
+            <operation name="sylius_api_shop_contact_post_send_contact_request" class="ApiPlatform\Metadata\Post" uriTemplate="/contact">
                 <denormalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Country.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Addressing\Model\Country">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/countries">
+            <operation name="sylius_api_shop_country_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/countries">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/countries/{code}">
+            <operation name="sylius_api_shop_country_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/countries/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Currency.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Currency.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Currency\Model\Currency">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/currencies">
+            <operation name="sylius_api_shop_currency_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/currencies">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +30,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/currencies/{code}">
+            <operation name="sylius_api_shop_currency_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/currencies/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Customer.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Customer">
         <operations>
             <operation
+                name="sylius_api_shop_customer_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/customers/{id}"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -35,6 +36,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_customer_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/shop/customers"
                 messenger="input"
@@ -67,6 +69,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_customer_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/shop/customers/{id}"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -103,6 +106,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_customer_put_password"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/shop/customers/{id}/password"
                 messenger="input"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerPassword.xml
@@ -23,6 +23,7 @@
     >
         <operations>
             <operation
+                name="sylius_api_shop_customer_post_reset_password"
                 class="ApiPlatform\Metadata\Post"
                 input="Sylius\Bundle\ApiBundle\Command\Account\RequestResetPasswordToken"
                 output="false"
@@ -55,6 +56,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_customer_patch_reset_password"
                 class="ApiPlatform\Metadata\Patch"
                 input="Sylius\Bundle\ApiBundle\Command\Account\ResetPassword"
                 output="false"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerVerification.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerVerification.xml
@@ -24,6 +24,7 @@
     >
         <operations>
             <operation
+                name="sylius_api_shop_customer_post_verify"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/shop/customers/verify"
                 input="Sylius\Bundle\ApiBundle\Command\Account\RequestShopUserVerification"
@@ -55,6 +56,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_customer_patch_verify"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/shop/customers/verify/{token}"
                 input="Sylius\Bundle\ApiBundle\Command\Account\VerifyShopUser"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ExchangeRate.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ExchangeRate.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Currency\Model\ExchangeRate">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/exchange-rates">
+            <operation
+                name="sylius_api_shop_exchange_rate_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/exchange-rates"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +34,11 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/exchange-rates/{id}">
+            <operation
+                name="sylius_api_shop_exchange_rate_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/exchange-rates/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Locale.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Locale.xml
@@ -18,7 +18,12 @@
 >
     <resource class="Sylius\Component\Locale\Model\Locale">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/locales" paginationEnabled="false">
+            <operation
+                name="sylius_api_shop_locale_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/locales"
+                paginationEnabled="false"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +35,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/locales/{code}">
+            <operation name="sylius_api_shop_locale_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/locales/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Order.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Order">
         <operations>
             <operation
+                name="sylius_api_shop_order_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/orders"
                 security="is_granted('SYLIUS_SHOP_USER')"
@@ -34,7 +35,7 @@
                 </normalizationContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/orders/{tokenValue}">
+            <operation name="sylius_api_shop_order_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/orders/{tokenValue}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -47,6 +48,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_payment_get_configuration"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/orders/{tokenValue}/payments/{paymentId}/configuration"
                 controller="Sylius\Bundle\ApiBundle\Controller\Payment\GetPaymentConfiguration"
@@ -63,21 +65,13 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/shop/orders"
                 itemUriTemplate="/shop/orders/{tokenValue}"
                 messenger="input"
                 input="Sylius\Bundle\ApiBundle\Command\Cart\PickupCart"
             >
-                <validationContext>
-                    <values>
-                        <value name="groups">
-                            <values>
-                                <value>sylius</value>
-                            </values>
-                        </value>
-                    </values>
-                </validationContext>
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -96,20 +90,6 @@
                         </value>
                     </values>
                 </normalizationContext>
-                <openapiContext>
-                    <values>
-                        <value name="summary">Pickups a new cart.</value>
-                    </values>
-                </openapiContext>
-            </operation>
-
-            <operation
-                class="ApiPlatform\Metadata\Post"
-                uriTemplate="/shop/orders/{tokenValue}/items"
-                itemUriTemplate="/shop/orders/{tokenValue}"
-                messenger="input"
-                input="Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart"
-            >
                 <validationContext>
                     <values>
                         <value name="groups">
@@ -119,6 +99,21 @@
                         </value>
                     </values>
                 </validationContext>
+                <openapiContext>
+                    <values>
+                        <value name="summary">Pickups a new cart.</value>
+                    </values>
+                </openapiContext>
+            </operation>
+
+            <operation
+                name="sylius_api_shop_order_order_item_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/shop/orders/{tokenValue}/items"
+                itemUriTemplate="/shop/orders/{tokenValue}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -137,19 +132,6 @@
                         </value>
                     </values>
                 </normalizationContext>
-                <openapiContext>
-                    <values>
-                        <value name="summary">Adds an item to the cart.</value>
-                    </values>
-                </openapiContext>
-            </operation>
-
-            <operation
-                class="ApiPlatform\Metadata\Put"
-                uriTemplate="/shop/orders/{tokenValue}"
-                messenger="input"
-                input="Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart"
-            >
                 <validationContext>
                     <values>
                         <value name="groups">
@@ -159,6 +141,20 @@
                         </value>
                     </values>
                 </validationContext>
+                <openapiContext>
+                    <values>
+                        <value name="summary">Adds an item to the cart.</value>
+                    </values>
+                </openapiContext>
+            </operation>
+
+            <operation
+                name="sylius_api_shop_order_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/shop/orders/{tokenValue}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart"
+            >
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -177,23 +173,6 @@
                         </value>
                     </values>
                 </normalizationContext>
-                <openapiContext>
-                    <values>
-                        <value name="summary">Addresses cart to given location, logged in Customer does not have to provide an email. Applies coupon to cart.</value>
-                    </values>
-                </openapiContext>
-            </operation>
-
-            <operation
-                class="ApiPlatform\Metadata\Patch"
-                uriTemplate="/shop/orders/{tokenValue}/items/{orderItemId}"
-                messenger="input"
-                input="Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart"
-            >
-                <uriVariables>
-                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
-                    <uriVariable parameterName="orderItemId" fromClass="Sylius\Component\Core\Model\OrderItem" fromProperty="order"/>
-                </uriVariables>
                 <validationContext>
                     <values>
                         <value name="groups">
@@ -203,6 +182,24 @@
                         </value>
                     </values>
                 </validationContext>
+                <openapiContext>
+                    <values>
+                        <value name="summary">Addresses cart to given location, logged in Customer does not have to provide an email. Applies coupon to cart.</value>
+                    </values>
+                </openapiContext>
+            </operation>
+
+            <operation
+                name="sylius_api_shop_order_order_item_patch"
+                class="ApiPlatform\Metadata\Patch"
+                uriTemplate="/shop/orders/{tokenValue}/items/{orderItemId}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
+                    <uriVariable parameterName="orderItemId" fromClass="Sylius\Component\Core\Model\OrderItem" fromProperty="order"/>
+                </uriVariables>
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -221,23 +218,6 @@
                         </value>
                     </values>
                 </normalizationContext>
-                <openapiContext>
-                    <values>
-                        <value name="summary">Changes quantity of an item in the cart.</value>
-                    </values>
-                </openapiContext>
-            </operation>
-
-            <operation
-                class="ApiPlatform\Metadata\Patch"
-                uriTemplate="/shop/orders/{tokenValue}/shipments/{shipmentId}"
-                messenger="input"
-                input="Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod"
-            >
-                <uriVariables>
-                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
-                    <uriVariable parameterName="shipmentId" fromClass="Sylius\Component\Core\Model\Shipment" fromProperty="order"/>
-                </uriVariables>
                 <validationContext>
                     <values>
                         <value name="groups">
@@ -247,6 +227,24 @@
                         </value>
                     </values>
                 </validationContext>
+                <openapiContext>
+                    <values>
+                        <value name="summary">Changes quantity of an item in the cart.</value>
+                    </values>
+                </openapiContext>
+            </operation>
+
+            <operation
+                name="sylius_api_shop_order_shipment_patch"
+                class="ApiPlatform\Metadata\Patch"
+                uriTemplate="/shop/orders/{tokenValue}/shipments/{shipmentId}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
+                    <uriVariable parameterName="shipmentId" fromClass="Sylius\Component\Core\Model\Shipment" fromProperty="order"/>
+                </uriVariables>
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -265,23 +263,6 @@
                         </value>
                     </values>
                 </normalizationContext>
-                <openapiContext>
-                    <values>
-                        <value name="summary">Selects a shipping method for particular shipment.</value>
-                    </values>
-                </openapiContext>
-            </operation>
-
-            <operation
-                class="ApiPlatform\Metadata\Patch"
-                uriTemplate="/shop/orders/{tokenValue}/payments/{paymentId}"
-                messenger="input"
-                input="Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod"
-            >
-                <uriVariables>
-                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
-                    <uriVariable parameterName="paymentId" fromClass="Sylius\Component\Core\Model\Payment" fromProperty="order"/>
-                </uriVariables>
                 <validationContext>
                     <values>
                         <value name="groups">
@@ -291,6 +272,24 @@
                         </value>
                     </values>
                 </validationContext>
+                <openapiContext>
+                    <values>
+                        <value name="summary">Selects a shipping method for particular shipment.</value>
+                    </values>
+                </openapiContext>
+            </operation>
+
+            <operation
+                name="sylius_api_shop_order_payment_patch"
+                class="ApiPlatform\Metadata\Patch"
+                uriTemplate="/shop/orders/{tokenValue}/payments/{paymentId}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order"/>
+                    <uriVariable parameterName="paymentId" fromClass="Sylius\Component\Core\Model\Payment" fromProperty="order"/>
+                </uriVariables>
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -309,6 +308,15 @@
                         </value>
                     </values>
                 </normalizationContext>
+                <validationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius</value>
+                            </values>
+                        </value>
+                    </values>
+                </validationContext>
                 <openapiContext>
                     <values>
                         <value name="summary">Selects a payment method for particular payment.</value>
@@ -317,21 +325,12 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_patch_complete"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/shop/orders/{tokenValue}/complete"
                 messenger="input"
                 input="Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder"
             >
-                <validationContext>
-                    <values>
-                        <value name="groups">
-                            <values>
-                                <value>sylius</value>
-                                <value>sylius_checkout_complete</value>
-                            </values>
-                        </value>
-                    </values>
-                </validationContext>
                 <denormalizationContext>
                     <values>
                         <value name="groups">
@@ -350,6 +349,16 @@
                         </value>
                     </values>
                 </normalizationContext>
+                <validationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius</value>
+                                <value>sylius_checkout_complete</value>
+                            </values>
+                        </value>
+                    </values>
+                </validationContext>
                 <openapiContext>
                     <values>
                         <value name="summary">Completes checkout process.</value>
@@ -358,6 +367,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_payment_patch_account"
                 class="ApiPlatform\Metadata\Patch"
                 uriTemplate="/shop/account/orders/{tokenValue}/payments/{paymentId}"
                 messenger="input"
@@ -402,6 +412,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/shop/orders/{tokenValue}"
             >
@@ -413,6 +424,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_order_order_item_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/shop/orders/{tokenValue}/items/{orderItemId}"
                 controller="Sylius\Bundle\ApiBundle\Controller\DeleteOrderItemAction"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItem.xml
@@ -21,7 +21,7 @@
             <uriVariable parameterName="tokenValue" fromClass="Sylius\Component\Core\Model\Order" fromProperty="items" />
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection">
+            <operation name="sylius_api_shop_order_order_item_get_collection" class="ApiPlatform\Metadata\GetCollection">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -41,7 +41,7 @@
             <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\OrderItem"/>
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\Get">
+            <operation name="sylius_api_shop_order_order_item_get" class="ApiPlatform\Metadata\Get">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItemUnit.xml
@@ -19,7 +19,7 @@
     <resource class="Sylius\Component\Core\Model\OrderItemUnit">
         <operations>
             <operation
-                name="sylius_api_shop_order_order_item_unit_get"
+                name="sylius_api_shop_order_item_unit_get"
                 class="ApiPlatform\Metadata\NotExposed"
                 uriTemplate="/shop/order-item-units/{id}"
             />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItemUnit.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/OrderItemUnit.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\OrderItemUnit">
         <operations>
-            <operation class="ApiPlatform\Metadata\NotExposed" uriTemplate="/shop/order-item-units/{id}" />
+            <operation
+                name="sylius_api_shop_order_order_item_unit_get"
+                class="ApiPlatform\Metadata\NotExposed"
+                uriTemplate="/shop/order-item-units/{id}"
+            />
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Payment.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Payment">
         <operations>
             <operation
+                name="sylius_api_shop_order_payment_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/orders/{tokenValue}/payments/{paymentId}"
                 provider="sylius_api.state_provider.shop.payment.item"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/PaymentMethod.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\PaymentMethod">
         <operations>
             <operation
+                name="sylius_api_shop_payment_method_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/payment-methods"
                 paginationEnabled="false"
@@ -39,7 +40,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/payment-methods/{code}">
+            <operation
+                name="sylius_api_shop_payment_method_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/payment-methods/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -60,7 +65,11 @@
         </uriVariables>
 
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.shop.order.payment.payment_method.collection">
+            <operation
+                name="sylius_api_shop_order_payment_payment_method_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.shop.order.payment.payment_method.collection"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Product.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Product">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/products">
+            <operation name="sylius_api_shop_product_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/products">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -62,7 +62,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/products/{code}">
+            <operation name="sylius_api_shop_product_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/products/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -96,6 +96,7 @@
             </operation>
 
             <operation
+                name="sylius_api_shop_product_get_by_slug"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/products-by-slug/{slug}"
                 controller="Sylius\Bundle\ApiBundle\Controller\GetProductBySlugAction"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAssociation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAssociation.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAssociation">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-associations/{id}">
+            <operation
+                name="sylius_api_shop_product_association_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-associations/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAssociationType.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAssociationType">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-association-types/{code}">
+            <operation
+                name="sylius_api_shop_product_association_type_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-association-types/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAttribute.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAttribute">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-attributes/{code}">
+            <operation
+                name="sylius_api_shop_product_attribute_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-attributes/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAttributeValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductAttributeValue.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductAttributeValue">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-attribute-values/{id}">
+            <operation
+                name="sylius_api_shop_product_attribute_value_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-attribute-values/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -37,7 +41,11 @@
             <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="attributes"/>
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.shop.product.product_attribute_value.collection">
+            <operation
+                name="sylius_api_shop_product_product_attribute_value_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.shop.product.product_attribute_value.collection"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductImage">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/products/{code}/images/{id}">
+            <operation
+                name="sylius_api_shop_product_product_image_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/products/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Product" fromProperty="images"/>
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\ProductImage"/>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOption.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOption">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-options/{code}">
+            <operation
+                name="sylius_api_shop_product_option_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-options/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOptionValue.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Product\Model\ProductOptionValue">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-options/{optionCode}/values/{code}">
+            <operation
+                name="sylius_api_shop_product_option_product_option_value_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-options/{optionCode}/values/{code}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="optionCode" fromClass="Sylius\Component\Product\Model\ProductOption" fromProperty="values"/>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Product\Model\ProductOptionValue" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductReview.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductReview">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/product-reviews">
+            <operation
+                name="sylius_api_shop_product_review_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/product-reviews"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -34,7 +38,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-reviews/{id}">
+            <operation
+                name="sylius_api_shop_product_review_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-reviews/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -47,11 +55,12 @@
             </operation>
 
             <operation
-                    class="ApiPlatform\Metadata\Post"
-                    uriTemplate="/shop/product-reviews"
-                    itemUriTemplate="/shop/product-reviews/{id}"
-                    messenger="input"
-                    input="Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview"
+                name="sylius_api_shop_product_review_post"
+                class="ApiPlatform\Metadata\Post"
+                uriTemplate="/shop/product-reviews"
+                itemUriTemplate="/shop/product-reviews/{id}"
+                messenger="input"
+                input="Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview"
             >
                 <denormalizationContext>
                     <values>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductTaxon.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductTaxon">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-taxons/{id}">
+            <operation
+                name="sylius_api_shop_product_taxon_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-taxons/{id}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductVariant.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\ProductVariant">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/product-variants">
+            <operation
+                name="sylius_api_shop_product_variant_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/product-variants"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -34,7 +38,11 @@
                 </filters>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/product-variants/{code}">
+            <operation
+                name="sylius_api_shop_product_variant_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/product-variants/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Addressing\Model\Province">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/provinces/{code}">
+            <operation name="sylius_api_shop_province_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/provinces/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Shipment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Shipment.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\Shipment">
         <operations>
             <operation
+                name="sylius_api_shop_order_shipment_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/orders/{tokenValue}/shipments/{shipmentId}"
                 provider="sylius_api.state_provider.shop.shipment.item"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ShippingMethod.xml
@@ -19,6 +19,7 @@
     <resource class="Sylius\Component\Core\Model\ShippingMethod">
         <operations>
             <operation
+                name="sylius_api_shop_shipping_method_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/shipping-methods"
                 paginationEnabled="false"
@@ -39,7 +40,11 @@
                 </order>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/shipping-methods/{code}">
+            <operation
+                name="sylius_api_shop_shipping_method_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/shipping-methods/{code}"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -59,7 +64,11 @@
             <uriVariable parameterName="shipmentId" fromClass="Sylius\Component\Core\Model\Shipment" fromProperty="method" />
         </uriVariables>
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" provider="sylius_api.state_provider.shop.order.shipment.shipping_method.collection">
+            <operation
+                name="sylius_api_shop_order_shipment_shipping_method_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                provider="sylius_api.state_provider.shop.order.shipment.shipping_method.collection"
+            >
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Taxon.xml
@@ -18,7 +18,7 @@
 >
     <resource class="Sylius\Component\Core\Model\Taxon">
         <operations>
-            <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/taxons">
+            <operation name="sylius_api_shop_taxon_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/shop/taxons">
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -50,7 +50,7 @@
                 </openapiContext>
             </operation>
 
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/taxons/{code}">
+            <operation name="sylius_api_shop_taxon_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/taxons/{code}">
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
@@ -18,7 +18,11 @@
 >
     <resource class="Sylius\Component\Core\Model\TaxonImage">
         <operations>
-            <operation class="ApiPlatform\Metadata\Get" uriTemplate="/shop/taxons/{code}/images/{id}">
+            <operation
+                name="sylius_api_shop_taxon_taxon_image_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/taxons/{code}/images/{id}"
+            >
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="Sylius\Component\Core\Model\Taxon" fromProperty="images"/>
                     <uriVariable parameterName="id" fromClass="Sylius\Component\Core\Model\TaxonImage"/>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -5,10 +5,10 @@ parameters:
     env(SYLIUS_API_AUTHORIZATION_HEADER): Authorization
     sylius.api.authorization_header: "%env(resolve:SYLIUS_API_AUTHORIZATION_HEADER)%"
     sylius.api.doctrine.orm.query.extension.shop.order.filter_cart.allowed_operations:
-        - "_api_/shop/orders/{tokenValue}/payments/{paymentId}_patch"
-        - "_api_/shop/account/orders/{tokenValue}/payments/{paymentId}_patch"
-        - "_api_/shop/orders/{tokenValue}_get"
-        - "_api_/shop/orders/{tokenValue}/payments/{paymentId}/configuration_get"
+        - "sylius_api_shop_order_get"
+        - "sylius_api_shop_order_payment_get_configuration"
+        - "sylius_api_shop_order_payment_patch"
+        - "sylius_api_shop_order_payment_patch_account"
     sylius.api.paths_to_hide:
         - "%sylius.security.new_api_route%/admin/address-log-entry/{id}"
         - "%sylius.security.new_api_route%/admin/catalog-promotion-actions/{id}"
@@ -33,7 +33,7 @@ sylius_api:
         restricted_resources:
             '%sylius.model.product.class%':
                 operations:
-                    _api_/shop/products_get_collection: ~
+                    sylius_api_shop_product_get_collection: ~
     order_states_to_filter_out:
         - !php/const Sylius\Component\Core\Model\OrderInterface::STATE_CART
     non_archived_classes:

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/ORM/QueryExtension/Shop/Order/StateBasedExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/ORM/QueryExtension/Shop/Order/StateBasedExtensionSpec.php
@@ -31,7 +31,10 @@ final class StateBasedExtensionSpec extends ObjectBehavior
 {
     function let(SectionProviderInterface $sectionProvider): void
     {
-        $this->beConstructedWith($sectionProvider, ['_api_/shop/orders/{tokenValue}_get', '_api_/shop/orders/{tokenValue}/payments/{paymentId}/configuration_get']);
+        $this->beConstructedWith(
+            $sectionProvider,
+            ['sylius_api_shop_order_get', 'sylius_api_shop_order_payment_get_configuration']
+        );
     }
 
     function it_does_not_apply_conditions_to_collection_for_unsupported_resource(
@@ -108,7 +111,7 @@ final class StateBasedExtensionSpec extends ObjectBehavior
         Operation $operation,
     ): void {
         $sectionProvider->getSection()->willReturn($section);
-        $operation->getName()->willReturn('_api_/shop/orders/{tokenValue}/payments/{paymentId}/configuration_get');
+        $operation->getName()->willReturn('sylius_api_shop_order_payment_get_configuration');
         $queryBuilder->getRootAliases()->shouldNotBeCalled();
 
         $this->applyToItem($queryBuilder, $queryNameGenerator, OrderInterface::class, [], $operation);
@@ -119,13 +122,12 @@ final class StateBasedExtensionSpec extends ObjectBehavior
         QueryBuilder $queryBuilder,
         QueryNameGeneratorInterface $queryNameGenerator,
         ShopApiSection $section,
-        CustomerInterface $customer,
         Operation $operation,
         Expr $expr,
         Expr\Func $exprEq,
     ): void {
         $sectionProvider->getSection()->willReturn($section);
-        $operation->getName()->willReturn('_api_/shop/orders/{tokenValue}/new_get');
+        $operation->getName()->willReturn('sylius_api_shop_order_get_custom');
 
         $queryBuilder->getRootAliases()->willReturn(['o']);
         $queryNameGenerator->generateParameterName('state')->willReturn('state');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | bases on #16960 
| License         | MIT

I would like to introduce operations' names for all endpoints to simplify customization in end applications.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
