### PR TITLE
[Maintenance] Fix invalid install command argument

### DIFF
--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -57,7 +57,7 @@ final class InstallerContext implements Context
         private readonly FactoryInterface $adminUserFactory,
         private readonly UserRepositoryInterface $adminUserRepository,
         private readonly ValidatorInterface $validator,
-        private readonly bool $publicDir,
+        private readonly string $publicDir,
     ) {
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Console/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/InstallSampleDataCommand.php
@@ -33,7 +33,7 @@ final class InstallSampleDataCommand extends AbstractInstallCommand
     public function __construct(
         protected readonly EntityManagerInterface $entityManager,
         protected readonly CommandDirectoryChecker $commandDirectoryChecker,
-        protected readonly bool $publicDir,
+        protected readonly string $publicDir,
     ) {
         parent::__construct($this->entityManager, $this->commandDirectoryChecker);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #16785
| License         | MIT

Due to this typehint the installation command is creating a hardcoded `1/` directory instead of whatever is set under `sylius_core.public_dir`.