### PR TITLE
Exclude non-shippable units from shipments in OrderShipmentProcessor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -86,7 +87,10 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         Assert::isInstanceOf($order, OrderInterface::class);
 
         foreach ($order->getItemUnits() as $itemUnit) {
-            if (null === $itemUnit->getShipment() && $itemUnit->getShippable()->isShippingRequired()) {
+            /** @var ProductVariantInterface $shippable */
+            $shippable = $itemUnit->getShippable();
+
+            if (null === $itemUnit->getShipment() && $shippable->isShippingRequired()) {
                 $shipment->addUnit($itemUnit);
             }
         }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -86,7 +86,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         Assert::isInstanceOf($order, OrderInterface::class);
 
         foreach ($order->getItemUnits() as $itemUnit) {
-            if (null === $itemUnit->getShipment()) {
+            if (null === $itemUnit->getShipment() && $itemUnit->getShippable()->isShippingRequired()) {
                 $shipment->addUnit($itemUnit);
             }
         }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -53,6 +53,8 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ShipmentInterface $shipment,
         ShippingMethodInterface $defaultShippingMethod,
         OrderItemInterface $orderItem,
+        ProductVariantInterface $productVariant1,
+        ProductVariantInterface $productVariant2,
     ): void {
         $order->canBeProcessed()->willReturn(true);
 
@@ -61,6 +63,15 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $shipmentFactory->createNew()->willReturn($shipment);
 
         $order->isShippingRequired()->willReturn(true);
+
+        $productVariant1->isShippingRequired()->willReturn(true);
+        $productVariant2->isShippingRequired()->willReturn(true);
+
+        $itemUnit1->getShippable()->willReturn($productVariant1);
+        $itemUnit1->getShipment()->willReturn(null);
+
+        $itemUnit2->getShipment()->willReturn(null);
+        $itemUnit2->getShippable()->willReturn($productVariant2);
 
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
@@ -87,6 +98,8 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         OrderItemUnitInterface $itemUnit2,
         ShipmentInterface $shipment,
         OrderItemInterface $orderItem,
+        ProductVariantInterface $productVariant1,
+        ProductVariantInterface $productVariant2,
     ): void {
         $order->canBeProcessed()->willReturn(true);
 
@@ -95,6 +108,15 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $shipmentFactory->createNew()->willReturn($shipment);
 
         $order->isShippingRequired()->willReturn(true);
+
+        $productVariant1->isShippingRequired()->willReturn(true);
+        $productVariant2->isShippingRequired()->willReturn(true);
+
+        $itemUnit1->getShippable()->willReturn($productVariant1);
+        $itemUnit1->getShipment()->willReturn(null);
+
+        $itemUnit2->getShipment()->willReturn(null);
+        $itemUnit2->getShippable()->willReturn($productVariant2);
 
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
@@ -168,14 +190,20 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $order->isShippingRequired()->willReturn(true);
 
+        $productVariant->isShippingRequired()->willReturn(true);
+
+        $itemUnit->getShippable()->willReturn($productVariant);
+        $itemUnit->getShipment()->willReturn($shipment);
+
+        $itemUnitWithoutShipment->getShippable()->willReturn($productVariant);
+        $itemUnitWithoutShipment->getShipment()->willReturn(null);
+
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
         $order->isEmpty()->willReturn(false);
         $order->hasShipments()->willReturn(true);
         $order->getItemUnits()->willReturn(new ArrayCollection([$itemUnit->getWrappedObject(), $itemUnitWithoutShipment->getWrappedObject()]));
         $order->getShipments()->willReturn($shipments);
-
-        $itemUnit->getShipment()->willReturn($shipment);
 
         $shipment->getUnits()->willReturn(new ArrayCollection([]));
         $shipment->addUnit($itemUnitWithoutShipment)->shouldBeCalled();
@@ -191,6 +219,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         Collection $shipments,
         OrderItemUnitInterface $itemUnit,
         OrderItemUnitInterface $itemUnitWithoutShipment,
+        ProductVariantInterface $productVariant,
         ShippingMethodInterface $shippingMethod,
     ): void {
         $order->canBeProcessed()->willReturn(true);
@@ -202,12 +231,18 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $order->isShippingRequired()->willReturn(true);
 
+        $productVariant->isShippingRequired()->willReturn(true);
+
+        $itemUnit->getShippable()->willReturn($productVariant);
+        $itemUnit->getShipment()->willReturn($shipment);
+
+        $itemUnitWithoutShipment->getShippable()->willReturn($productVariant);
+        $itemUnitWithoutShipment->getShipment()->willReturn(null);
+
         $order->isEmpty()->willReturn(false);
         $order->hasShipments()->willReturn(true);
         $order->getItemUnits()->willReturn(new ArrayCollection([$itemUnit->getWrappedObject(), $itemUnitWithoutShipment->getWrappedObject()]));
         $order->getShipments()->willReturn($shipments);
-
-        $itemUnit->getShipment()->willReturn($shipment);
 
         $shipment->getUnits()->willReturn(new ArrayCollection([$itemUnit->getWrappedObject()]));
         $shipment->removeUnit($itemUnit)->shouldBeCalled();
@@ -245,14 +280,20 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $order->isShippingRequired()->willReturn(true);
 
+        $productVariant->isShippingRequired()->willReturn(true);
+
+        $itemUnit->getShippable()->willReturn($productVariant);
+        $itemUnit->getShipment()->willReturn($shipment);
+
+        $itemUnitWithoutShipment->getShippable()->willReturn($productVariant);
+        $itemUnitWithoutShipment->getShipment()->willReturn(null);
+
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
 
         $order->isEmpty()->willReturn(false);
         $order->hasShipments()->willReturn(true);
         $order->getItemUnits()->willReturn(new ArrayCollection([$itemUnit->getWrappedObject(), $itemUnitWithoutShipment->getWrappedObject()]));
         $order->getShipments()->willReturn($shipments);
-
-        $itemUnit->getShipment()->willReturn($shipment);
 
         $shipment->getUnits()->willReturn(new ArrayCollection([]));
         $shipment->addUnit($itemUnitWithoutShipment)->shouldBeCalled();
@@ -270,6 +311,49 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $order->isShippingRequired()->shouldNotBeCalled();
         $order->hasShipments()->shouldNotBeCalled();
         $order->getShipments()->shouldNotBeCalled();
+
+        $this->process($order);
+    }
+
+    function it_does_not_add_item_units_that_do_not_require_shipping(
+        FactoryInterface $shipmentFactory,
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        OrderItemUnitInterface $shippableUnit,
+        OrderItemUnitInterface $nonShippableUnit,
+        ProductVariantInterface $shippableVariant,
+        ProductVariantInterface $nonShippableVariant,
+        DefaultShippingMethodResolverInterface $defaultShippingMethodResolver,
+        ShippingMethodInterface $shippingMethod,
+    ): void {
+        $order->canBeProcessed()->willReturn(true);
+        $order->isShippingRequired()->willReturn(true);
+        $order->isEmpty()->willReturn(false);
+        $order->hasShipments()->willReturn(false);
+        $order->getItemUnits()->willReturn(new ArrayCollection([
+            $shippableUnit->getWrappedObject(),
+            $nonShippableUnit->getWrappedObject(),
+        ]));
+
+        $shipmentFactory->createNew()->willReturn($shipment);
+        $defaultShippingMethodResolver->getDefaultShippingMethod($shipment)->willReturn($shippingMethod);
+
+        $shippableUnit->getShippable()->willReturn($shippableVariant);
+        $shippableVariant->isShippingRequired()->willReturn(true);
+        $shippableUnit->getShipment()->willReturn(null);
+
+        $nonShippableUnit->getShippable()->willReturn($nonShippableVariant);
+        $nonShippableVariant->isShippingRequired()->willReturn(false);
+        $nonShippableUnit->getShipment()->willReturn(null);
+
+        $shipment->setOrder($order)->shouldBeCalled();
+        $shipment->setMethod($shippingMethod)->shouldBeCalled();
+
+        $shipment->getUnits()->willReturn(new ArrayCollection([]));
+        $shipment->addUnit($shippableUnit)->shouldBeCalled();
+        $shipment->addUnit($nonShippableUnit)->shouldNotBeCalled();
+
+        $order->addShipment($shipment)->shouldBeCalled();
 
         $this->process($order);
     }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -70,8 +70,8 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $itemUnit1->getShippable()->willReturn($productVariant1);
         $itemUnit1->getShipment()->willReturn(null);
 
-        $itemUnit2->getShipment()->willReturn(null);
         $itemUnit2->getShippable()->willReturn($productVariant2);
+        $itemUnit2->getShipment()->willReturn(null);
 
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
@@ -115,8 +115,8 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $itemUnit1->getShippable()->willReturn($productVariant1);
         $itemUnit1->getShipment()->willReturn(null);
 
-        $itemUnit2->getShipment()->willReturn(null);
         $itemUnit2->getShippable()->willReturn($productVariant2);
+        $itemUnit2->getShipment()->willReturn(null);
 
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
@@ -316,14 +316,14 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
     }
 
     function it_does_not_add_item_units_that_do_not_require_shipping(
+        DefaultShippingMethodResolverInterface $defaultShippingMethodResolver,
         FactoryInterface $shipmentFactory,
         OrderInterface $order,
-        ShipmentInterface $shipment,
         OrderItemUnitInterface $shippableUnit,
         OrderItemUnitInterface $nonShippableUnit,
+        ShipmentInterface $shipment,
         ProductVariantInterface $shippableVariant,
         ProductVariantInterface $nonShippableVariant,
-        DefaultShippingMethodResolverInterface $defaultShippingMethodResolver,
         ShippingMethodInterface $shippingMethod,
     ): void {
         $order->canBeProcessed()->willReturn(true);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 & 2.1 |
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Deprecations?   | no |
| Related tickets | resolves #15180 |
| License         | MIT |

Resolves https://github.com/Sylius/Sylius/issues/15180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved shipment processing to ensure only items meeting shipping criteria are included.
- **Tests**
	- Enhanced testing to validate correct handling of shippable versus non-shippable items in orders.
	- Introduced new tests to ensure items that do not require shipping are not added to shipments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->