### PR TITLE
[Admin] Improve order history UI

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses.html.twig
@@ -1,12 +1,3 @@
-<div class="card mb-3">
-    <div class="card-header">
-        <div class="card-title">{{ 'sylius.ui.addresses'|trans }}</div>
-    </div>
-    <div class="py-3">
-        <div class="container-xl">
-            <div class="row">
-                {% hook 'addresses' %}
-            </div>
-        </div>
-    </div>
+<div>
+    {% hook 'addresses' %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses/address.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses/address.html.twig
@@ -7,7 +7,7 @@
         <div class="h2">{{ header }}</div>
     </div>
     {%- for log in address_logs -%}
-        <div class="row">
+        <div class="row" {{ sylius_test_html_attribute('address-log') }}>
             <div class="col-12 col-sm-4 col-md-2 text-sm-end mb-3 pe-xl-5">
                 {{ label(log) }}
                 <div class="d-inline d-sm-block text-secondary pe-sm-3 pt-3">
@@ -16,18 +16,18 @@
                 </div>
             </div>
             <div class="col-12 col-sm-8 col-md-9">
-                    <div class="alert alert-{{ log.action == 'create' ? 'success' : (log.action == 'update' ? 'yellow') }}">
-                        <div class="table-responsive text-secondary">
-                            <table class="table table-sm table-vcenter">
-                                {%- for field, data in log.data|filter(data => not data is empty) -%}
-                                    <tr>
-                                        <td class="col-4 border-0"><strong>{{ ('sylius.ui.' ~ field|u.snake)|trans }}</strong></td>
-                                        <td class="col-8 border-0 text-body w-full"><span>{{ data }}</span></td>
-                                    </tr>
-                                {%- endfor -%}
-                            </table>
-                        </div>
+                <div class="alert alert-{{ log.action == 'create' ? 'success' : (log.action == 'update' ? 'yellow') }}">
+                    <div class="table-responsive text-secondary">
+                        <table class="table table-sm table-vcenter">
+                            {%- for field, data in log.data|filter(data => not data is empty) -%}
+                                <tr>
+                                    <td class="col-4 border-0"><strong>{{ ('sylius.ui.' ~ field|u.snake)|trans }}</strong></td>
+                                    <td class="col-8 border-0 text-body w-full"><span>{{ data }}</span></td>
+                                </tr>
+                            {%- endfor -%}
+                        </table>
                     </div>
+                </div>
             </div>
         </div>
     {%- endfor -%}

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses/address.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/content/sections/addresses/address.html.twig
@@ -2,46 +2,33 @@
 
 {% set header = (header|default('sylius.ui.address'))|trans %}
 
-<div class="col-12 col-md-6" {{ sylius_test_html_attribute('address-type', header) }}>
-    <div class="card mb-3">
-        <div class="card-header">
-            <div class="card-title">{{ header }}</div>
-        </div>
-        <div class="table-responsive">
-            <table class="table table-vcenter table-bordered card-table">
-                <thead>
-                <tr>
-                    <th>{{ 'sylius.ui.actions'|trans }}</th>
-                    <th>{{ 'sylius.ui.logged_at'|trans }}</th>
-                    <th>{{ 'sylius.ui.changes'|trans }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                {%- for log in address_logs -%}
-                    <tr {{ sylius_test_html_attribute('address-log') }}>
-                        <td>{{ label(log) }}</td>
-                        <td>
-                            <span class="text-nowrap">{{ log.loggedAt|date('Y-m-d') }}</span><br>
-                            <span class="text-nowrap">{{ log.loggedAt|date('H:i:s') }}</span>
-                        </td>
-                        <td>
-                            <div class="table-responsive">
-                                <table class="table table-sm table-vcenter">
-                                    <tbody>
-                                    {%- for field, data in log.data|filter(data => not data is empty) -%}
-                                        <tr{% if loop.last %} style="border-bottom: hidden;"{% endif %}>
-                                            <td class="col-5"><strong>{{ ('sylius.ui.' ~ field|u.snake)|trans }}</strong></td>
-                                            <td class="col-7"><span>{{ data }}</span></td>
-                                        </tr>
-                                    {%- endfor -%}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </td>
-                    </tr>
-                {%- endfor -%}
-                </tbody>
-            </table>
-        </div>
+<div class="mb-5" {{ sylius_test_html_attribute('address-type', header) }}>
+    <div class="mb-6 border-bottom">
+        <div class="h2">{{ header }}</div>
     </div>
+    {%- for log in address_logs -%}
+        <div class="row">
+            <div class="col-12 col-sm-4 col-md-2 text-sm-end mb-3 pe-xl-5">
+                {{ label(log) }}
+                <div class="d-inline d-sm-block text-secondary pe-sm-3 pt-3">
+                    <span class="text-nowrap">{{ log.loggedAt|date('Y-m-d') }}</span>
+                    <span class="text-nowrap">{{ log.loggedAt|date('H:i:s') }}</span>
+                </div>
+            </div>
+            <div class="col-12 col-sm-8 col-md-9">
+                    <div class="alert alert-{{ log.action == 'create' ? 'success' : (log.action == 'update' ? 'yellow') }}">
+                        <div class="table-responsive text-secondary">
+                            <table class="table table-sm table-vcenter">
+                                {%- for field, data in log.data|filter(data => not data is empty) -%}
+                                    <tr>
+                                        <td class="col-4 border-0"><strong>{{ ('sylius.ui.' ~ field|u.snake)|trans }}</strong></td>
+                                        <td class="col-8 border-0 text-body w-full"><span>{{ data }}</span></td>
+                                    </tr>
+                                {%- endfor -%}
+                            </table>
+                        </div>
+                    </div>
+            </div>
+        </div>
+    {%- endfor -%}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/macro/action_label.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/macro/action_label.html.twig
@@ -1,23 +1,24 @@
 {%- macro label(log) -%}
     {% if log.action == 'create' %}
-        <div class="badge rounded-pill align-middle bg-success text-light d-flex w-fit-content">
-            {{ ux_icon('tabler:plus') }}
+        <div class="status status-success">
             <div class="text-start ps-2">
                 {{ 'sylius.ui.created'|trans }}
             </div>
+            {{ ux_icon('tabler:plus') }}
         </div>
     {% elseif log.action == 'update' %}
-        <div class="badge rounded-pill align-middle bg-yellow text-dark d-flex w-fit-content">
-            {{ ux_icon('tabler:pencil') }}
+        <div class="status status-yellow">
             <div class="text-start ps-2">
                 {{ 'sylius.ui.updated'|trans }}
             </div>
+            {{ ux_icon('tabler:pencil') }}
         </div>
     {% else %}
-        <div class="badge rounded-pill align-middle bg-secondary text-light d-flex w-fit-content">
-            <div class="text-start">
+        <div class="status status-secondary">
+            <div class="text-start ps-2">
                 {{ log.action|title }}
             </div>
+            <span class="status-dot"></span>
         </div>
     {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
# Before
<img width="1648" alt="image" src="https://github.com/user-attachments/assets/265a3d43-0e71-4924-adf1-c6934b5c5244" />

# After
<img width="1716" alt="image" src="https://github.com/user-attachments/assets/7be498b6-a160-4bf3-b0a6-8fb5c95a4cee" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI/UX Improvements**
	- Simplified address section layout in order history.
	- Redesigned address log display with a more responsive, row-based format.
	- Updated action label styling with new status classes for improved clarity.
	- Enhanced visual feedback for different log action types through conditional alert classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->