### PR TITLE
[Bug] Turn off stimulus debug mode in production

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
@@ -37,3 +37,5 @@ app.register('product-taxon-tree', ProductTaxonTree);
 app.register('save-positions', SavePositionsController);
 app.register('compound-form-errors', CompoundFormErrorsController);
 app.register('tabs-errors', TabsErrorsController);
+
+app.debug = process.env.NODE_ENV !== 'production';

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
@@ -20,3 +20,5 @@ export const app = startStimulusApp(require.context(
 
 app.register('live', LiveController);
 app.register('api-login', ApiLoginController);
+
+app.debug = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Fixes stimulus debug mode in prod env

Debug mode enabled:
```
yarn encore dev 
```

Debug mode disabled:
```
yarn encore prod
```
