### PR TITLE
[API][DOC]Adding a tip about api's preventing methods beside GET to load non cart orders by default

### DIFF
--- a/docs/customization/api/adding_and_removing_endpoints.rst
+++ b/docs/customization/api/adding_and_removing_endpoints.rst
@@ -32,6 +32,7 @@ Good to Know
     is not ``GET``. So if you need to add an endpoint to an API that needs to edit orders that are not in the state 
     ``cart``, you will need to whitelist this endpoint. This can be done by adding your API route to the 
     ``sylius.api.doctrine_extension.order_shop_user_item.filter_cart.allowed_non_get_operations`` parameter. 
+
 How to remove an endpoint?
 --------------------------
 

--- a/docs/customization/api/adding_and_removing_endpoints.rst
+++ b/docs/customization/api/adding_and_removing_endpoints.rst
@@ -27,9 +27,11 @@ Good to Know
 ~~~~~~~~~~~~
 
 .. tip::
-    Api Platform is configured to prevent modifications to orders  not in the ``cart`` state. There is only a few specific actions allowed. This is done by preventing orders not in the state ``cart`` from loading if the api's method is not ``GET``. So if you need to add an endpoint to an api that needs to edit orders that are not in the state ``cart`` you will need to whitelist your api. This can be done by adding your api's route to the ``sylius.api.doctrine_extension.order_shop_user_item.filter_cart.allowed_non_get_operations`` parameter. 
-
-
+    API Platform is configured to prevent modifications to orders not in the ``cart`` state. There are only a few 
+    specific actions allowed. This is done by preventing orders not in the state ``cart`` from loading if the method 
+    is not ``GET``. So if you need to add an endpoint to an API that needs to edit orders that are not in the state 
+    ``cart``, you will need to whitelist this endpoint. This can be done by adding your API route to the 
+    ``sylius.api.doctrine_extension.order_shop_user_item.filter_cart.allowed_non_get_operations`` parameter. 
 How to remove an endpoint?
 --------------------------
 

--- a/docs/customization/api/adding_and_removing_endpoints.rst
+++ b/docs/customization/api/adding_and_removing_endpoints.rst
@@ -23,6 +23,13 @@ And that's all, now you have a new endpoint with your custom logic.
 
     Read more about API Platform endpoint configuration `here <https://api-platform.com/docs/core/operations/>`_
 
+Good to Know
+~~~~~~~~~~~~
+
+.. tip::
+    Api Platform is configured to prevent modifications to orders  not in the ``cart`` state. There is only a few specific actions allowed. This is done by preventing orders not in the state ``cart`` from loading if the api's method is not ``GET``. So if you need to add an endpoint to an api that needs to edit orders that are not in the state ``cart`` you will need to whitelist your api. This can be done by adding your api's route to the ``sylius.api.doctrine_extension.order_shop_user_item.filter_cart.allowed_non_get_operations`` parameter. 
+
+
 How to remove an endpoint?
 --------------------------
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?           | 1.13
| Bug fix?           | no
| New feature?  | no
| BC breaks?      | no
| Deprecations? | no
| Related tickets | na
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Hello, 

If we add a custom API endpoint to the Orders using any method besides GET, we end up with a very unclear 404 error. 

Investigating this led us to find this "feature" which prevents us from loading the order with a given token due to the order not being in the state `cart`. In our case, we needed to update the customer cart with information from an older order. So it was logical for us to use `POST` as we are updating the cart, and it was logical to have the order token in the URL to specify the order we need to pull the data from. 

It was therefore quite frustrating to debug; I thought adding a little tip about it in the docs wouldn't hurt any future developer coming across this issue. 

Reference to the class where this filtering is done: https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Order/StateBasedExtension.php

Hope I contributed as needed, with ❤️ 

Regards