### PR TITLE
[Admin] Pass admin path name parameter to AdminUriBasedSectionResolver

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -69,7 +69,7 @@
         </service>
 
         <service id="sylius.section_resolver.admin_uri_based_section_resolver" class="Sylius\Bundle\AdminBundle\SectionResolver\AdminUriBasedSectionResolver">
-            <argument>/admin</argument>
+            <argument>/%sylius_admin.path_name%</argument>
             <tag name="sylius.uri_based_section_resolver" priority="20" />
         </service>
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/16793
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
