### PR TITLE
Update typehint for $publicDir

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Console/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/InstallAssetsCommand.php
@@ -29,7 +29,7 @@ final class InstallAssetsCommand extends AbstractInstallCommand
     public function __construct(
         protected readonly EntityManagerInterface $entityManager,
         protected readonly CommandDirectoryChecker $commandDirectoryChecker,
-        protected readonly bool $publicDir,
+        protected readonly string $publicDir,
     ) {
         parent::__construct($this->entityManager, $this->commandDirectoryChecker);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

$publicDir is a value of `%sylius_core.public_dir%` which is a string value (usually a `sylius_core.public_dir: '%kernel.project_dir%/public'`), not a bool value. Which now causes assets to be installed into a wrong directory.

Pre-fix:
```bash
➜ bin/console sylius:install:assets --no-interaction;
Installing Sylius assets for environment dev.
Created "/Users/username/Code/Sylius-Standard/1/assets" directory.
Created "/Users/username/Code/Sylius-Standard/1/bundles" directory.
```

Post-fix:
```bash
➜ bin/console sylius:install:assets --no-interaction;
Installing Sylius assets for environment dev.
Created "/Users/username/Code/Sylius-Standard/public/assets" directory.
Created "/Users/username/Code/Sylius-Standard/public/bundles" directory.
```
