### PR TITLE
Fixing docker images for running local test suites

### DIFF
--- a/.docker/test/Dockerfile
+++ b/.docker/test/Dockerfile
@@ -1,10 +1,12 @@
 FROM ghcr.io/sylius/sylius-php:8.2-fixuid-xdebug-alpine
 
 USER root
-RUN apk add --update apk add nano \
+RUN apk add --update;
+RUN apk add nano \
     # for all test commands, they use makefile
-    make \ 
+        make \
     # for the integration tests, they need the frontend running
-    nodejs npm yarn
+        nodejs npm yarn \
+    ;
 
 USER sylius

--- a/.docker/test/Dockerfile
+++ b/.docker/test/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/sylius/sylius-php:8.2-fixuid-xdebug-alpine
+
+USER root
+RUN apk add --update apk add nano \
+    # for all test commands, they use makefile
+    make \ 
+    # for the integration tests, they need the frontend running
+    nodejs npm yarn
+
+USER sylius

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,21 +1,25 @@
 services:
     static:
-        image: sylius/standard:1.11-traditional
+        build:
+            dockerfile: .docker/test/Dockerfile
+            context: .
         entrypoint: ["make", "static"]
         profiles: ["static-analyze"]
         environment:
             APP_ENV: "test_cached"
             PHP_DATE_TIMEZONE: "Europe/Warsaw"
         volumes:
-            - ./:/app:delegated
-            - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
-            - ./.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated
+            - ./:/srv/sylius:delegated
+            - .docker/test/php.ini:/etc/php/8.2/fpm/php.ini:delegated
+            - .docker/test/php.ini:/usr/local/etc/php/php-cli.ini:delegated
         networks:
             - sylius
     
     behat:
-        image: sylius/standard:1.11-traditional
-        entrypoint: ["make", "integration"]
+        build:
+            dockerfile: .docker/test/Dockerfile
+            context: .
+        entrypoint: ["make", "phpunit-integration"]
         profiles: ["integration"]
         environment:
             APP_ENV: "test_cached"
@@ -27,9 +31,9 @@ services:
             SYLIUS_MESSENGER_TRANSPORT_CATALOG_PROMOTION_REMOVAL_DSN: "sync://"
             SYLIUS_MESSENGER_TRANSPORT_CATALOG_PROMOTION_REMOVAL_FAILED_DSN: "sync://"
         volumes:
-            - ./:/app:delegated
-            - ./.docker/test/php.ini:/etc/php/8.0/fpm/php.ini:delegated
-            - ./.docker/test/php.ini:/etc/php/8.0/cli/php.ini:delegated
+            - ./:/srv/sylius:delegated
+            - .docker/test/php.ini:/etc/php/8.2/fpm/php.ini:delegated
+            - .docker/test/php.ini:/usr/local/etc/php/php-cli.ini:delegated
         depends_on:
             - mysql
         networks:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,7 +19,7 @@ services:
         build:
             dockerfile: .docker/test/Dockerfile
             context: .
-        entrypoint: ["make", "phpunit-integration"]
+        entrypoint: ["make", "integration"]
         profiles: ["integration"]
         environment:
             APP_ENV: "test_cached"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | 
| Related tickets | 
| License         | MIT


Running the local test suite fails, due to mismatching PHP versions on `sylius/standard:1.11-traditional` as defined in the `docker-compose.test.yml` file

<img width="888" alt="image" src="https://github.com/user-attachments/assets/9e2f8134-926d-43e0-b34d-fd9380a0e2e5">

Therefore branch/tag `2.0` no longer works.

I have taken the latest sylius 8.2 docker image, and added on top the "missing bits"

```
FROM ghcr.io/sylius/sylius-php:8.2-fixuid-xdebug-alpine

USER root
RUN apk update && apk add nano make 
RUN apk add nodejs npm yarn

USER sylius
```

The docker-compose.yml volume paths are now different, so I've updated this line

```
- ./:/srv/sylius:delegated
- 
```

That's it .. everything else works again :-)

## Static Tests Running

```
 docker-compose -f docker-compose.test.yml run static
```

<img width="466" alt="image" src="https://github.com/user-attachments/assets/46e75c17-81a6-4597-8bfd-397664ddecdf">

## Integration Tests Running

```
docker-compose -f docker-compose.test.yml up -d mysql
docker-compose -f docker-compose.test.yml up behat
```


<img width="471" alt="image" src="https://github.com/user-attachments/assets/40d71233-7d8d-4f3a-8200-ed93578d4af4">


<img width="518" alt="image" src="https://github.com/user-attachments/assets/5b5efae6-fddd-4213-a65b-8d7e874fc350">


<img width="596" alt="image" src="https://github.com/user-attachments/assets/7e9cad8d-1cd6-4df5-9ed6-8536e8a47e82">


