### PR TITLE
Update system-requirements.md

### DIFF
--- a/docs/the-book/installation/system-requirements.md
+++ b/docs/the-book/installation/system-requirements.md
@@ -7,7 +7,7 @@ Before you dive into Sylius, your local environment must first meet some require
 | <p>PHP <code>8.2</code>or higher<br>with the following <a data-footnote-ref href="#user-content-fn-1">extensions</a>:</p><ul><li><code>gd</code></li><li><code>exif</code></li><li><code>fileinfo</code></li><li><code>intl</code></li></ul> |
 | [Composer](https://getcomposer.org/download/)                                                                                                                                                                                                |
 | <p>One of the supported database engines:</p><ul><li>MySQL <code>8.0</code> or higher</li><li>MariaDB <code>10.4.10</code> or higher</li><li>PostgreSQL <code>13.9</code> or higher</li></ul>                                                |
-| [Node.js](https://nodejs.org/en) `^18 \|\| ^20`                                                                                                                                                                                              |
+| [Node.js](https://nodejs.org/en) `^20 \|\| ^22`                                                                                                                                                                                              |
 | Git                                                                                                                                                                                                                                          |
 
 {% hint style="info" %}


### PR DESCRIPTION
Sylius 2.0

Changed system requirements:
NodeJS 18.x || 20.x
to:
NodeJS 20.x || 22.x

> error @sylius-ui/admin@2.0.0: The engine "node" is incompatible with this module. Expected version "^20 || ^22". Got "18.20.5"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated system requirements to reflect the new Node.js version requirement from `^18 || ^20` to `^20 || ^22`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->