### PR TITLE
[shop][2.0] fix: prevent loading when go back on product page after redirection

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
@@ -12,7 +12,7 @@
             </div>
         </div>
         <div class="my-4" {{ sylius_test_html_attribute('product-selecting-variant') }}>
-            {{ form_start(form, {'attr': {'data-action': 'live#action:prevent', 'data-live-action-param': 'addToCart'}}) }}
+            {{ form_start(form, {'attr': {'data-action': 'live#action:prevent live#$render', 'data-live-action-param': 'addToCart', 'data-model': 'norender|*'}}) }}
             {{ form_errors(form) }}
 
             {% hook 'add_to_cart' with { product, form } %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart.html.twig
@@ -12,7 +12,7 @@
             </div>
         </div>
         <div class="my-4" {{ sylius_test_html_attribute('product-selecting-variant') }}>
-            {{ form_start(form, {'attr': {'data-action': 'live#action:prevent live#$render', 'data-live-action-param': 'addToCart', 'data-model': 'norender|*'}}) }}
+            {{ form_start(form, {'attr': {'data-action': 'live#action:prevent live#$render', 'data-live-action-param': 'addToCart'}}) }}
             {{ form_errors(form) }}
 
             {% hook 'add_to_cart' with { product, form } %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

when performing "backward" using browser from cart summary after being redirected `AddToCartFormComponent` is not reset and can lead to a stucked loader in the storefront
so explicitely force component to re-render as stated in ux live component [documentation](https://symfony.com/bundles/ux-live-component/current/index.html#forcing-a-re-render-explicitly)

[Screencast_19-11-2024_11_14_02.webm](https://github.com/user-attachments/assets/b06c5f20-1a5a-47e4-8770-265385b0b64d)
