### PR TITLE
[Admin][HotFix] Fix form without live component

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
@@ -1,11 +1,15 @@
+{% if form is not defined %}
+    {% set form = hookable_metadata.context.form %}
+{% endif %}
+
 {% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-<div class="container-xl" {{ attributes }}>
+<div class="container-xl" {% if attributes is defined %} {{ attributes }} {% endif %}>
     {{ form_start(form, {'attr': {'novalidate': 'novalidate', 'id': form.vars.id}}) }}
     <div class="card-body">
         {% if hookable_metadata.configuration.method is defined %}
             <input type="hidden" name="_method" value="{{ hookable_metadata.configuration.method }}"/>
-        {% elseif form.vars.data.id is not null %}
+        {% elseif form.vars.data.id|default(null) is not null %}
             <input type="hidden" name="_method" value="PUT"/>
         {% endif %}
         {{ form_errors(form) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
@@ -2,6 +2,10 @@
     {% set form = hookable_metadata.context.form %}
 {% endif %}
 
+{% if resource is not defined %}
+    {% set resource = hookable_metadata.context.resource %}
+{% endif %}
+
 {% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}
 
 <div class="container-xl" {% if attributes is defined %} {{ attributes }} {% endif %}>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         |2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

We want to create a new CRUD for a Sylius Resource.

Given we set all the php attributes on the Doctrine entity.
When I want to access the creation page to create a new resource.
Then I get an error about missing variables in the template @AdminBundle/templates\shared\crud\common\content\form.html.twig.

This error happen because no Twig component is defined for this route and this template only accept to be render via an existing twig component.

```php
#[ORM\Entity]
#[ORM\Table(name: 'app_book')]
#[AsResource(alias: 'app.book', section: 'admin', templatesDir: '@SyliusAdmin\\shared\\crud', routePrefix: 'admin', formType: 'App\\Form\\Type\\BookType')]
#[Index(grid: 'app_book')]
#[Create]
#[Update]
#[Show]
#[Create(formType: BookType::class)]
class Book implements ResourceInterface{}
```
