### PR TITLE
[Core][Promotion] Add missing type to AsCatalogPromotionPriceCalculator attribute + add missing AsCatalogPromotionVariantChecker attribute

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Attribute/AsCatalogPromotionPriceCalculator.php
+++ b/src/Sylius/Bundle/CoreBundle/Attribute/AsCatalogPromotionPriceCalculator.php
@@ -19,8 +19,14 @@ final class AsCatalogPromotionPriceCalculator
     public const SERVICE_TAG = 'sylius.catalog_promotion.price_calculator';
 
     public function __construct(
+        private string $type,
         private int $priority = 0,
     ) {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
     }
 
     public function getPriority(): int

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -226,7 +226,10 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
         $container->registerAttributeForAutoconfiguration(
             AsCatalogPromotionPriceCalculator::class,
             static function (ChildDefinition $definition, AsCatalogPromotionPriceCalculator $attribute): void {
-                $definition->addTag(AsCatalogPromotionPriceCalculator::SERVICE_TAG, ['priority' => $attribute->getPriority()]);
+                $definition->addTag(AsCatalogPromotionPriceCalculator::SERVICE_TAG, [
+                    'type' => $attribute->getType(),
+                    'priority' => $attribute->getPriority(),
+                ]);
             },
         );
 

--- a/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DependencyInjection/SyliusCoreExtensionTest.php
@@ -256,7 +256,7 @@ final class SyliusCoreExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithTag(
             'acme.catalog_promotion_price_calculator_with_attribute',
             AsCatalogPromotionPriceCalculator::SERVICE_TAG,
-            ['priority' => 9],
+            ['type' => 'custom', 'priority' => 9],
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Tests/Stub/CatalogPromotionPriceCalculatorStub.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Stub/CatalogPromotionPriceCalculatorStub.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\CatalogPromotionPriceCa
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
-#[AsCatalogPromotionPriceCalculator(priority: 9)]
+#[AsCatalogPromotionPriceCalculator(type: 'custom', priority: 9)]
 final class CatalogPromotionPriceCalculatorStub implements CatalogPromotionPriceCalculatorInterface
 {
     public function calculate(ChannelPricingInterface $channelPricing, CatalogPromotionActionInterface $action): int

--- a/src/Sylius/Bundle/PromotionBundle/Attribute/AsCatalogPromotionVariantChecker.php
+++ b/src/Sylius/Bundle/PromotionBundle/Attribute/AsCatalogPromotionVariantChecker.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsCatalogPromotionVariantChecker
+{
+    public const SERVICE_TAG = 'sylius.catalog_promotion.variant_checker';
+
+    public function __construct(
+        private string $type,
+        private int $priority = 0,
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\DependencyInjection;
 
+use Sylius\Bundle\PromotionBundle\Attribute\AsCatalogPromotionVariantChecker;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionAction;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionCouponEligibilityChecker;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionEligibilityChecker;
@@ -49,6 +50,16 @@ final class SyliusPromotionExtension extends AbstractResourceExtension
 
     private function registerAutoconfiguration(ContainerBuilder $container): void
     {
+        $container->registerAttributeForAutoconfiguration(
+            AsCatalogPromotionVariantChecker::class,
+            static function (ChildDefinition $definition, AsCatalogPromotionVariantChecker $attribute): void {
+                $definition->addTag(AsCatalogPromotionVariantChecker::SERVICE_TAG, [
+                    'type' => $attribute->getType(),
+                    'priority' => $attribute->getPriority(),
+                ]);
+            },
+        );
+
         $container->registerAttributeForAutoconfiguration(
             AsPromotionAction::class,
             static function (ChildDefinition $definition, AsPromotionAction $attribute): void {

--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/SyliusPromotionExtensionTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/SyliusPromotionExtensionTest.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PromotionBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sylius\Bundle\PromotionBundle\Attribute\AsCatalogPromotionVariantChecker;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionAction;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionCouponEligibilityChecker;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionEligibilityChecker;
 use Sylius\Bundle\PromotionBundle\Attribute\AsPromotionRuleChecker;
 use Sylius\Bundle\PromotionBundle\DependencyInjection\SyliusPromotionExtension;
+use Sylius\Bundle\PromotionBundle\Tests\Stub\CatalogPromotionVariantCheckerStub;
 use Sylius\Bundle\PromotionBundle\Tests\Stub\PromotionActionStub;
 use Sylius\Bundle\PromotionBundle\Tests\Stub\PromotionCouponEligibilityCheckerStub;
 use Sylius\Bundle\PromotionBundle\Tests\Stub\PromotionEligibilityCheckerStub;
@@ -28,6 +30,27 @@ use Symfony\Component\DependencyInjection\Definition;
 
 final class SyliusPromotionExtensionTest extends AbstractExtensionTestCase
 {
+    /** @test */
+    public function it_autoconfigures_catalog_promotion_variant_checker_with_attribute(): void
+    {
+        $this->container->setParameter('kernel.environment', 'prod');
+        $this->container->setDefinition(
+            'acme.catalog_promotion_variant_checker_with_attribute',
+            (new Definition())
+                ->setClass(CatalogPromotionVariantCheckerStub::class)
+                ->setAutoconfigured(true),
+        );
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.catalog_promotion_variant_checker_with_attribute',
+            AsCatalogPromotionVariantChecker::SERVICE_TAG,
+            ['type' => 'custom', 'priority' => 9],
+        );
+    }
+
     /** @test */
     public function it_autoconfigures_promotion_action_with_attribute(): void
     {

--- a/src/Sylius/Bundle/PromotionBundle/Tests/Stub/CatalogPromotionVariantCheckerStub.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/Stub/CatalogPromotionVariantCheckerStub.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Tests\Stub;
+
+use Sylius\Bundle\PromotionBundle\Attribute\AsCatalogPromotionVariantChecker;
+
+#[AsCatalogPromotionVariantChecker(type: 'custom', priority: 9)]
+final class CatalogPromotionVariantCheckerStub
+{
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
