### PR TITLE
[Admin] Fix services imports not to import integrations every time

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -17,7 +17,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <imports>
-        <import resource="services/**/*.xml" />
+        <import resource="services/*.xml" />
+        <import resource="services/product/*.xml" />
+        <import resource="services/twig/*.xml" />
     </imports>
 
     <parameters>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #17596 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated service configuration import strategy to improve organization of service definitions.
	- Refined XML service imports to be more specific and targeted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->