### PR TITLE
[Shop][Grid] Add update action

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -19,8 +19,9 @@ sylius_grid:
     templates:
         action:
             shop_delete: "@SyliusShop/grid/action/delete.html.twig"
-            shop_show: "@SyliusShop/grid/action/show.html.twig"
             shop_pay: "@SyliusShop/account/order/grid/action/pay.html.twig"
+            shop_show: "@SyliusShop/grid/action/show.html.twig"
+            shop_update: "@SyliusShop/grid/action/update.html.twig"
         filter:
             shop_string: "@SyliusShop/grid/filter/string.html.twig"
 

--- a/src/Sylius/Bundle/ShopBundle/templates/grid/action/update.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/grid/action/update.html.twig
@@ -1,0 +1,6 @@
+{% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+
+{% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('update')), options.link.parameters|default({'id': data.id}))) %}
+{% set label = action.label|default('sylius.ui.edit') %}
+
+{{ buttons.default(path, label, 'update', null, 'btn-sm btn-outline-gray') }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

![image](https://github.com/user-attachments/assets/658d05ff-0723-43f2-a212-04b9d8d05c46)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded grid actions by introducing an update option, enabling users to initiate edits directly within the shop interface.
  - Integrated a new update button with intuitive labeling and consistent styling to complement existing view actions.
  - These enhancements aim to offer a more dynamic and flexible interaction model for managing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->