### PR TITLE
Fix form template without resource factory

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/form.html.twig
@@ -3,7 +3,7 @@
 {% endif %}
 
 {% if resource is not defined %}
-    {% set resource = hookable_metadata.context.resource %}
+    {% set resource = hookable_metadata.context.resource|default(null) %}
 {% endif %}
 
 {% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Related to #https://github.com/Sylius/Stack/pull/194
| License         | MIT

To have more explanation, see comments in #https://github.com/Sylius/Stack/pull/194

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `resource` variable in the form template to ensure it defaults to `null` when undefined, enhancing template robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->