### PR TITLE
Center the labels in the variant table

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_variant.yml
@@ -25,12 +25,16 @@ sylius_grid:
                     label: sylius.ui.enabled
                     options:
                         template: "@SyliusAdmin/shared/grid/field/boolean.html.twig"
+                        vars:
+                            th_class: "text-center"
                 inventory:
                     type: twig
                     path: .
                     label: sylius.ui.inventory
                     options:
                         template: "@SyliusAdmin/product_variant/grid/field/inventory.html.twig"
+                        vars:
+                            th_class: "text-center"
                 position:
                     type: twig
                     label: sylius.ui.position
@@ -38,6 +42,8 @@ sylius_grid:
                     sortable: position
                     options:
                         template: "@SyliusAdmin/product_variant/grid/field/position.html.twig"
+                        vars:
+                            th_class: "text-center"
             filters:
                 code:
                     type: string

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/field/inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/field/inventory.html.twig
@@ -1,8 +1,10 @@
-{% if data.isTracked %}
-    <span class="onHand" data-product-variant-id="{{ data.id }}" {{ sylius_test_html_attribute('on-hand') }}>{{ data.onHand }}</span> {{ 'sylius.ui.available_on_hand'|trans }}
-    {% if data.onHold > 0 %}
-        <span class="onHold" data-product-variant-id="{{ data.id }}" {{ sylius_test_html_attribute('on-hold') }}>{{ data.onHold }}</span> {{ 'sylius.ui.reserved'|trans }}
+<div class="text-center">
+    {% if data.isTracked %}
+        <span class="onHand" data-product-variant-id="{{ data.id }}" {{ sylius_test_html_attribute('on-hand') }}>{{ data.onHand }}</span> {{ 'sylius.ui.available_on_hand'|trans }}
+        {% if data.onHold > 0 %}
+            <span class="onHold" data-product-variant-id="{{ data.id }}" {{ sylius_test_html_attribute('on-hold') }}>{{ data.onHold }}</span> {{ 'sylius.ui.reserved'|trans }}
+        {% endif %}
+    {% else %}
+        {{ 'sylius.ui.not_tracked'|trans }}
     {% endif %}
-{% else %}
-    {{ 'sylius.ui.not_tracked'|trans }}
-{% endif %}
+</div>


### PR DESCRIPTION
<img width="1358" alt="image" src="https://github.com/user-attachments/assets/02099283-e670-4455-9174-dc6ace988ede" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the visual alignment of the `enabled`, `inventory`, and `position` fields in the product variant grid by centering the content.
  
- **Bug Fixes**
	- Improved the display logic in the inventory template to ensure the "not tracked" message appears correctly based on the product variant's tracking status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->