### PR TITLE
Fix comparison of order items

### DIFF
--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -82,7 +82,7 @@ class OrderItem extends BaseOrderItem implements OrderItemInterface
 
     public function equals(BaseOrderItemInterface $orderItem): bool
     {
-        return parent::equals($orderItem) || ($orderItem instanceof static && $orderItem->getVariant() === $this->variant);
+        return parent::equals($orderItem) || ($orderItem instanceof self && $orderItem->getVariant() === $this->variant);
     }
 
     /**


### PR DESCRIPTION
Fix comparison of order items when one of them is Doctrine proxy object

| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Having two OrderItem objects, with exact same content, but one of them Doctrine proxy, then comparison of `$orderItem instanceof static` in proxy object fails, because compared object is not a Doctrine proxy. That is probably not intentional and can break app in imports and other "I have created an order item copy and I am looking for original" situations.