### PR TITLE
[Maintenance] Remove AsLiveComponent and AsTwigComponent attributes

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,8 @@
+# UPGRADE FROM `2.0.6` TO `2.0.7`
+
+1. The `AsTwigComponent` and `AsLiveComponent` attributes have been removed from components classes.
+   If you have extended any of these components and used these attributes, no action is required on your part
+
 # UPGRADE FROM `2.0.5` TO `2.0.6`
 
 ### Behat

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Customer/OrderStatisticsComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Customer/OrderStatisticsComponent.php
@@ -24,7 +24,6 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class OrderStatisticsComponent
 {
     use HookableLiveComponentTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/ChannelSelectorComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/ChannelSelectorComponent.php
@@ -25,7 +25,6 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class ChannelSelectorComponent
 {
     use ComponentToolsTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/NewOrdersComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/NewOrdersComponent.php
@@ -25,7 +25,6 @@ use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class NewOrdersComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/StatisticsComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/StatisticsComponent.php
@@ -28,7 +28,6 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class StatisticsComponent
 {
     use ComponentToolsTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Order/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Order/FormComponent.php
@@ -19,7 +19,6 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 
-#[AsLiveComponent]
 class FormComponent
 {
     /** @use ResourceFormComponentTrait<OrderInterface> */

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/Form/ProductTaxonsComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/Form/ProductTaxonsComponent.php
@@ -17,7 +17,6 @@ use Sylius\Bundle\AdminBundle\Doctrine\Query\Taxon\AllTaxonsInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
 use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 
-#[AsTwigComponent]
 class ProductTaxonsComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductAttribute/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductAttribute/FormComponent.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 
-#[AsLiveComponent]
 class FormComponent
 {
     use LiveCollectionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductOption/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductOption/FormComponent.php
@@ -21,7 +21,6 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 
-#[AsLiveComponent]
 class FormComponent
 {
     use LiveCollectionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductVariant/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/ProductVariant/FormComponent.php
@@ -25,7 +25,6 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 
-#[AsLiveComponent]
 class FormComponent
 {
     /** @use ResourceFormComponentTrait<ProductVariantInterface> */

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/PromotionCoupon/GeneratorInstructionFormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/PromotionCoupon/GeneratorInstructionFormComponent.php
@@ -21,7 +21,6 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
 class GeneratorInstructionFormComponent
 {
     use ComponentWithFormTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Shipment/ShipFormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Shipment/ShipFormComponent.php
@@ -19,7 +19,6 @@ use Sylius\Component\Core\Model\ShipmentInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class ShipFormComponent
 {
     /** @use ResourceFormComponentTrait<ShipmentInterface> */

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/DeleteComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/DeleteComponent.php
@@ -23,7 +23,6 @@ use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 final class DeleteComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/FormComponent.php
@@ -24,7 +24,6 @@ use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 
-#[AsLiveComponent]
 class FormComponent
 {
     use LiveCollectionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/TreeComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/TreeComponent.php
@@ -24,7 +24,6 @@ use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
 class TreeComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Zone/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Zone/FormComponent.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 
-#[AsLiveComponent]
 class FormComponent
 {
     use LiveCollectionTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/Address/DefaultFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/Address/DefaultFormComponent.php
@@ -17,9 +17,7 @@ use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 
-#[AsLiveComponent]
 class DefaultFormComponent
 {
     /** @use ResourceFormComponentTrait<CustomerInterface> */

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/Address/FormComponent.php
@@ -17,9 +17,7 @@ use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
 use Sylius\Component\Core\Model\AddressInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 
-#[AsLiveComponent]
 class FormComponent
 {
     /** @use ResourceFormComponentTrait<AddressInterface> */

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/ChangePasswordFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Account/ChangePasswordFormComponent.php
@@ -18,12 +18,10 @@ use Sylius\Bundle\UserBundle\Form\Model\ChangePassword;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
 class ChangePasswordFormComponent
 {
     use ComponentWithFormTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/SummaryComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/SummaryComponent.php
@@ -19,13 +19,11 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Resource\Model\ResourceInterface;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
 class SummaryComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/WidgetComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/WidgetComponent.php
@@ -21,14 +21,12 @@ use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Context\CartNotFoundException;
 use Sylius\Resource\Model\ResourceInterface;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\PreMount;
 
-#[AsLiveComponent]
 class WidgetComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/AddressBookComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/AddressBookComponent.php
@@ -18,13 +18,11 @@ use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Customer\Context\CustomerContextInterface;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsLiveComponent]
 class AddressBookComponent
 {
     use DefaultActionTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -23,13 +23,11 @@ use Sylius\Component\Customer\Context\CustomerContextInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveListener;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\Attribute\PreReRender;
 
-#[AsLiveComponent]
 class FormComponent
 {
     /** @use ResourceFormComponentTrait<OrderInterface> */

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/CurrencySwitcherComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/CurrencySwitcherComponent.php
@@ -18,10 +18,8 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class CurrencySwitcherComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/LocaleSwitcherComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/LocaleSwitcherComponent.php
@@ -16,10 +16,8 @@ namespace Sylius\Bundle\ShopBundle\Twig\Component\Common;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class LocaleSwitcherComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/TaxonMenuComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Common/TaxonMenuComponent.php
@@ -19,10 +19,8 @@ use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class TaxonMenuComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -35,7 +35,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
@@ -45,7 +44,6 @@ use Symfony\UX\LiveComponent\ComponentWithFormTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 use Symfony\UX\TwigComponent\Attribute\PostMount;
 
-#[AsLiveComponent]
 class AddToCartFormComponent
 {
     use ComponentToolsTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AssociationComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AssociationComponent.php
@@ -19,10 +19,8 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\ProductAssociationRepositoryInterface;
 use Sylius\Component\Product\Model\ProductAssociationInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class AssociationComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/BreadcrumbComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/BreadcrumbComponent.php
@@ -18,10 +18,8 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class BreadcrumbComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/BySlugComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/BySlugComponent.php
@@ -19,10 +19,8 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class BySlugComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/CardComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/CardComponent.php
@@ -24,11 +24,9 @@ use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Attribute\PostMount;
 
-#[AsTwigComponent]
 class CardComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/ListComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/ListComponent.php
@@ -19,10 +19,8 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class ListComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/PriceComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/PriceComponent.php
@@ -22,11 +22,9 @@ use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 use Symfony\UX\TwigComponent\Attribute\PostMount;
 
-#[AsTwigComponent]
 class PriceComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/ProductReview/CountComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/ProductReview/CountComponent.php
@@ -17,10 +17,8 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductReview;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class CountComponent
 {
     use HookableComponentTrait;

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/ProductReview/ListComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/ProductReview/ListComponent.php
@@ -18,10 +18,8 @@ use Sylius\Component\Core\Model\ProductReview;
 use Sylius\Component\Core\Repository\ProductReviewRepositoryInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
 use Sylius\TwigHooks\Twig\Component\HookableComponentTrait;
-use Symfony\UX\TwigComponent\Attribute\AsTwigComponent;
 use Symfony\UX\TwigComponent\Attribute\ExposeInTemplate;
 
-#[AsTwigComponent]
 class ListComponent
 {
     use HookableComponentTrait;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Attributes `AsTwigComponent` and `AsLiveComponent` have been removed from components because if someone uses them in the end application with autoconfigure set to true, it results in an error. Symfony tries to add a tag based on this attribute, but defaults parameters do not support it.

Attribute form class [Product/FormComponent](https://github.com/Sylius/Sylius/blob/2.1/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php) has not been removed because it is needed for checking this condition ([link](https://github.com/symfony/ux/blob/v2.23.0/src/LiveComponent/src/Util/LiveComponentStack.php#L44))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upgrade guide for version 2.0.4.

- **Refactor**
  - Streamlined component integrations to improve live interactions and template rendering.
  - Standardized configurations, routing, and dependency management for a consistent user experience.

- **Chores**
  - Removed deprecated elements and optimized internal structures for enhanced performance and maintainability.

These improvements ensure a smoother experience without requiring any additional effort from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->