### PR TITLE
Fix name of argument in deprecation trigger for PriceExtension

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -37,7 +37,7 @@ final class PriceExtension extends AbstractExtension
             trigger_deprecation(
                 'sylius/core-bundle',
                 '1.14',
-                'The argument name $helper is deprecated and will be renamed to $productVariantPriceCalculator in Sylius 2.0.',
+                'The argument name $helper is deprecated and will be renamed to $productVariantPricesCalculator in Sylius 2.0.',
             );
         }
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fix https://github.com/Sylius/Sylius/pull/17061
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
