### PR TITLE
[Admin] Chore: Remove useless route vars

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/admin_user.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/admin_user.yml
@@ -10,13 +10,6 @@ sylius_admin_admin_user:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\AdminUserType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_users_able_to_access_administration_panel
-                templates:
-                    form: "@SyliusAdmin/AdminUser/_form.html.twig"
-            index:
-                icon: "tabler:lock"
     type: sylius.resource
 
 sylius_admin_admin_user_remove_avatar:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/channel.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/channel.yml
@@ -9,11 +9,4 @@ sylius_admin_channel:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ChannelType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.configure_channels_available_in_your_store
-                templates:
-                    form: "@SyliusAdmin/Channel/_form.html.twig"
-            index:
-                icon: "tabler:share"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
@@ -9,9 +9,4 @@ sylius_admin_country:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\CountryType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_shipping_destinations
-            index:
-                icon: "tabler:flag"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -9,13 +9,6 @@ sylius_admin_customer:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\CustomerType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_your_customers
-                templates:
-                    form: "@SyliusAdmin/Customer/_form.html.twig"
-            index:
-                icon: "tabler:users"
     type: sylius.resource
 
 sylius_admin_customer_order_index:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer_group.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer_group.yml
@@ -9,12 +9,4 @@ sylius_admin_customer_group:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\CustomerGroupType
         permission: true
-        vars:
-            all:
-                header: sylius.ui.customer_groups
-                subheader: sylius.ui.manage_customer_groups
-                templates:
-                    form: "@SyliusAdmin/CustomerGroup/_form.html.twig"
-            index:
-                icon: "tabler:archive"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/locale.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/locale.yml
@@ -9,13 +9,6 @@ sylius_admin_locale:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\LocaleType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_languages_available_in_the_store
-                templates:
-                    form: "@SyliusAdmin/Locale/_form.html.twig"
-            index:
-                icon: "tabler:bubble-text"
     type: sylius.resource
 
 sylius_admin_locale_delete:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -8,11 +8,6 @@ sylius_admin_order:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\OrderType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.process_your_orders
-            index:
-                icon: "tabler:shopping-cart"
     type: sylius.resource
 
 sylius_admin_order_show:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment.yml
@@ -6,11 +6,6 @@ sylius_admin_payment:
         only: ['index']
         grid: sylius_admin_payment
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_payments
-            index:
-                icon: "tabler:credit-card-pay"
     type: sylius.resource
 
 sylius_admin_payment_complete:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
@@ -9,13 +9,6 @@ sylius_admin_payment_method:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\PaymentMethodType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_payment_methods_available_to_your_customers
-                templates:
-                    form: "@SyliusAdmin/PaymentMethod/_form.html.twig"
-            index:
-                icon: "tabler:credit-card-pay"
     type: sylius.resource
 
 sylius_admin_payment_method_create:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
@@ -8,13 +8,6 @@ sylius_admin_product:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ProductType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_your_product_catalog
-                templates:
-                    form: "@SyliusAdmin/Product/_form.html.twig"
-            index:
-                icon: "tabler:cube"
     type: sylius.resource
 
 sylius_admin_product_create_simple:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
@@ -9,11 +9,4 @@ sylius_admin_product_association_type:
         grid: sylius_admin_product_association_type
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ProductAssociationTypeType
-        vars:
-            all:
-                subheader: sylius.ui.manage_association_types_of_your_products
-                templates:
-                    form: "@SyliusAdmin/ProductAssociationType/_form.html.twig"
-            index:
-                icon: "tabler:subtask"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
@@ -9,13 +9,6 @@ sylius_admin_product_attribute:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ProductAttributeType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_attributes_of_your_products
-                templates:
-                    form: "@SyliusAdmin/ProductAttribute/_form.html.twig"
-            index:
-                icon: "tabler:cube-spark"
     type: sylius.resource
 
 sylius_admin_product_attribute_create:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_option.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_option.yml
@@ -9,11 +9,4 @@ sylius_admin_product_option:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ProductOptionType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_configuration_options_of_your_products
-                templates:
-                    form: "@SyliusAdmin/ProductOption/_form.html.twig"
-            index:
-                icon: "tabler:settings"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
@@ -9,13 +9,6 @@ sylius_admin_product_review:
         grid: sylius_admin_product_review
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ProductReviewType
-        vars:
-            all:
-                subheader: sylius.ui.manage_reviews_of_your_products
-                templates:
-                    form: "@SyliusAdmin/ProductReview/_form.html.twig"
-            index:
-                icon: "tabler:news"
     type: sylius.resource
 
 sylius_admin_product_review_accept:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -13,7 +13,6 @@ sylius_admin_product_variant_index:
                 route:
                     parameters:
                         productId: $productId
-                subheader: sylius.ui.manage_variants
 
 sylius_admin_product_variant_create:
     path: /new

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion.yml
@@ -9,17 +9,6 @@ sylius_admin_promotion:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\PromotionType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_discounts_and_promotional_campaigns
-                templates:
-                    form: "@SyliusAdmin/Promotion/_form.html.twig"
-            index:
-                icon: "tabler:shopping-cart-down"
-            update:
-                templates:
-                    form: "@SyliusAdmin/Promotion/_form.html.twig"
-                    toolbar: "@SyliusAdmin/Promotion/_toolbar.html.twig"
     type: sylius.resource
 
 sylius_admin_promotion_archive:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipment.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipment.yml
@@ -6,11 +6,6 @@ sylius_admin_shipment:
         only: ['index', 'show']
         grid: sylius_admin_shipment
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_shipments
-            index:
-                icon: "tabler:truck"
     type: sylius.resource
 
 sylius_admin_shipment_ship:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_category.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_category.yml
@@ -9,11 +9,4 @@ sylius_admin_shipping_category:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ShippingCategoryType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_shipping_categories_for_your_store
-                templates:
-                    form: "@SyliusAdmin/ShippingCategory/_form.html.twig"
-            index:
-                icon: "tabler:layout-list"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_category.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_category.yml
@@ -9,11 +9,4 @@ sylius_admin_tax_category:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\TaxCategoryType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_taxation_of_your_products
-                templates:
-                    form: "@SyliusAdmin/TaxCategory/_form.html.twig"
-            index:
-                icon: "tabler:tags"
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
@@ -9,11 +9,6 @@ sylius_admin_zone:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\ZoneType
         permission: true
-        vars:
-            all:
-                subheader: sylius.ui.manage_geographical_zones
-            index:
-                icon: "tabler:world"
     type: sylius.resource
 
 sylius_admin_zone_create:
@@ -33,7 +28,6 @@ sylius_admin_zone_create:
             redirect: sylius_admin_zone_update
             permission: true
             vars:
-                subheader: sylius.ui.manage_geographical_zones
                 route:
                     parameters:
                         type: $type


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Icon, form templates, header and subheader are not used anymore.
- Form templates are now handled by Twig hooks
- Icons only exist on the menu sidebar
- Headers are displayed with resource metadata or twig hooks configuration (https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/title.html.twig#L5) & https://github.com/Sylius/Sylius/blob/2.0/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create/content/header/title_block/title.html.twig
- There's no sub-headers anymore

