### PR TITLE
[Zone] Added priority property

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -44,6 +45,10 @@ final class ZoneType extends AbstractResourceType
             ])
             ->add('type', ZoneTypeChoiceType::class, [
                 'disabled' => true,
+            ])
+            ->add('priority', IntegerType::class, [
+                'label' => 'sylius.form.zone.priority',
+                'required' => true,
             ])
         ;
 

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -33,6 +33,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
             ->setParameter('type', $type)
             ->setMaxResults(1)
+            ->addOrderBy('o.priority', 'DESC')
         ;
 
         return $queryBuilder->getQuery()->getOneOrNullResult();

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -22,6 +22,7 @@
         <field name="name" column="name" type="string" />
         <field name="type" column="type" type="string" length="8" />
         <field name="scope" column="scope" type="string" nullable="true"/>
+        <field name="priority" column="priority" type="integer"/>
 
         <one-to-many field="members" target-entity="Sylius\Component\Addressing\Model\ZoneMemberInterface" mapped-by="belongsTo" orphan-removal="true">
             <cascade>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -38,5 +38,6 @@ sylius:
                 all: Alle
             select: Gebiet auswählen
             select_scope: Bereich wählen
+            priority: Priorität
         zone_member:
             select: Mitglied auswählen

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -34,5 +34,6 @@ sylius:
             scopes:
                 all: All
             select: Select
+            priority: Priority
         zone_member:
             select: Select

--- a/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
@@ -98,6 +98,7 @@ class GeographicalFixture extends AbstractFixture
                 ->arrayNode('zones')->scalarPrototype()->end()->end()
                 ->arrayNode('provinces')->scalarPrototype()->end()->end()
                 ->scalarNode('scope')->end()
+                ->integerNode('priority')->defaultValue(0)->end()
         ;
 
         $zoneNode
@@ -151,6 +152,7 @@ class GeographicalFixture extends AbstractFixture
                 $zone->setCode($zoneCode);
                 $zone->setName($zoneName);
                 $zone->setType($zoneType);
+                $zone->setPriority($zoneOptions['priority']);
 
                 if (isset($zoneOptions['scope'])) {
                     $zone->setScope($zoneOptions['scope']);

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20241010135921.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20241010135921.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241010135921 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_zone ADD priority INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_zone DROP priority');
+    }
+}

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -36,6 +36,8 @@ class Zone implements ZoneInterface, \Stringable
     /** @var Collection<array-key, ZoneMemberInterface> */
     protected $members;
 
+    protected $priority = 0;
+
     public function __construct()
     {
         /** @var ArrayCollection<array-key, ZoneMemberInterface> $this->members */
@@ -133,5 +135,15 @@ class Zone implements ZoneInterface, \Stringable
     public function hasMember(ZoneMemberInterface $member): bool
     {
         return $this->members->contains($member);
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function setPriority(int $priority): void
+    {
+        $this->priority = $priority;
     }
 }

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -54,4 +54,8 @@ interface ZoneInterface extends ResourceInterface, CodeAwareInterface
     public function removeMember(ZoneMemberInterface $member): void;
 
     public function hasMember(ZoneMemberInterface $member): bool;
+
+    public function getPriority(): int;
+
+    public function setPriority(int $priority): void;
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | none
| License         | MIT

The PR https://github.com/Sylius/Sylius/pull/15275 broke the tax calculation in our shop. The reason being that the `ZoneMatcher` now returns the first matching zone, while previously it was the last.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
