### PR TITLE
Revert skipped phpunit test

### DIFF
--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -21,7 +21,6 @@ use Sylius\Bundle\CoreBundle\CatalogPromotion\Checker\InForVariantsScopeVariantC
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Kernel;
 
 final class CatalogPromotionsTest extends JsonApiTestCase
 {
@@ -163,12 +162,6 @@ final class CatalogPromotionsTest extends JsonApiTestCase
     /** @test */
     public function it_does_not_create_a_catalog_promotion_with_invalid_scopes(): void
     {
-        if (Kernel::VERSION_ID >= 70200) {
-            // Behavior of validation changed in Symfony starting from version 7.2.0
-            // Details: https://github.com/symfony/symfony/pull/57436
-            $this->markTestSkipped('This test is skipped due to a behavior change in Symfony starting from version 7.2.0.');
-        }
-
         $this->loadFixturesFromFiles([
             'authentication/api_administrator.yaml',
             'channel/channel.yaml',


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

https://github.com/symfony/symfony/pull/57436 was merged and released, we can now revert our skipped test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test configuration to remove Symfony version-specific test skipping
	- Ensured test for catalog promotion scope validation now runs unconditionally

<!-- end of auto-generated comment: release notes by coderabbit.ai -->