### PR TITLE
[Admin] Define title icon and subheader on Twig hooks configuration

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/title.html.twig
@@ -7,10 +7,12 @@
     {% set header = hookable_metadata.configuration.title %}
 {% endif %}
 
+{% set icon = hookable_metadata.configuration.icon|default(null) %}
+{% set subheader = hookable_metadata.configuration.subheader|default(null) %}
 {% set test_attribute = hookable_metadata.configuration.sylius_test_html_attribute is defined ? sylius_test_html_attribute(hookable_metadata.configuration.sylius_test_html_attribute) : null %}
 
 <div class="col-12 col-md" {{ test_attribute }}>
     <div class="d-md-flex gap-2 align-items-center">
-        {{ header.h1(header|trans) }}
+        {{ header.h1(header|trans, icon, subheader|trans) }}
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes (small improvement)
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Improvement to #17579
And also related to https://github.com/Sylius/Stack/pull/193

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced header rendering with the ability to include an icon and a subheader.
	- Support for translations for the new header elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->