### PR TITLE
[Inventory] Fix availability checker aliases

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -31,6 +31,7 @@ final class SyliusInventoryExtension extends AbstractResourceExtension
         $loader->load('services.xml');
 
         $container->setAlias('sylius.availability_checker', $config['checker']);
-        $container->setAlias(AvailabilityCheckerInterface::class, $config['checker']);
+        $container->setAlias('sylius.checker.inventory.availability', 'sylius.availability_checker');
+        $container->setAlias(AvailabilityCheckerInterface::class, 'sylius.checker.inventory.availability');
     }
 }

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -16,7 +16,6 @@
         <defaults public="true" />
 
         <service id="sylius.availability_checker.default" class="Sylius\Component\Inventory\Checker\AvailabilityChecker" />
-        <service id="sylius.checker.inventory.availability" alias="sylius.availability_checker.default" />
 
         <service id="sylius.validator.in_stock" class="Sylius\Bundle\InventoryBundle\Validator\Constraints\InStockValidator">
             <argument type="service" id="sylius.checker.inventory.availability" />


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17606, after https://github.com/Sylius/Sylius/pull/17306
| License         | MIT

Indeed, the id used on other services was changed from `sylius.availability_checker` to the new `sylius.checker.inventory.availability` and it did not point to the alias previously used, so this can create problems in end applications, the proposed solution should solve this problem.

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
