### PR TITLE
[API] Add conflict with api-platform/jsonld 4.1.1

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -1,0 +1,9 @@
+# CONFLICTS
+
+This document explains why certain conflicts were added to `composer.json` and
+references related issues.
+
+- `api-platform/jsonld: 4.1.1`
+
+  API Platform introduced changes in version 4.1.1 that modify API responses, potentially breaking compatibility with our current implementation.  
+  To ensure stable behavior, we have added this conflict until we can verify and adapt to the changes.

--- a/composer.json
+++ b/composer.json
@@ -241,6 +241,9 @@
         "winzou/state-machine": "If you want to use Winzou State Machine (^0.4)",
         "winzou/state-machine-bundle": "If you want to use Winzou State Machine (^0.6)"
     },
+    "conflict": {
+        "api-platform/jsonld": "4.1.1"
+    },
     "config": {
         "preferred-install": {
             "*": "dist"

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -47,6 +47,9 @@
         "symfony/webpack-encore-bundle": "^2.2",
         "theofidry/alice-data-fixtures": "^1.7"
     },
+    "conflict": {
+        "api-platform/jsonld": "4.1.1"
+    },
     "config": {
         "allow-plugins": {
             "symfony/flex": true


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Added conflict with `api-platform/jsonld: 4.1.1`. APIP has added BC in patch version: https://github.com/api-platform/core/pull/7021 