### PR TITLE
Tag attribute case mismatch on sylius php attributes

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
+++ b/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
@@ -55,9 +55,9 @@ final class SyliusAttributeExtension extends AbstractResourceExtension
             AsAttributeType::class,
             static function (ChildDefinition $definition, AsAttributeType $attribute): void {
                 $definition->addTag(AsAttributeType::SERVICE_TAG, [
-                    'attribute-type' => $attribute->getType(),
+                    'attribute_type' => $attribute->getType(),
                     'label' => $attribute->getLabel(),
-                    'form-type' => $attribute->getFormType(),
+                    'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
                 ]);
             },

--- a/src/Sylius/Bundle/AttributeBundle/Tests/DependencyInjection/SyliusAttributeExtensionTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/Tests/DependencyInjection/SyliusAttributeExtensionTest.php
@@ -38,9 +38,9 @@ final class SyliusAttributeExtensionTest extends AbstractExtensionTestCase
             'acme.attribute_type_with_attribute',
             AsAttributeType::SERVICE_TAG,
             [
-                'attribute-type' => 'test',
+                'attribute_type' => 'test',
                 'label' => 'Test',
-                'form-type' => 'SomeFormType',
+                'form_type' => 'SomeFormType',
                 'priority' => 15,
             ],
         );

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
@@ -55,7 +55,7 @@ final class SyliusPromotionExtension extends AbstractResourceExtension
                 $definition->addTag(AsPromotionAction::SERVICE_TAG, [
                     'type' => $attribute->getType(),
                     'label' => $attribute->getLabel(),
-                    'form-type' => $attribute->getFormType(),
+                    'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
                 ]);
             },
@@ -81,7 +81,7 @@ final class SyliusPromotionExtension extends AbstractResourceExtension
                 $definition->addTag(AsPromotionRuleChecker::SERVICE_TAG, [
                     'type' => $attribute->getType(),
                     'label' => $attribute->getLabel(),
-                    'form-type' => $attribute->getFormType(),
+                    'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
                 ]);
             },

--- a/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/SyliusPromotionExtensionTest.php
+++ b/src/Sylius/Bundle/PromotionBundle/Tests/DependencyInjection/SyliusPromotionExtensionTest.php
@@ -47,7 +47,7 @@ final class SyliusPromotionExtensionTest extends AbstractExtensionTestCase
             [
                 'type' => 'test',
                 'label' => 'Test',
-                'form-type' => 'SomeFormType',
+                'form_type' => 'SomeFormType',
                 'priority' => 10,
             ],
         );
@@ -112,7 +112,7 @@ final class SyliusPromotionExtensionTest extends AbstractExtensionTestCase
             [
                 'type' => 'test',
                 'label' => 'Test',
-                'form-type' => 'SomeFormType',
+                'form_type' => 'SomeFormType',
                 'priority' => 40,
             ],
         );

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
@@ -48,7 +48,7 @@ final class SyliusShippingExtension extends AbstractResourceExtension
                 $definition->addTag(AsShippingCalculator::SERVICE_TAG, [
                     'calculator' => $attribute->getCalculator(),
                     'label' => $attribute->getLabel(),
-                    'form-type' => $attribute->getFormType(),
+                    'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
                 ]);
             },
@@ -71,7 +71,7 @@ final class SyliusShippingExtension extends AbstractResourceExtension
                 $definition->addTag(AsShippingMethodRuleChecker::SERVICE_TAG, [
                     'type' => $attribute->getType(),
                     'label' => $attribute->getLabel(),
-                    'form-type' => $attribute->getFormType(),
+                    'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
                 ]);
             },

--- a/src/Sylius/Bundle/ShippingBundle/Tests/DependencyInjection/SyliusShippingExtensionTest.php
+++ b/src/Sylius/Bundle/ShippingBundle/Tests/DependencyInjection/SyliusShippingExtensionTest.php
@@ -44,7 +44,7 @@ final class SyliusShippingExtensionTest extends AbstractExtensionTestCase
             [
                 'calculator' => 'test',
                 'label' => 'Test',
-                'form-type' => 'SomeFormType',
+                'form_type' => 'SomeFormType',
                 'priority' => 0,
             ],
         );
@@ -93,7 +93,7 @@ final class SyliusShippingExtensionTest extends AbstractExtensionTestCase
             [
                 'type' => 'test',
                 'label' => 'Test',
-                'form-type' => 'SomeFormType',
+                'form_type' => 'SomeFormType',
                 'priority' => 20,
             ],
         );


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17531
| License         | MIT

The XmlFileLoader add extra service tag attribute name with `_` when it contains `-`. Exemple : 
```php
<tag name="sylius.shipping_method_rule_checker" type="order_total_greater_than_or_equal"
     form-type="Sylius\Bundle\CoreBundle\Form\Type\Shipping\Rule\ChannelBasedOrderTotalGreaterThanOrEqualConfigurationType"/>
```
transformed to array of 
```php
[
    'form-type' => '...',
    'form_type' => '...',
]
```
https://github.com/symfony/dependency-injection/blob/7a379d8871f6a36f01559c14e11141cc02eb8dc8/Loader/XmlFileLoader.php#L695-L697

To fix this issue #17531, we need to replace the autoconfiguration from `form-type` to `form_type`.
