### PR TITLE
[API] Add get taxon by slug

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/GetTaxonBySlugAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/GetTaxonBySlugAction.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Controller;
+
+use ApiPlatform\Metadata\IriConverterInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final readonly class GetTaxonBySlugAction
+{
+    public function __construct(
+        private LocaleContextInterface $localeContext,
+        private TaxonRepositoryInterface $taxonRepository,
+        private IriConverterInterface $iriConverter,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function __invoke(string $slug): RedirectResponse
+    {
+        $locale = $this->localeContext->getLocaleCode();
+
+        $taxon = $this->taxonRepository->findOneBySlug($slug, $locale);
+
+        if (null === $taxon) {
+            throw new NotFoundHttpException('Not Found');
+        }
+
+        $iri = $this->iriConverter->getIriFromResource($taxon);
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        $requestQuery = $request->getQueryString();
+        if (null !== $requestQuery) {
+            $iri .= sprintf('?%s', $requestQuery);
+        }
+
+        return new RedirectResponse($iri, Response::HTTP_MOVED_PERMANENTLY);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Taxon.xml
@@ -41,6 +41,30 @@
                     </values>
                 </normalizationContext>
             </operation>
+
+            <operation
+                name="sylius_api_shop_taxon_get_by_slug"
+                class="ApiPlatform\Metadata\Get"
+                uriTemplate="/shop/taxons-by-slug/{slug}"
+                controller="sylius_api.controller.get_taxon_by_slug"
+                read="false"
+            >
+                <requirements>
+                    <requirement property="slug">.+</requirement>
+                </requirements>
+                <uriVariables>
+                    <uriVariable parameterName="slug" fromClass="%sylius.model.taxon.class%" />
+                </uriVariables>
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:shop:taxon:show</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+            </operation>
         </operations>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/controllers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/controllers.xml
@@ -52,5 +52,12 @@
             <argument type="service" id="validator" />
             <argument>%sylius_core.orders_statistics.intervals_map%</argument>
         </service>
+
+        <service id="sylius_api.controller.get_taxon_by_slug" class="Sylius\Bundle\ApiBundle\Controller\GetTaxonBySlugAction">
+            <argument type="service" id="sylius.context.locale" />
+            <argument type="service" id="sylius.repository.taxon" />
+            <argument type="service" id="api_platform.symfony.iri_converter" />
+            <argument type="service" id="request_stack" />
+        </service>
     </services>
 </container>

--- a/tests/Api/Shop/TaxonsTest.php
+++ b/tests/Api/Shop/TaxonsTest.php
@@ -62,4 +62,20 @@ final class TaxonsTest extends JsonApiTestCase
 
         $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
+
+    /** @test */
+    public function it_preserves_query_param_when_redirecting_from_taxon_slug_to_taxon_code(): void
+    {
+        $this->loadFixturesFromFile('taxonomy.yaml');
+
+        $this->client->request(
+            method: 'GET',
+            uri: '/api/v2/shop/taxons-by-slug/categories/t-shirts?paramName=paramValue',
+            server: self::CONTENT_TYPE_HEADER,
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertEquals('/api/v2/shop/taxons/T_SHIRTS?paramName=paramValue', $response->headers->get(('Location')));
+        $this->assertResponseCode($response, Response::HTTP_MOVED_PERMANENTLY);
+    }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.13 branch
 - Features and deprecations must be submitted against the 1.14 branch
 - Features, removing deprecations and BC breaks must be submitted against the 2.0 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

For headless implementations I needed to allow the client to search for a Taxon through its slug since there were indexed pages that represented them.

Since this endpoint is not provided, I took inspiration from what has already been implemented for the Product to replicate it.

In the endpoint definition I had to add a requirement to allow sending slugs that contain slashes since they are of a lower level in the tree. More information here https://github.com/api-platform/core/issues/2953#issuecomment-515425149

So the new endpoint available is

```bash
curl -X 'GET' \
  'http://localhost/api/v2/shop/taxons-by-slug/categories%2Ft-shirts' \
  -H 'accept: application/ld+json' \
  -H 'Accept-Language: en_US'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint that retrieves taxon information using a slug. Requests to this endpoint now redirect permanently to the correct taxon URL while automatically preserving any query parameters provided. This enhancement improves the navigation and retrieval of taxon details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->