### PR TITLE
[API][PHPSpec] Remove unused arguments from ImageNormalizerSpec

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ImageNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ImageNormalizerSpec.php
@@ -189,8 +189,6 @@ final class ImageNormalizerSpec extends ObjectBehavior
         CacheManager $cacheManager,
         RequestStack $requestStack,
         NormalizerInterface $normalizer,
-        Request $request,
-        ParameterBag $queryBag,
         ImageInterface $image,
     ): void {
         $normalizer


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/16601 and builds on 2.0 😅 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
