### PR TITLE
[Admin][UI] Improve inputs contrast ratio

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
@@ -40,7 +40,7 @@ textarea.form-control {
 }
 
 .form-select:disabled {
-    color: var(--tblr-gray-500);
+    color: var(--tblr-gray-600);
 }
 
 .input-group {
@@ -49,4 +49,12 @@ textarea.form-control {
     .form-check {
         flex-grow: 1;
     }
+
+    .input-group-text {
+        color: var(--tblr-gray-600);
+    }
+}
+
+.form-control:focus {
+    box-shadow: none;
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_tom-select.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_tom-select.scss
@@ -20,9 +20,8 @@
 }
 
 .focus .ts-control {
-    border-color: #adb5bd;
-    outline: 0;
-    box-shadow: var(--tblr-box-shadow-input), 0 0 0 0.25rem rgba(173, 181, 189, 0.25);
+    border: 1px solid var(--tblr-focus-ring-color);
+    box-shadow: 0 0 0 1px var(--tblr-focus-ring-color);
 }
 
 .ts-dropdown, .ts-dropdown.form-control, .ts-dropdown.form-select {

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_variables.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_variables.scss
@@ -24,23 +24,35 @@ $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
 $black:    #000 !default;
 
-$body-color:                $gray-900;
+$body-color: $gray-900;
 
-$link-color:                $body-color;
-$link-decoration:           underline;
-$link-hover-color:          $primary;
-$link-hover-decoration:     null;
+$text-secondary: $gray-600;
+$text-secondary-light: $gray-500;
+$text-secondary-dark: $gray-700;
 
-$input-focus-border-color:    $gray-500;
+$link-color: $body-color;
+$link-decoration: underline;
+$link-hover-color: $primary;
+$link-hover-decoration: null;
 
-$focus-ring-width:      .25rem;
-$focus-ring-opacity:    .25;
-$focus-ring-color:      rgba($gray-500, $focus-ring-opacity);
-$focus-ring-blur:       0;
+$disabled-color: $gray-600;
+$form-secondary-color: $gray-600;
+
+$input-border-color: $gray-400;
+$input-border-color-translucent: $gray-400;
+$input-focus-border-color: $gray-600;
+
+$focus-ring-width: 0;
+$focus-ring-color: $input-focus-border-color;
+$focus-ring-blur: 0;
 $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color;
 
-$pagination-active-color:           inherit;
-$pagination-active-bg:              $gray-200;
+$input-btn-focus-width: $focus-ring-width;
+
+$btn-border-color: $input-border-color;
+
+$pagination-active-color: inherit;
+$pagination-active-bg: $gray-200;
 
 $font-family-sans-serif: 'Inter', serif;
 


### PR DESCRIPTION
Improve the input contrast ratio to more closely meet WCAG 2.1 specifications.

# Before
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/cb695c5a-60bf-4507-812b-9b90778e6822">

# After
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/0249e873-a88d-4126-98c8-c095164402fd">
