### PR TITLE
[Admin] Remove pagination selector if there are no other limits

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/pagination.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/pagination.html.twig
@@ -11,15 +11,19 @@
 {% endmacro %}
 
 {% macro number_of_results_selector(paginator, pagination_limits) %}
-    <div class="dropdown">
-        <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
-            {{ 'sylius.ui.show'|trans }} {{ paginator.maxPerPage }}
-        </button>
-        <div class="dropdown-menu dropdown-menu-end ">
-            {% for limit in pagination_limits|filter(limit => limit != paginator.maxPerPage) %}
-                {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')|merge(app.request.query)|merge({'limit': limit})) %}
-                <a class="dropdown-item" href="{{ path }}">{{ limit }}</a>
-            {% endfor %}
+    {% set other_pagination_limits = pagination_limits|filter(limit => limit != paginator.maxPerPage) %}
+
+    {% if other_pagination_limits is not empty %}
+        <div class="dropdown">
+            <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
+                {{ 'sylius.ui.show'|trans }} {{ paginator.maxPerPage }}
+            </button>
+            <div class="dropdown-menu dropdown-menu-end ">
+                {% for limit in other_pagination_limits %}
+                    {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')|merge(app.request.query)|merge({'limit': limit})) %}
+                    <a class="dropdown-item" href="{{ path }}">{{ limit }}</a>
+                {% endfor %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

More explanation on Sylius stack side
https://github.com/Sylius/Stack/pull/163

We can reproduce here easily
```yaml
sylius_grid:
    grids:
        sylius_admin_zone:
            limits: [10]
```