### PR TITLE
[Admin][Shop] Remove SyliusUiBundle config import

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -1,6 +1,4 @@
 imports:
-    - { resource: "@SyliusUiBundle/Resources/config/app/config.yml" }
-
     - { resource: 'twig_hooks/**/*.yaml' }
     - { resource: "@SyliusAdminBundle/Resources/config/app/sylius/sylius_mailer.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/*.yml" }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -2,8 +2,6 @@
 # (c) Sylius Sp. z o.o.
 
 imports:
-    - { resource: "@SyliusUiBundle/Resources/config/app/config.yml" }
-
     - { resource: 'twig_hooks/**/*.yaml' }
     - { resource: "@SyliusShopBundle/Resources/config/app/sylius/sylius_mailer.yml" }
     - { resource: "@SyliusShopBundle/Resources/config/grids/account/order.yml" }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Removed SyliusUiBundle config import both in Admin and Shop. It was making mess in Sylius-Standard
