### PR TITLE
[Maintenance] Move order related commands to separate namespace

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Command/Order/ChangePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/ChangePaymentMethod.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command\Account;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 use Sylius\Bundle\ApiBundle\Attribute\OrderTokenValueAware;
 use Sylius\Bundle\ApiBundle\Attribute\PaymentIdAware;

--- a/src/Sylius/Bundle/ApiBundle/Command/Order/ResendOrderConfirmationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/ResendOrderConfirmationEmail.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 use Sylius\Bundle\ApiBundle\Attribute\OrderTokenValueAware;
 use Sylius\Bundle\CoreBundle\Command\ResendOrderConfirmationEmail as BaseResendOrderConfirmationEmail;

--- a/src/Sylius/Bundle/ApiBundle/Command/Order/ResendShipmentConfirmationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/ResendShipmentConfirmationEmail.php
@@ -11,16 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command\Checkout;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 use Sylius\Bundle\ApiBundle\Attribute\ShipmentIdAware;
+use Sylius\Bundle\CoreBundle\Command\ResendShipmentConfirmationEmail as BaseResendShipmentConfirmationEmail;
 
 #[ShipmentIdAware]
-class ShipShipment
+class ResendShipmentConfirmationEmail extends BaseResendShipmentConfirmationEmail
 {
-    public function __construct(
-        public readonly mixed $shipmentId = null,
-        public readonly ?string $trackingCode = null,
-    ) {
-    }
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/Order/SendOrderConfirmation.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/SendOrderConfirmation.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command\Checkout;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 class SendOrderConfirmation
 {

--- a/src/Sylius/Bundle/ApiBundle/Command/Order/SendShipmentConfirmationEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/SendShipmentConfirmationEmail.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command\Checkout;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 class SendShipmentConfirmationEmail
 {

--- a/src/Sylius/Bundle/ApiBundle/Command/Order/ShipShipment.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Order/ShipShipment.php
@@ -11,12 +11,16 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Command;
+namespace Sylius\Bundle\ApiBundle\Command\Order;
 
 use Sylius\Bundle\ApiBundle\Attribute\ShipmentIdAware;
-use Sylius\Bundle\CoreBundle\Command\ResendShipmentConfirmationEmail as BaseResendShipmentConfirmationEmail;
 
 #[ShipmentIdAware]
-class ResendShipmentConfirmationEmail extends BaseResendShipmentConfirmationEmail
+class ShipShipment
 {
+    public function __construct(
+        public readonly mixed $shipmentId = null,
+        public readonly ?string $trackingCode = null,
+    ) {
+    }
 }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/ChangePaymentMethodHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/ChangePaymentMethodHandler.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\CommandHandler\Account;
+namespace Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use Sylius\Bundle\ApiBundle\Changer\PaymentMethodChangerInterface;
-use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
+use Sylius\Bundle\ApiBundle\Command\Order\ChangePaymentMethod;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/SendOrderConfirmationHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/SendOrderConfirmationHandler.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendOrderConfirmation;
+use Sylius\Bundle\ApiBundle\Command\Order\SendOrderConfirmation;
 use Sylius\Bundle\CoreBundle\Mailer\OrderEmailManagerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/SendShipmentConfirmationEmailHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/SendShipmentConfirmationEmailHandler.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail;
+use Sylius\Bundle\ApiBundle\Command\Order\SendShipmentConfirmationEmail;
 use Sylius\Bundle\CoreBundle\Mailer\ShipmentEmailManagerInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/ShipShipmentHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Order/ShipShipmentHandler.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail;
-use Sylius\Bundle\ApiBundle\Command\Checkout\ShipShipment;
+use Sylius\Bundle\ApiBundle\Command\Order\SendShipmentConfirmationEmail;
+use Sylius\Bundle\ApiBundle\Command\Order\ShipShipment;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
 use Sylius\Component\Shipping\ShipmentTransitions;

--- a/src/Sylius/Bundle/ApiBundle/EventHandler/OrderCompletedHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/EventHandler/OrderCompletedHandler.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\EventHandler;
 
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendOrderConfirmation;
+use Sylius\Bundle\ApiBundle\Command\Order\SendOrderConfirmation;
 use Sylius\Bundle\ApiBundle\Event\OrderCompleted;
 use Symfony\Component\Messenger\MessageBusInterface;
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -94,14 +94,14 @@
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\ShipShipmentHandler">
+        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Order\ShipShipmentHandler">
             <argument type="service" id="sylius.repository.shipment" />
             <argument type="service" id="sylius_abstraction.state_machine" />
             <argument type="service" id="sylius.command_bus" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Account\ChangePaymentMethodHandler">
+        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Order\ChangePaymentMethodHandler">
             <argument type="service" id="Sylius\Bundle\ApiBundle\Changer\PaymentMethodChangerInterface" />
             <argument type="service" id="sylius.repository.order"/>
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
@@ -169,7 +169,7 @@
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendOrderConfirmationHandler">
+        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Order\SendOrderConfirmationHandler">
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Mailer\OrderEmailManagerInterface" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
@@ -182,7 +182,7 @@
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
         </service>
 
-        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendShipmentConfirmationEmailHandler">
+        <service id="Sylius\Bundle\ApiBundle\CommandHandler\Order\SendShipmentConfirmationEmailHandler">
             <argument type="service" id="sylius.repository.shipment" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Mailer\ShipmentEmailManagerInterface" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChangedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChangedValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
+use Sylius\Bundle\ApiBundle\Command\Order\ChangePaymentMethod;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShippedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShippedValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\Checkout\ShipShipment;
+use Sylius\Bundle\ApiBundle\Command\Order\ShipShipment;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderShippingStates;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/ChangePaymentMethodHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/ChangePaymentMethodHandlerSpec.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Account;
+namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ApiBundle\Changer\PaymentMethodChangerInterface;
-use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
+use Sylius\Bundle\ApiBundle\Command\Order\ChangePaymentMethod;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/SendOrderConfirmationHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/SendOrderConfirmationHandlerSpec.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendOrderConfirmation;
+use Sylius\Bundle\ApiBundle\Command\Order\SendOrderConfirmation;
 use Sylius\Bundle\CoreBundle\Mailer\OrderEmailManagerInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/SendShipmentConfirmationEmailHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/SendShipmentConfirmationEmailHandlerSpec.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail;
+use Sylius\Bundle\ApiBundle\Command\Order\SendShipmentConfirmationEmail;
 use Sylius\Bundle\CoreBundle\Mailer\ShipmentEmailManagerInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/ShipShipmentHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/Order/ShipShipmentHandlerSpec.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
+namespace spec\Sylius\Bundle\ApiBundle\CommandHandler\Order;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
-use Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail;
-use Sylius\Bundle\ApiBundle\Command\Checkout\ShipShipment;
+use Sylius\Bundle\ApiBundle\Command\Order\SendShipmentConfirmationEmail;
+use Sylius\Bundle\ApiBundle\Command\Order\ShipShipment;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
 use Sylius\Component\Shipping\ShipmentTransitions;

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/CanPaymentMethodBeChangedValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/CanPaymentMethodBeChangedValidatorSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\ApiBundle\Command\Account\ChangePaymentMethod;
+use Sylius\Bundle\ApiBundle\Command\Order\ChangePaymentMethod;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\CanPaymentMethodBeChanged;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/ShipmentAlreadyShippedValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/ShipmentAlreadyShippedValidatorSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\ApiBundle\Command\Checkout\ShipShipment;
+use Sylius\Bundle\ApiBundle\Command\Order\ShipShipment;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\ShipmentAlreadyShipped;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderShippingStates;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

As a part of preparing to API Platform Con I deeply reviewed the state of our integration. One of the things I would like to fix 
is namepasce, which is related to several commands. I'm not sure if my proposal of `Order` is correct, but I'm sure `Checkout` does not suit commands like:  

* ChangePaymentMethod
* ResendOrderConfirmationEmail
* ResendShipmentConfirmationEmail
* SendOrderConfirmation
* SendShipmentConfirmationEmail
* ShipShipment