### PR TITLE
Correct the parameter name for states that should be cancelled, when payment method is changed

### DIFF
--- a/src/Sylius/Bundle/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PaymentBundle/DependencyInjection/Configuration.php
@@ -60,7 +60,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('payment_request')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->arrayNode('states_that_should_be_cancelled_when_payment_request_has_changed')
+                        ->arrayNode('states_to_be_cancelled_when_payment_method_changed')
                             ->scalarPrototype()->end()
                         ->end()
                     ->end()

--- a/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
+++ b/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
@@ -34,7 +34,7 @@ final class SyliusPaymentExtension extends AbstractResourceExtension
 
         $container->setParameter('sylius.payment_gateways', $config['gateways']);
         $container->setParameter('sylius.gateway_config.validation_groups', $config['gateway_config']['validation_groups']);
-        $container->setParameter('sylius.payment_request.states_that_should_be_cancelled_when_payment_request_has_changed', $config['payment_request']['states_that_should_be_cancelled_when_payment_request_has_changed']);
+        $container->setParameter('sylius.payment_request.states_to_be_cancelled_when_payment_method_changed', $config['payment_request']['states_to_be_cancelled_when_payment_method_changed']);
 
         $this->registerAutoconfiguration($container);
     }

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/app/config.yml
@@ -13,6 +13,6 @@ jms_serializer:
 
 sylius_payment:
     payment_request:
-        states_that_should_be_cancelled_when_payment_request_has_changed:
+        states_to_be_cancelled_when_payment_method_changed:
             - !php/const Sylius\Component\Payment\Model\PaymentRequestInterface::STATE_PROCESSING
             - !php/const Sylius\Component\Payment\Model\PaymentRequestInterface::STATE_NEW

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/services/canceller.xml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/services/canceller.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="sylius.repository.payment_request" />
             <argument type="service" id="sylius_abstraction.state_machine" />
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument>%sylius.payment_request.states_that_should_be_cancelled_when_payment_request_has_changed%</argument>
+            <argument>%sylius.payment_request.states_to_be_cancelled_when_payment_method_changed%</argument>
         </service>
         <service id="Sylius\Component\Payment\Canceller\PaymentRequestCancellerInterface" alias="sylius.canceller.payment_request" />
     </services>

--- a/src/Sylius/Bundle/PaymentBundle/Tests/DependencyInjection/SyliusPaymentExtensionTest.php
+++ b/src/Sylius/Bundle/PaymentBundle/Tests/DependencyInjection/SyliusPaymentExtensionTest.php
@@ -87,7 +87,7 @@ final class SyliusPaymentExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([
             'payment_request' => [
-                'states_that_should_be_cancelled_when_payment_request_has_changed' => [
+                'states_to_be_cancelled_when_payment_method_changed' => [
                     PaymentRequestInterface::STATE_NEW,
                     PaymentRequestInterface::STATE_PROCESSING,
                 ],
@@ -95,7 +95,7 @@ final class SyliusPaymentExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasParameter(
-            'sylius.payment_request.states_that_should_be_cancelled_when_payment_request_has_changed',
+            'sylius.payment_request.states_to_be_cancelled_when_payment_method_changed',
             [PaymentRequestInterface::STATE_NEW, PaymentRequestInterface::STATE_PROCESSING],
         );
     }

--- a/src/Sylius/Bundle/PaymentBundle/Tests/EventListener/PaymentMethodChangeEventListenerTest.php
+++ b/src/Sylius/Bundle/PaymentBundle/Tests/EventListener/PaymentMethodChangeEventListenerTest.php
@@ -34,9 +34,7 @@ final class PaymentMethodChangeEventListenerTest extends TestCase
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $unitOfWork = $this->createMock(UnitOfWork::class);
 
-        $payment->expects($this->once())
-            ->method('getId')
-            ->willReturn(1);
+        $payment->expects($this->once())->method('getId')->willReturn(1);
 
         $newMethod->expects($this->once())
             ->method('getCode')

--- a/src/Sylius/Bundle/PaymentBundle/spec/Canceller/PaymentRequestCancellerSpec.php
+++ b/src/Sylius/Bundle/PaymentBundle/spec/Canceller/PaymentRequestCancellerSpec.php
@@ -37,8 +37,10 @@ final class PaymentRequestCancellerSpec extends ObjectBehavior
         StateMachineInterface $stateMachine,
         ObjectManager $objectManager,
     ): void {
-        $paymentRequestRepository->findByPaymentIdAndStates(1, [PaymentRequestInterface::STATE_NEW, PaymentRequestInterface::STATE_PROCESSING])
-            ->willReturn([$paymentRequest1, $paymentRequest2]);
+        $paymentRequestRepository
+            ->findByPaymentIdAndStates(1, [PaymentRequestInterface::STATE_NEW, PaymentRequestInterface::STATE_PROCESSING])
+            ->willReturn([$paymentRequest1, $paymentRequest2])
+        ;
 
         $paymentRequest1->getMethod()->willReturn($paymentMethod1);
         $paymentMethod1->getCode()->willReturn('payment_method_with_different_code');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | payment-request <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
continuation of:

https://github.com/Sylius/Sylius/pull/15950