### PR TITLE
[Admin][TwigHook] Allow configuring primary Twig hook for CRUD templates

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/order/history.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history.html.twig
@@ -1,9 +1,14 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
+{% set prefixes = [
+    'sylius_admin.order.history',
+    'sylius_admin.common'
+] %}
+
 {% block title %}
     {{ 'sylius.ui.history'|trans }} | {{ parent() }}
 {% endblock %}
 
 {% block body %}
-    {% hook 'sylius_admin.order.history' with { resource, metadata, configuration } %}
+    {% hook prefixes with { resource, metadata, configuration } %}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/product/generate_variants.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/generate_variants.html.twig
@@ -1,9 +1,14 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
+{% set prefixes = [
+    'sylius_admin.product.generate_variants',
+    'sylius_admin.common'
+] %}
+
 {% block title %}
     {{ 'sylius.ui.generate_variants'|trans }} {{ parent() }}
 {% endblock %}
 
 {% block body %}
-    {% hook 'sylius_admin.product.generate_variants' with { resource, metadata, configuration, form } %}
+    {% hook prefixes with { resource, metadata, configuration, form } %}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion_coupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion_coupon/generate.html.twig
@@ -1,9 +1,14 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
+{% set prefixes = [
+    'sylius_admin.promotion_coupon.generate',
+    'sylius_admin.common'
+] %}
+
 {% block title %}
     {{ 'sylius.ui.generate_coupons'|trans }} {{ parent() }}
 {% endblock %}
 
 {% block body %}
-    {% hook 'sylius_admin.promotion_coupon.generate' with { resource: promotion, metadata, configuration, form } %}
+    {% hook prefixes with { resource: promotion, metadata, configuration, form } %}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/create.html.twig
@@ -1,9 +1,10 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
-{% set prefixes = [
+{% set prefixes = configuration.vars.hook_prefix is defined ? [configuration.vars.hook_prefix] %}
+{% set prefixes = prefixes|default({})|merge([
     'sylius_admin.%resource_name%'|replace({'%resource_name%': resource_name|default(metadata.name)}),
     'sylius_admin.common'
-] %}
+]) %}
 
 {% set header = metadata.applicationName ~ '.ui.' ~ metadata.pluralName %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index.html.twig
@@ -1,9 +1,11 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
-{% set prefixes = [
+{% set prefixes = configuration.vars.hook_prefix is defined ? [configuration.vars.hook_prefix] %}
+{% set prefixes = prefixes|default({})|merge([
     'sylius_admin.%resource_name%'|replace({'%resource_name%': resource_name|default(metadata.name)}),
     'sylius_admin.common'
-] %}
+]) %}
+
 {% set header = custom_header|default(metadata.applicationName ~ '.ui.' ~ metadata.pluralName) %}
 
 {% block title %}{{ header|trans }} | {{ parent() }}{% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/show.html.twig
@@ -1,9 +1,10 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
-{% set prefixes = [
+{% set prefixes = configuration.vars.hook_prefix is defined ? [configuration.vars.hook_prefix] %}
+{% set prefixes = prefixes|default({})|merge([
     'sylius_admin.%resource_name%'|replace({'%resource_name%': resource_name|default(metadata.name)}),
     'sylius_admin.common'
-] %}
+]) %}
 
 {% set header = metadata.applicationName ~ '.ui.' ~ metadata.pluralName %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/update.html.twig
@@ -1,9 +1,10 @@
 {% extends '@SyliusAdmin/shared/layout/base.html.twig' %}
 
-{% set prefixes = [
+{% set prefixes = configuration.vars.hook_prefix is defined ? [configuration.vars.hook_prefix] %}
+{% set prefixes = prefixes|default({})|merge([
     'sylius_admin.%resource_name%'|replace({'%resource_name%': resource_name|default(metadata.name)}),
     'sylius_admin.common'
-] %}
+]) %}
 
 {% set header = metadata.applicationName ~ '.ui.' ~ metadata.pluralName %}
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

By default, when using a resource controller with admin CRUD templates in plugins or applications, the hook prefix is hard coded as `sylius_admin.%resource_name%`. This PR introduces the ability to configure additional prefix using a new `hook_prefix` option, allowing for more flexibility in defining hook names. 

```
sylius_refund_credit_memo:
    resource: |
        alias: sylius_refund.credit_memo
        section: admin
        templates: "@SyliusAdmin\\shared\\crud"
        only: ['index']
        grid: sylius_refund_credit_memo
        permission: true
        vars:
            all:
                hook_prefix: sylius_refund.admin.credit_memo
```
With this configuration. hooks related to this resource will use `sylius_refund.admin.credit_memo` and `sylius_admin.credit_memo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated hook prefix handling in multiple Twig templates to support more dynamic configuration
	- Introduced a flexible `prefixes` variable to manage hook references across different admin templates
	- Enhanced template configuration with conditional prefix assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->