### PR TITLE
[Core] Deprecate sylius_core.state_machine configuration parameter

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -459,3 +459,6 @@
     - `sylius_shop_partial_product_show_by_slug`
     - `sylius_shop_partial_taxon_index_by_code`
     - `sylius_shop_partial_taxon_show_by_slug`
+
+1. The `sylius_core.state_machine` configuration parameter is deprecated and will be removed in 2.0. 
+   Use `sylius_state_machine_abstraction.state_machine` instead.

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -133,6 +133,7 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('state_machine')
+                    ->setDeprecated('sylius/core-bundle', '1.14', 'The "%path%.%node%" is deprecated and will be removed in 2.0.')
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('default_adapter')->defaultValue('winzou_state_machine')->end()


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
