### PR TITLE
[CI] Remove defining API Platform version from matrix

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -44,7 +44,7 @@ jobs:
     behat-no-js:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}, API Platform ${{ matrix.api-platform }}"
+        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -95,8 +95,8 @@ jobs:
                 uses: SyliusLabs/BuildTestAppAction@v2.2.1
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
                     database_version: ${{ matrix.mysql }}
                     legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
@@ -124,7 +124,7 @@ jobs:
                 uses: actions/upload-artifact@v3
                 if: failure()
                 with:
-                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}), ApiPlatform ${{ matrix.api-platform }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}"
+                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}), Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}"
                     path: |
                         etc/build/
                         var/log
@@ -133,7 +133,7 @@ jobs:
     behat-ui-js-chromedriver:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}, API Platform ${{ matrix.api-platform }}"
+        name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -173,8 +173,8 @@ jobs:
                 uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
-                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
+                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
 
             -   name: Restrict Twig
                 if: matrix.twig == '^2.12'
@@ -184,8 +184,8 @@ jobs:
                 uses: SyliusLabs/BuildTestAppAction@v2.2.1
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
                     e2e_js: "yes"
                     database_version: ${{ matrix.mysql }}
@@ -202,7 +202,7 @@ jobs:
                 uses: actions/upload-artifact@v3
                 if: failure()
                 with:
-                    name: "Logs (JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ApiPlatform ${{ matrix.api-platform }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }})"
+                    name: "Logs (JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }})"
                     path: |
                         etc/build/
                         var/log
@@ -211,7 +211,7 @@ jobs:
     behat-ui-js-panther:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}, API Platform ${{ matrix.api-platform }}"
+        name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -251,8 +251,8 @@ jobs:
                 uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
-                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
+                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
 
             -   name: Restrict Twig
                 if: matrix.twig == '^2.12'
@@ -262,8 +262,8 @@ jobs:
                 uses: SyliusLabs/BuildTestAppAction@v2.2.1
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
                     e2e_js: "yes"
                     database_version: ${{ matrix.mysql }}
@@ -283,7 +283,7 @@ jobs:
                 uses: actions/upload-artifact@v3
                 if: failure()
                 with:
-                    name: "Logs (JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ApiPlatform ${{ matrix.api-platform }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }})"
+                    name: "Logs (JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }})"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -45,7 +45,7 @@ jobs:
     static-checks:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, API Platform ${{ matrix.api-platform }}"
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -77,14 +77,6 @@ jobs:
                     composer global config --no-plugins allow-plugins.symfony/flex true
                     composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^2.4"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
-                    composer require "api-platform/symfony:${{ matrix.api-platform }}" --no-update --no-scripts --no-interaction
-                    composer require "api-platform/doctrine-orm:${{ matrix.api-platform }}" --no-update --no-scripts --no-interaction
-
-            -   name: Restrict API Platform version for ApiBundle
-                run: |
-                    composer require "api-platform/symfony:${{ matrix.api-platform }}" --no-update --no-scripts --no-interaction
-                    composer require "api-platform/doctrine-orm:${{ matrix.api-platform }}" --no-update --no-scripts --no-interaction
-                working-directory: "src/Sylius/Bundle/ApiBundle"
 
             -   name: Get Composer cache directory
                 id: composer-cache
@@ -95,7 +87,7 @@ jobs:
                 with:
                     path: |
                         ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-api-platform-${{ matrix.api-platform }}
+                    key: ${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}
 
             -   name: "Require ext-random"
                 if: matrix.php == '8.2'

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -4,13 +4,11 @@
       "include": [
         {
           "php": "8.2",
-          "symfony": "^6.4",
-          "api-platform": "^4.0.3"
+          "symfony": "^6.4"
         },
         {
           "php": "8.3",
-          "symfony": "^7.1",
-          "api-platform": "^4.0.3"
+          "symfony": "^7.1"
         }
       ]
     },
@@ -44,21 +42,18 @@
         {
           "php": "8.2",
           "symfony": "^6.4",
-          "api-platform": "^4.0.3",
           "mysql": "8.0",
           "twig": "^3.3"
         },
         {
           "php": "8.3",
           "symfony": "^7.1",
-          "api-platform": "^4.0.3",
           "mysql": "8.4",
           "twig": "^3.3"
         },
         {
           "php": "8.3",
           "symfony": "^6.4",
-          "api-platform": "^4.0.3",
           "mysql": "8.4",
           "twig": "^3.3",
           "env": "test_cached_payum"
@@ -102,8 +97,7 @@
   "full": {
     "static-checks": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.1"],
-      "api-platform": ["^4.0.3"]
+      "symfony": ["^6.4", "^7.1"]
     },
     "e2e-mariadb": {
       "php": ["8.2", "8.3"],
@@ -122,14 +116,12 @@
     "e2e-mysql": {
       "php": ["8.2", "8.3"],
       "symfony": ["^6.4", "^7.1"],
-      "api-platform": ["^4.0.3"],
       "mysql": ["8.0", "8.4"],
       "twig": ["^3.3"],
       "include": [
         {
           "php": "8.3",
           "symfony": "^6.4",
-          "api-platform": "^4.0.3",
           "mysql": "8.4",
           "twig": "^3.3",
           "env": "test_cached_payum"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

As we are supporting only one version of API Platform, there is no more need to define it in the CI matrix.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
