### PR TITLE
Remove winzouStateMachineBundle from packages' test applications to support ResourceBundle 1.12

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/InventoryBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/InventoryBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),

--- a/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
@@ -21,7 +21,6 @@ class AppKernel extends Kernel
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
@@ -20,7 +20,6 @@ class AppKernel extends Kernel
     {
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
@@ -21,7 +21,6 @@ class AppKernel extends Kernel
         return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),


### PR DESCRIPTION


| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | https://github.com/Sylius/SyliusResourceBundle/pull/873
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
