### PR TITLE
Add help on channel pricing when product is simple

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
@@ -74,8 +74,10 @@ sylius:
                 <a href="https://github.com/Sylius/PayPalPlugin" target="_blank">PayPal Commerce Platform</a> integration.
         lowest_price_before_discount: 'Lowest price before discount'
         minimum_price_details: Minimum price - this is the pricing threshold below which the current price cannot be discounted by neither catalog nor cart promotions. Use this to guard the profitability of your sales.
-        original_price_details: Original price - this is the price of the product variant It is displayed as crossed-out in the catalog. It is used as the base for current price calculations. If this value is not defined, Catalog Promotion logic will copy value from Price to Original Price.
+        original_price_details: Original price - this is the price of the product variant. It is displayed as crossed-out in the catalog. It is used as the base for current price calculations. If this value is not defined, Catalog Promotion logic will copy value from Price to Original Price.
+        original_product_price_details: Original price - this is the price of the product. It is displayed as crossed-out in the catalog. It is used as the base for current price calculations. If this value is not defined, Catalog Promotion logic will copy value from Price to Original Price.
         price_details: Price - this is the current price of the product variant displayed in the catalog. It can be modified explicitly by i.e. catalog promotions.
+        product_price_details: Price - this is the current price of the product displayed in the catalog. It can be modified explicitly by i.e. catalog promotions.
         price_history: Price history
         product:
             product_not_active_in_channel: The product is not yet activated in this channel.

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.fr.yml
@@ -77,7 +77,9 @@ sylius:
         lowest_price_before_discount: 'Prix le plus bas avant remise'
         minimum_price_details: Prix minimum - il s'agit du seuil de prix en dessous duquel le prix actuel ne peut être remisé par une quelconque promotion. Utilisez ceci pour garder la rentabilité de vos ventes.
         original_price_details: Prix original (aussi appelé prix barré) - il s'agit du prix de la variante de produit, il est affiché barré dans le catalogue. Il est utilisé comme base pour les calculs de prix actuels. Si cette valeur n'est pas définie, la logique de promotion du catalogue (Catalog Promotion) copiera la valeur du prix dans le prix d'origine.
+        original_product_price_details: Prix original (aussi appelé prix barré) - il s'agit du prix du produit, il est affiché barré dans le catalogue. Il est utilisé comme base pour les calculs de prix actuels. Si cette valeur n'est pas définie, la logique de promotion du catalogue (Catalog Promotion) copiera la valeur du prix dans le prix d'origine.
         price_details: 'Prix - il s''agit du prix actuel de la variante de produit affichée dans le catalogue. Il peut être modifié par des mécanismes internes, ex: les promotions du catalogue.'
+        product_price_details: 'Prix - il s''agit du prix actuel du produit affiché dans le catalogue. Il peut être modifié par des mécanismes internes, ex: les promotions du catalogue.'
         price_history: Historique des prix
         product:
             product_not_active_in_channel: Le produit n'est pas encore activé pour ce canal.

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_channel_pricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_channel_pricing.html.twig
@@ -1,3 +1,10 @@
+<div class="ui info message">
+    {{ 'sylius.ui.product_price_details'|trans }}
+    <br/>
+    {{ 'sylius.ui.original_product_price_details'|trans }}
+    <br/>
+    {{ 'sylius.ui.minimum_price_details'|trans }}
+</div>
 <div id="sylius_product_variant_channelPricings">
     {{ form_errors(variantForm.channelPricings) }}
     <div class="ui top attached tabular menu">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When we configure prices for a variant in the admin panel, a useful help message is displayed to understand how prices are managed.
For a better user experience, I think it would be beneficial to display the same help messages in product section, when the product is a simple product.  
To achieve this, I needed to add two translation keys to distinguish between the variant and product messages.