### PR TITLE
[Login] remove loader login page in safari when loading page from cache

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
@@ -42,6 +42,12 @@ $(document).ready(() => {
   $('.ui.card .dimmable.image, .ui.cards .card .dimmable.image').dimmer({ on: 'hover' });
   $('.ui.rating').rating('disable');
 
+  $(window).on('pageshow', (event) => {
+    if (event.originalEvent.persisted) {
+      $('form.loadable').removeClass('loading');
+    }
+  });
+  
   $('form.loadable button[type=submit]').on('click', (event) => {
     $(event.currentTarget).closest('form').addClass('loading');
   });


### PR DESCRIPTION
prevent loader in safari when loading the page from cache

| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no/
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #17483
| License         | MIT


<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
