### PR TITLE
[Behat] Remove `final` keyword from element classes

### DIFF
--- a/src/Sylius/Behat/Element/Admin/Account/ResetElement.php
+++ b/src/Sylius/Behat/Element/Admin/Account/ResetElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\Account;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class ResetElement extends Element implements ResetElementInterface
+class ResetElement extends Element implements ResetElementInterface
 {
     public function reset(): void
     {

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Admin\CatalogPromotion;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 use Sylius\Component\Core\Model\ChannelInterface;
 
-final class FilterElement extends Element implements FilterElementInterface
+class FilterElement extends Element implements FilterElementInterface
 {
     private const BOOLEAN_FILTER_TRUE = 'Yes';
 

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
@@ -18,7 +18,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 
 class FilterElement extends Element implements FilterElementInterface
 {
-    private const BOOLEAN_FILTER_TRUE = 'Yes';
+    protected const BOOLEAN_FILTER_TRUE = 'Yes';
 
     public function chooseChannel(ChannelInterface $channel): void
     {

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
@@ -24,7 +24,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
     public function __construct(
         Session $session,
         $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
@@ -19,7 +19,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Behat\Service\TabsHelper;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Channel/DiscountedProductsCheckingPeriodInputElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/DiscountedProductsCheckingPeriodInputElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\Channel;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class DiscountedProductsCheckingPeriodInputElement extends Element implements DiscountedProductsCheckingPeriodInputElementInterface
+class DiscountedProductsCheckingPeriodInputElement extends Element implements DiscountedProductsCheckingPeriodInputElementInterface
 {
     public function specifyPeriod(int $period): void
     {

--- a/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
@@ -19,7 +19,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 
-final class ExcludeTaxonsFromShowingLowestPriceInputElement extends BaseFormElement implements ExcludeTaxonsFromShowingLowestPriceInputElementInterface
+class ExcludeTaxonsFromShowingLowestPriceInputElement extends BaseFormElement implements ExcludeTaxonsFromShowingLowestPriceInputElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
@@ -24,7 +24,7 @@ class ExcludeTaxonsFromShowingLowestPriceInputElement extends BaseFormElement im
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }

--- a/src/Sylius/Behat/Element/Admin/Channel/LowestPriceFlagElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/LowestPriceFlagElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\Channel;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class LowestPriceFlagElement extends Element implements LowestPriceFlagElementInterface
+class LowestPriceFlagElement extends Element implements LowestPriceFlagElementInterface
 {
     public function enable(): void
     {

--- a/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
@@ -19,9 +19,9 @@ use Webmozart\Assert\Assert;
 
 class ShippingAddressInCheckoutRequiredElement extends Element implements ShippingAddressInCheckoutRequiredElementInterface
 {
-    private const ADDRESS_TYPE_BILLING = 'billing';
+    protected const ADDRESS_TYPE_BILLING = 'billing';
 
-    private const ADDRESS_TYPE_SHIPPING = 'shipping';
+    protected const ADDRESS_TYPE_SHIPPING = 'shipping';
 
     public function requireShippingAddressInCheckout(): void
     {
@@ -61,7 +61,7 @@ class ShippingAddressInCheckoutRequiredElement extends Element implements Shippi
         ]);
     }
 
-    private function getChoiceForAddressType(string $type): NodeElement
+    protected function getChoiceForAddressType(string $type): NodeElement
     {
         $choices = $this->getChoices();
         Assert::keyExists($choices, $type);
@@ -70,7 +70,7 @@ class ShippingAddressInCheckoutRequiredElement extends Element implements Shippi
     }
 
     /** @return array<string, NodeElement> */
-    private function getChoices(): array
+    protected function getChoices(): array
     {
         $element = $this->getElement('shipping_address_in_checkout_required');
         $labelsElements = $element->findAll('css', 'label');

--- a/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 use Webmozart\Assert\Assert;
 
-final class ShippingAddressInCheckoutRequiredElement extends Element implements ShippingAddressInCheckoutRequiredElementInterface
+class ShippingAddressInCheckoutRequiredElement extends Element implements ShippingAddressInCheckoutRequiredElementInterface
 {
     private const ADDRESS_TYPE_BILLING = 'billing';
 

--- a/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\Channel;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class ShopBillingDataElement extends Element implements ShopBillingDataElementInterface
+class ShopBillingDataElement extends Element implements ShopBillingDataElementInterface
 {
     public function specifyCompany(string $company): void
     {

--- a/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
@@ -79,7 +79,7 @@ class FormElement extends Element implements FormElementInterface
      *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element, array $parameters): NodeElement
+    protected function getFieldElement(string $element, array $parameters): NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Element/Admin/Currency/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Currency/FormElement.php
@@ -23,7 +23,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }

--- a/src/Sylius/Behat/Element/Admin/Currency/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Currency/FormElement.php
@@ -18,7 +18,7 @@ use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/CustomerGroup/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CustomerGroup/FormElement.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     use ChecksCodeImmutability;
 

--- a/src/Sylius/Behat/Element/Admin/ExchangeRate/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/ExchangeRate/FormElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\ExchangeRate;
 
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function isFieldDisabled(string $fieldName): bool
     {

--- a/src/Sylius/Behat/Element/Admin/Locale/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Locale/FormElement.php
@@ -23,7 +23,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }

--- a/src/Sylius/Behat/Element/Admin/Locale/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Locale/FormElement.php
@@ -18,7 +18,7 @@ use FriendsOfBehat\SymfonyExtension\Mink\MinkParameters;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/NotificationsElement.php
+++ b/src/Sylius/Behat/Element/Admin/NotificationsElement.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 use Sylius\Behat\Service\DriverHelper;
 
-final class NotificationsElement extends Element implements NotificationsElementInterface
+class NotificationsElement extends Element implements NotificationsElementInterface
 {
     public function hasNotification(string $type, string $message): bool
     {

--- a/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
@@ -25,7 +25,7 @@ class AssociationsFormElement extends BaseFormElement implements AssociationsFor
     public function __construct(
         Session $session,
         $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -76,7 +76,7 @@ class AssociationsFormElement extends BaseFormElement implements AssociationsFor
         );
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
@@ -20,7 +20,7 @@ use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 
-final class AssociationsFormElement extends BaseFormElement implements AssociationsFormElementInterface
+class AssociationsFormElement extends BaseFormElement implements AssociationsFormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
@@ -23,7 +23,7 @@ class AttributesFormElement extends BaseFormElement implements AttributesFormEle
     public function __construct(
         Session $session,
         $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -143,7 +143,7 @@ class AttributesFormElement extends BaseFormElement implements AttributesFormEle
         ]);
     }
 
-    private function selectAttributeToBeAdded(string $attributeName): void
+    protected function selectAttributeToBeAdded(string $attributeName): void
     {
         $this->autocompleteHelper->selectByName(
             $this->getDriver(),
@@ -152,7 +152,7 @@ class AttributesFormElement extends BaseFormElement implements AttributesFormEle
         );
     }
 
-    private function clickTabIfItsNotActive(): void
+    protected function clickTabIfItsNotActive(): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => 'attributes']);
         if (!$attributesTab->hasClass('active')) {
@@ -160,7 +160,7 @@ class AttributesFormElement extends BaseFormElement implements AttributesFormEle
         }
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;
@@ -169,7 +169,7 @@ class AttributesFormElement extends BaseFormElement implements AttributesFormEle
         $this->getElement('side_navigation_tab', ['%name%' => 'attributes'])->click();
     }
 
-    private function changeAttributeTab(string $attributeName): void
+    protected function changeAttributeTab(string $attributeName): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AttributesFormElement.php
@@ -18,7 +18,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 
-final class AttributesFormElement extends BaseFormElement implements AttributesFormElementInterface
+class AttributesFormElement extends BaseFormElement implements AttributesFormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Product/ChannelPricingsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/ChannelPricingsFormElement.php
@@ -60,7 +60,7 @@ class ChannelPricingsFormElement extends BaseFormElement implements ChannelPrici
         ]);
     }
 
-    private function changeChannelTab(string $channelCode): void
+    protected function changeChannelTab(string $channelCode): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;
@@ -69,7 +69,7 @@ class ChannelPricingsFormElement extends BaseFormElement implements ChannelPrici
         $this->getElement('channel_tab', ['%channel_code%' => $channelCode])->click();
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/ChannelPricingsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/ChannelPricingsFormElement.php
@@ -17,7 +17,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Component\Core\Model\ChannelInterface;
 
-final class ChannelPricingsFormElement extends BaseFormElement implements ChannelPricingsFormElementInterface
+class ChannelPricingsFormElement extends BaseFormElement implements ChannelPricingsFormElementInterface
 {
     public function specifyPrice(ChannelInterface $channel, string $price): void
     {

--- a/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
@@ -26,7 +26,7 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
     public function __construct(
         Session $session,
         $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -213,7 +213,7 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
         );
     }
 
-    private function getFirstImageSubform(): NodeElement
+    protected function getFirstImageSubform(): NodeElement
     {
         $images = $this->getElement('images');
         $imageSubforms = $images->findAll('css', '[data-test-image-subform]');
@@ -221,7 +221,7 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
         return reset($imageSubforms);
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
@@ -21,7 +21,7 @@ use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
-final class MediaFormElement extends BaseFormElement implements MediaFormElementInterface
+class MediaFormElement extends BaseFormElement implements MediaFormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Product/TaxonomyFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/TaxonomyFormElement.php
@@ -21,7 +21,7 @@ use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 
-final class TaxonomyFormElement extends BaseFormElement implements TaxonomyFormElementInterface
+class TaxonomyFormElement extends BaseFormElement implements TaxonomyFormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Product/TaxonomyFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/TaxonomyFormElement.php
@@ -26,7 +26,7 @@ class TaxonomyFormElement extends BaseFormElement implements TaxonomyFormElement
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -138,7 +138,7 @@ class TaxonomyFormElement extends BaseFormElement implements TaxonomyFormElement
         );
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/TranslationsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/TranslationsFormElement.php
@@ -87,7 +87,7 @@ class TranslationsFormElement extends BaseFormElement implements TranslationsFor
         );
     }
 
-    private function expandTranslationAccordion(string $localeCode): void
+    protected function expandTranslationAccordion(string $localeCode): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;
@@ -102,7 +102,7 @@ class TranslationsFormElement extends BaseFormElement implements TranslationsFor
         $translationAccordion->click();
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Product/TranslationsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/TranslationsFormElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Admin\Product;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\DriverHelper;
 
-final class TranslationsFormElement extends BaseFormElement implements TranslationsFormElementInterface
+class TranslationsFormElement extends BaseFormElement implements TranslationsFormElementInterface
 {
     public function nameItIn(string $name, string $localeCode): void
     {

--- a/src/Sylius/Behat/Element/Admin/ProductAttribute/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/ProductAttribute/FormElement.php
@@ -109,7 +109,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
         ]);
     }
 
-    private function getLastChoiceElement(): NodeElement
+    protected function getLastChoiceElement(): NodeElement
     {
         $choices = $this->getDocument()->findAll('css', '[data-test-choice-key]');
 

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
@@ -20,7 +20,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Behat\Service\TabsHelper;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Promotion/FormElement.php
@@ -25,7 +25,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
     public function __construct(
         Session $session,
         $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -244,12 +244,12 @@ class FormElement extends BaseFormElement implements FormElementInterface
         ]);
     }
 
-    private function getLastAction(): NodeElement
+    protected function getLastAction(): NodeElement
     {
         return $this->getElement('last_action');
     }
 
-    private function getChannelConfigurationOfLastAction(string $channelCode): NodeElement
+    protected function getChannelConfigurationOfLastAction(string $channelCode): NodeElement
     {
         $lastAction = $this->getLastAction();
 
@@ -260,12 +260,12 @@ class FormElement extends BaseFormElement implements FormElementInterface
         ;
     }
 
-    private function getLastRule(): NodeElement
+    protected function getLastRule(): NodeElement
     {
         return $this->getElement('last_rule');
     }
 
-    private function getChannelConfigurationOfLastRule(string $channelCode): NodeElement
+    protected function getChannelConfigurationOfLastRule(string $channelCode): NodeElement
     {
         $lastRule = $this->getLastRule();
 

--- a/src/Sylius/Behat/Element/Admin/PromotionCoupon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/PromotionCoupon/FormElement.php
@@ -18,7 +18,7 @@ use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\SpecifiesItsField;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     use SpecifiesItsField;
     use ChecksCodeImmutability;

--- a/src/Sylius/Behat/Element/Admin/ShippingMethod/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/ShippingMethod/FormElement.php
@@ -170,7 +170,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
         );
     }
 
-    private function selectCalculatorConfigurationChannelTab(string $channelCode): void
+    protected function selectCalculatorConfigurationChannelTab(string $channelCode): void
     {
         if (!DriverHelper::isJavascript($this->getDriver())) {
             throw new \RuntimeException('This method can be used only with JavaScript enabled');

--- a/src/Sylius/Behat/Element/Admin/ShippingMethod/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/ShippingMethod/FormElement.php
@@ -17,7 +17,7 @@ use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\TabsHelper;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function getCode(): string
     {

--- a/src/Sylius/Behat/Element/Admin/TaxCategory/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/TaxCategory/FormElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\TaxCategory;
 
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     public function setCode(string $code): void
     {

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -23,7 +23,7 @@ use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\Helper\AutocompleteHelperInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 
-final class FormElement extends BaseFormElement implements FormElementInterface
+class FormElement extends BaseFormElement implements FormElementInterface
 {
     use ChecksCodeImmutability;
     use SpecifiesItsField;

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -31,7 +31,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
     public function __construct(
         Session $session,
         array|MinkParameters $minkParameters,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters);
     }
@@ -125,7 +125,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
         return $this->getElement('code');
     }
 
-    private function expandTranslationAccordion(string $localeCode): void
+    protected function expandTranslationAccordion(string $localeCode): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Element/Admin/Taxon/ImageFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/ImageFormElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Admin\Taxon;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Element\Admin\Crud\FormElement as BaseFormElement;
 
-final class ImageFormElement extends BaseFormElement implements ImageFormElementInterface
+class ImageFormElement extends BaseFormElement implements ImageFormElementInterface
 {
     public function attachImage(string $path, ?string $type = null): void
     {

--- a/src/Sylius/Behat/Element/Admin/Taxon/TreeElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/TreeElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin\Taxon;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element as BaseElement;
 
-final class TreeElement extends BaseElement implements TreeElementInterface
+class TreeElement extends BaseElement implements TreeElementInterface
 {
     public function getTaxonsNames(): array
     {

--- a/src/Sylius/Behat/Element/Admin/TopBarElement.php
+++ b/src/Sylius/Behat/Element/Admin/TopBarElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Admin;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class TopBarElement extends Element implements TopBarElementInterface
+class TopBarElement extends Element implements TopBarElementInterface
 {
     public function hasAvatarInMainBar(string $avatarPath): bool
     {

--- a/src/Sylius/Behat/Element/Admin/TopBarElement.php
+++ b/src/Sylius/Behat/Element/Admin/TopBarElement.php
@@ -27,7 +27,7 @@ class TopBarElement extends Element implements TopBarElementInterface
         return $this->getAvatarImagePath() === '';
     }
 
-    private function getAvatarImagePath(): string
+    protected function getAvatarImagePath(): string
     {
         $userAvatar = $this->getElement('user_avatar');
 

--- a/src/Sylius/Behat/Element/Admin/Zone/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Zone/FormElement.php
@@ -110,7 +110,7 @@ class FormElement extends BaseFormElement implements FormElementInterface
         ]);
     }
 
-    private function waitForElement(
+    protected function waitForElement(
         int $timeout,
         string $elementName,
         array $parameters = [],

--- a/src/Sylius/Behat/Element/BrowserElement.php
+++ b/src/Sylius/Behat/Element/BrowserElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class BrowserElement extends Element implements BrowserElementInterface
+class BrowserElement extends Element implements BrowserElementInterface
 {
     public function goBack(): void
     {

--- a/src/Sylius/Behat/Element/Product/IndexPage/VerticalMenuElement.php
+++ b/src/Sylius/Behat/Element/Product/IndexPage/VerticalMenuElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Product\IndexPage;
 use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class VerticalMenuElement extends Element implements VerticalMenuElementInterface
+class VerticalMenuElement extends Element implements VerticalMenuElementInterface
 {
     public function getMenuItems(): array
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class AssociationsElement extends Element implements AssociationsElementInterface
+class AssociationsElement extends Element implements AssociationsElementInterface
 {
     public function hasAssociation(string $associationName): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
@@ -44,7 +44,7 @@ class AssociationsElement extends Element implements AssociationsElementInterfac
         ]);
     }
 
-    private function getAssociatedProducts(NodeElement $associations, string $name): array
+    protected function getAssociatedProducts(NodeElement $associations, string $name): array
     {
         return $associations->findAll(
             'css',

--- a/src/Sylius/Behat/Element/Product/ShowPage/AttributesElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/AttributesElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class AttributesElement extends Element implements AttributesElementInterface
+class AttributesElement extends Element implements AttributesElementInterface
 {
     public function hasAttributeInLocale(string $attribute, string $localeCode, string $value): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class DetailsElement extends Element implements DetailsElementInterface
+class DetailsElement extends Element implements DetailsElementInterface
 {
     public function getProductCode(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/LowestPriceInformationElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/LowestPriceInformationElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class LowestPriceInformationElement extends Element implements LowestPriceInformationElementInterface
+class LowestPriceInformationElement extends Element implements LowestPriceInformationElementInterface
 {
     public function isThereInformationAboutProductLowestPriceWithPrice(string $lowestPriceBeforeDiscount): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/MediaElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/MediaElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class MediaElement extends Element implements MediaElementInterface
+class MediaElement extends Element implements MediaElementInterface
 {
     public function isImageDisplayed(): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/OptionsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/OptionsElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class OptionsElement extends Element implements OptionsElementInterface
+class OptionsElement extends Element implements OptionsElementInterface
 {
     public function isOptionDefined(string $optionName): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -99,7 +99,7 @@ class PricingElement extends Element implements PricingElementInterface
         return $channelPriceRow->findAll('css', '[data-test-applied-promotion]');
     }
 
-    protected function getChannelPriceRow(string $channelCode): ?NodeElement
+    protected function getChannelPriceRow(string $channelCode): NodeElement
     {
         try {
             return $this->getElement('price_row', ['%channel_code%' => $channelCode]);

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class PricingElement extends Element implements PricingElementInterface
+class PricingElement extends Element implements PricingElementInterface
 {
     public function getPriceForChannel(string $channelCode): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -91,7 +91,7 @@ class PricingElement extends Element implements PricingElementInterface
         ]);
     }
 
-    private function getAppliedPromotionsForChannel(string $channelCode): array
+    protected function getAppliedPromotionsForChannel(string $channelCode): array
     {
         /** @var NodeElement $channelPriceRow */
         $channelPriceRow = $this->getChannelPriceRow($channelCode);
@@ -99,7 +99,7 @@ class PricingElement extends Element implements PricingElementInterface
         return $channelPriceRow->findAll('css', '[data-test-applied-promotion]');
     }
 
-    private function getChannelPriceRow(string $channelCode): ?NodeElement
+    protected function getChannelPriceRow(string $channelCode): ?NodeElement
     {
         try {
             return $this->getElement('price_row', ['%channel_code%' => $channelCode]);

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -21,9 +21,9 @@ class PricingElement extends Element implements PricingElementInterface
 {
     public function getPriceForChannel(string $channelCode): string
     {
-        $channelPriceRow = $this->getChannelPriceRow($channelCode);
-
-        if (null === $channelPriceRow) {
+        try {
+            $channelPriceRow = $this->getChannelPriceRow($channelCode);
+        } catch (ElementNotFoundException) {
             return '';
         }
 
@@ -34,7 +34,11 @@ class PricingElement extends Element implements PricingElementInterface
 
     public function getOriginalPriceForChannel(string $channelCode): string
     {
-        $channelPriceRow = $this->getChannelPriceRow($channelCode);
+        try {
+            $channelPriceRow = $this->getChannelPriceRow($channelCode);
+        } catch (ElementNotFoundException) {
+            return '';
+        }
 
         $priceForChannel = $channelPriceRow->find('css', '[data-test-original-price]');
 
@@ -91,20 +95,21 @@ class PricingElement extends Element implements PricingElementInterface
         ]);
     }
 
+    /** @return NodeElement[] */
     protected function getAppliedPromotionsForChannel(string $channelCode): array
     {
-        /** @var NodeElement $channelPriceRow */
-        $channelPriceRow = $this->getChannelPriceRow($channelCode);
+        try {
+            $channelPriceRow = $this->getChannelPriceRow($channelCode);
+        } catch (ElementNotFoundException) {
+            return [];
+        }
 
         return $channelPriceRow->findAll('css', '[data-test-applied-promotion]');
     }
 
+    /** @throws ElementNotFoundException */
     protected function getChannelPriceRow(string $channelCode): NodeElement
     {
-        try {
-            return $this->getElement('price_row', ['%channel_code%' => $channelCode]);
-        } catch (ElementNotFoundException) {
-            return null;
-        }
+        return $this->getElement('price_row', ['%channel_code%' => $channelCode]);
     }
 }

--- a/src/Sylius/Behat/Element/Product/ShowPage/ShippingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/ShippingElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class ShippingElement extends Element implements ShippingElementInterface
+class ShippingElement extends Element implements ShippingElementInterface
 {
     public function getProductShippingCategory(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/TaxonomyElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/TaxonomyElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class TaxonomyElement extends Element implements TaxonomyElementInterface
+class TaxonomyElement extends Element implements TaxonomyElementInterface
 {
     public function getProductMainTaxon(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/TranslationsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/TranslationsElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class TranslationsElement extends Element implements TranslationsElementInterface
+class TranslationsElement extends Element implements TranslationsElementInterface
 {
     public function getDescription(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class VariantsElement extends Element implements VariantsElementInterface
+class VariantsElement extends Element implements VariantsElementInterface
 {
     public function countVariantsOnPage(): int
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
@@ -83,7 +83,7 @@ class VariantsElement extends Element implements VariantsElementInterface
         ]);
     }
 
-    private function hasProductWithGivenNameCodePriceAndCurrentStock(
+    protected function hasProductWithGivenNameCodePriceAndCurrentStock(
         NodeElement $variant,
         string $name,
         string $code,

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
@@ -114,7 +114,7 @@ class RegisterElement extends Element implements RegisterElementInterface
      *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element, array $parameters): NodeElement
+    protected function getFieldElement(string $element, array $parameters): NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class RegisterElement extends Element implements RegisterElementInterface
+class RegisterElement extends Element implements RegisterElementInterface
 {
     public function register(): void
     {

--- a/src/Sylius/Behat/Element/Shop/CartWidgetElement.php
+++ b/src/Sylius/Behat/Element/Shop/CartWidgetElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Shop;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class CartWidgetElement extends Element implements CartWidgetElementInterface
+class CartWidgetElement extends Element implements CartWidgetElementInterface
 {
     public function getCartTotalQuantity(): int
     {

--- a/src/Sylius/Behat/Element/Shop/CheckoutSubtotalElement.php
+++ b/src/Sylius/Behat/Element/Shop/CheckoutSubtotalElement.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Element\Shop;
 
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class CheckoutSubtotalElement extends Element implements CheckoutSubtotalElementInterface
+class CheckoutSubtotalElement extends Element implements CheckoutSubtotalElementInterface
 {
     public function getProductQuantity(string $productName): int
     {

--- a/src/Sylius/Behat/Element/Shop/MenuElement.php
+++ b/src/Sylius/Behat/Element/Shop/MenuElement.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Element\Shop;
 use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
-final class MenuElement extends Element implements MenuElementInterface
+class MenuElement extends Element implements MenuElementInterface
 {
     public function getMenuItems(): array
     {

--- a/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
@@ -44,7 +44,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         ]);
     }
 
-    private function getAvatarImagePath(): string
+    protected function getAvatarImagePath(): string
     {
         $avatarImage = $this->getElement('avatar_image');
         $imagePath = $avatarImage->getAttribute('data-test-avatar-image');

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -36,7 +36,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/Channel/FormTrait.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/FormTrait.php
@@ -126,7 +126,7 @@ trait FormTrait
         $this->getElement('tax_calculation_strategy')->selectOption($taxCalculationStrategy);
     }
 
-    private function getSelectedOptionText(string $element): string
+    protected function getSelectedOptionText(string $element): string
     {
         return $this
             ->getElement($element)

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
@@ -32,7 +32,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/Country/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/CreatePage.php
@@ -60,7 +60,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ]);
     }
 
-    private function getProvinceItems(): array
+    protected function getProvinceItems(): array
     {
         $items = $this->getElement('provinces')->findAll('css', '[data-test-province]');
         Assert::isArray($items);

--- a/src/Sylius/Behat/Page/Admin/Country/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         return $this->checkCountryStatus($country, 'enabled');
     }
 
-    private function checkCountryStatus(CountryInterface $country, string $status): bool
+    protected function checkCountryStatus(CountryInterface $country, string $status): bool
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
@@ -124,7 +124,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         ]);
     }
 
-    private function getProvinceItems(): array
+    protected function getProvinceItems(): array
     {
         $items = $this->getElement('provinces')->findAll('css', '[data-test-province]');
         Assert::isArray($items);
@@ -132,7 +132,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $items;
     }
 
-    private function getProvinceElement(string $provinceName): NodeElement|null
+    protected function getProvinceElement(string $provinceName): NodeElement|null
     {
         return $this->getDocument()->find('xpath', sprintf('//*[@data-test-province and .//*[contains(@value, \'%s\')]]', $provinceName));
     }

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -113,7 +113,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    protected function getFieldElement(string $element, array $parameters = []): ?NodeElement
+    protected function getFieldElement(string $element, array $parameters = []): NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -28,7 +28,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private readonly string $routeName,
+        protected readonly string $routeName,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -113,7 +113,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element, array $parameters = []): ?NodeElement
+    protected function getFieldElement(string $element, array $parameters = []): ?NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -27,8 +27,8 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private readonly TableAccessorInterface $tableAccessor,
-        private readonly string $routeName,
+        protected readonly TableAccessorInterface $tableAccessor,
+        protected readonly string $routeName,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -124,7 +124,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    protected function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element): NodeElement
     {
         $element = $this->getElement(StringInflector::nameToCode($element));
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -29,7 +29,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private readonly string $routeName,
+        protected readonly string $routeName,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -124,7 +124,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element): NodeElement
+    protected function getFieldElement(string $element): ?NodeElement
     {
         $element = $this->getElement(StringInflector::nameToCode($element));
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Currency/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/IndexPage.php
@@ -31,7 +31,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
     /**
      * @throws \InvalidArgumentException
      */
-    private function checkCurrencyStatus(CurrencyInterface $currency, string $status): bool
+    protected function checkCurrencyStatus(CurrencyInterface $currency, string $status): bool
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Customer/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -155,7 +155,7 @@ class DashboardPage extends SymfonyPage implements DashboardPageInterface
         ]);
     }
 
-    private function waitForStatisticsUpdate(): void
+    protected function waitForStatisticsUpdate(): void
     {
         sleep(1); // we need to sleep, as sometimes the check below is executed faster than the form sets the busy attribute
         $liveElement = $this->getElement('statistics_component');

--- a/src/Sylius/Behat/Page/Admin/Inventory/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Inventory/IndexPage.php
@@ -27,7 +27,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }
@@ -101,7 +101,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         ]);
     }
 
-    private function specifyAutocompleteFilter(NodeElement $autocomplete, string $value): void
+    protected function specifyAutocompleteFilter(NodeElement $autocomplete, string $value): void
     {
         if (!$this->areFiltersVisible()) {
             $this->toggleFilters();

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -439,7 +439,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    protected function getRowWithItem(string $itemName): ?NodeElement
+    protected function getRowWithItem(string $itemName): NodeElement
     {
         return $this->getElement('item', ['%name%' => $itemName]);
     }

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -27,7 +27,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private readonly TableAccessorInterface $tableAccessor,
+        protected readonly TableAccessorInterface $tableAccessor,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -34,7 +34,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->specifyAddress($address, self::TYPE_SHIPPING);
     }
 
-    private function specifyAddress(AddressInterface $address, $addressType): void
+    protected function specifyAddress(AddressInterface $address, $addressType): void
     {
         $this->specifyElementValue($addressType . '_first_name', $address->getFirstName());
         $this->specifyElementValue($addressType . '_last_name', $address->getLastName());
@@ -88,7 +88,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @return array<string>
      */
-    private function getOptionTextsFor(NodeElement $element): array
+    protected function getOptionTextsFor(NodeElement $element): array
     {
         return array_map(fn ($option) => $option->getText(), $element->findAll('css', 'option'));
     }
@@ -119,7 +119,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    private function specifyElementValue(string $elementName, ?string $value): void
+    protected function specifyElementValue(string $elementName, ?string $value): void
     {
         $this->getElement($elementName)->setValue($value);
     }
@@ -127,7 +127,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    private function chooseCountry(?string $country, string $addressType): void
+    protected function chooseCountry(?string $country, string $addressType): void
     {
         $this->getElement($addressType . '_country')->selectOption($country ?? 'Select');
     }
@@ -135,7 +135,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element): ?NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -135,7 +135,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @throws ElementNotFoundException
      */
-    protected function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element): NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Payment/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Payment/IndexPage.php
@@ -73,7 +73,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         ]);
     }
 
-    private function getOrderLinkForRow(int $paymentNumber): NodeElement
+    protected function getOrderLinkForRow(int $paymentNumber): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');
@@ -83,7 +83,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         return $row->find('css', 'td:nth-child(2)');
     }
 
-    private function getField(string $orderNumber, string $fieldName): NodeElement
+    protected function getField(string $orderNumber, string $fieldName): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }
@@ -57,7 +57,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         ]);
     }
 
-    private function specifyAutocompleteFilter(NodeElement $autocomplete, string $value): void
+    protected function specifyAutocompleteFilter(NodeElement $autocomplete, string $value): void
     {
         if (!$this->areFiltersVisible()) {
             $this->toggleFilters();

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
@@ -36,7 +36,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }
@@ -98,7 +98,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         return parent::getElement($name, $parameters);
     }
 
-    private function changeTab(): void
+    protected function changeTab(): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -36,7 +36,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }
@@ -65,7 +65,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->getElement('channel', ['%channel_code%' => $channelCode])->check();
     }
 
-    private function changeTab(string $tabName): void
+    protected function changeTab(string $tabName): void
     {
         if (DriverHelper::isNotJavascript($this->getDriver())) {
             return;

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -28,8 +28,8 @@ class IndexPage extends CrudIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private ImageExistenceCheckerInterface $imageExistenceChecker,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected ImageExistenceCheckerInterface $imageExistenceChecker,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/ShowPage.php
@@ -110,14 +110,14 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     }
 
     /** @return NodeElement[] */
-    private function getAppliedCatalogPromotions(string $variantName, string $channelName): array
+    protected function getAppliedCatalogPromotions(string $variantName, string $channelName): array
     {
         $pricingElement = $this->getPricingRow($variantName, $channelName);
 
         return $pricingElement->findAll('css', '.applied-promotion');
     }
 
-    private function getPricingRow(string $variantName, string $channelName): NodeElement
+    protected function getPricingRow(string $variantName, string $channelName): NodeElement
     {
         /** @var NodeElement|null $pricingRow */
         $pricingRow = $this->getDocument()->find(

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPage.php
@@ -35,7 +35,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -32,7 +32,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $minkParameters,
         RouterInterface $router,
         string $routeName,
-        private readonly AutocompleteHelperInterface $autocompleteHelper,
+        protected readonly AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $routeName);
     }

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }
@@ -64,7 +64,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         $this->waitForFormUpdate();
     }
 
-    private function changeState(string $state, array $parameters): void
+    protected function changeState(string $state, array $parameters): void
     {
         $action = $this->getActionsForResource($parameters)->find('css', sprintf('[data-test-action="%s"]', $state));
         Assert::notNull($action, sprintf('There is no "%s" action available for this resource', $state));

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -48,9 +48,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     }
 
     /** @throws ElementNotFoundException */
-    protected function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element, array $parameters = []): NodeElement
     {
-        $element = $this->getElement($element);
+        $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {
             $element = $element->getParent();
         }

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -48,7 +48,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     }
 
     /** @throws ElementNotFoundException */
-    private function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element): ?NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Promotion/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/IndexPage.php
@@ -68,7 +68,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         ]);
     }
 
-    private function getPromotionFieldsWithHeader(PromotionInterface $promotion, string $header): NodeElement
+    protected function getPromotionFieldsWithHeader(PromotionInterface $promotion, string $header): NodeElement
     {
         return $this->getCellForResource($header, ['code' => $promotion->getCode()]);
     }

--- a/src/Sylius/Behat/Page/Admin/Shipment/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Shipment/IndexPage.php
@@ -28,7 +28,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
         string $routeName,
-        private AutocompleteHelperInterface $autocompleteHelper,
+        protected AutocompleteHelperInterface $autocompleteHelper,
     ) {
         parent::__construct($session, $minkParameters, $router, $tableAccessor, $routeName);
     }
@@ -104,7 +104,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         ]);
     }
 
-    private function getField(string $orderNumber, string $fieldName): NodeElement
+    protected function getField(string $orderNumber, string $fieldName): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');
@@ -114,7 +114,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         return $tableAccessor->getFieldFromRow($table, $row, $fieldName);
     }
 
-    private function getOrderLinkForRow(int $shipmentNumber): NodeElement
+    protected function getOrderLinkForRow(int $shipmentNumber): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPage.php
@@ -66,7 +66,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         return null !== $this->getRowFor($shippingMethod)->find('css', '[data-test-status-enabled]');
     }
 
-    private function getRowFor(ResourceInterface $shippingMethod): NodeElement
+    protected function getRowFor(ResourceInterface $shippingMethod): NodeElement
     {
         return $this->getElement('row', ['%resourceId%' => $shippingMethod->getId()]);
     }

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -117,7 +117,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
         throw new UnexpectedPageException($message);
     }
 
-    private function waitForElement(int $timeout, string $elementName): void
+    protected function waitForElement(int $timeout, string $elementName): void
     {
         $this->getDocument()->waitFor($timeout, fn () => $this->hasElement($elementName));
     }

--- a/src/Sylius/Behat/Page/Shop/Account/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/DashboardPage.php
@@ -56,7 +56,7 @@ class DashboardPage extends SymfonyPage implements DashboardPageInterface
         ]);
     }
 
-    private function hasValueInCustomerSection(string $value): bool
+    protected function hasValueInCustomerSection(string $value): bool
     {
         $customerText = $this->getElement('customer')->getText();
 

--- a/src/Sylius/Behat/Page/Shop/Account/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/IndexPage.php
@@ -25,7 +25,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private TableAccessorInterface $tableAccessor,
+        protected TableAccessorInterface $tableAccessor,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }

--- a/src/Sylius/Behat/Page/Shop/Account/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/ShowPage.php
@@ -25,7 +25,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private TableAccessorInterface $tableAccessor,
+        protected TableAccessorInterface $tableAccessor,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -177,7 +177,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ]);
     }
 
-    private function hasAddress(
+    protected function hasAddress(
         string $elementText,
         string $customerName,
         string $street,

--- a/src/Sylius/Behat/Page/Shop/Account/ProfileUpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ProfileUpdatePage.php
@@ -88,7 +88,7 @@ class ProfileUpdatePage extends SymfonyPage implements ProfileUpdatePageInterfac
         ]);
     }
 
-    private function waitForElementToBeReady(): void
+    protected function waitForElementToBeReady(): void
     {
         if (DriverHelper::isJavascript($this->getDriver())) {
             $this->getDocument()->waitFor(1, fn (): bool => $this->isOpen());

--- a/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPage.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Page\Shop\Account;
 
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
-final class RegisterThankYouPage extends SymfonyPage implements RegisterThankYouPageInterface
+class RegisterThankYouPage extends SymfonyPage implements RegisterThankYouPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
+++ b/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
@@ -251,7 +251,7 @@ class SummaryPage extends ShopPage implements SummaryPageInterface
         ]);
     }
 
-    private function waitForComponentsUpdate(): void
+    protected function waitForComponentsUpdate(): void
     {
         $this->waitForElementUpdate('form');
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -34,7 +34,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private AddressFactoryInterface $addressFactory,
+        protected AddressFactoryInterface $addressFactory,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -317,7 +317,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
     }
 
     /** @return string[] */
-    private function getOptionsFromSelect(NodeElement $element): array
+    protected function getOptionsFromSelect(NodeElement $element): array
     {
         return array_map(
             /** @return string[] */
@@ -326,7 +326,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
         );
     }
 
-    private function getPreFilledAddress(string $type): AddressInterface
+    protected function getPreFilledAddress(string $type): AddressInterface
     {
         $this->assertAddressType($type);
 
@@ -350,7 +350,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
         return $address;
     }
 
-    private function specifyAddress(AddressInterface $address, string $type): void
+    protected function specifyAddress(AddressInterface $address, string $type): void
     {
         $this->assertAddressType($type);
 
@@ -371,7 +371,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
         }
     }
 
-    private function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element): ?NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {
@@ -381,19 +381,19 @@ class AddressPage extends ShopPage implements AddressPageInterface
         return $element;
     }
 
-    private function waitForLoginAction(): bool
+    protected function waitForLoginAction(): bool
     {
         return $this->getDocument()->waitFor(5, fn () => !$this->hasElement('login_password'));
     }
 
-    private function assertAddressType(string $type): void
+    protected function assertAddressType(string $type): void
     {
         $availableTypes = [self::TYPE_BILLING, self::TYPE_SHIPPING];
 
         Assert::oneOf($type, $availableTypes, sprintf('There are only two available types %s, %s. %s given', self::TYPE_BILLING, self::TYPE_SHIPPING, $type));
     }
 
-    private function chooseDifferentAddress(string $type): void
+    protected function chooseDifferentAddress(string $type): void
     {
         $elem = $this->getElement(sprintf('different_%s_address', $type));
         $elem->click();

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -72,7 +72,7 @@ class AddressPage extends ShopPage implements AddressPageInterface
     public function checkInvalidCredentialsValidation(): bool
     {
         /** @var NodeElement $validationElement */
-        $validationElement = $this->getDocument()->waitFor(3, function (): ?NodeElement {
+        $validationElement = $this->getDocument()->waitFor(3, function (): NodeElement {
             try {
                 $validationElement = $this->getElement('login_validation_error');
             } catch (ElementNotFoundException) {
@@ -87,8 +87,9 @@ class AddressPage extends ShopPage implements AddressPageInterface
 
     public function checkValidationMessageFor(string $element, string $message): bool
     {
-        $foundElement = $this->getFieldElement($element);
-        if (null === $foundElement) {
+        try {
+            $foundElement = $this->getFieldElement($element);
+        } catch(ElementNotFoundException) {
             throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
@@ -371,9 +372,9 @@ class AddressPage extends ShopPage implements AddressPageInterface
         }
     }
 
-    protected function getFieldElement(string $element): ?NodeElement
+    protected function getFieldElement(string $element, array $parameters = []): NodeElement
     {
-        $element = $this->getElement($element);
+        $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {
             $element = $element->getParent();
         }

--- a/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
@@ -30,7 +30,7 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private TableAccessorInterface $tableAccessor,
+        protected TableAccessorInterface $tableAccessor,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -278,7 +278,7 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
         ]);
     }
 
-    private function isAddressValid(string $displayedAddress, AddressInterface $address): bool
+    protected function isAddressValid(string $displayedAddress, AddressInterface $address): bool
     {
         return
             $this->hasAddressPart($displayedAddress, $address->getCompany(), true) &&
@@ -293,7 +293,7 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
         ;
     }
 
-    private function hasAddressPart(string $address, ?string $addressPart, bool $optional = false): bool
+    protected function hasAddressPart(string $address, ?string $addressPart, bool $optional = false): bool
     {
         if ($optional && null === $addressPart) {
             return true;
@@ -302,24 +302,24 @@ class CompletePage extends SymfonyPage implements CompletePageInterface
         return str_contains($address, $addressPart);
     }
 
-    private function getCountryName(string $countryCode): string
+    protected function getCountryName(string $countryCode): string
     {
         return strtoupper(Countries::getName($countryCode, 'en'));
     }
 
-    private function getPriceFromString(string $price): int
+    protected function getPriceFromString(string $price): int
     {
         return (int) round((float) str_replace(['€', '£', '$'], '', $price) * 100, 2);
     }
 
-    private function getTotalFromString(string $total): int
+    protected function getTotalFromString(string $total): int
     {
         $total = str_replace('Total:', '', $total);
 
         return $this->getPriceFromString($total);
     }
 
-    private function getBaseTotalFromString(string $total): int
+    protected function getBaseTotalFromString(string $total): int
     {
         $total = str_replace('Total in base currency:', '', $total);
 

--- a/src/Sylius/Behat/Page/Shop/HomePage.php
+++ b/src/Sylius/Behat/Page/Shop/HomePage.php
@@ -113,7 +113,7 @@ class HomePage extends SymfonyPage implements HomePageInterface
         ]);
     }
 
-    private function getProductsNames(string $elementName): array
+    protected function getProductsNames(string $elementName): array
     {
         return array_map(
             fn (NodeElement $element) => $element->getText(),

--- a/src/Sylius/Behat/Page/Shop/Page.php
+++ b/src/Sylius/Behat/Page/Shop/Page.php
@@ -53,7 +53,7 @@ abstract class Page extends SymfonyPage implements PageInterface
      *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element, array $parameters): NodeElement
+    protected function getFieldElement(string $element, array $parameters): NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -30,7 +30,7 @@ class ShowPage extends ShopPage implements ShowPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private readonly SummaryPageInterface $summaryPage,
+        protected readonly SummaryPageInterface $summaryPage,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -382,7 +382,7 @@ class ShowPage extends ShopPage implements ShowPageInterface
         ]);
     }
 
-    private function waitForElementToBeReady(): void
+    protected function waitForElementToBeReady(): void
     {
         if (DriverHelper::isJavascript($this->getDriver())) {
             $this->getDocument()->waitFor(1, fn (): bool => $this->summaryPage->isOpen());
@@ -399,7 +399,7 @@ class ShowPage extends ShopPage implements ShowPageInterface
      *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement(string $element, array $parameters): NodeElement
+    protected function getFieldElement(string $element, array $parameters): NodeElement
     {
         $element = $this->getElement($element, $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Shop/ProductReview/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/ProductReview/CreatePage.php
@@ -85,7 +85,7 @@ class CreatePage extends Page implements CreatePageInterface
         ]);
     }
 
-    private function getValidationMessageFor(string $element): string
+    protected function getValidationMessageFor(string $element): string
     {
         $errorElement = $this->getElement($element)->getParent()->find('css', '[data-test-validation-error]');
         Assert::notNull($errorElement);

--- a/src/Sylius/Behat/Page/TestPlugin/MainPage.php
+++ b/src/Sylius/Behat/Page/TestPlugin/MainPage.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Page\TestPlugin;
 
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
-final class MainPage extends SymfonyPage implements MainPageInterface
+class MainPage extends SymfonyPage implements MainPageInterface
 {
     public function getContent(): string
     {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved component flexibility by relaxing restrictions on class extension across multiple classes. These under-the-hood changes maintain existing functionality while paving the way for enhanced customizability and future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->