### PR TITLE
fix: json_decode check always pass #17171

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20240315112656.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20240315112656.php
@@ -81,8 +81,8 @@ final class Version20240315112656 extends AbstractMigration
             $id = $row['id'];
             $data = $row[$dataColumn];
 
-            $this->skipIf(@json_decode($data) === false, sprintf('Data in %s is not json', $table));
             $decodedData = json_decode($data, true);
+            $this->skipIf(json_last_error() !== JSON_ERROR_NONE, sprintf('Data in %s is not json', $table));
             $decodedData = serialize($decodedData);
 
             $connection->UPDATE($table, [$dataColumn => $decodedData], ['id' => $id]);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #17171
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
