### PR TITLE
ref #17608 Fix division by zero when promotion usage limit is 0

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/grid/field/usage.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/grid/field/usage.html.twig
@@ -1,4 +1,4 @@
-{% if not data.usageLimit %}
+{% if data.usageLimit is empty %}
     <div class="d-flex align-items-center gap-2">
         <div class="text-blue"><span {{ sylius_test_html_attribute('used') }}>{{ data.used }}</span> / &#8734;</div>
     </div>
@@ -13,7 +13,7 @@
 
     <div class="d-flex align-items-center gap-2">
         <div class="progress usage-progress-bar">
-            <div class="progress-bar bg-{{ color }}" style="width: {{ (data.used / data.usageLimit)|format_number(style='percent') }}" role="progressbar"></div>
+            <div class="progress-bar bg-{{ color }}" style="width: {{ (data.usageLimit > 0 ? (data.used / data.usageLimit) : 1)|format_number(style='percent') }}" role="progressbar"></div>
         </div>
         <div class="text-{{ color }}"><span {{ sylius_test_html_attribute('used') }}>{{ data.used }}</span> / {{ data.usageLimit }}</div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/grid/field/usage.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/grid/field/usage.html.twig
@@ -1,4 +1,4 @@
-{% if data.usageLimit is empty %}
+{% if not data.usageLimit %}
     <div class="d-flex align-items-center gap-2">
         <div class="text-blue"><span {{ sylius_test_html_attribute('used') }}>{{ data.used }}</span> / &#8734;</div>
     </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17608
| License         | MIT

Use `not` instead of `empty` to check if `usageLimit` is `null` or `0` because the Twig `empty` behavior differs from PHP's.

This feature is only available on Sylius 2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced progress bar width calculation to prevent division by zero errors.
	- Improved handling of usage limit scenarios in promotion grid display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->