### PR TITLE
[Admin] Fix deleting customer account

### DIFF
--- a/features/admin/user/managing_users/deleting_account.feature
+++ b/features/admin/user/managing_users/deleting_account.feature
@@ -9,10 +9,17 @@ Feature: Deleting the customer account
         And there is a user "theodore@example.com" identified by "pswd"
         And I am logged in as an administrator
 
-    @api @ui
+    @api @no-ui
     Scenario: Deleting account should not delete customer details
         When I delete the account of "theodore@example.com" user
         Then the user account should be deleted
+        But the customer with this email should still exist
+
+    @no-api @ui
+    Scenario: Deleting account should not delete customer details
+        When I delete the account of "theodore@example.com" user
+        Then I should be notified that it has been successfully deleted
+        And the customer should have no account
         But the customer with this email should still exist
 
     @api @ui

--- a/src/Sylius/Behat/Context/Ui/UserContext.php
+++ b/src/Sylius/Behat/Context/Ui/UserContext.php
@@ -54,12 +54,11 @@ final class UserContext implements Context
     }
 
     /**
-     * @Then the user account should be deleted
+     * @Then the customer should have no account
      */
-    public function accountShouldBeDeleted()
+    public function theCustomerShouldHaveNoAccount(): void
     {
         $deletedUser = $this->sharedStorage->get('deleted_user');
-
         $this->customerShowPage->open(['id' => $deletedUser->getCustomer()->getId()]);
 
         Assert::false($this->customerShowPage->hasAccount());

--- a/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/customer/show/content/header/title_block/actions/delete.html.twig
@@ -1,7 +1,8 @@
-{% set user = hookable_metadata.context.resource.user %}
+{% set customer = hookable_metadata.context.resource %}
+{% set user = customer.user %}
 
 {% if user != null %}
-    <form action="{{ path('sylius_admin_shop_user_delete', {'id': user.id}) }}" method="POST">
+    <form action="{{ path('sylius_admin_shop_user_delete', {'id': user.id, 'customerId': customer.id}) }}" method="POST">
         <input type="hidden" name="_method" value="DELETE" />
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(user.id) }}" />
         <button type="submit" class="dropdown-item" {{ sylius_test_html_attribute('customer-actions-delete') }}>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/17443
| License         | MIT

Now, after deleting the customer account, we are properly redirected to the customer show page with a flash:
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/08c8b9ec-e061-40cb-b122-7a5ebe06e445">

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
