### PR TITLE
[CI] Add PHP 8.4 and SF 7.2 to unstable build

### DIFF
--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -22,9 +22,15 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.2"]
-                symfony: ["^6.4"]
-                mysql: ["8.4"]
+                include:
+                    -
+                        php: "8.3"
+                        symfony: "~7.2.0-RC1"
+                        mysql: "8.4"
+                    -
+                        php: "8.4"
+                        symfony: "~7.1.0"
+                        mysql: "8.4"
 
         env:
             APP_ENV: test_cached
@@ -37,7 +43,7 @@ jobs:
             -   name: Change minimum-stability to dev
                 run: |
                     composer config minimum-stability dev
-                    composer config prefer-stable false
+                    composer config prefer-stable true
                     
             -   name: Prepare manifest.json files
                 run: |


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
