### PR TITLE
removing the double "private" in UPGRADE-1.14.md

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1036,7 +1036,7 @@ The old namespaces are deprecated and may be removed in future versions. Update 
 
         public function __construct(
     -       private FormatMoneyHelperInterface $helper,
-    +       private private FormatMoneyHelperInterface|MoneyFormatterInterface $helper,
+    +       private FormatMoneyHelperInterface|MoneyFormatterInterface $helper,
         )
     ```
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
