### PR TITLE
[BUG] Fix sass loader compilation on path containing dot character

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -23,7 +23,7 @@ class SyliusAdmin {
       .enableVersioning(Encore.isProduction())
       .enableSassLoader((options) => {
         // eslint-disable-next-line no-param-reassign
-        options.additionalData = `$rootDir: ${rootDir};`;
+        options.additionalData = `$rootDir: '${rootDir}';`;
       })
       .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -22,7 +22,7 @@ class SyliusShop {
       .enableVersioning(Encore.isProduction())
       .enableSassLoader((options) => {
         // eslint-disable-next-line no-param-reassign
-        options.additionalData = `$rootDir: ${rootDir};`;
+        options.additionalData = `$rootDir: '${rootDir}';`;
       })
       .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/symfony/webpack-encore/issues/1353
| License         | MIT

If you build the shop on a directory containing a dot the process will fail. This will fix the issue.