### PR TITLE
Replace deprecated DOMNodeInserted event with MutationObserver

### DIFF
--- a/features/promotion/managing_promotions/adding_promotion_with_action_in_different_channels.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action_in_different_channels.feature
@@ -9,8 +9,7 @@ Feature: Adding a new promotion with action configured in different channels
         And the store also operates on another channel named "Web-GB" in "GBP" currency
         And I am logged in as an administrator
 
-    # Temporarily disable in UI context because of the timeout exceptions in build
-    @api @todo-ui @mink:chromedriver
+    @ui @mink:chromedriver @api
     Scenario: Adding a new promotion with item fixed discount
         When I want to create a new promotion
         And I specify its code as "20_for_all_products"

--- a/features/promotion/managing_promotions/adding_promotion_with_rule_in_different_channels.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_rule_in_different_channels.feature
@@ -9,8 +9,7 @@ Feature: Adding a new promotion with rule configured in different channels
         And the store operates on a channel named "Web-GB" in "GBP" currency
         And I am logged in as an administrator
 
-    # Temporarily disable in UI context because of the timeout exceptions in build
-    @api @todo-ui @mink:chromedriver
+    @api @ui @mink:chromedriver
     Scenario: Adding a new promotion with total price of items
         When I want to create a new promotion
         And I specify its code as "100_IN_EVERY_CURRENCY"

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -122,14 +122,31 @@ $(document).ready(() => {
 
   $(document).previewUploadedImage('#add-avatar');
 
-  $('body').on('DOMNodeInserted', '[data-form-collection="item"]', (event) => {
-    if ($(event.target).find('.ui.accordion').length > 0) {
-      $(event.target).find('.ui.accordion').accordion();
-    }
-    if ($(event.target).find('.ui.tabular.menu').length > 0) {
-      $(event.target).find('.ui.tabular.menu .item').tab();
-    }
+  const newNodeObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.addedNodes.length > 0) {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            const formCollectionItem = node.closest('[data-form-collection="item"]');
+            if (formCollectionItem) {
+              if ($(formCollectionItem).find('.ui.accordion').length > 0) {
+                $(formCollectionItem).find('.ui.accordion').accordion();
+              }
+              if ($(formCollectionItem).find('.ui.tabular.menu').length > 0) {
+                $(formCollectionItem).find('.ui.tabular.menu .item').tab();
+              }
+            }
+          }
+        });
+      }
+    });
   });
+  const observerConfig = {
+    childList: true,
+    subtree: true,
+  };
+  const targetNode = document.querySelector('body');
+  newNodeObserver.observe(targetNode, observerConfig);
 
   const taxonomyTree = new SyliusTaxonomyTree();
 


### PR DESCRIPTION
This PR replaces the use of the deprecated (started from Chrome 130) `DOMNodeInserted` event with the modern `MutationObserver` API
