### PR TITLE
[Maintenance] Fix invalid default address component prop config

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
@@ -82,6 +82,6 @@ sylius_twig_hooks:
             set_default:
                 component: 'sylius_shop:account:address:default_form'
                 props:
-                    customer: '@=_context.customer'
+                    resource: '@=_context.customer'
                     template: '@SyliusShop/account/address_book/set_as_default.html.twig'
                 priority: 0


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | -
| License         | MIT

There is no `customer` prop in the component.