### PR TITLE
[OrderPay] Avoid instantiating all available Payum gateways

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestPayResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestPayResponseProvider.php
@@ -42,7 +42,7 @@ final class PaymentRequestPayResponseProvider implements PayResponseProviderInte
         private DefaultActionProviderInterface $defaultActionProvider,
         private DefaultPayloadProviderInterface $defaultPayloadProvider,
         private PaymentToPayResolverInterface $paymentToPayResolver,
-        private AfterPayUrlProvider $afterPayUrlProvider,
+        private AfterPayUrlProviderInterface $afterPayUrlProvider,
     ) {
     }
 

--- a/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumPayResponseProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/OrderPay/Provider/PayumPayResponseProvider.php
@@ -17,6 +17,7 @@ use Payum\Core\Payum;
 use Payum\Core\Security\TokenInterface;
 use Sylius\Bundle\CoreBundle\OrderPay\Provider\PayResponseProviderInterface;
 use Sylius\Bundle\CoreBundle\OrderPay\Resolver\PaymentToPayResolverInterface;
+use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface as PayumGatewayConfigInterface;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -66,9 +67,11 @@ final class PayumPayResponseProvider implements PayResponseProviderInterface
             return false;
         }
 
-        $gatewayName = $gatewayConfig->getGatewayName() ?? '';
+        if (!$gatewayConfig instanceof PayumGatewayConfigInterface) {
+            return false;
+        }
 
-        return isset($this->payum->getGateways()[$gatewayName]);
+        return $gatewayConfig->getUsePayum();
     }
 
     /**

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/order_pay/offline/providers.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/order_pay/offline/providers.xml
@@ -17,7 +17,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <services>
-        <service id="sylius_shop.provider.order_pay.http_response.offline.capture" class="Sylius\Bundle\CoreBundle\OrderPay\Provider\Offline\StatusHttpResponseProvider">
+        <service id="sylius_shop.provider.order_pay.http_response.offline.status" class="Sylius\Bundle\CoreBundle\OrderPay\Provider\Offline\StatusHttpResponseProvider">
             <argument type="service" id="sylius_shop.provider.order_pay.final_url" />
             <tag name="sylius.provider.http_response.offline" action="status" />
         </service>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

`$this->payum->getGateways()` is kind of heavy if you have huge Payum gateways, the flag `use_payum` and can now be used to avoid instantiating all available Payum gateways.