### PR TITLE
[Admin][Grid][Customer] Fix show orders icon

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/customer.yml
@@ -74,7 +74,7 @@ sylius_grid:
                     show_orders:
                         type: show
                         label: sylius.ui.show_orders
-                        icon: shopping-bag
+                        icon: shopping_bag
                         options:
                             link:
                                 route: sylius_admin_customer_order_index


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Hello ! 

Trying the new BS admin panel on v2, I noticed that there is no icon on customer grid for "show orders" button. 

![image](https://github.com/user-attachments/assets/14eef7ea-9c5d-43cf-b365-51866e5410ac)

Let's fix it 🥳

![image](https://github.com/user-attachments/assets/b6894475-a408-4a0b-86f8-0a0692510ecd)

