### PR TITLE
[ADMIN] layout modifications - crud container fluid, data_table r…

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid.html.twig
@@ -1,5 +1,5 @@
 <div class="page-body">
-    <div class="container-xl">
+    <div class="container-fluid">
         {% hook 'grid' %}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/data_table.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/data_table.html.twig
@@ -22,7 +22,7 @@
             </div>
         </div>
         <div class="table-responsive">
-            <table class="table card-table table-vcenter text-nowrap datatable" {{ sylius_test_html_attribute('grid-table') }}>
+            <table class="table card-table table-vcenter datatable" {{ sylius_test_html_attribute('grid-table') }}>
                 <thead>
                 <tr>
                     {{ table.headers(resources, resources.definition, app.request.attributes) }}


### PR DESCRIPTION
…emoved text-nowrap class
[ AdminBundle Template ]

| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Before
![Screenshot from 2024-11-18 11-33-22](https://github.com/user-attachments/assets/f1205ecc-0ec9-4a70-8b8f-c2ad7e23d9c6)
After
![Screenshot from 2024-11-18 11-37-07](https://github.com/user-attachments/assets/53af51b5-a6fa-4313-a419-72d6e4ef8918)

Small change in layout template for CRUD grid and data_table. Container now is fluid for 100% with and text is wrapping in the name cell.
