### PR TITLE
Deprecate templating helpers

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -95,6 +95,9 @@
     ```
 
 1. The following templating helpers and its interfaces have been deprecated and will be removed in Sylius 2.0:
+    - `Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper`
+    - `Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper`
+    - `Sylius\Bundle\CoreBundle\Templating\Helper\VariantResolverHelper`
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper`
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface`
     - `Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper`
@@ -107,6 +110,41 @@
     - `Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper`
 
 1. The following constructor signatures have been changed:
+
+   `Sylius\Bundle\CoreBundle\Twig\CheckoutStepsExtension`
+    ```diff
+    
+    use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
+    use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
+
+        public function __construct(
+    -       private CheckoutStepsHelper $checkoutStepsHelper,
+    +       private readonly CheckoutStepsHelper|OrderPaymentMethodSelectionRequirementCheckerInterface $checkoutStepsHelper,
+    +       private readonly ?OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker = null,
+        )
+    ```
+
+   `Sylius\Bundle\CoreBundle\Twig\PriceExtension`
+    ```diff
+    
+    use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+
+        public function __construct(
+    -       private PriceHelper $helper,
+    +       private readonly PriceHelper|ProductVariantPricesCalculatorInterface $helper,
+        )
+    ```
+
+   `Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension`
+    ```diff
+    
+    use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+
+        public function __construct(
+    -       private VariantResolverHelper $helper,
+    +       private readonly VariantResolverHelper|ProductVariantResolverInterface $helper,
+        )
+    ```
 
    `Sylius\Bundle\InventoryBundle\Twig\InventoryExtension`
     ```diff

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -97,12 +97,34 @@
 1. The following templating helpers and its interfaces have been deprecated and will be removed in Sylius 2.0:
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper`
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface`
+    - `Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelperInterface`
 
 1. The following constructor signatures have been changed:
+
+   `Sylius\Bundle\InventoryBundle\Twig\InventoryExtension`
+    ```diff
+    use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
+
+        public function __construct(
+    -       private InventoryHelper $helper,
+    +       private InventoryHelper|AvailabilityCheckerInterface $helper
+        )
+    ```
+
+   `Sylius\Bundle\LocaleBundle\Twig\LocaleExtension`
+    ```diff
+    use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+
+        public function __construct(
+    -       private LocaleHelperInterface $localeHelper,
+    +       private LocaleHelperInterface|LocaleConverterInterface $localeHelper,
+    +       private ?LocaleContextInterface $localeContext = null,
+        )
+    ```
 
    `Sylius\Bundle\MoneyBundle\Twig\ConvertMoneyExtension`
     ```diff

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -95,6 +95,8 @@
     ```
 
 1. The following templating helpers and its interfaces have been deprecated and will be removed in Sylius 2.0:
+    - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper`
+    - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper`

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -104,6 +104,7 @@
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelperInterface`
+    - `Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper`
 
 1. The following constructor signatures have been changed:
 
@@ -146,6 +147,16 @@
         public function __construct(
     -       private FormatMoneyHelperInterface $helper,
     +       private private FormatMoneyHelperInterface|MoneyFormatterInterface $helper,
+        )
+    ```
+
+   `Sylius\Bundle\OrderBundle\Twig\AggregateAdjustmentsExtension`
+    ```diff
+    use Sylius\Component\Order\Aggregator\AdjustmentsAggregatorInterface;
+
+        public function __construct(
+    -       private AdjustmentsHelper $adjustmentsHelper,
+    +       private AdjustmentsHelper|AdjustmentsAggregatorInterface $adjustmentsHelper,
         )
     ```
 

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -98,6 +98,8 @@
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper`
     - `Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface`
     - `Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper`
+    - `Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper`
+    - `Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface`
     - `Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper`
@@ -117,7 +119,8 @@
 
    `Sylius\Bundle\LocaleBundle\Twig\LocaleExtension`
     ```diff
-    use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+    use Sylius\Component\Locale\Context\LocaleContextInterface;
+    use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 
         public function __construct(
     -       private LocaleHelperInterface $localeHelper,

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -150,7 +150,8 @@
         </service>
 
         <service id="sylius.twig.extension.checkout_steps" class="Sylius\Bundle\CoreBundle\Twig\CheckoutStepsExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.checkout_steps" />
+            <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
+            <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -31,7 +31,7 @@
         </service>
 
         <service id="sylius.twig.extension.price" class="Sylius\Bundle\CoreBundle\Twig\PriceExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.price" />
+            <argument type="service" id="sylius.calculator.product_variant_price" />
             <tag name="twig.extension" />
         </service>
 
@@ -41,7 +41,7 @@
         </service>
 
         <service id="sylius.twig.extension.variant_resolver" class="Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.variant_resolver" />
+            <argument type="service" id="Sylius\Component\Product\Resolver\ProductVariantResolverInterface" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -23,11 +23,13 @@
         <service id="sylius.templating.helper.product_variants_prices" class="Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper">
             <argument type="service" id="sylius.provider.product_variants_prices" />
             <tag name="templating.helper" alias="sylius_product_variants_prices" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.templating.helper.price" class="Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper" lazy="true">
             <argument type="service" id="sylius.calculator.product_variant_price" />
             <tag name="templating.helper" alias="sylius_calculate_price" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.price" class="Sylius\Bundle\CoreBundle\Twig\PriceExtension" public="false">
@@ -38,6 +40,7 @@
         <service id="sylius.templating.helper.variant_resolver" class="Sylius\Bundle\CoreBundle\Templating\Helper\VariantResolverHelper">
             <argument type="service" id="Sylius\Component\Product\Resolver\ProductVariantResolverInterface" />
             <tag name="templating.helper" alias="sylius_resolve_variant" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.variant_resolver" class="Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension" public="false">
@@ -49,6 +52,7 @@
             <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
             <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
             <tag name="templating.helper" alias="sylius_checkout_steps" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.channel_url" class="Sylius\Bundle\CoreBundle\Twig\ChannelUrlExtension" public="false">

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
@@ -13,11 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Templating\Helper;
 
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker;
 use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker;
 use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" and "%s" instead.',
+    CheckoutStepsHelper::class,
+    OrderPaymentMethodSelectionRequirementChecker::class,
+    OrderShippingMethodSelectionRequirementChecker::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker} and {@see \Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker} instead. */
 class CheckoutStepsHelper extends Helper
 {
     public function __construct(

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/PriceHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/PriceHelper.php
@@ -13,12 +13,22 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Templating\Helper;
 
+use Sylius\Component\Core\Calculator\ProductVariantPriceCalculator;
 use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
 use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Symfony\Component\Templating\Helper\Helper;
 use Webmozart\Assert\Assert;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" instead.',
+    PriceHelper::class,
+    ProductVariantPriceCalculator::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Core\Calculator\ProductVariantPriceCalculator} instead. */
 class PriceHelper extends Helper
 {
     public function __construct(private ProductVariantPriceCalculatorInterface $productVariantPriceCalculator)

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/VariantResolverHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/VariantResolverHelper.php
@@ -15,9 +15,19 @@ namespace Sylius\Bundle\CoreBundle\Templating\Helper;
 
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
+use Sylius\Component\Product\Resolver\CompositeProductVariantResolver;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/core-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" instead.',
+    VariantResolverHelper::class,
+    CompositeProductVariantResolver::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Product\Resolver\CompositeProductVariantResolver} instead. */
 class VariantResolverHelper extends Helper
 {
     public function __construct(private ProductVariantResolverInterface $productVariantResolver)

--- a/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
@@ -14,17 +14,47 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper;
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class CheckoutStepsExtension extends AbstractExtension
 {
-    public function __construct(private CheckoutStepsHelper $checkoutStepsHelper)
-    {
+    public function __construct(
+        private readonly CheckoutStepsHelper|OrderPaymentMethodSelectionRequirementCheckerInterface $checkoutStepsHelper,
+        private readonly ?OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker = null,
+    ) {
+        if ($this->checkoutStepsHelper instanceof CheckoutStepsHelper) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                CheckoutStepsHelper::class,
+                self::class,
+                OrderPaymentMethodSelectionRequirementCheckerInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'The argument name $checkoutStepsHelper is deprecated and will be renamed to $orderPaymentMethodSelectionRequirementChecker in Sylius 2.0.',
+            );
+        }
     }
 
     public function getFunctions(): array
     {
+        if (
+            $this->checkoutStepsHelper instanceof OrderPaymentMethodSelectionRequirementCheckerInterface &&
+            $this->orderShippingMethodSelectionRequirementChecker instanceof OrderShippingMethodSelectionRequirementCheckerInterface
+        ) {
+            return [
+                new TwigFunction('sylius_is_shipping_required', [$this->orderShippingMethodSelectionRequirementChecker, 'isShippingMethodSelectionRequired']),
+                new TwigFunction('sylius_is_payment_required', [$this->checkoutStepsHelper, 'isPaymentMethodSelectionRequired']),
+            ];
+        }
+
         return [
             new TwigFunction('sylius_is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
             new TwigFunction('sylius_is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -14,17 +14,46 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Webmozart\Assert\Assert;
 
 final class PriceExtension extends AbstractExtension
 {
-    public function __construct(private PriceHelper $helper)
+    public function __construct(private readonly PriceHelper|ProductVariantPricesCalculatorInterface $helper)
     {
+        if ($this->helper instanceof PriceHelper) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                PriceHelper::class,
+                self::class,
+                ProductVariantPricesCalculatorInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'The argument name $helper is deprecated and will be renamed to $productVariantPriceCalculator in Sylius 2.0.',
+            );
+        }
     }
 
     public function getFilters(): array
     {
+        if ($this->helper instanceof ProductVariantPricesCalculatorInterface) {
+            return [
+                new TwigFilter('sylius_calculate_price', [$this, 'getPrice']),
+                new TwigFilter('sylius_calculate_original_price', [$this, 'getOriginalPrice']),
+                new TwigFilter('sylius_has_discount', [$this, 'hasDiscount']),
+                new TwigFilter('sylius_has_lowest_price', [$this, 'hasLowestPriceBeforeDiscount']),
+                new TwigFilter('sylius_calculate_lowest_price', [$this, 'getLowestPriceBeforeDiscount']),
+            ];
+        }
+
         return [
             new TwigFilter('sylius_calculate_price', [$this->helper, 'getPrice']),
             new TwigFilter('sylius_calculate_original_price', [$this->helper, 'getOriginalPrice']),
@@ -32,5 +61,49 @@ final class PriceExtension extends AbstractExtension
             new TwigFilter('sylius_has_lowest_price', [$this->helper, 'hasLowestPriceBeforeDiscount']),
             new TwigFilter('sylius_calculate_lowest_price', [$this->helper, 'getLowestPriceBeforeDiscount']),
         ];
+    }
+
+    /** @throws \InvalidArgumentException */
+    private function getPrice(ProductVariantInterface $productVariant, array $context): int
+    {
+        Assert::keyExists($context, 'channel');
+
+        return $this->helper->calculate($productVariant, $context);
+    }
+
+    /** @throws \InvalidArgumentException */
+    private function getOriginalPrice(ProductVariantInterface $productVariant, array $context): int
+    {
+        Assert::keyExists($context, 'channel');
+
+        return $this->helper->calculateOriginal($productVariant, $context);
+    }
+
+    /** @throws \InvalidArgumentException */
+    private function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): ?int
+    {
+        Assert::keyExists($context, 'channel');
+
+        if (\method_exists($this->helper, 'calculateLowestPriceBeforeDiscount')) {
+            return $this->helper->calculateLowestPriceBeforeDiscount($productVariant, $context);
+        }
+
+        return $this->getPrice($productVariant, $context);
+    }
+
+    /** @throws \InvalidArgumentException */
+    private function hasLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): bool
+    {
+        Assert::keyExists($context, 'channel');
+
+        return null !== $this->getLowestPriceBeforeDiscount($productVariant, $context);
+    }
+
+    /** @throws \InvalidArgumentException */
+    private function hasDiscount(ProductVariantInterface $productVariant, array $context): bool
+    {
+        Assert::keyExists($context, 'channel');
+
+        return $this->getOriginalPrice($productVariant, $context) > $this->getPrice($productVariant, $context);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -68,7 +68,7 @@ final class PriceExtension extends AbstractExtension
      *
      * @throws \InvalidArgumentException
      */
-    private function getPrice(ProductVariantInterface $productVariant, array $context): int
+    public function getPrice(ProductVariantInterface $productVariant, array $context): int
     {
         Assert::keyExists($context, 'channel');
 
@@ -80,7 +80,7 @@ final class PriceExtension extends AbstractExtension
      *
      * @throws \InvalidArgumentException
      */
-    private function getOriginalPrice(ProductVariantInterface $productVariant, array $context): int
+    public function getOriginalPrice(ProductVariantInterface $productVariant, array $context): int
     {
         Assert::keyExists($context, 'channel');
 
@@ -92,7 +92,7 @@ final class PriceExtension extends AbstractExtension
      *
      * @throws \InvalidArgumentException
      */
-    private function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): ?int
+    public function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): ?int
     {
         Assert::keyExists($context, 'channel');
 
@@ -108,7 +108,7 @@ final class PriceExtension extends AbstractExtension
      *
      * @throws \InvalidArgumentException
      */
-    private function hasLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): bool
+    public function hasLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): bool
     {
         Assert::keyExists($context, 'channel');
 
@@ -120,7 +120,7 @@ final class PriceExtension extends AbstractExtension
      *
      * @throws \InvalidArgumentException
      */
-    private function hasDiscount(ProductVariantInterface $productVariant, array $context): bool
+    public function hasDiscount(ProductVariantInterface $productVariant, array $context): bool
     {
         Assert::keyExists($context, 'channel');
 

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -63,7 +63,11 @@ final class PriceExtension extends AbstractExtension
         ];
     }
 
-    /** @throws \InvalidArgumentException */
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws \InvalidArgumentException
+     */
     private function getPrice(ProductVariantInterface $productVariant, array $context): int
     {
         Assert::keyExists($context, 'channel');
@@ -71,7 +75,11 @@ final class PriceExtension extends AbstractExtension
         return $this->helper->calculate($productVariant, $context);
     }
 
-    /** @throws \InvalidArgumentException */
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws \InvalidArgumentException
+     */
     private function getOriginalPrice(ProductVariantInterface $productVariant, array $context): int
     {
         Assert::keyExists($context, 'channel');
@@ -79,7 +87,11 @@ final class PriceExtension extends AbstractExtension
         return $this->helper->calculateOriginal($productVariant, $context);
     }
 
-    /** @throws \InvalidArgumentException */
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws \InvalidArgumentException
+     */
     private function getLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): ?int
     {
         Assert::keyExists($context, 'channel');
@@ -91,7 +103,11 @@ final class PriceExtension extends AbstractExtension
         return $this->getPrice($productVariant, $context);
     }
 
-    /** @throws \InvalidArgumentException */
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws \InvalidArgumentException
+     */
     private function hasLowestPriceBeforeDiscount(ProductVariantInterface $productVariant, array $context): bool
     {
         Assert::keyExists($context, 'channel');
@@ -99,7 +115,11 @@ final class PriceExtension extends AbstractExtension
         return null !== $this->getLowestPriceBeforeDiscount($productVariant, $context);
     }
 
-    /** @throws \InvalidArgumentException */
+    /**
+     * @param array<array-key, mixed> $context
+     *
+     * @throws \InvalidArgumentException
+     */
     private function hasDiscount(ProductVariantInterface $productVariant, array $context): bool
     {
         Assert::keyExists($context, 'channel');

--- a/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
@@ -14,17 +14,40 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Templating\Helper\VariantResolverHelper;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class VariantResolverExtension extends AbstractExtension
 {
-    public function __construct(private VariantResolverHelper $helper)
+    public function __construct(private readonly VariantResolverHelper|ProductVariantResolverInterface $helper)
     {
+        if ($this->helper instanceof VariantResolverHelper) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                VariantResolverHelper::class,
+                self::class,
+                ProductVariantResolverInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '1.14',
+                'The argument name $helper is deprecated and will be renamed to $productVariantResolver in Sylius 2.0.',
+            );
+        }
     }
 
     public function getFilters(): array
     {
+        if ($this->helper instanceof ProductVariantResolverInterface) {
+            return [
+                new TwigFilter('sylius_resolve_variant', [$this->helper, 'getVariant']),
+            ];
+        }
+
         return [
             new TwigFilter('sylius_resolve_variant', [$this->helper, 'resolveVariant']),
         ];

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
@@ -34,7 +34,6 @@
         </service>
 
         <service id="sylius.twig.extension.currency" class="Sylius\Bundle\CurrencyBundle\Twig\CurrencyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.currency" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
@@ -31,6 +31,7 @@
 
         <service id="sylius.templating.helper.currency" class="Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper" lazy="true">
             <tag name="templating.helper" alias="sylius_currency" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.currency" class="Sylius\Bundle\CurrencyBundle\Twig\CurrencyExtension" public="false">

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
@@ -16,6 +16,15 @@ namespace Sylius\Bundle\CurrencyBundle\Templating\Helper;
 use Symfony\Component\Intl\Currencies;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/currency-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s::getSymbol" instead.',
+    CurrencyHelper::class,
+    Currencies::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Symfony\Component\Intl\Currencies} instead. */
 class CurrencyHelper extends Helper implements CurrencyHelperInterface
 {
     public function convertCurrencyCodeToSymbol(string $code): string

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
@@ -13,6 +13,14 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CurrencyBundle\Templating\Helper;
 
+trigger_deprecation(
+    'sylius/currency-bundle',
+    '1.14',
+    'The "%s" interface is deprecated.',
+    CurrencyHelperInterface::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 interface CurrencyHelperInterface
 {
     public function convertCurrencyCodeToSymbol(string $code): string;

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -46,7 +46,7 @@ final class CurrencyExtension extends AbstractExtension
         ];
     }
 
-    private function convertCurrencyCodeToSymbol(string $code): string
+    public function convertCurrencyCodeToSymbol(string $code): string
     {
         return Currencies::getSymbol($code);
     }

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -14,19 +14,40 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CurrencyBundle\Twig;
 
 use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface;
+use Symfony\Component\Intl\Currencies;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class CurrencyExtension extends AbstractExtension
 {
-    public function __construct(private CurrencyHelperInterface $helper)
+    public function __construct(private ?CurrencyHelperInterface $helper = null)
     {
+        if ($this->helper instanceof CurrencyHelperInterface) {
+            trigger_deprecation(
+                'sylius/currency-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0.',
+                CurrencyHelperInterface::class,
+                self::class,
+            );
+        }
     }
 
     public function getFilters(): array
     {
+        if ($this->helper === null) {
+            return [
+                new TwigFilter('sylius_currency_symbol', [$this, 'convertCurrencyCodeToSymbol']),
+            ];
+        }
+
         return [
             new TwigFilter('sylius_currency_symbol', [$this->helper, 'convertCurrencyCodeToSymbol']),
         ];
+    }
+
+    private function convertCurrencyCodeToSymbol(string $code): string
+    {
+        return Currencies::getSymbol($code);
     }
 }

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
         <service id="sylius.templating.helper.inventory" class="Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper">
             <argument type="service" id="sylius.availability_checker" />
             <tag name="templating.helper" alias="sylius_inventory" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.inventory" class="Sylius\Bundle\InventoryBundle\Twig\InventoryExtension" public="false">

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
         </service>
 
         <service id="sylius.twig.extension.inventory" class="Sylius\Bundle\InventoryBundle\Twig\InventoryExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.inventory" />
+            <argument type="service" id="sylius.availability_checker" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/InventoryBundle/Templating/Helper/InventoryHelper.php
+++ b/src/Sylius/Bundle/InventoryBundle/Templating/Helper/InventoryHelper.php
@@ -13,10 +13,20 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\InventoryBundle\Templating\Helper;
 
+use Sylius\Component\Inventory\Checker\AvailabilityChecker;
 use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 use Sylius\Component\Inventory\Model\StockableInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/inventory-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" instead.',
+    InventoryHelper::class,
+    AvailabilityChecker::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Inventory\Checker\AvailabilityChecker} instead. */
 final class InventoryHelper extends Helper
 {
     public function __construct(private AvailabilityCheckerInterface $checker)

--- a/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
@@ -14,13 +14,30 @@ declare(strict_types=1);
 namespace Sylius\Bundle\InventoryBundle\Twig;
 
 use Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper;
+use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class InventoryExtension extends AbstractExtension
 {
-    public function __construct(private InventoryHelper $helper)
+    public function __construct(private InventoryHelper|AvailabilityCheckerInterface $helper)
     {
+        if ($this->helper instanceof InventoryHelper) {
+            trigger_deprecation(
+                'sylius/inventory-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                InventoryHelper::class,
+                self::class,
+                AvailabilityCheckerInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/inventory-bundle',
+                '1.14',
+                'The argument name $helper is deprecated and will be renamed to $availabilityChecker in Sylius 2.0.',
+            );
+        }
     }
 
     public function getFunctions(): array

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -77,6 +77,7 @@
             <argument type="service" id="sylius.locale_converter" />
             <argument type="service" id="sylius.context.locale" />
             <tag name="templating.helper" alias="sylius_locale" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.locale" class="Sylius\Bundle\LocaleBundle\Twig\LocaleExtension" public="false">

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -80,7 +80,8 @@
         </service>
 
         <service id="sylius.twig.extension.locale" class="Sylius\Bundle\LocaleBundle\Twig\LocaleExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.locale" />
+            <argument type="service" id="sylius.locale_converter" />
+            <argument type="service" id="sylius.context.locale" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -15,9 +15,19 @@ namespace Sylius\Bundle\LocaleBundle\Templating\Helper;
 
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
+use Sylius\Component\Locale\Converter\LocaleConverter;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/locale-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" instead.',
+    LocaleHelper::class,
+    LocaleConverter::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Locale\Converter\LocaleConverter} instead. */
 final class LocaleHelper extends Helper implements LocaleHelperInterface
 {
     public function __construct(

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
@@ -13,8 +13,18 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\LocaleBundle\Templating\Helper;
 
+use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Symfony\Component\Templating\Helper\HelperInterface;
 
+trigger_deprecation(
+    'sylius/locale-bundle',
+    '1.14',
+    'The "%s" interface is deprecated, use "%s" instead.',
+    LocaleHelperInterface::class,
+    LocaleConverterInterface::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Locale\Converter\LocaleConverterInterface} instead. */
 interface LocaleHelperInterface extends HelperInterface
 {
     /**

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -14,21 +14,87 @@ declare(strict_types=1);
 namespace Sylius\Bundle\LocaleBundle\Twig;
 
 use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Locale\Context\LocaleNotFoundException;
+use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class LocaleExtension extends AbstractExtension
 {
-    public function __construct(private LocaleHelperInterface $localeHelper)
-    {
+    public function __construct(
+        private LocaleHelperInterface|LocaleConverterInterface $localeHelper,
+        private ?LocaleContextInterface $localeContext = null,
+    ) {
+        if ($this->localeHelper instanceof LocaleHelperInterface) {
+            trigger_deprecation(
+                'sylius/locale-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                LocaleHelperInterface::class,
+                self::class,
+                LocaleConverterInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/locale-bundle',
+                '1.14',
+                'The argument name $localeHelper is deprecated and will be renamed to $localeConverter in Sylius 2.0.',
+            );
+        }
+
+        if ($this->localeContext === null) {
+            trigger_deprecation(
+                'sylius/locale-bundle',
+                '1.14',
+                'Not passing a $localeContext to %s constructor as a second argument is deprecated and will be prohibited in Sylius 2.0.',
+                self::class,
+            );
+        }
     }
 
     public function getFilters(): array
     {
+        if (
+            $this->localeHelper instanceof LocaleConverterInterface &&
+            $this->localeContext instanceof LocaleContextInterface
+        ) {
+            return [
+                new TwigFilter('sylius_locale_name', [$this, 'convertCodeToName']),
+                new TwigFilter('sylius_locale_country', [$this, 'getCountryCode']),
+            ];
+        }
+
         return [
             new TwigFilter('sylius_locale_name', [$this->localeHelper, 'convertCodeToName']),
             new TwigFilter('sylius_locale_country', [$this, 'getCountryCode']),
         ];
+    }
+
+    private function convertCodeToName(string $code, ?string $localeCode = null): ?string
+    {
+        try {
+            return $this->localeHelper->convertCodeToName($code, $this->getLocaleCode($localeCode));
+        } catch (\InvalidArgumentException) {
+            return $code;
+        }
+    }
+
+    private function getLocaleCode(?string $localeCode): ?string
+    {
+        if (null !== $localeCode) {
+            return $localeCode;
+        }
+
+        if (null === $this->localeContext) {
+            return null;
+        }
+
+        try {
+            return $this->localeContext->getLocaleCode();
+        } catch (LocaleNotFoundException) {
+            return null;
+        }
     }
 
     public function getCountryCode(string $locale): ?string

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -71,7 +71,7 @@ final class LocaleExtension extends AbstractExtension
         ];
     }
 
-    private function convertCodeToName(string $code, ?string $localeCode = null): ?string
+    public function convertCodeToName(string $code, ?string $localeCode = null): ?string
     {
         try {
             return $this->localeHelper->convertCodeToName($code, $this->getLocaleCode($localeCode));
@@ -80,7 +80,7 @@ final class LocaleExtension extends AbstractExtension
         }
     }
 
-    private function getLocaleCode(?string $localeCode): ?string
+    public function getLocaleCode(?string $localeCode): ?string
     {
         if (null !== $localeCode) {
             return $localeCode;

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
         </service>
 
         <service id="sylius.twig.extension.money" class="Sylius\Bundle\MoneyBundle\Twig\FormatMoneyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.format_money" />
+            <argument type="service" id="sylius.money_formatter" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
         <service id="sylius.templating.helper.format_money" class="Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper" lazy="true">
             <argument type="service" id="sylius.money_formatter" />
             <tag name="templating.helper" alias="sylius_format_money" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.money" class="Sylius\Bundle\MoneyBundle\Twig\FormatMoneyExtension" public="false">

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
@@ -21,7 +21,7 @@
         </service>
 
         <service id="sylius.twig.extension.convert_amount" class="Sylius\Bundle\MoneyBundle\Twig\ConvertMoneyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.convert_money" />
+            <argument type="service" id="sylius.currency_converter" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
@@ -18,6 +18,7 @@
         <service id="sylius.templating.helper.convert_money" class="Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper" lazy="true">
             <argument type="service" id="sylius.currency_converter" />
             <tag name="templating.helper" alias="sylius_convert_money" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.convert_amount" class="Sylius\Bundle\MoneyBundle\Twig\ConvertMoneyExtension" public="false">

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/templating.xml
@@ -18,6 +18,7 @@
         <service id="sylius.templating.helper.adjustment" class="Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper">
             <argument type="service" id="sylius.adjustments_aggregator" />
             <tag name="templating.helper" alias="sylius_adjustments" />
+            <deprecated package="sylius/sylius" version="1.14">The "%service_id%" is deprecated since Sylius 1.14 and will be removed in 2.0.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/twig.xml
@@ -16,7 +16,7 @@
         <defaults public="true" />
 
         <service id="sylius.twig.extension.aggregate_adjustments" class="Sylius\Bundle\OrderBundle\Twig\AggregateAdjustmentsExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.adjustment" />
+            <argument type="service" id="sylius.adjustments_aggregator" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/OrderBundle/Templating/Helper/AdjustmentsHelper.php
+++ b/src/Sylius/Bundle/OrderBundle/Templating/Helper/AdjustmentsHelper.php
@@ -14,9 +14,19 @@ declare(strict_types=1);
 namespace Sylius\Bundle\OrderBundle\Templating\Helper;
 
 use Sylius\Component\Order\Aggregator\AdjustmentsAggregatorInterface;
+use Sylius\Component\Order\Aggregator\AdjustmentsByLabelAggregator;
 use Sylius\Component\Order\Model\AdjustmentInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
+trigger_deprecation(
+    'sylius/order-bundle',
+    '1.14',
+    'The "%s" class is deprecated, use "%s" instead.',
+    AdjustmentsHelper::class,
+    AdjustmentsByLabelAggregator::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. Use {@see \Sylius\Component\Order\Aggregator\AdjustmentsAggregatorInterface} instead. */
 class AdjustmentsHelper extends Helper
 {
     public function __construct(private AdjustmentsAggregatorInterface $adjustmentsAggregator)

--- a/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
@@ -14,17 +14,40 @@ declare(strict_types=1);
 namespace Sylius\Bundle\OrderBundle\Twig;
 
 use Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper;
+use Sylius\Component\Order\Aggregator\AdjustmentsAggregatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class AggregateAdjustmentsExtension extends AbstractExtension
 {
-    public function __construct(private AdjustmentsHelper $adjustmentsHelper)
+    public function __construct(private AdjustmentsHelper|AdjustmentsAggregatorInterface $adjustmentsHelper)
     {
+        if ($this->adjustmentsHelper instanceof AdjustmentsHelper) {
+            trigger_deprecation(
+                'sylius/order-bundle',
+                '1.14',
+                'Passing an instance of %s as constructor argument for %s is deprecated and will be prohibited in Sylius 2.0. Pass an instance of %s instead.',
+                AdjustmentsHelper::class,
+                self::class,
+                AdjustmentsAggregatorInterface::class,
+            );
+
+            trigger_deprecation(
+                'sylius/order-bundle',
+                '1.14',
+                'The argument name $adjustmentsHelper is deprecated and will be renamed to $adjustmentsAggregator in Sylius 2.0.',
+            );
+        }
     }
 
     public function getFunctions(): array
     {
+        if ($this->adjustmentsHelper instanceof AdjustmentsAggregatorInterface) {
+            return [
+                new TwigFunction('sylius_aggregate_adjustments', [$this->adjustmentsHelper, 'aggregate']),
+            ];
+        }
+
         return [
             new TwigFunction('sylius_aggregate_adjustments', [$this->adjustmentsHelper, 'getAggregatedAdjustments']),
         ];


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | related to https://github.com/Sylius/Sylius/pull/16769
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
