### PR TITLE
Deprecate ResourceDeleteSubcriber

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -66,6 +66,9 @@
 
 1. The class `Sylius\Bundle\ApiBundle\Filter\Doctrine\PromotionCouponPromotionFilter` has been deprecated and will be removed in Sylius 2.0.
 
+1. The class `Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber` has been deprecated and will be removed in Sylius 2.0.
+   It will be replaced with the `ResourceDeleteListener`.
+
 1. Extending `\InvalidArgumentException` by `Sylius\Component\Core\Inventory\Exception\NotEnoughUnitsOnHandException` 
    and `Sylius\Component\Core\Inventory\Exception\NotEnoughUnitsOnHoldException` is deprecated, instead they will extend 
    `\RuntimeException` in Sylius 2.0.

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -25,6 +25,14 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+trigger_deprecation(
+    'sylius/admin-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. It will be replaced with the ResourceDeleteListener.',
+    ResourceDeleteSubscriber::class,
+);
+
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 final class ResourceDeleteSubscriber implements EventSubscriberInterface
 {
     public function __construct(


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


