### PR TITLE
[Admin] Improve product grid layout and main taxon display

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product.yml
@@ -17,6 +17,8 @@ sylius_grid:
                     path: .
                     options:
                         template: "@SyliusAdmin/product/grid/field/product_image.html.twig"
+                        vars:
+                            th_class: "w-1"
                 name:
                     type: twig
                     label: sylius.ui.name
@@ -24,15 +26,13 @@ sylius_grid:
                     options:
                         template: "@SyliusAdmin/product/grid/field/name.html.twig"
                         vars:
-                            th_class: "w-75"
+                            th_class: "w-33"
                 code:
                     type: twig
                     label: sylius.ui.code
                     sortable: ~
                     options:
                         template: "@SyliusAdmin/shared/grid/field/code.html.twig"
-                        vars:
-                            th_class: "w-25"
                 mainTaxon:
                     type: twig
                     label: sylius.ui.main_taxon

--- a/src/Sylius/Bundle/AdminBundle/templates/product/grid/field/main_taxon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/grid/field/main_taxon.html.twig
@@ -1,7 +1,10 @@
 {% if data.fullname is defined %}
-    {{ data.fullname }}
+    {% set categories = data.fullname|replace({ (data.name): '' }) %}
+
+    {% if categories %}
+        <span class="text-muted cursor-default" data-bs-toggle="tooltip" data-bs-title="{{ categories[:-2] }}">.. /</span>
+    {% endif %}
+    {{ data.name }}
 {% else %}
-    <span class="text-danger">
-        {{ ux_icon('tabler:exclamation-circle') }} <i>{{ 'sylius.ui.no_main_taxon'|trans }}</i>
-    </span>
+    <span class="text-muted">{{ ux_icon('tabler:exclamation-circle') }} {{ 'sylius.ui.no_main_taxon'|trans }}</span>
 {% endif %}


### PR DESCRIPTION
Change in category path display. The proposed change is to display the full path only on hover, as the path can be very long and disrupt the table.

# Before
<img width="1339" alt="Zrzut ekranu 2025-01-10 o 12 44 42" src="https://github.com/user-attachments/assets/17a1d872-9843-46bd-8879-86fdba9699ad" />

# After
<img width="1339" alt="Zrzut ekranu 2025-01-10 o 12 33 07" src="https://github.com/user-attachments/assets/c44f5748-0eb5-4622-bdd1-7a51b73d039a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI/UX Improvements**
  - Adjusted product grid column widths for better layout
  - Enhanced main taxon display with truncated view and tooltip
  - Refined error message styling for undefined taxon names
<!-- end of auto-generated comment: release notes by coderabbit.ai -->