### PR TITLE
[Zone] Added priority property

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -44,6 +45,10 @@ final class ZoneType extends AbstractResourceType
             ])
             ->add('type', ZoneTypeChoiceType::class, [
                 'disabled' => true,
+            ])
+            ->add('position', IntegerType::class, [
+                'label' => 'sylius.form.zone.position',
+                'required' => true,
             ])
         ;
 

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -33,6 +33,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
             ->setParameter('type', $type)
             ->setMaxResults(1)
+            ->addOrderBy('o.position', 'DESC')
         ;
 
         return $queryBuilder->getQuery()->getOneOrNullResult();

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -11,7 +11,8 @@
 
 -->
 
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
     <mapped-superclass name="Sylius\Component\Addressing\Model\Zone" table="sylius_zone">
         <id name="id" column="id" type="integer">
@@ -22,6 +23,10 @@
         <field name="name" column="name" type="string" />
         <field name="type" column="type" type="string" length="8" />
         <field name="scope" column="scope" type="string" nullable="true"/>
+
+        <field name="position" type="integer">
+            <gedmo:sortable-position />
+        </field>
 
         <one-to-many field="members" target-entity="Sylius\Component\Addressing\Model\ZoneMemberInterface" mapped-by="belongsTo" orphan-removal="true">
             <cascade>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -38,5 +38,6 @@ sylius:
                 all: Alle
             select: Gebiet auswählen
             select_scope: Bereich wählen
+            position: Position
         zone_member:
             select: Mitglied auswählen

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -34,5 +34,6 @@ sylius:
             scopes:
                 all: All
             select: Select
+            position: Position
         zone_member:
             select: Select

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Zone/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Zone/_form.html.twig
@@ -8,6 +8,9 @@
         {{ form_row(form.name) }}
         {{ form_row(form.scope) }}
     </div>
+    <div class="two fields">
+        {{ form_row(form.position) }}
+    </div>
 </div>
 <div class="ui segment">
     <h4 class="ui dividing header">{{ 'sylius.ui.members'|trans }}</h4>

--- a/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
@@ -98,6 +98,7 @@ class GeographicalFixture extends AbstractFixture
                 ->arrayNode('zones')->scalarPrototype()->end()->end()
                 ->arrayNode('provinces')->scalarPrototype()->end()->end()
                 ->scalarNode('scope')->end()
+                ->integerNode('position')->defaultValue(0)->end()
         ;
 
         $zoneNode
@@ -151,6 +152,7 @@ class GeographicalFixture extends AbstractFixture
                 $zone->setCode($zoneCode);
                 $zone->setName($zoneName);
                 $zone->setType($zoneType);
+                $zone->setPosition($zoneOptions['position']);
 
                 if (isset($zoneOptions['scope'])) {
                     $zone->setScope($zoneOptions['scope']);

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20241010135921.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20241010135921.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
+
+final class Version20241010135921 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add position property to the Zone';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_zone ADD position INT NOT NULL DEFAULT 0');
+        $this->addSql('UPDATE sylius_zone SET position = id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_zone DROP position');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20241126095850.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20241126095850.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20241126095850 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add position property to the Zone';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_zone ADD position INT NOT NULL DEFAULT 0');
+        $this->addSql('UPDATE sylius_zone SET position = id');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_zone DROP position');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/GeographicalFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/GeographicalFixtureTest.php
@@ -116,6 +116,17 @@ final class GeographicalFixtureTest extends TestCase
     /**
      * @test
      */
+    public function zones_can_have_position(): void
+    {
+        $this->assertConfigurationIsValid(
+            [['zones' => ['EU' => ['name' => 'Some EU countries', 'countries' => ['PL', 'DE', 'FR'], 'position' => 2]]]],
+            'zones',
+        );
+    }
+
+    /**
+     * @test
+     */
     public function zones_can_be_defined_as_province_based(): void
     {
         $this->assertConfigurationIsValid(

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/GeographicalFixtureSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/GeographicalFixtureSpec.php
@@ -110,6 +110,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
         $zone->setCode('POLAND')->shouldBeCalled();
         $zone->setName('Poland')->shouldBeCalled();
         $zone->setType(ZoneInterface::TYPE_COUNTRY)->shouldBeCalled();
+        $zone->setPosition(0)->shouldBeCalled();
 
         $countryManager->persist($country)->shouldBeCalled();
         $zoneManager->persist($zone)->shouldBeCalled();
@@ -123,6 +124,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => ['PL'],
                 'provinces' => [],
                 'zones' => [],
+                'position' => 0,
             ],
         ]]);
     }
@@ -144,6 +146,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
         $zone->setName('Poland')->shouldBeCalled();
         $zone->setType(ZoneInterface::TYPE_COUNTRY)->shouldBeCalled();
         $zone->setScope('tax')->shouldBeCalled();
+        $zone->setPosition(0)->shouldBeCalled();
 
         $countryManager->persist($country)->shouldBeCalled();
         $zoneManager->persist($zone)->shouldBeCalled();
@@ -158,6 +161,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'provinces' => [],
                 'zones' => [],
                 'scope' => 'tax',
+                'position' => 0,
             ],
         ]]);
     }
@@ -187,6 +191,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
         $zone->setCode('SILESIA')->shouldBeCalled();
         $zone->setName('Silesia')->shouldBeCalled();
         $zone->setType(ZoneInterface::TYPE_PROVINCE)->shouldBeCalled();
+        $zone->setPosition(0)->shouldBeCalled();
 
         $countryManager->persist($country)->shouldBeCalled();
         $provinceManager->persist($province)->shouldBeCalled();
@@ -202,6 +207,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => [],
                 'provinces' => ['PL-SL'],
                 'zones' => [],
+                'position' => 0,
             ],
         ]]);
     }
@@ -223,11 +229,13 @@ final class GeographicalFixtureSpec extends ObjectBehavior
         $countryTypeZone->setCode('POLAND')->shouldBeCalled();
         $countryTypeZone->setName('Poland')->shouldBeCalled();
         $countryTypeZone->setType(ZoneInterface::TYPE_COUNTRY)->shouldBeCalled();
+        $countryTypeZone->setPosition(0)->shouldBeCalled();
 
         $zoneFactory->createWithMembers(['POLAND'])->willReturn($zoneTypeZone);
         $zoneTypeZone->setCode('YO-DAWG')->shouldBeCalled();
         $zoneTypeZone->setName('Yo dawg')->shouldBeCalled();
         $zoneTypeZone->setType(ZoneInterface::TYPE_ZONE)->shouldBeCalled();
+        $zoneTypeZone->setPosition(0)->shouldBeCalled();
 
         $countryManager->persist($country)->shouldBeCalled();
         $zoneManager->persist($countryTypeZone)->shouldBeCalled();
@@ -242,12 +250,14 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => ['PL'],
                 'provinces' => [],
                 'zones' => [],
+                'position' => 0,
             ],
             'YO-DAWG' => [
                 'name' => 'Yo dawg',
                 'countries' => [],
                 'provinces' => [],
                 'zones' => ['POLAND'],
+                'position' => 0,
             ],
         ]]);
     }
@@ -260,6 +270,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => ['PL'],
                 'provinces' => [],
                 'zones' => [],
+                'position' => 0,
             ],
         ]]]);
     }
@@ -272,6 +283,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => [],
                 'provinces' => ['PL-SL'],
                 'zones' => [],
+                'position' => 0,
             ],
         ]]]);
     }
@@ -284,6 +296,7 @@ final class GeographicalFixtureSpec extends ObjectBehavior
                 'countries' => [],
                 'provinces' => [],
                 'zones' => ['DAWG'],
+                'position' => 0,
             ],
         ]]]);
     }

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -36,6 +36,9 @@ class Zone implements ZoneInterface, \Stringable
     /** @var Collection<array-key, ZoneMemberInterface> */
     protected $members;
 
+    /** @var int */
+    protected $position = 0;
+
     public function __construct()
     {
         /** @var ArrayCollection<array-key, ZoneMemberInterface> $this->members */
@@ -133,5 +136,15 @@ class Zone implements ZoneInterface, \Stringable
     public function hasMember(ZoneMemberInterface $member): bool
     {
         return $this->members->contains($member);
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
     }
 }

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -54,4 +54,8 @@ interface ZoneInterface extends ResourceInterface, CodeAwareInterface
     public function removeMember(ZoneMemberInterface $member): void;
 
     public function hasMember(ZoneMemberInterface $member): bool;
+
+    public function getPosition(): int;
+
+    public function setPosition(int $priority): void;
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | none
| License         | MIT

The PR https://github.com/Sylius/Sylius/pull/15275 broke the tax calculation in our shop. The reason being that the `ZoneMatcher` now returns the first matching zone, while previously it was the last.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
