### PR TITLE
[Shop] Order button hook refactor

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/order/show.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/order/show.yaml
@@ -37,3 +37,8 @@ sylius_twig_hooks:
             currency:
                 template: "@SyliusShop/account/order/show/content/main/header/details/currency.html.twig"
                 priority: 0
+                
+        'sylius_shop.account.order.show.content.main.header.buttons':
+            pay_button:
+                template: "@SyliusShop/account/order/show/content/main/header/buttons/pay_button.html.twig"
+                priority: 0

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/order/show.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/order/show.yaml
@@ -39,6 +39,6 @@ sylius_twig_hooks:
                 priority: 0
                 
         'sylius_shop.account.order.show.content.main.header.buttons':
-            pay_button:
-                template: "@SyliusShop/account/order/show/content/main/header/buttons/pay_button.html.twig"
+            pay:
+                template: "@SyliusShop/account/order/show/content/main/header/buttons/pay.html.twig"
                 priority: 0

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
@@ -1,9 +1,6 @@
 {% set order = hookable_metadata.context.order %}
 
-{% if order.paymentState == 'awaiting_payment' %}
-    {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+<div class="d-flex flex-wrap gap-3 justify-content-end mb-3">
+    {% hook 'buttons' %}
+</div>
 
-    <div class="d-flex gap-3 justify-content-end mb-3">
-        {{ buttons.primary(path('sylius_shop_order_show', {'tokenValue': order.tokenValue}), 'sylius.ui.pay', null, 'tabler:credit-card', 'green') }}
-    </div>
-{% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
@@ -1,5 +1,3 @@
-{% set order = hookable_metadata.context.order %}
-
 <div class="d-flex flex-wrap gap-3 justify-content-end mb-3">
     {% hook 'buttons' %}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay.html.twig
@@ -2,6 +2,6 @@
 
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{% if order.paymentState == 'awaiting_payment' %}
+{% if order.paymentState == constant('Sylius\\Component\\Core\\OrderPaymentStates::STATE_AWAITING_PAYMENT') %}
     {{ buttons.primary(path('sylius_shop_order_show', {'tokenValue': order.tokenValue}), 'sylius.ui.pay', null, 'tabler:credit-card', 'green') }}
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay_button.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay_button.html.twig
@@ -1,0 +1,7 @@
+{% set order = hookable_metadata.context.order %}
+
+{% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
+
+{% if order.paymentState == 'awaiting_payment' %}
+    {{ buttons.primary(path('sylius_shop_order_show', {'tokenValue': order.tokenValue}), 'sylius.ui.pay', null, 'tabler:credit-card', 'green') }}
+{% endif %}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1cfd6400-2375-4692-971d-c0821642c065)

After analyzing the container and button placement, I've confirmed that the container supports up to 3 buttons, which are aligned to the flex-end position by default.

Below screenshots illustrating the layout across various window sizes:
 
 **Max 3 buttons**
![sfdfsdfsdfds](https://github.com/user-attachments/assets/d7844dac-14ac-49c5-b016-f57ae09ab14d)
![gfzvxcv](https://github.com/user-attachments/assets/d80d0973-486d-4f7f-85b0-79437490229b)
![fsfsdvcvxvxvc](https://github.com/user-attachments/assets/10326270-07e9-470b-a7f6-eb6800d35ad7)

When adding **more than 3** hooks with buttons, we need to introduce flex-wrap to ensure buttons wrap correctly to the next line, as currently they overlap with the "YourAccount" column. Additionally, we should reconsider the justify-content: flex-end alignment, as it results in awkward spacing and excessive empty space, especially noticeable at smaller window sizes.


**More than 3 buttons**
![1](https://github.com/user-attachments/assets/99e63aec-72d4-43ee-ae18-72cc83861437)
![3](https://github.com/user-attachments/assets/60824c63-a901-4819-b504-78d84398f3b1)
![4](https://github.com/user-attachments/assets/5234e7f6-7b48-4533-bf77-46825057d9d7)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a payment button on the order details page to facilitate pending payments.
- **Refactor**
  - Streamlined the button display in the order header, ensuring the payment option appears when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->