### PR TITLE
[Admin][Shop] Set http_method_override to true by default

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -74,3 +74,6 @@ liip_imagine:
 sylius_twig_hooks:
     enable_autoprefixing: true
     hook_name_section_separator: '#'
+
+framework:
+    http_method_override: true

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -68,3 +68,6 @@ sylius_ui:
         anonymous_component_template_prefixes:
             sylius_shop: "@SyliusShop/shared/components"
         component_default_template: "@SyliusUi/components/default.html.twig"
+
+framework:
+    http_method_override: true


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
lets make it true by default, as it can cause some problems on plugins