### PR TITLE
[Refactor] Rename Constructor Argument `stateMachineFactory` to `stateMachine`  Across Services

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -79,29 +79,29 @@
 
 * The parameter order of `Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType::__construct` has been changed:
 
-```php
-    public function __construct(
-    +   private readonly AddressComparatorInterface $addressComparator,
-        string $dataClass,
-        array $validationGroups = []
-    -   private readonly AddressComparatorInterface $addressComparator = null,
-    )
-```
+    ```php
+        public function __construct(
+        +   private readonly AddressComparatorInterface $addressComparator,
+            string $dataClass,
+            array $validationGroups = []
+        -   private readonly AddressComparatorInterface $addressComparator = null,
+        )
+    ```
 
 * The `\Serializable` interface has been removed from the `Sylius\Component\User\Model\UserInterface`.
 
 * The parameter order of the `Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor::__construct` has been
   changed:
 
-```php
-    public function __construct(
-        private OrderPaymentProviderInterface $orderPaymentProvider,
-    -   private string $targetState = PaymentInterface::STATE_CART,
-        private OrderPaymentsRemoverInterface $orderPaymentsRemover,
-        private array $unprocessableOrderStates,
-    +   private string $targetState = PaymentInterface::STATE_CART,
-    )
-```
+    ```php
+        public function __construct(
+            private OrderPaymentProviderInterface $orderPaymentProvider,
+        -   private string $targetState = PaymentInterface::STATE_CART,
+            private OrderPaymentsRemoverInterface $orderPaymentsRemover,
+            private array $unprocessableOrderStates,
+        +   private string $targetState = PaymentInterface::STATE_CART,
+        )
+    ```
 
 * The `swiftmailer/swiftmailer` dependency has been removed. Use `symfony/mailer` instead.
 
@@ -185,6 +185,13 @@
   your `config/packages/_sylius.yaml` file.
   This is handled by `Sylius\Bundle\AddressingBundle\Validator\Constraints\ZoneMemberGroup` and it resolves the groups
   based on the type of the passed zone.
+
+* The following constructor parameter has been changed across the codebase:
+
+    ```php
+    -   private StateMachineInterface $stateMachineFactory,
+    +   private StateMachineInterface $stateMachine,
+    ```    
 
   ```yaml
   sylius_addressing:

--- a/src/Sylius/Bundle/AdminBundle/Menu/OrderShowMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/OrderShowMenuBuilder.php
@@ -28,11 +28,12 @@ final class OrderShowMenuBuilder
     public function __construct(
         private FactoryInterface $factory,
         private EventDispatcherInterface $eventDispatcher,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
         private CsrfTokenManagerInterface $csrfTokenManager,
     ) {
     }
 
+    /** @param array<string, mixed> $options */
     public function createMenu(array $options): ItemInterface
     {
         $menu = $this->factory->createItem('root');
@@ -52,7 +53,7 @@ final class OrderShowMenuBuilder
             ->setLabel('sylius.ui.history')
             ->setLabelAttribute('icon', 'history');
 
-        if ($this->stateMachineFactory->can($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_CANCEL)) {
+        if ($this->stateMachine->can($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_CANCEL)) {
             $menu
                 ->addChild('cancel', [
                     'route' => 'sylius_admin_order_cancel',
@@ -69,7 +70,7 @@ final class OrderShowMenuBuilder
         }
 
         $this->eventDispatcher->dispatch(
-            new OrderShowMenuBuilderEvent($this->factory, $menu, $order, $this->stateMachineFactory),
+            new OrderShowMenuBuilderEvent($this->factory, $menu, $order, $this->stateMachine),
             self::EVENT_NAME,
         );
 

--- a/src/Sylius/Bundle/ApiBundle/Applicator/OrderStateMachineTransitionApplicator.php
+++ b/src/Sylius/Bundle/ApiBundle/Applicator/OrderStateMachineTransitionApplicator.php
@@ -20,7 +20,7 @@ use Sylius\Component\Order\OrderTransitions;
 
 final class OrderStateMachineTransitionApplicator implements OrderStateMachineTransitionApplicatorInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -33,10 +33,10 @@ final class OrderStateMachineTransitionApplicator implements OrderStateMachineTr
 
     private function applyTransition(OrderInterface $order, string $transition): void
     {
-        if (false === $this->stateMachineFactory->can($order, OrderTransitions::GRAPH, $transition)) {
+        if (false === $this->stateMachine->can($order, OrderTransitions::GRAPH, $transition)) {
             throw new StateMachineTransitionFailedException('Cannot cancel the order.');
         }
 
-        $this->stateMachineFactory->apply($order, OrderTransitions::GRAPH, $transition);
+        $this->stateMachine->apply($order, OrderTransitions::GRAPH, $transition);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Applicator/PaymentStateMachineTransitionApplicator.php
+++ b/src/Sylius/Bundle/ApiBundle/Applicator/PaymentStateMachineTransitionApplicator.php
@@ -20,7 +20,7 @@ use Sylius\Component\Payment\PaymentTransitions;
 
 final readonly class PaymentStateMachineTransitionApplicator implements PaymentStateMachineTransitionApplicatorInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -40,7 +40,7 @@ final readonly class PaymentStateMachineTransitionApplicator implements PaymentS
 
     private function applyTransition(PaymentInterface $payment, string $transition): void
     {
-        if (false === $this->stateMachineFactory->can($payment, PaymentTransitions::GRAPH, $transition)) {
+        if (false === $this->stateMachine->can($payment, PaymentTransitions::GRAPH, $transition)) {
             throw new StateMachineTransitionFailedException(sprintf(
                 'Transition "%s" cannot be applied on "%s" payment.',
                 $transition,
@@ -48,6 +48,6 @@ final readonly class PaymentStateMachineTransitionApplicator implements PaymentS
             ));
         }
 
-        $this->stateMachineFactory->apply($payment, PaymentTransitions::GRAPH, $transition);
+        $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, $transition);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Applicator/ProductReviewStateMachineTransitionApplicator.php
+++ b/src/Sylius/Bundle/ApiBundle/Applicator/ProductReviewStateMachineTransitionApplicator.php
@@ -20,7 +20,7 @@ use Sylius\Component\Review\Model\ReviewInterface;
 
 final class ProductReviewStateMachineTransitionApplicator implements ProductReviewStateMachineTransitionApplicatorInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -40,10 +40,10 @@ final class ProductReviewStateMachineTransitionApplicator implements ProductRevi
 
     private function applyTransition(ReviewInterface $review, string $transition): void
     {
-        if (false === $this->stateMachineFactory->can($review, ProductReviewTransitions::GRAPH, $transition)) {
+        if (false === $this->stateMachine->can($review, ProductReviewTransitions::GRAPH, $transition)) {
             throw new StateMachineTransitionFailedException(sprintf('Cannot %s  the product review.', $transition));
         }
 
-        $this->stateMachineFactory->apply($review, ProductReviewTransitions::GRAPH, $transition);
+        $this->stateMachine->apply($review, ProductReviewTransitions::GRAPH, $transition);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChoosePaymentMethodHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChoosePaymentMethodHandler.php
@@ -32,7 +32,7 @@ final readonly class ChoosePaymentMethodHandler implements MessageHandlerInterfa
         private OrderRepositoryInterface $orderRepository,
         private PaymentMethodRepositoryInterface $paymentMethodRepository,
         private PaymentRepositoryInterface $paymentRepository,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
         private PaymentMethodChangerInterface $paymentMethodChanger,
     ) {
     }
@@ -64,12 +64,12 @@ final readonly class ChoosePaymentMethodHandler implements MessageHandlerInterfa
 
         if ($cart->getState() === OrderInterface::STATE_CART) {
             Assert::true(
-                $this->stateMachineFactory->can($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT),
+                $this->stateMachine->can($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT),
                 'Order cannot have payment method assigned.',
             );
 
             $payment->setMethod($paymentMethod);
-            $this->stateMachineFactory->apply($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
+            $this->stateMachine->apply($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
 
             return $cart;
         }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/CompleteOrderHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/CompleteOrderHandler.php
@@ -32,7 +32,7 @@ final readonly class CompleteOrderHandler implements MessageHandlerInterface
 {
     public function __construct(
         private OrderRepositoryInterface $orderRepository,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
         private MessageBusInterface $commandBus,
         private MessageBusInterface $eventBus,
         private OrderPromotionsIntegrityCheckerInterface $orderPromotionsIntegrityChecker,
@@ -73,11 +73,11 @@ final readonly class CompleteOrderHandler implements MessageHandlerInterface
         }
 
         Assert::true(
-            $this->stateMachineFactory->can($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE),
+            $this->stateMachine->can($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE),
             sprintf('Order with %s token cannot be completed.', $orderTokenValue),
         );
 
-        $this->stateMachineFactory->apply($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE);
+        $this->stateMachine->apply($cart, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE);
 
         $this->eventBus->dispatch(new OrderCompleted($cart->getTokenValue()), [new DispatchAfterCurrentBusStamp()]);
 

--- a/src/Sylius/Bundle/ApiBundle/Modifier/OrderAddressModifier.php
+++ b/src/Sylius/Bundle/ApiBundle/Modifier/OrderAddressModifier.php
@@ -23,7 +23,7 @@ use Webmozart\Assert\Assert;
 final readonly class OrderAddressModifier implements OrderAddressModifierInterface
 {
     public function __construct(
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
         private AddressMapperInterface $addressMapper,
     ) {
     }
@@ -34,7 +34,7 @@ final readonly class OrderAddressModifier implements OrderAddressModifierInterfa
         ?AddressInterface $shippingAddress = null,
     ): OrderInterface {
         Assert::true(
-            $this->stateMachineFactory->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_ADDRESS),
+            $this->stateMachine->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_ADDRESS),
             sprintf('Order with %s token cannot be addressed.', $order->getTokenValue()),
         );
 
@@ -57,7 +57,7 @@ final readonly class OrderAddressModifier implements OrderAddressModifierInterfa
         $this->setBillingAddress($order, $oldBillingAddress, $billingAddress);
         $this->setShippingAddress($order, $oldShippingAddress, $shippingAddress);
 
-        $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_ADDRESS);
+        $this->stateMachine->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_ADDRESS);
 
         return $order;
     }

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionStateProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionStateProcessor.php
@@ -22,28 +22,28 @@ final class CatalogPromotionStateProcessor implements CatalogPromotionStateProce
 {
     public function __construct(
         private CatalogPromotionEligibilityCheckerInterface $catalogPromotionEligibilityChecker,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
     ) {
     }
 
     public function process(CatalogPromotionInterface $catalogPromotion): void
     {
-        if ($this->stateMachineFactory->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_PROCESS)) {
-            $this->stateMachineFactory->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_PROCESS);
+        if ($this->stateMachine->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_PROCESS)) {
+            $this->stateMachine->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_PROCESS);
 
             return;
         }
 
         if (!$this->catalogPromotionEligibilityChecker->isCatalogPromotionEligible($catalogPromotion)) {
-            if ($this->stateMachineFactory->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_DEACTIVATE)) {
-                $this->stateMachineFactory->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_DEACTIVATE);
+            if ($this->stateMachine->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_DEACTIVATE)) {
+                $this->stateMachine->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_DEACTIVATE);
             }
 
             return;
         }
 
-        if ($this->stateMachineFactory->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_ACTIVATE)) {
-            $this->stateMachineFactory->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_ACTIVATE);
+        if ($this->stateMachine->can($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_ACTIVATE)) {
+            $this->stateMachine->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_ACTIVATE);
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
@@ -29,7 +29,7 @@ final class CheckoutResolver implements EventSubscriberInterface
         private CartContextInterface $cartContext,
         private CheckoutStateUrlGeneratorInterface $urlGenerator,
         private RequestMatcherInterface $requestMatcher,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
     ) {
     }
 
@@ -73,7 +73,7 @@ final class CheckoutResolver implements EventSubscriberInterface
             return;
         }
 
-        if ($this->stateMachineFactory->can($order, $graph, $transition)) {
+        if ($this->stateMachine->can($order, $graph, $transition)) {
             return;
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
@@ -69,7 +69,7 @@ class OrderExampleFactory extends AbstractExampleFactory implements ExampleFacto
         protected PaymentMethodRepositoryInterface $paymentMethodRepository,
         protected ShippingMethodRepositoryInterface $shippingMethodRepository,
         protected FactoryInterface $addressFactory,
-        protected StateMachineInterface $stateMachineFactory,
+        protected StateMachineInterface $stateMachine,
         protected OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker,
         protected OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker,
     ) {
@@ -267,7 +267,7 @@ class OrderExampleFactory extends AbstractExampleFactory implements ExampleFacto
 
     protected function applyCheckoutStateTransition(OrderInterface $order, string $transition): void
     {
-        $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, $transition);
+        $this->stateMachine->apply($order, OrderCheckoutTransitions::GRAPH, $transition);
     }
 
     protected function generateInvalidSkipMessage(string $type, string $channelCode): string
@@ -298,8 +298,8 @@ class OrderExampleFactory extends AbstractExampleFactory implements ExampleFacto
     protected function completePayments(OrderInterface $order): void
     {
         foreach ($order->getPayments() as $payment) {
-            if ($this->stateMachineFactory->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_COMPLETE)) {
-                $this->stateMachineFactory->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_COMPLETE);
+            if ($this->stateMachine->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_COMPLETE)) {
+                $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_COMPLETE);
             }
         }
     }
@@ -307,8 +307,8 @@ class OrderExampleFactory extends AbstractExampleFactory implements ExampleFacto
     protected function completeShipments(OrderInterface $order): void
     {
         foreach ($order->getShipments() as $shipment) {
-            if ($this->stateMachineFactory->can($shipment, ShipmentTransitions::GRAPH, ShipmentTransitions::TRANSITION_SHIP)) {
-                $this->stateMachineFactory->apply($shipment, ShipmentTransitions::GRAPH, ShipmentTransitions::TRANSITION_SHIP);
+            if ($this->stateMachine->can($shipment, ShipmentTransitions::GRAPH, ShipmentTransitions::TRANSITION_SHIP)) {
+                $this->stateMachine->apply($shipment, ShipmentTransitions::GRAPH, ShipmentTransitions::TRANSITION_SHIP);
             }
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
@@ -35,7 +35,7 @@ class ProductReviewExampleFactory extends AbstractExampleFactory implements Exam
         private ReviewFactoryInterface $productReviewFactory,
         private ProductRepositoryInterface $productRepository,
         private CustomerRepositoryInterface $customerRepository,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();
@@ -95,10 +95,10 @@ class ProductReviewExampleFactory extends AbstractExampleFactory implements Exam
 
     private function applyReviewTransition(ReviewInterface $productReview, string $targetState): void
     {
-        $transition = $this->stateMachineFactory->getTransitionToState($productReview, ProductReviewTransitions::GRAPH, $targetState);
+        $transition = $this->stateMachine->getTransitionToState($productReview, ProductReviewTransitions::GRAPH, $targetState);
 
         if (null !== $transition) {
-            $this->stateMachineFactory->apply($productReview, ProductReviewTransitions::GRAPH, $transition);
+            $this->stateMachine->apply($productReview, ProductReviewTransitions::GRAPH, $transition);
         }
     }
 }

--- a/src/Sylius/Component/Core/Payment/Provider/OrderPaymentProvider.php
+++ b/src/Sylius/Component/Core/Payment/Provider/OrderPaymentProvider.php
@@ -29,7 +29,7 @@ final class OrderPaymentProvider implements OrderPaymentProviderInterface
     public function __construct(
         private DefaultPaymentMethodResolverInterface $defaultPaymentMethodResolver,
         private PaymentFactoryInterface $paymentFactory,
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
     ) {
     }
 
@@ -87,9 +87,9 @@ final class OrderPaymentProvider implements OrderPaymentProviderInterface
             return;
         }
 
-        $targetTransition = $this->stateMachineFactory->getTransitionToState($payment, PaymentTransitions::GRAPH, $targetState);
+        $targetTransition = $this->stateMachine->getTransitionToState($payment, PaymentTransitions::GRAPH, $targetState);
         if (null !== $targetTransition) {
-            $this->stateMachineFactory->apply($payment, PaymentTransitions::GRAPH, $targetTransition);
+            $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, $targetTransition);
         }
     }
 }

--- a/src/Sylius/Component/Core/StateResolver/CheckoutStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/CheckoutStateResolver.php
@@ -25,7 +25,7 @@ use Webmozart\Assert\Assert;
 final class CheckoutStateResolver implements StateResolverInterface
 {
     public function __construct(
-        private StateMachineInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
         private OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker,
         private OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker,
     ) {
@@ -37,16 +37,16 @@ final class CheckoutStateResolver implements StateResolverInterface
 
         if (
             !$this->orderShippingMethodSelectionRequirementChecker->isShippingMethodSelectionRequired($order) &&
-            $this->stateMachineFactory->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING)
+            $this->stateMachine->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING)
         ) {
-            $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING);
+            $this->stateMachine->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING);
         }
 
         if (
             !$this->orderPaymentMethodSelectionRequirementChecker->isPaymentMethodSelectionRequired($order) &&
-            $this->stateMachineFactory->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT)
+            $this->stateMachine->can($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT)
         ) {
-            $this->stateMachineFactory->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT);
+            $this->stateMachine->apply($order, OrderCheckoutTransitions::GRAPH, OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT);
         }
     }
 }

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -25,7 +25,7 @@ use Webmozart\Assert\Assert;
 
 final class OrderPaymentStateResolver implements StateResolverInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -36,8 +36,8 @@ final class OrderPaymentStateResolver implements StateResolverInterface
 
         $targetTransition = $this->getTargetTransition($order);
         if (null !== $targetTransition) {
-            if ($this->stateMachineFactory->can($order, OrderPaymentTransitions::GRAPH, $targetTransition)) {
-                $this->stateMachineFactory->apply($order, OrderPaymentTransitions::GRAPH, $targetTransition);
+            if ($this->stateMachine->can($order, OrderPaymentTransitions::GRAPH, $targetTransition)) {
+                $this->stateMachine->apply($order, OrderPaymentTransitions::GRAPH, $targetTransition);
             }
         }
     }

--- a/src/Sylius/Component/Core/StateResolver/OrderShippingStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderShippingStateResolver.php
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
 
 final class OrderShippingStateResolver implements StateResolverInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -38,11 +38,11 @@ final class OrderShippingStateResolver implements StateResolverInterface
         }
 
         if ($this->allShipmentsInStateButOrderStateNotUpdated($order, ShipmentInterface::STATE_SHIPPED, OrderShippingStates::STATE_SHIPPED)) {
-            $this->stateMachineFactory->apply($order, OrderShippingTransitions::GRAPH, OrderShippingTransitions::TRANSITION_SHIP);
+            $this->stateMachine->apply($order, OrderShippingTransitions::GRAPH, OrderShippingTransitions::TRANSITION_SHIP);
         }
 
         if ($this->isPartiallyShippedButOrderStateNotUpdated($order)) {
-            $this->stateMachineFactory->apply($order, OrderShippingTransitions::GRAPH, OrderShippingTransitions::TRANSITION_PARTIALLY_SHIP);
+            $this->stateMachine->apply($order, OrderShippingTransitions::GRAPH, OrderShippingTransitions::TRANSITION_PARTIALLY_SHIP);
         }
     }
 

--- a/src/Sylius/Component/Core/StateResolver/OrderStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderStateResolver.php
@@ -24,7 +24,7 @@ use Webmozart\Assert\Assert;
 
 final class OrderStateResolver implements StateResolverInterface
 {
-    public function __construct(private StateMachineInterface $stateMachineFactory)
+    public function __construct(private StateMachineInterface $stateMachine)
     {
     }
 
@@ -34,9 +34,9 @@ final class OrderStateResolver implements StateResolverInterface
 
         if (
             $this->canOrderBeFulfilled($order) &&
-            $this->stateMachineFactory->can($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_FULFILL)
+            $this->stateMachine->can($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_FULFILL)
         ) {
-            $this->stateMachineFactory->apply($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_FULFILL);
+            $this->stateMachine->apply($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_FULFILL);
         }
     }
 

--- a/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
+++ b/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
@@ -19,9 +19,9 @@ use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Sylius\Abstraction\StateMachine\Exception\StateMachineExecutionException;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Updater\UnpaidOrdersStateUpdaterInterface;
-use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\OrderTransitions;
 
 final class UnpaidOrdersStateUpdaterSpec extends ObjectBehavior


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | https://github.com/Sylius/Sylius/pull/15797
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
