### PR TITLE
[Maintenance] Allow exporting package.json files from bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,7 +28,7 @@ ecs.php                         export-ignore
 gulpfile.babel.js               export-ignore
 Makefile                        export-ignore
 monorepo-builder.php            export-ignore
-package.json                    export-ignore
+/package.json                   export-ignore
 phparkitect.php                 export-ignore
 phpspec.yml.dist                export-ignore
 phpstan.neon.dist               export-ignore


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

It enables using package.json form vendor in Sylius-Standard
