### PR TITLE
[Shop][Grid] Add delete action

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -18,6 +18,7 @@ webpack_encore:
 sylius_grid:
     templates:
         action:
+            shop_delete: "@SyliusShop/grid/action/delete.html.twig"
             shop_show: "@SyliusShop/grid/action/show.html.twig"
             shop_pay: "@SyliusShop/account/order/grid/action/pay.html.twig"
         filter:

--- a/src/Sylius/Bundle/ShopBundle/templates/grid/action/delete.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/grid/action/delete.html.twig
@@ -1,0 +1,5 @@
+{% set id = options.link.parameters['id']|default(data.id)  %}
+
+{% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('delete')), options.link.parameters|default({'id': id}))) %}
+
+{{ component('sylius_shop:delete_modal', {id: id, path: path, label: action.label, icon: action.icon}) }}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/components/confirmation_modal.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/components/confirmation_modal.html.twig
@@ -1,0 +1,23 @@
+{% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+{% props modal_id = null, type = null%}
+
+<div {{ attributes }} {{ sylius_test_html_attribute('modal', type) }}>
+    {% block trigger %}{% endblock %}
+
+    <div class="modal fade" id="{{ modal_id }}" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            {% block content %}
+                <div class="modal-content">
+                    <div class="modal-header">
+                        {% block header %}
+                            <h6 class="modal-title py-3">{{ 'sylius.ui.are_your_sure_you_want_to_perform_this_action'|trans }}</h6>
+                        {% endblock %}
+                    </div>
+                    <div class="modal-footer">
+                        {% block footer %}{% endblock %}
+                    </div>
+                </div>
+            {% endblock %}
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/components/delete_modal.html.twig
@@ -1,0 +1,25 @@
+{% extends '@SyliusShop/shared/components/confirmation_modal.html.twig' %}
+{% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+
+{% props id = null, path = null, label = 'sylius.ui.delete', icon = 'tabler:trash', disabled = false, form_attr = null, type = 'delete' %}
+{% set modal_id = 'delete-modal-' ~ id %}
+
+{% block trigger %}
+    <button type="button" class="btn btn-sm btn-outline-danger" {% if disabled %}disabled {% endif %}data-bs-toggle="modal" data-bs-target="#{{ modal_id }}">
+        {{ ux_icon(icon, {'class': 'icon icon-xs'})}} {{ label|trans }}
+    </button>
+{% endblock %}
+
+{% block footer %}
+    <form action="{{ path }}" method="post" {{ form_attr }}>
+        <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token(id) }}" />
+
+        <button type="button" class="btn btn-sm" data-bs-dismiss="modal">
+            {{ 'sylius.ui.cancel'|trans }}
+        </button>
+        <button type="submit" class="btn btn-sm btn-danger" {{ sylius_test_html_attribute('confirm-button') }}>
+            {{ label|trans }}
+        </button>
+    </form>
+{% endblock %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

![image](https://github.com/user-attachments/assets/28ae9a90-b665-40f7-81e1-3c7b88368b76)
![image](https://github.com/user-attachments/assets/c2bbe220-b14e-43b0-8ce7-9d8bbe0bb0e8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new delete action to the shop interface, enabling users to initiate deletions directly from grid views.
  - Introduced a responsive confirmation modal for delete actions, allowing users to review and confirm deletions with customizable labels and icons.
  - Launched a generic confirmation modal component to enhance user experience during critical actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->