### PR TITLE
[API] Make promotion coupon operations' names consistnent with other after refactor them

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionCoupon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/PromotionCoupon.xml
@@ -19,7 +19,7 @@
     <resource class="%sylius.model.promotion_coupon.class%">
         <operations>
             <operation
-                name="sylius_api_admin_promotion_coupon_get_collection"
+                name="sylius_api_admin_promotion_promotion_coupon_get_collection"
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons"
             >
@@ -48,7 +48,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_promotion_coupon_get"
+                name="sylius_api_admin_promotion_promotion_coupon_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons/{couponCode}"
             >
@@ -69,7 +69,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_promotion_coupon_post"
+                name="sylius_api_admin_promotion_promotion_coupon_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons"
                 processor="sylius_api.state_processor.admin.promotion.promotion_coupon.persist"
@@ -108,7 +108,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_promotion_coupon_post_generate"
+                name="sylius_api_admin_promotion_promotion_coupon_post_generate"
                 class="ApiPlatform\Metadata\Post"
                 messenger="input"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons/generate"
@@ -155,7 +155,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_promotion_coupon_put"
+                name="sylius_api_admin_promotion_promotion_coupon_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons/{couponCode}"
             >
@@ -194,7 +194,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_promotion_coupon_delete"
+                name="sylius_api_admin_promotion_promotion_coupon_delete"
                 class="ApiPlatform\Metadata\Delete"
                 uriTemplate="/admin/promotions/{promotionCode}/coupons/{couponCode}"
                 processor="sylius_api.state_processor.admin.promotion.promotion_coupon.remove"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | resolves https://github.com/Sylius/Sylius/pull/16996#discussion_r1773308400
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
