### PR TITLE
Add note about ResourceDeleteSubcriber class being removed in 2.0

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -60,6 +60,9 @@
   To change the default resolver and/or loader for `LiipImagineBundle`, configure `cache` and/or `data_loader`
   parameters under the `liip_imagine` key.
 
+* The class `Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber` has been removed and replaced with
+  `Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteListener`.
+
 * The `sylius/calendar` package has been replaced with `symfony/clock` package. All usages of
   the `Sylius\Calendar\Provider\DateTimeProviderInterface` class
   have been replaced with `Symfony\Component\Clock\ClockInterface` class.


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
