### PR TITLE
[UiBundle] Deprecate classes and services moved to TwigExtra package

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -139,8 +139,6 @@
     | **TaxonomyBundle**                                                                                         |                                                                                      |
     | `sylius.doctrine.odm.mongodb.unitOfWork`                                                                   | `sylius.doctrine.odm.mongodb.unit_of_work`                                           |
     | **UiBundle**                                                                                               |                                                                                      |
-    | `sylius.twig.extension.form_test_attribute_array`                                                          | `sylius.twig.extension.test_form_attribute`                                          |
-    | `sylius.twig.extension.form_test_attribute_name`                                                           | `sylius.twig.extension.test_html_attribute`                                          |
     | `Sylius\Bundle\UiBundle\Twig\RedirectPathExtension`                                                        | `sylius.twig.extension.redirect_path`                                                |
     | `Sylius\Bundle\UiBundle\Storage\FilterStorage`                                                             | `sylius.twig.storage.filter`                                                         |
     | **UserBundle**                                                                                             |                                                                                      |

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -26,23 +26,24 @@
         <service id="sylius.twig.extension.form_test_attribute_array" class="Sylius\Bundle\UiBundle\Twig\TestFormAttributeExtension">
             <argument>%kernel.environment%</argument>
             <tag name="twig.extension" />
+            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0.</deprecated>
         </service>
-        <service id="sylius.twig.extension.test_form_attribute" alias="sylius.twig.extension.form_test_attribute_array" />
 
         <service id="sylius.twig.extension.form_test_attribute_name" class="Sylius\Bundle\UiBundle\Twig\TestHtmlAttributeExtension">
             <argument>%kernel.environment%</argument>
             <tag name="twig.extension" />
+            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0.</deprecated>
         </service>
-        <service id="sylius.twig.extension.test_html_attribute" alias="sylius.twig.extension.form_test_attribute_name" />
 
         <service id="sylius.twig.extension.sort_by" class="Sylius\Bundle\UiBundle\Twig\SortByExtension" public="false">
             <tag name="twig.extension" />
+            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.template_event" class="Sylius\Bundle\UiBundle\Twig\TemplateEventExtension" public="false">
             <argument type="service" id="Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface" />
             <tag name="twig.extension" />
-            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0."</deprecated>
+            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0.</deprecated>
         </service>
 
         <service id="sylius.twig.extension.merge_recursive" class="Sylius\Bundle\UiBundle\Twig\MergeRecursiveExtension">
@@ -52,7 +53,7 @@
         <service id="Sylius\Bundle\UiBundle\Twig\LegacySonataBlockExtension">
             <argument>%sylius_ui.sonata_block.whitelisted_variables%</argument>
             <tag name="twig.extension" />
-            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0."</deprecated>
+            <deprecated package="sylius/ui-bundle" version="1.14">The service %service_id% is deprecated and will be removed in Sylius 2.0.</deprecated>
         </service>
 
         <service id="Sylius\Bundle\UiBundle\Twig\RedirectPathExtension">

--- a/src/Sylius/Bundle/UiBundle/Twig/SortByExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/SortByExtension.php
@@ -18,6 +18,12 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
+trigger_deprecation(
+    'sylius/ui-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use sylius/twig-extra package instead.',
+    TestFormAttributeExtension::class,
+);
 class SortByExtension extends AbstractExtension
 {
     public function getFilters(): array

--- a/src/Sylius/Bundle/UiBundle/Twig/TestFormAttributeExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TestFormAttributeExtension.php
@@ -16,6 +16,12 @@ namespace Sylius\Bundle\UiBundle\Twig;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+trigger_deprecation(
+    'sylius/ui-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use sylius/twig-extra package instead.',
+    TestFormAttributeExtension::class,
+);
 final class TestFormAttributeExtension extends AbstractExtension
 {
     public function __construct(private string $environment)

--- a/src/Sylius/Bundle/UiBundle/Twig/TestHtmlAttributeExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TestHtmlAttributeExtension.php
@@ -16,6 +16,12 @@ namespace Sylius\Bundle\UiBundle\Twig;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+trigger_deprecation(
+    'sylius/ui-bundle',
+    '1.14',
+    'The "%s" class is deprecated and will be removed in Sylius 2.0. Use sylius/twig-extra package instead.',
+    TestFormAttributeExtension::class,
+);
 final class TestHtmlAttributeExtension extends AbstractExtension
 {
     public function __construct(private string $env)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | related to #17211 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
