### PR TITLE
removal of double ‘private’ from upgrade-2.0.md

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -315,7 +315,7 @@ your app as necessary.
     use Sylius\Bundle\MoneyBundle\Formatter\MoneyFormatterInterface;
 
         public function __construct(
-    -       private private FormatMoneyHelperInterface|MoneyFormatterInterface $helper,
+    -       private FormatMoneyHelperInterface|MoneyFormatterInterface $helper,
     +       private MoneyFormatterInterface $moneyFormatter,
         )
     ```


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
