### PR TITLE
[UI] Refix invalid key setting on adding a collection item

### DIFF
--- a/features/admin/product/managing_product_attributes/adding_select_product_attribute.feature
+++ b/features/admin/product/managing_product_attributes/adding_select_product_attribute.feature
@@ -29,6 +29,8 @@ Feature: Adding a new select product attribute
         And I add it
         Then I should be notified that it has been successfully created
         And the select attribute "Mug material" should appear in the store
+        And the "Mug material" product attribute should have value "Banana Skin"
+        And the "Mug material" product attribute should also have value "Plastic"
 
     @no-api @ui
     Scenario: Seeing disabled type field while adding a select product attribute

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAttributesContext.php
@@ -370,6 +370,7 @@ final readonly class ManagingProductAttributesContext implements Context
 
     /**
      * @Then /^(this product attribute) should have value "([^"]+)"$/
+     * @Then /^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/
      */
     public function thisProductAttributeShouldHaveValue(
         ProductAttributeInterface $productAttribute,

--- a/src/Sylius/Behat/Context/Transform/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductAttributeContext.php
@@ -28,6 +28,7 @@ final class ProductAttributeContext implements Context
     /**
      * @Transform :attribute
      * @Transform :productAttribute
+     * @Transform /^"([^"]+)" product attribute$/
      */
     public function getProductAttributeByName(string $name): ProductAttributeInterface
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -366,6 +366,7 @@ final readonly class ManagingProductAttributesContext implements Context
 
     /**
      * @Then /^(this product attribute) should have value "([^"]*)"/
+     * @Then /^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/
      */
     public function theSelectAttributeShouldHaveValue(ProductAttributeInterface $productAttribute, string $value): void
     {

--- a/src/Sylius/Behat/Resources/config/suites/api/product/managing_product_attributes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/product/managing_product_attributes.yml
@@ -8,6 +8,7 @@ default:
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.locale
+                - sylius.behat.context.transform.product_attribute
                 - sylius.behat.context.transform.shared_storage
 
                 - sylius.behat.context.setup.admin_api_security

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
@@ -10,6 +10,7 @@ default:
 
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.locale
+                - sylius.behat.context.transform.product_attribute
                 - sylius.behat.context.transform.shared_storage
 
                 - sylius.behat.context.setup.locale

--- a/src/Sylius/Bundle/UiBundle/Twig/Component/LiveCollectionTrait.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/Component/LiveCollectionTrait.php
@@ -39,7 +39,7 @@ trait LiveCollectionTrait
             $data = [];
         }
 
-        $index = [] !== $data ? max(array_keys($data)) + 1 : 0;
+        $index = $this->provideNewCollectionItemIndex($data);
         $propertyAccessor->setValue(
             $this->formValues,
             sprintf('%s[%s]', $propertyPath, $index),
@@ -61,7 +61,7 @@ trait LiveCollectionTrait
         $propertyAccessor->setValue($this->formValues, $propertyPath, $data);
     }
 
-    private function fieldNameToPropertyPath(string $collectionFieldName, string $rootFormName): string
+    protected function fieldNameToPropertyPath(string $collectionFieldName, string $rootFormName): string
     {
         $propertyPath = $collectionFieldName;
 
@@ -74,5 +74,25 @@ trait LiveCollectionTrait
         }
 
         return $propertyPath;
+    }
+
+    /** @param array<int|string, mixed> $data */
+    protected function provideNewCollectionItemIndex(array $data): int
+    {
+        if ([] === $data) {
+            return 0;
+        }
+
+        $keys = array_keys($data);
+        $numericKeys = array_filter($keys, 'is_numeric');
+        if ([] === $numericKeys) {
+            return 0;
+        }
+
+        if (count($keys) === count($numericKeys)) {
+            return max($keys) + 1;
+        }
+
+        return max($numericKeys) + 1;
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17713, related #17685
| License         | MIT

The fix for collection items being substituted when removing an item from anywhere but the end of the collection and adding a new item has inadvertently caused a different bug to prop up, breaking the adding of multiple select product attributes due to their collection keys not being comparable.

Curiously, we have an UI test for this exact case, but it seems to just ignore the exception popup and continue with other steps; Updated to check the saved values so we can be sure of the outcome.