### PR TITLE
Remove duplicated AllowedImageMimeTypes constraint from images configs

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/AvatarImage.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/AvatarImage.xml
@@ -23,9 +23,6 @@
             <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
                 <option name="groups">sylius</option>
             </constraint>
-            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
-                <option name="groups">sylius</option>
-            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ProductImage.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ProductImage.xml
@@ -27,9 +27,6 @@
             <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
                 <option name="groups">sylius</option>
             </constraint>
-            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
-                <option name="groups">sylius</option>
-            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/TaxonImage.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/TaxonImage.xml
@@ -23,9 +23,6 @@
             <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
                 <option name="groups">sylius</option>
             </constraint>
-            <constraint name="Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypes">
-                <option name="groups">sylius</option>
-            </constraint>
         </property>
     </class>
 </constraint-mapping>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/17351#discussion_r1820779243
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
