### PR TITLE
Allow grid action button's link URL to be defined without defining a …

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Grid/deleteCatalogPromotion.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Grid/deleteCatalogPromotion.html.twig
@@ -1,4 +1,4 @@
-{% set path = options.link.url|default(path(options.link.route, options.link.parameters)) %}
+{% set path = options.link.url|default('') is not empty ? options.link.url : path(options.link.route, options.link.parameters) %}
 
 <form action="{{ path }}" method="post">
     <button

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/default.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
-{% set path = options.link.url|default(path(options.link.route, options.link.parameters|default({}))) %}
+{% set path = options.link.url|default('') is not empty ? options.link.url : path(options.link.route, options.link.parameters|default({})) %}
 
 {{ buttons.default(path, action.label, null, action.icon) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17565 
| License         | MIT