### PR TITLE
[Docs] Add links to 2.x docs on the 1.x documentation

### DIFF
--- a/docs/_themes/sylius_rtd_theme/layout.html
+++ b/docs/_themes/sylius_rtd_theme/layout.html
@@ -99,6 +99,7 @@
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+        <a href="https://docs.sylius.com/" target="_blank"><b>📖 2.0 Documentation</b></a>
         {% set toctree = toctree(maxdepth=2, collapse=False, includehidden=True) %}
         {% if toctree %}
             {{ toctree }}

--- a/docs/_themes/sylius_rtd_theme/versions.html
+++ b/docs/_themes/sylius_rtd_theme/versions.html
@@ -9,6 +9,7 @@
     <div class="rst-other-versions">
       <dl>
         <dt>Versions</dt>
+          <dd><a href="https://docs.sylius.com/">2.0</a></dd>
         {% for slug, url in versions %}
           <dd><a href="{{ url }}">{{ slug }}</a></dd>
         {% endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,14 @@ import sys, os
 from sphinx.highlighting import lexers
 from pygments.lexers.web import PhpLexer
 
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "https://docs.sylius.com")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
@@ -21,8 +29,10 @@ copyright = u'2011-2024, Sylius Sp. z o.o.'
 version = ''
 release = ''
 exclude_patterns = ['_includes/*.rst']
-html_theme = 'sylius_rtd_theme'
+html_theme = "sylius_rtd_theme"
 html_theme_path = ["_themes"]
+html_context = html_context if 'html_context' in globals() else {}
+html_context['style'] = 'css/theme.css'
 html_favicon = 'favicon.ico'
 htmlhelp_basename = 'Syliusdoc'
 man_pages = [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-sphinx==1.8.5
-alabaster==0.7.13
-docutils<0.18
-jinja2==3.0.0
-pyOpenSSL
-requests[security]
-sphinx-copybutton
-sphinx-autobuild
+sphinx>=7.0.1
+alabaster>=0.7.13
+docutils>=0.18.1,<0.21
+jinja2>=3.0.0,<4.0
+pyOpenSSL>=21.0.0
+requests[security]>=2.25.0
+sphinx-copybutton>=0.5.0
+sphinx-autobuild>=2021.3.14


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12, 1.13, 1.14
| License         | MIT

We are hosting the 2.x documentation on docs.sylius.com while 1.x documentation is living on old-docs.sylius.com.

Adding links to the new docs on the old docs 🫡 
