### PR TITLE
[Shop] Reduce the Size of the Main Offer Photo

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images.html.twig
@@ -3,7 +3,7 @@
 {% if product.images.first %}
     {% set source_path = product.images.first.path %}
     {% set original_path = source_path|imagine_filter('sylius_shop_product_original') %}
-    {% set path = source_path|imagine_filter(filter|default('sylius_shop_product_large_thumbnail')) %}
+    {% set path = source_path|imagine_filter(filter|default('sylius_shop_product_thumbnail')) %}
 {% else %}
     {% set original_path = asset('build/shop/images/400x300.png', 'shop') %}
     {% set path = original_path %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images/main_image.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images/main_image.html.twig
@@ -1,8 +1,8 @@
 {% set product = hookable_metadata.context.product %}
 
 <div class="mb-3">
-    <a href="{{ hookable_metadata.context.original_path }}" class="d-block overflow-auto bg-light rounded-3 spotlight">
-        <img src="{{ hookable_metadata.context.path }}" alt="{{ product.name }}" class="img-fluid w-100 h-100 object-fit-cover"
+    <a href="{{ hookable_metadata.context.original_path }}" class="d-block overflow-auto bg-transparent rounded-3 spotlight">
+        <img src="{{ hookable_metadata.context.path }}" alt="{{ product.name }}" class="d-block mx-auto img-fluid object-fit-cover"
             {% if product.images.first %}
                 {{ sylius_test_html_attribute('main-image', product.images.first.type) }}
             {% else %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Following the complete change of assets related to fixtures, the main photo no longer fits on the screen. This PR adjusts its size slightly to ensure it fits properly.

Before:
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/2cd718ea-0ab2-443d-b71d-32ba677a164a">

After:
<img width="1389" alt="image" src="https://github.com/user-attachments/assets/de1cd5e8-f089-4dc9-9454-61fd0634535a">

