### PR TITLE
fix: migration fails when migrations have a custom table name

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/Migrations/AbstractPostgreSQLMigration.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/Migrations/AbstractPostgreSQLMigration.php
@@ -19,10 +19,12 @@ use Doctrine\Migrations\AbstractMigration as BaseAbstractMigration;
 
 abstract class AbstractPostgreSQLMigration extends BaseAbstractMigration
 {
+    private bool $markCompletedWhenSkip = false;
+
     public function preUp(Schema $schema): void
     {
         if (!$this->isPostgreSQL()) {
-            $this->markAsExecuted($this->getVersion());
+            $this->setMarkCompletedWhenSkip();
             $this->skipIf(true, 'This migration can only be executed on \'PostgreSQL\'.');
         }
     }
@@ -40,6 +42,9 @@ abstract class AbstractPostgreSQLMigration extends BaseAbstractMigration
         ;
     }
 
+    /**
+     * @deprecated
+     */
     protected function markAsExecuted(string $version): void
     {
         $this->connection->executeQuery(
@@ -51,5 +56,15 @@ abstract class AbstractPostgreSQLMigration extends BaseAbstractMigration
     protected function getVersion(): string
     {
         return addslashes((new \ReflectionClass($this))->getName());
+    }
+
+    public function isMarkCompletedWhenSkip(): bool
+    {
+        return $this->markCompletedWhenSkip;
+    }
+
+    protected function setMarkCompletedWhenSkip(): void
+    {
+        $this->markCompletedWhenSkip = true;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/PostgreSQLSkipMigration.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PostgreSQLSkipMigration.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Event\MigrationsVersionEventArgs;
+use Doctrine\Migrations\Version\Direction;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class PostgreSQLSkipMigration
+{
+    public function __construct(
+        private readonly DependencyFactory $dependencyFactory,
+    ) {
+    }
+
+    public function onMigrationsVersionSkipped(MigrationsVersionEventArgs $event): void
+    {
+        $migration = $event->getPlan()->getMigration();
+        $result = $event->getPlan()->result;
+        $direction = $event->getPlan()->getDirection();
+
+        if (
+            $direction === Direction::UP &&
+            $migration instanceof AbstractPostgreSQLMigration &&
+            $result->isSkipped() &&
+            $migration->isMarkCompletedWhenSkip()
+        ) {
+            $metadataStorage = $this->dependencyFactory->getMetadataStorage();
+            $metadataStorage->complete($event->getPlan()->result);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20230419092354.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20230419092354.php
@@ -26,7 +26,7 @@ final class Version20230419092354 extends AbstractPostgreSQLMigration
     public function up(Schema $schema): void
     {
         if ($schema->hasTable('sylius_address')) {
-            $this->markAsExecuted($this->getVersion());
+            $this->setMarkCompletedWhenSkip();
             $this->skipIf(true, 'This migration is marked as completed.');
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -123,5 +123,10 @@
         <service id="Sylius\Bundle\CoreBundle\EventListener\PostgreSQLDefaultSchemaListener">
             <tag name="doctrine.event_listener" event="postGenerateSchema" method="postGenerateSchema" lazy="true" />
         </service>
+
+        <service id="Sylius\Bundle\CoreBundle\EventListener\PostgreSQLSkipMigration">
+            <argument type="service" id="doctrine.migrations.dependency_factory"/>
+            <tag name="doctrine.event_listener" event="onMigrationsVersionSkipped" method="onMigrationsVersionSkipped" lazy="true" />
+        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #17032
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
