### PR TITLE
[Admin] Deprecate unused sylius_admin_customer_orders_statistics route

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,0 +1,3 @@
+# UPGRADE FROM `2.0` TO `2.1`
+
+1. The `sylius_admin_customer_orders_statistics` route has been deprecated.

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -22,6 +22,7 @@ sylius_admin_customer_order_index:
             template: "@SyliusAdmin/shared/crud/index.html.twig"
             grid: sylius_admin_customer_order
 
+# This route is deprecated since Sylius 2.0 and will be removed in 3.0.
 sylius_admin_customer_orders_statistics:
     path: /orders-statistics
     methods: [GET]


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #17640
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upgrade guide to inform users about changes in administrative customer order statistics.
  
- **Chores**
  - Deprecated an older administrative route for customer order statistics, with removal planned for a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->