### PR TITLE
Fix phpspec namespace

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/spec/Resetter/CartChangesResetterSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Resetter/CartChangesResetterSpec.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Bundle\OrderBundle\ChangesResetter;
+namespace spec\Sylius\Bundle\OrderBundle\Resetter;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated namespace for `CartChangesResetterSpec` to improve code organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->