### PR TITLE
Fix session unavailable in locale context

### DIFF
--- a/src/Sylius/Component/Core/Locale/Context/StorageBasedLocaleContext.php
+++ b/src/Sylius/Component/Core/Locale/Context/StorageBasedLocaleContext.php
@@ -19,6 +19,7 @@ use Sylius\Component\Core\Locale\LocaleStorageInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
+use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
 
 final class StorageBasedLocaleContext implements LocaleContextInterface
 {
@@ -35,7 +36,7 @@ final class StorageBasedLocaleContext implements LocaleContextInterface
 
         try {
             $localeCode = $this->localeStorage->get($this->channelContext->getChannel());
-        } catch (ChannelNotFoundException $exception) {
+        } catch (ChannelNotFoundException|\RuntimeException|SessionUnavailableException $exception) {
             throw new LocaleNotFoundException(null, $exception);
         }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #15011
| License         | MIT

Since 1.13 still supports `resource-bundle:^1.9`, the exception catching is a bit messy but will be straightened out in 1.14 cause the minimum version there is 1.11, where a concrete exception has been added for cases like this.