### PR TITLE
[Admin] Render a default form (useful for custom resources)

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/admin_user/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/admin_user/create.yaml
@@ -11,6 +11,8 @@ twig_hooks:
                 template: '@SyliusAdmin/admin_user/form/sections.html.twig'
 
         'sylius_admin.admin_user.create.content.form.sections':
+            general:
+                enabled: false
             account:
                 template: '@SyliusAdmin/admin_user/form/sections/account.html.twig'
             personal_information:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/admin_user/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/admin_user/update.yaml
@@ -11,6 +11,8 @@ twig_hooks:
                 template: '@SyliusAdmin/admin_user/form/sections.html.twig'
 
         'sylius_admin.admin_user.update.content.form.sections':
+            general:
+                enabled: false
             account:
                 template: '@SyliusAdmin/admin_user/form/sections/account.html.twig'
             personal_information:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/catalog_promotion/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/catalog_promotion/create.yaml
@@ -28,6 +28,8 @@ twig_hooks:
                 template: '@SyliusAdmin/catalog_promotion/form/sections/translations/description.html.twig'
 
         'sylius_admin.catalog_promotion.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/catalog_promotion/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/catalog_promotion/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/catalog_promotion/update.yaml
@@ -30,6 +30,8 @@ twig_hooks:
                 template: '@SyliusAdmin/catalog_promotion/form/sections/translations/description.html.twig'
 
         'sylius_admin.catalog_promotion.update.content.form.sections.general':
+            default: 
+                enabled: false
             code:
                 template: '@SyliusAdmin/catalog_promotion/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/channel/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/channel/create.yaml
@@ -24,6 +24,8 @@ twig_hooks:
                 template: '@SyliusAdmin/channel/form/sections/look_and_feel.html.twig'
 
         'sylius_admin.channel.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/channel/form/sections/general/code.html.twig'
             color:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/channel/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/channel/update.yaml
@@ -26,6 +26,8 @@ twig_hooks:
                 template: '@SyliusAdmin/channel/form/sections/look_and_feel.html.twig'
 
         'sylius_admin.channel.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/channel/form/sections/general/code.html.twig'
             color:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/create.yaml
@@ -40,3 +40,15 @@ twig_hooks:
                 template: '@SyliusAdmin/shared/crud/common/content/header/title_block/actions/cancel.html.twig'
             create:
                 template: '@SyliusAdmin/shared/crud/common/content/header/title_block/actions/create.html.twig'
+
+        'sylius_admin.common.create.content.form':
+            sections:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections.html.twig'
+
+        'sylius_admin.common.create.content.form.sections':
+            general:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections/general.html.twig'
+
+        'sylius_admin.common.create.content.form.sections.general':
+            default:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections/general/default.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/update.yaml
@@ -45,3 +45,15 @@ twig_hooks:
             update:
                 template: '@SyliusAdmin/shared/crud/common/content/header/title_block/actions/update.html.twig'
                 priority: -300
+
+        'sylius_admin.common.update.content.form':
+            sections:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections.html.twig'
+                
+        'sylius_admin.common.update.content.form.sections':
+            general:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections/general.html.twig'                
+
+        'sylius_admin.common.update.content.form.sections.general':
+            default:
+                template: '@SyliusAdmin/shared/crud/common/content/form/sections/general/default.html.twig'            

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/country/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/country/create.yaml
@@ -16,6 +16,8 @@ twig_hooks:
                 template: '@SyliusAdmin/country/form/sections/general.html.twig'
 
         'sylius_admin.country.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/country/form/sections/general/code.html.twig'
             enabled:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/country/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/country/update.yaml
@@ -18,6 +18,8 @@ twig_hooks:
                 template: '@SyliusAdmin/country/form/sections/general.html.twig'
 
         'sylius_admin.country.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/country/form/sections/general/code.html.twig'
             enabled:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/currency/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/currency/create.yaml
@@ -15,5 +15,7 @@ twig_hooks:
                 template: '@SyliusAdmin/currency/form/sections/general.html.twig'
 
         'sylius_admin.currency.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/currency/form/sections/general/code.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer/create.yaml
@@ -19,6 +19,8 @@ twig_hooks:
                 template: '@SyliusAdmin/customer/form/sections/account_credentials.html.twig'
 
         'sylius_admin.customer.create.content.form.sections.general':
+            default:
+                enabled: false
             first_name:
                 template: '@SyliusAdmin/customer/form/sections/general/first_name.html.twig'
             last_name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer/update.yaml
@@ -25,6 +25,8 @@ twig_hooks:
                 template: '@SyliusAdmin/customer/form/sections/account_credentials.html.twig'
 
         'sylius_admin.customer.update.content.form.sections.general':
+            default:
+                enabled: false
             first_name:
                 template: '@SyliusAdmin/customer/form/sections/general/first_name.html.twig'
             last_name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer_group/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer_group/create.yaml
@@ -18,6 +18,8 @@ twig_hooks:
                 template: '@SyliusAdmin/customer_group/form/sections/general.html.twig'
 
         'sylius_admin.customer_group.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/customer_group/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer_group/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/customer_group/update.yaml
@@ -19,6 +19,8 @@ twig_hooks:
                 template: '@SyliusAdmin/customer_group/form/sections/general.html.twig'
 
         'sylius_admin.customer_group.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/customer_group/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/exchange_rate/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/exchange_rate/create.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/exchange_rate/form/sections/general.html.twig'
 
         'sylius_admin.exchange_rate.create.content.form.sections.general':
+            default:
+                enabled: false
             ratio:
                 template: '@SyliusAdmin/exchange_rate/form/sections/general/ratio.html.twig'
             source_currency:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/exchange_rate/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/exchange_rate/update.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/exchange_rate/form/sections/general.html.twig'
 
         'sylius_admin.exchange_rate.update.content.form.sections.general':
+            default:
+                enabled: false
             ratio:
                 template: '@SyliusAdmin/exchange_rate/form/sections/general/ratio.html.twig'
             source_currency:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/locale/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/locale/create.yaml
@@ -15,5 +15,7 @@ twig_hooks:
                 template: '@SyliusAdmin/locale/form/sections/general.html.twig'
 
         'sylius_admin.locale.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/locale/form/sections/general/code.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/order/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/order/update.yaml
@@ -21,6 +21,8 @@ twig_hooks:
                 template: '@SyliusAdmin/order/form/billing_address.html.twig'
             shipping_address:
                 template: '@SyliusAdmin/order/form/shipping_address.html.twig'
+            sections:
+                enabled: false
 
         'sylius_admin.order.update.content.form.billing_address':
             company:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/payment_method/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/payment_method/create.yaml
@@ -20,6 +20,8 @@ twig_hooks:
                 template: '@SyliusAdmin/payment_method/form/sections/translations.html.twig'
 
         'sylius_admin.payment_method.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/payment_method/form/sections/general/code.html.twig'
             position:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/payment_method/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/payment_method/update.yaml
@@ -22,6 +22,8 @@ twig_hooks:
                 template: '@SyliusAdmin/payment_method/form/sections/translations.html.twig'
 
         'sylius_admin.payment_method.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/payment_method/form/sections/general/code.html.twig'
             position:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product/create.yaml
@@ -66,6 +66,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product/form/sections/media.html.twig'
 
         'sylius_admin.product.create.content.form.sections.general':
+            default: 
+                enabled: false
             code:
                 template: '@SyliusAdmin/product/form/sections/general/code.html.twig'
             enabled:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product/update.yaml
@@ -84,6 +84,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product/form/sections/media.html.twig'
 
         'sylius_admin.product.update.content.form.sections.general':
+            default: 
+                enabled: false
             code:
                 template: '@SyliusAdmin/product/form/sections/general/code.html.twig'
             enabled:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_association_type/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_association_type/create.yaml
@@ -11,6 +11,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_association_type/form/general.html.twig'
             translations:
                 template: '@SyliusAdmin/product_association_type/form/translations.html.twig'
+            sections:
+                enabled: false             
 
         'sylius_admin.product_association_type.create.content.form.general':
             code:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_association_type/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_association_type/update.yaml
@@ -11,6 +11,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_association_type/form/general.html.twig'
             translations:
                 template: '@SyliusAdmin/product_association_type/form/translations.html.twig'
+            sections:
+                enabled: false
 
         'sylius_admin.product_association_type.update.content.form.general':
             code:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_attribute/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_attribute/create.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_attribute/form/translations.html.twig'
             configuration:
                 template: '@SyliusAdmin/product_attribute/form/configuration.html.twig'
+            sections:
+                enabled: false
 
         'sylius_admin.product_attribute.create.content.form.general':
             code:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_attribute/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_attribute/update.yaml
@@ -17,6 +17,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_attribute/form/translations.html.twig'
             configuration:
                 template: '@SyliusAdmin/product_attribute/form/configuration.html.twig'
+            sections:
+                enabled: false
 
         'sylius_admin.product_attribute.update.content.form.general':
             code:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/create.yaml
@@ -20,6 +20,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_option/form/sections/values.html.twig'
                 
         'sylius_admin.product_option.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/product_option/form/sections/general/code.html.twig'
             position:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_option/update.yaml
@@ -22,6 +22,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_option/form/sections/values.html.twig'
         
         'sylius_admin.product_option.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/product_option/form/sections/general/code.html.twig'
             position:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_review/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/product_review/update.yaml
@@ -17,6 +17,8 @@ twig_hooks:
                 template: '@SyliusAdmin/product_review/form/sections/info.html.twig'
 
         'sylius_admin.product_review.update.content.form.sections.general':
+            default:
+                enabled: false
             title:
                 template: '@SyliusAdmin/product_review/form/sections/general/title.html.twig'
             comment:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion/create.yaml
@@ -28,6 +28,8 @@ twig_hooks:
                 template: '@SyliusAdmin/promotion/form/sections/translations/label.html.twig'
         
         'sylius_admin.promotion.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/promotion/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion/update.yaml
@@ -32,6 +32,8 @@ twig_hooks:
                 template: '@SyliusAdmin/promotion/form/sections/translations/label.html.twig'
         
         'sylius_admin.promotion.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/promotion/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion_coupon/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion_coupon/create.yaml
@@ -27,9 +27,10 @@ twig_hooks:
         'sylius_admin.promotion_coupon.create.content.form.sections#right':
             configuration:
                 template: '@SyliusAdmin/promotion_coupon/form/sections/configuration.html.twig'
-            
 
         'sylius_admin.promotion_coupon.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/promotion_coupon/form/sections/general/code.html.twig'
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion_coupon/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/promotion_coupon/update.yaml
@@ -29,6 +29,8 @@ twig_hooks:
                 template: '@SyliusAdmin/promotion_coupon/form/sections/configuration.html.twig'
 
         'sylius_admin.promotion_coupon.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/promotion_coupon/form/sections/general/code.html.twig'
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_category/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_category/create.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/shipping_category/form/sections/general.html.twig'
 
         'sylius_admin.shipping_category.create.content.form.sections.general':
+            default:
+                enabled: false
             name:
                 template: '@SyliusAdmin/shipping_category/form/sections/general/name.html.twig'
             code:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_category/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_category/update.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/shipping_category/form/sections/general.html.twig'
 
         'sylius_admin.shipping_category.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/shipping_category/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_method/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_method/create.yaml
@@ -6,6 +6,10 @@ twig_hooks:
                 props:
                     form: '@=_context.form'
                     resource: '@=_context.resource'
+                    
+        'sylius_admin.shipping_method.create.content.form':
+            sections:
+                enabled: false                    
 
         'sylius_admin.shipping_method.create.content.form#left':
             general:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_method/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/shipping_method/update.yaml
@@ -9,6 +9,10 @@ twig_hooks:
                 configuration:
                     method: PUT
 
+        'sylius_admin.shipping_method.update.content.form':
+            sections:
+                enabled: false
+        
         'sylius_admin.shipping_method.update.content.form#left':
             general:
                 template: '@SyliusAdmin/shipping_method/form/general.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_category/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_category/create.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/tax_category/form/sections/general.html.twig'
 
         'sylius_admin.tax_category.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/tax_category/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_category/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_category/update.yaml
@@ -15,6 +15,8 @@ twig_hooks:
                 template: '@SyliusAdmin/tax_category/form/sections/general.html.twig'
 
         'sylius_admin.tax_category.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/tax_category/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_rate/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_rate/create.yaml
@@ -17,6 +17,8 @@ twig_hooks:
                 template: '@SyliusAdmin/tax_rate/form/sections/configuration.html.twig'
 
         'sylius_admin.tax_rate.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/tax_rate/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_rate/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/tax_rate/update.yaml
@@ -17,6 +17,8 @@ twig_hooks:
                 template: '@SyliusAdmin/tax_rate/form/sections/configuration.html.twig'
 
         'sylius_admin.tax_rate.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/tax_rate/form/sections/general/code.html.twig'
             name:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/zone/create.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/zone/create.yaml
@@ -23,6 +23,8 @@ twig_hooks:
                 template: '@SyliusAdmin/zone/form/sections/members/member.html.twig'
 
         'sylius_admin.zone.create.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/zone/form/sections/general/code.html.twig'
             type:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/zone/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/zone/update.yaml
@@ -25,6 +25,8 @@ twig_hooks:
                 template: '@SyliusAdmin/zone/form/sections/members/member.html.twig'
 
         'sylius_admin.zone.update.content.form.sections.general':
+            default:
+                enabled: false
             code:
                 template: '@SyliusAdmin/zone/form/sections/general/code.html.twig'
             type:

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections.html.twig
@@ -1,0 +1,3 @@
+<div class="row">
+    {% hook 'sections' %}
+</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections/general.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections/general.html.twig
@@ -1,0 +1,9 @@
+<div class="col-12">
+    <div class="card">
+        <div class="card-body">
+            <div class="row align-items-center">
+                {% hook 'general' %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections/general/default.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form/sections/general/default.html.twig
@@ -1,0 +1,1 @@
+{{ form_widget(hookable_metadata.context.form) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

In the future Sylius stack, some default Twig hooks are defined to render a form with `form_widget(form)`.
Indeed, most of the time, for custom resources we create for an e-commerce, we do not need to improve the default form template rendering. Moreover, the user could see this as an issue of his configuration cause the creation/edition page will be empty even if he has defined his Form builder.

So in this PR, I've added the same twig hooks as Sylius stack to make the transition easier and to allow empty configuration of Twig hooks to render a form a Sylius developer in an end application. 
Moreover, I've disabled this default Twig hooks form rendering in out of the box Sylius resources. 

An example with default form rendering
![image](https://github.com/user-attachments/assets/13765730-a0dc-4d35-abad-a4b69080e8ca)
