### PR TITLE
Allow to add extra filters on promotion actions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/PromotionAction.xml
@@ -92,6 +92,7 @@
                             <value key="filters">
                                 <constraint name="Optional">
                                     <constraint name="Collection">
+                                        <option name="allowExtraFields">true</option>
                                         <option name="fields">
                                             <value key="price_range_filter">
                                                 <constraint name="Optional">
@@ -199,6 +200,7 @@
                             <value key="filters">
                                 <constraint name="Optional">
                                     <constraint name="Collection">
+                                        <option name="allowExtraFields">true</option>
                                         <option name="fields">
                                             <value key="price_range_filter">
                                                 <constraint name="Optional">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | maybe
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

By default Collection constraint has allowExtraFields property set to false (https://symfony.com/doc/current/reference/constraints/Collection.html#allowextrafields), but this does not allow users to add extra filters to the promotion action. These changes will fix it.