### PR TITLE
[Maintenance] Resolve gedmo/doctrine-extension conflict

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -37,8 +37,3 @@ references related issues.
 
   This version has a bug, which lead to a fatal error:
   `An exception has been thrown during the rendering of a template ("Warning: Undefined variable $blocks").`
-
-- `gedmo/doctrine-extensions:3.17.0`:
-
-  This version has a bug, which on Symfony 6.4 leads to a fatal error:
-  `[Semantical Error] The annotation "@note" in property Gedmo\Loggable\Entity\MappedSuperclass\AbstractLogEntry::$data was never imported.`

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "fakerphp/faker": "^1.10",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
         "friendsofsymfony/rest-bundle": "^3.0",
-        "gedmo/doctrine-extensions": "^3.2",
+        "gedmo/doctrine-extensions": "^3.17.1",
         "guzzlehttp/guzzle": "^6.5 || ^7.0",
         "guzzlehttp/psr7": "^2.5",
         "jms/serializer-bundle": "^4.2",
@@ -192,8 +192,7 @@
         "lexik/jwt-authentication-bundle": "^2.18",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "symfony/validator": "5.4.25",
-        "twig/twig": "3.9.0",
-        "gedmo/doctrine-extensions": "^3.17.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Bump `gedmo/doctrine-extensions` to 3.17.1 with fixed bug and remove conflict
