### PR TITLE
Fullscreen order table view

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
@@ -13,6 +13,7 @@ import './app';
 
 import './scripts/bulk-delete';
 import './scripts/check-all';
+import './scripts/fullscreen';
 import './scripts/menu-search';
 import './scripts/spotlight';
 import './scripts/statistics_chart';

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/scripts/fullscreen.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/scripts/fullscreen.js
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+document.querySelectorAll('[data-fullscreen-btn]').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const containerId = btn.getAttribute('data-fullscreen-btn');
+        const container = document.querySelector(`[data-fullscreen-container="${containerId}"]`);
+
+        if (!container) {
+            console.error(`Fullscreen container with ID "${containerId}" not found`);
+            return;
+        }
+
+        if (!document.fullscreenElement) {
+            if (container.requestFullscreen) {
+                container.requestFullscreen();
+            }
+        } else {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            }
+        }
+    });
+});

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
@@ -74,6 +74,7 @@ sylius:
         create_new:
             customer_group: 'Create a new customer group'
         delete_avatar: 'Delete avatar'
+        full_screen: 'Full screen'
         global: 'Global'
         ip_address: 'IP address'
         language: 'Language'

--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/items.html.twig
@@ -1,10 +1,17 @@
-<div class="card mb-3">
+<div class="card mb-3" data-fullscreen-container="orders">
     <div class="card-header">
-        <div class="card-title">{{ 'sylius.ui.items'|trans }}</div>
+        <div class="card-title">
+            {{ 'sylius.ui.items'|trans }}
+        </div>
+        <div class="card-actions btn-actions">
+            <button type="button" class="btn-action" data-fullscreen-btn="orders" data-bs-toggle="tooltip" data-bs-title="{{ 'sylius.ui.full_screen'|trans }}">
+                {{ ux_icon('tabler:maximize') }}
+            </button>
+        </div>
     </div>
     <div class="table-responsive">
         <table class="table table-hover table-vcenter card-table" {{ sylius_test_html_attribute('table-items') }}>
-            {% hook 'items'  %}
+            {% hook 'items' %}
         </table>
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| License         | MIT

In many cases, the order table is compressed and difficult to read. This PR adds a feature that allows users to open the table in fullscreen mode, making more products visible and improving readability.

## Preview

https://github.com/user-attachments/assets/2f0f6bff-5163-423b-9699-3a9086e55892




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added fullscreen functionality for order items section
	- Introduced a button to toggle fullscreen mode for specific elements
	- Implemented a mechanism to handle fullscreen mode for designated elements

- **Documentation**
	- Added English translation for "Full screen" feature

- **Style**
	- Updated card header layout to include fullscreen toggle button
	- Enhanced functionality with new attributes for fullscreen display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->