### PR TITLE
General UI improvements #3

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/filters.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/grid/filters.html.twig
@@ -6,28 +6,30 @@
 {% set path = path(app.request.attributes.get('_route'), app.request.attributes.all('_route_params')) %}
 {% set are_criteria_set = app.request.query.has('criteria') %}
 
-<div class="position-relative z-1 bg-white mb-5">
-    {% set content %}
-        <div class="mb-3">
-            <form method="get" action="{{ path }}" novalidate {{ sylius_test_html_attribute('filters-form') }}>
-                <div class="sylius-filters">
-                    {% for filter in resources.definition.enabledFilters|filter(filter => filter.enabled)|sylius_sort_by('position') %}
-                        <div class="sylius-filters__item">
-                            {{ sylius_grid_render_filter(resources, filter) }}
-                        </div>
-                    {% endfor %}
-                </div>
-                <div>
-                    {{ button.primary({ text: 'sylius.ui.filter'|trans, icon: 'tabler:adjustments', type: 'submit', attr: sylius_test_html_attribute('filter') }) }}
-                    {{ button.default({ text: 'sylius.ui.reset'|trans, url: path, attr: sylius_test_html_attribute('reset') }) }}
-                </div>
-            </form>
-        </div>
-    {% endset %}
+{% if resources.definition.enabledFilters is not empty %}
+    <div class="position-relative z-1 bg-white mb-5">
+        {% set content %}
+            <div class="mb-3">
+                <form method="get" action="{{ path }}" novalidate {{ sylius_test_html_attribute('filters-form') }}>
+                    <div class="sylius-filters">
+                        {% for filter in resources.definition.enabledFilters|filter(filter => filter.enabled)|sylius_sort_by('position') %}
+                            <div class="sylius-filters__item">
+                                {{ sylius_grid_render_filter(resources, filter) }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <div>
+                        {{ button.primary({ text: 'sylius.ui.filter'|trans, icon: 'tabler:adjustments', type: 'submit', attr: sylius_test_html_attribute('filter') }) }}
+                        {{ button.default({ text: 'sylius.ui.reset'|trans, url: path, attr: sylius_test_html_attribute('reset') }) }}
+                    </div>
+                </form>
+            </div>
+        {% endset %}
 
-    {{ accordion([{
-        title: 'sylius.ui.filters'|trans,
-        content: content,
-        icon: 'tabler:adjustments',
-    }], are_criteria_set) }}
-</div>
+        {{ accordion([{
+            title: 'sylius.ui.filters'|trans,
+            content: content,
+            icon: 'tabler:adjustments',
+        }], are_criteria_set) }}
+    </div>
+{% endif %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/pagination.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/pagination.html.twig
@@ -25,5 +25,9 @@
                 {% endfor %}
             </div>
         </div>
+    {% else %}
+        <button type="button" class="btn btn-ghost-secondary dropdown-toggle" disabled>
+            {{ 'sylius.ui.show'|trans }} {{ paginator.maxPerPage }}
+        </button>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Hide filters box if none are present
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/38d0a58b-8452-44e8-b4b5-c3c03c769bda" />

Display disabled limit button if there are no other limits - related to https://github.com/Sylius/Stack/pull/163
<img width="1474" alt="image" src="https://github.com/user-attachments/assets/7d82a366-7e83-4bbd-961a-6b64d02591f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering logic for filters, ensuring the filter section only displays when filters are available.
	- Updated pagination interface to show a disabled button when no other pagination limits are available, enhancing user experience.

- **Bug Fixes**
	- Fixed potential display issues by preventing unnecessary HTML generation for filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->