### PR TITLE
[Admin] - admin panel layout modifications - CRUD removed text-nowrap class 

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/data_table.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/data_table.html.twig
@@ -22,7 +22,7 @@
             </div>
         </div>
         <div class="table-responsive">
-            <table class="table card-table table-vcenter text-nowrap datatable" {{ sylius_test_html_attribute('grid-table') }}>
+            <table class="table card-table table-vcenter datatable" {{ sylius_test_html_attribute('grid-table') }}>
                 <thead>
                 <tr>
                     {{ table.headers(resources, resources.definition, app.request.attributes) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Small change in layout template for CRUD data_table. Text is wrapping in the name cell.