### PR TITLE
[Maintenance] Resolve gedmo/doctrine-extension conflicts

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -12,8 +12,3 @@ references related issues.
 
     - https://github.com/stof/StofDoctrineExtensionsBundle/issues/455
     - https://github.com/doctrine-extensions/DoctrineExtensions/issues/2600
-
-- `gedmo/doctrine-extensions:3.17.0`:
-
-  This version has a bug, which on Symfony 6.4 leads to a fatal error:
-  `[Semantical Error] The annotation "@note" in property Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry::$data was never imported.`

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "enshrined/svg-sanitize": "^0.16",
         "fakerphp/faker": "^1.10",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
-        "gedmo/doctrine-extensions": "^3.2",
+        "gedmo/doctrine-extensions": "^3.17.1",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "guzzlehttp/psr7": "^2.5",
         "knplabs/gaufrette": "^0.10 || ^0.11",
@@ -187,7 +187,6 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "gedmo/doctrine-extensions": "^3.17.0",
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
+++ b/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
@@ -1,9 +1,0 @@
-# CONFLICTS
-
-This document explains why certain conflicts were added to `composer.json` and
-references related issues.
-
-- `gedmo/doctrine-extensions:3.17.0`:
-
-  This version has a bug, which on Symfony 6.4 leads to a fatal error:
-  `[Semantical Error] The annotation "@note" in property Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry::$data was never imported.`

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -46,9 +46,6 @@
         "symfony/webpack-encore-bundle": "^2.1",
         "theofidry/alice-data-fixtures": "^1.4"
     },
-    "conflict": {
-        "gedmo/doctrine-extensions": "^3.17.0"
-    },
     "config": {
         "allow-plugins": {
             "symfony/flex": true


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Bump `gedmo/doctrine-extensions` to version `3.17.1` with fixed bug and removed conflicts
