### PR TITLE
[Admin][Action] use dynamic crud action route name instead of static prefixed paths

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/title_block/actions/edit.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show/content/header/title_block/actions/edit.html.twig
@@ -1,8 +1,12 @@
-{% set resource_id = hookable_metadata.context.resource.id %}
-{% set resource_name = hookable_metadata.context.metadata.name %}
-{% set url = 'sylius_admin_' ~ resource_name ~ '_update' %}
+{% set configuration = hookable_metadata.context.configuration %}
+{% set update_route_name = configuration.vars.update.route.name|default(configuration.getRouteName('update')) %}
 
-<a class="btn" href="{{ path(url, {'id': resource_id}) }}" {{ sylius_test_html_attribute('edit-' ~ resource_name) }}>
-    {{ ux_icon('tabler:pencil') }}
-    {{ 'sylius.ui.edit'|trans }}
-</a>
+{% if sylius_route_exists(update_route_name) %}
+    {% set resource_id = hookable_metadata.context.resource.id %}
+    {% set resource_name = hookable_metadata.context.metadata.name %}
+
+    <a class="btn" href="{{ path(update_route_name, {'id': resource_id}) }}" {{ sylius_test_html_attribute('edit-' ~ resource_name) }}>
+        {{ ux_icon('tabler:pencil') }}
+        {{ 'sylius.ui.edit'|trans }}
+    </a>
+{% endif %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/actions/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/actions/show.html.twig
@@ -5,7 +5,7 @@
     {% set resource_id = hookable_metadata.context.resource.id %}
     {% set resource_name = hookable_metadata.context.metadata.name %}
 
-    <a class="btn" href="{{ path(show_route_name, { id: resource_id }) }}" {{ sylius_test_html_attribute('show-' ~ resource_name) }}>
+    <a class="btn" href="{{ path(show_route_name, {'id': resource_id}) }}" {{ sylius_test_html_attribute('show-' ~ resource_name) }}>
         {{ ux_icon('tabler:eye') }}
         {{ 'sylius.ui.show'|trans }}
     </a>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/actions/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update/content/header/title_block/actions/show.html.twig
@@ -4,9 +4,8 @@
 {% if sylius_route_exists(show_route_name) %}
     {% set resource_id = hookable_metadata.context.resource.id %}
     {% set resource_name = hookable_metadata.context.metadata.name %}
-    {% set url = 'sylius_admin_' ~ resource_name ~ '_show' %}
 
-    <a class="btn" href="{{ path(url, {'id': resource_id}) }}" {{ sylius_test_html_attribute('show-' ~ resource_name) }}>
+    <a class="btn" href="{{ path(show_route_name, { id: resource_id }) }}" {{ sylius_test_html_attribute('show-' ~ resource_name) }}>
         {{ ux_icon('tabler:eye') }}
         {{ 'sylius.ui.show'|trans }}
     </a>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17513
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
