### PR TITLE
[API] Use model class parameter instead of hardcoded class for ShippingMethodRule resource

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethodRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethodRule.xml
@@ -15,7 +15,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
-    <resource class="Sylius\Component\Shipping\Model\ShippingMethodRule" shortName="ShippingMethodRule">
+    <resource class="%sylius.model.shipping_method_rule.class%" shortName="ShippingMethodRule">
         <attribute name="route_prefix">admin</attribute>
 
         <itemOperations>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
