### PR TITLE
[API] Make Province endpoints to be subresources of Country

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -178,7 +178,9 @@ final class ManagingCountriesContext implements Context
      */
     public function iRemoveProvinceName(ProvinceInterface $province): void
     {
-        $this->client->buildUpdateRequest(Resources::PROVINCES, $province->getCode());
+        $this->client->buildUpdateRequest(
+            sprintf('countries/%s/provinces/%s', $province->getCountry()->getCode(), $province->getCode()),
+        );
         $this->client->addRequestData('name', '');
         $this->client->update();
     }

--- a/src/Sylius/Behat/Context/Api/Resources.php
+++ b/src/Sylius/Behat/Context/Api/Resources.php
@@ -75,8 +75,6 @@ final class Resources
 
     public const PROMOTIONS = 'promotions';
 
-    public const PROVINCES = 'provinces';
-
     public const SHIPMENTS = 'shipments';
 
     public const SHIPPING_CATEGORIES = 'shipping-categories';

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
@@ -19,7 +19,7 @@
     <resource class="%sylius.model.province.class%">
         <operations>
             <operation
-                name="sylius_api_admin_province_get"
+                name="sylius_api_admin_country_province_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/admin/countries/{countryCode}/provinces/{provinceCode}"
             >
@@ -39,7 +39,7 @@
             </operation>
 
             <operation
-                name="sylius_api_admin_province_put"
+                name="sylius_api_admin_country_province_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/admin/countries/{countryCode}/provinces/{provinceCode}"
             >

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Province.xml
@@ -18,7 +18,15 @@
 >
     <resource class="%sylius.model.province.class%">
         <operations>
-            <operation name="sylius_api_admin_province_get" class="ApiPlatform\Metadata\Get" uriTemplate="/admin/provinces/{code}">
+            <operation
+                name="sylius_api_admin_province_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/admin/countries/{countryCode}/provinces/{provinceCode}"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="countryCode" fromClass="%sylius.model.country.class%" fromProperty="provinces" />
+                    <uriVariable parameterName="provinceCode" fromClass="%sylius.model.province.class%"/>
+                </uriVariables>
                 <normalizationContext>
                     <values>
                         <value name="groups">
@@ -30,7 +38,15 @@
                 </normalizationContext>
             </operation>
 
-            <operation name="sylius_api_admin_province_put" class="ApiPlatform\Metadata\Put" uriTemplate="/admin/provinces/{code}">
+            <operation
+                name="sylius_api_admin_province_put"
+                class="ApiPlatform\Metadata\Put"
+                uriTemplate="/admin/countries/{countryCode}/provinces/{provinceCode}"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="countryCode" fromClass="%sylius.model.country.class%" fromProperty="provinces" />
+                    <uriVariable parameterName="provinceCode" fromClass="%sylius.model.province.class%"/>
+                </uriVariables>
                 <denormalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
@@ -18,7 +18,15 @@
 >
     <resource class="%sylius.model.province.class%">
         <operations>
-            <operation name="sylius_api_shop_province_get" class="ApiPlatform\Metadata\Get" uriTemplate="/shop/provinces/{code}">
+            <operation
+                name="sylius_api_shop_province_get"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/countries/{countryCode}/provinces/{provinceCode}"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="countryCode" fromClass="%sylius.model.country.class%" fromProperty="provinces" />
+                    <uriVariable parameterName="provinceCode" fromClass="%sylius.model.province.class%"/>
+                </uriVariables>
                 <normalizationContext>
                     <values>
                         <value name="groups">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Province.xml
@@ -19,7 +19,7 @@
     <resource class="%sylius.model.province.class%">
         <operations>
             <operation
-                name="sylius_api_shop_province_get"
+                name="sylius_api_shop_country_province_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/countries/{countryCode}/provinces/{provinceCode}"
             >

--- a/src/Sylius/Bundle/ApiBundle/Tests/Resolver/PathPrefixBasedOperationResolverTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Resolver/PathPrefixBasedOperationResolverTest.php
@@ -17,7 +17,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use Sylius\Bundle\ApiBundle\Provider\PathPrefixes;
 use Sylius\Bundle\ApiBundle\Resolver\OperationResolverInterface;
 use Sylius\Bundle\ApiBundle\Resolver\PathPrefixBasedOperationResolver;
-use Sylius\Component\Addressing\Model\Province;
+use Sylius\Component\Addressing\Model\Country;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class PathPrefixBasedOperationResolverTest extends KernelTestCase
@@ -35,17 +35,17 @@ final class PathPrefixBasedOperationResolverTest extends KernelTestCase
     /** @test */
     public function it_provides_shop_operation_if_request_prefix_is_shop(): void
     {
-        $operation = $this->operationResolver->resolve(Province::class, PathPrefixes::SHOP_PREFIX, null);
+        $operation = $this->operationResolver->resolve(Country::class, PathPrefixes::SHOP_PREFIX, null);
 
-        $this->assertSame('/shop/provinces/{code}', $operation->getUriTemplate());
+        $this->assertSame('/shop/countries/{code}', $operation->getUriTemplate());
     }
 
     /** @test */
     public function it_provides_admin_operation_if_request_prefix_is_admin(): void
     {
-        $operation = $this->operationResolver->resolve(Province::class, PathPrefixes::ADMIN_PREFIX, null);
+        $operation = $this->operationResolver->resolve(Country::class, PathPrefixes::ADMIN_PREFIX, null);
 
-        $this->assertSame('/admin/provinces/{code}', $operation->getUriTemplate());
+        $this->assertSame('/admin/countries/{code}', $operation->getUriTemplate());
     }
 
     private function getResourceMetadataCollectionFactory(): ResourceMetadataCollectionFactoryInterface

--- a/tests/Api/Admin/ProvincesTest.php
+++ b/tests/Api/Admin/ProvincesTest.php
@@ -33,7 +33,7 @@ final class ProvincesTest extends JsonApiTestCase
 
         $this->client->request(
             method: 'GET',
-            uri: sprintf('/api/v2/admin/provinces/%s', $province->getCode()),
+            uri: sprintf('/api/v2/admin/countries/%s/provinces/%s', $province->getCountry()->getCode(), $province->getCode()),
             server: $header,
         );
 
@@ -55,7 +55,7 @@ final class ProvincesTest extends JsonApiTestCase
 
         $this->client->request(
             method: 'PUT',
-            uri: '/api/v2/admin/provinces/' . $province->getCode(),
+            uri: sprintf('/api/v2/admin/countries/%s/provinces/%s', $province->getCountry()->getCode(), $province->getCode()),
             server: $header,
             content: json_encode([
                 'abbreviation' => 'Minn.',

--- a/tests/Api/Responses/admin/country/get_countries_response.json
+++ b/tests/Api/Responses/admin/country/get_countries_response.json
@@ -11,8 +11,8 @@
             "name": "United States",
             "enabled": true,
             "provinces": [
-                "\/api\/v2\/admin\/provinces\/US-MI",
-                "\/api\/v2\/admin\/provinces\/US-WY"
+                "\/api\/v2\/admin\/countries\/US\/provinces\/US-MI",
+                "\/api\/v2\/admin\/countries\/US\/provinces\/US-WY"
             ]
         },
         {

--- a/tests/Api/Responses/admin/country/get_provinces_response.json
+++ b/tests/Api/Responses/admin/country/get_provinces_response.json
@@ -4,14 +4,14 @@
     "@type": "hydra:Collection",
     "hydra:member": [
         {
-            "@id": "\/api\/v2\/admin\/provinces\/US-WY",
+            "@id": "\/api\/v2\/admin\/countries\/US\/provinces\/US-WY",
             "@type": "Province",
             "code": "US-WY",
             "name": "Wyoming",
             "abbreviation": null
         },
         {
-            "@id": "\/api\/v2\/admin\/provinces\/US-MI",
+            "@id": "\/api\/v2\/admin\/countries\/US\/provinces\/US-MI",
             "@type": "Province",
             "code": "US-MI",
             "name": "Minnesota",

--- a/tests/Api/Responses/admin/country/post_country_response.json
+++ b/tests/Api/Responses/admin/country/post_country_response.json
@@ -7,7 +7,7 @@
     "enabled": true,
     "name": "Ireland",
     "provinces": [
-        "\/api\/v2\/admin\/provinces\/IE-CON",
-        "\/api\/v2\/admin\/provinces\/IE-LEI"
+        "\/api\/v2\/admin\/countries\/IE\/provinces\/IE-CON",
+        "\/api\/v2\/admin\/countries\/IE\/provinces\/IE-LEI"
     ]
 }

--- a/tests/Api/Responses/admin/country/put_country_response.json
+++ b/tests/Api/Responses/admin/country/put_country_response.json
@@ -7,6 +7,6 @@
     "enabled": false,
     "name": "United States",
     "provinces": [
-        "\/api\/v2\/admin\/provinces\/US-WA"
+        "\/api\/v2\/admin\/countries\/US\/provinces\/US-WA"
     ]
 }

--- a/tests/Api/Responses/admin/province/get_province_response.json
+++ b/tests/Api/Responses/admin/province/get_province_response.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/v2\/contexts\/Province",
-    "@id": "\/api\/v2\/admin\/provinces\/US-WY",
+    "@id": "\/api\/v2\/admin\/countries\/US\/provinces\/US-WY",
     "@type": "Province",
     "code": "US-WY",
     "name": "Wyoming",

--- a/tests/Api/Responses/admin/province/put_province_response.json
+++ b/tests/Api/Responses/admin/province/put_province_response.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/v2\/contexts\/Province",
-    "@id": "\/api\/v2\/admin\/provinces\/US-MI",
+    "@id": "\/api\/v2\/admin\/countries\/US\/provinces\/US-MI",
     "@type": "Province",
     "code": "US-MI",
     "name": "Minnesota",

--- a/tests/Api/Responses/shop/country/get_countries_from_channel_response.json
+++ b/tests/Api/Responses/shop/country/get_countries_from_channel_response.json
@@ -10,13 +10,13 @@
             "name": "United States",
             "provinces": [
                 {
-                    "@id": "\/api\/v2\/shop\/provinces\/US-MI",
+                    "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-MI",
                     "@type": "Province",
                     "code": "US-MI",
                     "name": "Minnesota"
                 },
                 {
-                    "@id": "\/api\/v2\/shop\/provinces\/US-WY",
+                    "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-WY",
                     "@type": "Province",
                     "code": "US-WY",
                     "name": "Wyoming"

--- a/tests/Api/Responses/shop/country/get_countries_response.json
+++ b/tests/Api/Responses/shop/country/get_countries_response.json
@@ -11,13 +11,13 @@
             "name": "United States",
             "provinces": [
                 {
-                    "@id": "\/api\/v2\/shop\/provinces\/US-MI",
+                    "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-MI",
                     "@type": "Province",
                     "code": "US-MI",
                     "name": "Minnesota"
                 },
                 {
-                    "@id": "\/api\/v2\/shop\/provinces\/US-WY",
+                    "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-WY",
                     "@type": "Province",
                     "code": "US-WY",
                     "name": "Wyoming"

--- a/tests/Api/Responses/shop/country/get_country_response.json
+++ b/tests/Api/Responses/shop/country/get_country_response.json
@@ -6,13 +6,13 @@
     "name": "United States",
     "provinces": [
         {
-            "@id": "\/api\/v2\/shop\/provinces\/US-MI",
+            "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-MI",
             "@type": "Province",
             "code": "US-MI",
             "name": "Minnesota"
         },
         {
-            "@id": "\/api\/v2\/shop\/provinces\/US-WY",
+            "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-WY",
             "@type": "Province",
             "code": "US-WY",
             "name": "Wyoming"

--- a/tests/Api/Responses/shop/province/get_province_response.json
+++ b/tests/Api/Responses/shop/province/get_province_response.json
@@ -1,6 +1,6 @@
 {
     "@context": "\/api\/v2\/contexts\/Province",
-    "@id": "\/api\/v2\/shop\/provinces\/US-WY",
+    "@id": "\/api\/v2\/shop\/countries\/US\/provinces\/US-WY",
     "@type": "Province",
     "code": "US-WY",
     "name": "Wyoming"

--- a/tests/Api/Shop/ProvincesTest.php
+++ b/tests/Api/Shop/ProvincesTest.php
@@ -33,7 +33,9 @@ final class ProvincesTest extends JsonApiTestCase
         /** @var ProvinceInterface $province */
         $province = $fixtures['province_US_WY'];
 
-        $this->requestGet(sprintf('/api/v2/shop/provinces/%s', $province->getCode()));
+        $this->requestGet(
+            sprintf('/api/v2/shop/countries/%s/provinces/%s', $province->getCountry()->getCode(), $province->getCode()),
+        );
 
         $this->assertResponse($this->client->getResponse(), 'shop/province/get_province_response');
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
