### PR TITLE
Stricter shop and admin firewall regexp

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -107,9 +107,9 @@ security:
         - { path: "%sylius.security.shop_regex%/_partial", role: PUBLIC_ACCESS, ips: [127.0.0.1, ::1] }
         - { path: "%sylius.security.shop_regex%/_partial", role: ROLE_NO_ACCESS }
 
-        - { path: "%sylius.security.admin_regex%/forgotten-password", role: PUBLIC_ACCESS }
+        - { path: "%sylius.security.admin_regex%forgotten-password", role: PUBLIC_ACCESS }
 
-        - { path: "%sylius.security.admin_regex%/login", role: PUBLIC_ACCESS }
+        - { path: "%sylius.security.admin_regex%login", role: PUBLIC_ACCESS }
         - { path: "%sylius.security.shop_regex%/login", role: PUBLIC_ACCESS }
 
         - { path: "%sylius.security.shop_regex%/register", role: PUBLIC_ACCESS }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -40,7 +40,7 @@ imports:
 parameters:
     env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
     sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
-    sylius.security.admin_regex: "^/%sylius_admin.path_name%"
+    sylius.security.admin_regex: "^/%sylius_admin.path_name%($|/.*)"
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/AdminBundle/Tests/Security/AdminFirewallTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Security/AdminFirewallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Tests\Security;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class AdminFirewallTest extends WebTestCase
+{
+    private string $adminRegexp;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->adminRegexp = static::getContainer()->getParameter('sylius.security.admin_regex');
+    }
+
+    /**
+     * @dataProvider getUrls
+     */
+    public function test_regexp(string $url, bool $expected): void
+    {
+        /**
+         * Symfony is using # char as delimiter
+         * @see \Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration::addFirewallsSection()
+         */
+        $this->assertSame($expected, (bool) preg_match('#'.$this->adminRegexp.'#', $url));
+    }
+
+    /**
+     * @return iterable<array{string, bool}>
+     */
+    public static function getUrls(): iterable
+    {
+        yield 'Admin url without ending slash' => ['/admin', true];
+        yield 'Admin url with ending slash' => ['/admin/', true];
+        yield 'Admin url with suffix' => ['/admin/foo', true];
+
+        yield 'Admin url without starting slash' => ['admin', false];
+        yield 'Random url starting with admin' => ['/adminfoo', false];
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Tests/Security/AdminFirewallTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Security/AdminFirewallTest.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\AdminBundle\Tests\Security;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class AdminFirewallTest extends WebTestCase
+final class AdminFirewallTest extends WebTestCase
 {
     private string $adminRegexp;
 

--- a/src/Sylius/Bundle/AdminBundle/test/config/packages/config.yaml
+++ b/src/Sylius/Bundle/AdminBundle/test/config/packages/config.yaml
@@ -1,5 +1,6 @@
 imports:
     - { resource: "@SyliusCoreBundle/Resources/config/app/config.yml" }
+    - { resource: "@SyliusAdminBundle/Resources/config/app/config.yml" }
 
 parameters:
     locale: en_US

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -9,7 +9,7 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/grids/product.yml" }
 
 parameters:
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius.security.shop_regex: "^(?!/%sylius_admin.path_name%$|/%sylius_admin.path_name%/.*|/api/.*|/api$|/media/.*)"
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/ShopBundle/Tests/Security/ShopFirewallTest.php
+++ b/src/Sylius/Bundle/ShopBundle/Tests/Security/ShopFirewallTest.php
@@ -15,7 +15,7 @@ namespace Sylius\Bundle\ShopBundle\Tests\Security;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class ShopFirewallTest extends WebTestCase
+final class ShopFirewallTest extends WebTestCase
 {
     private string $shopRegexp;
 

--- a/src/Sylius/Bundle/ShopBundle/Tests/Security/ShopFirewallTest.php
+++ b/src/Sylius/Bundle/ShopBundle/Tests/Security/ShopFirewallTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Tests\Security;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ShopFirewallTest extends WebTestCase
+{
+    private string $shopRegexp;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->shopRegexp = static::getContainer()->getParameter('sylius.security.shop_regex');
+    }
+
+    /**
+     * @dataProvider getUrls
+     */
+    public function test_regexp(string $url, bool $expected): void
+    {
+        /**
+         * Symfony is using # char as delimiter
+         * @see \Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration::addFirewallsSection()
+         */
+        $this->assertSame($expected, (bool) preg_match('#'.$this->shopRegexp.'#', $url));
+    }
+
+    /**
+     * @return iterable<array{string, bool}>
+     */
+    public static function getUrls(): iterable
+    {
+        yield 'Homepage with slash' => ['/', true];
+        yield 'Homepage without slash' => ['', true];
+        yield 'Random foo' => ['/foo', true];
+        yield 'Random foo without starting slash' => ['foo', true];
+        yield 'Random url starting with admin' => ['/adminfoo', true];
+        yield 'Random url starting with admin and suffix' => ['/adminfoo/bar', true];
+        yield 'Random url starting with api' => ['/apifoo', true];
+        yield 'Random url starting with api and suffix' => ['/apifoo/bar', true];
+        yield 'Media folder without ending slash' =>  ['/media', true]; // Maybe this one should be false
+        yield 'Random url starting with media' => ['/mediafoo', true];
+        yield 'Random url starting with media and suffix' => ['/mediafoo/bar', true];
+
+        yield 'Admin url without ending slash' => ['/admin', false];
+        yield 'API url and suffix' => ['/api/foo', false];
+        yield 'API url without ending slash' => ['/api', false];
+        yield 'Media url and suffix' => ['/media/foo', false];
+    }
+}

--- a/tests/Functional/Bundles/ShopBundle/Security/ShopFirewallTest.php
+++ b/tests/Functional/Bundles/ShopBundle/Security/ShopFirewallTest.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ShopBundle\Tests\Security;
+namespace Sylius\Tests\Functional\Bundles\ShopBundle\Security;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-final class ShopFirewallTest extends WebTestCase
+final class ShopFirewallTest extends KernelTestCase
 {
     private string $shopRegexp;
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/Sylius/Sylius/pull/17680#discussion_r1961931790
| License         | MIT

The current shop regexp is not allowing empty url to be able to ensure that non localized shop can works.
This PR adapt and test a new pattern allowing both localized and non localized shop firewall to work.

On the admin firewall, if you have any other url starting with `/admin` the admin firewall is used which can be not intended.
The new regexp make it more strict the admin firewall pattern.