### PR TITLE
Fix channel collector's name to match the tag's id

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -70,7 +70,7 @@ final class ChannelCollector extends DataCollector
 
     public function getName(): string
     {
-        return 'sylius.collector.channel';
+        return 'sylius.channel_collector';
     }
 
     private function pluckChannel(ChannelInterface $channel): array


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/17468
| License         | MIT

According to [the Symfony docs](https://symfony.com/doc/current/profiler.html#enabling-custom-data-collectors), the value returned by the getName() method must match the id defined in the `data_collector` tag.
<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
