### PR TITLE
Missing configurationFormType to AsAttributeType

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Attribute/AsAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Attribute/AsAttributeType.php
@@ -23,6 +23,7 @@ final class AsAttributeType
         private string $label,
         private string $formType,
         private int $priority = 0,
+        private ?string $configurationFormType = null,
     ) {
     }
 
@@ -44,5 +45,10 @@ final class AsAttributeType
     public function getPriority(): int
     {
         return $this->priority;
+    }
+
+    public function getConfigurationFormType(): ?string
+    {
+        return $this->configurationFormType;
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
+++ b/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
@@ -59,6 +59,7 @@ final class SyliusAttributeExtension extends AbstractResourceExtension
                     'label' => $attribute->getLabel(),
                     'form_type' => $attribute->getFormType(),
                     'priority' => $attribute->getPriority(),
+                    'configuration_form_type' => $attribute->getConfigurationFormType(),
                 ]);
             },
         );

--- a/src/Sylius/Bundle/AttributeBundle/Tests/DependencyInjection/SyliusAttributeExtensionTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/Tests/DependencyInjection/SyliusAttributeExtensionTest.php
@@ -42,6 +42,42 @@ final class SyliusAttributeExtensionTest extends AbstractExtensionTestCase
                 'label' => 'Test',
                 'form_type' => 'SomeFormType',
                 'priority' => 15,
+                'configuration_form_type' => null,
+            ],
+        );
+    }
+
+    /** @test */
+    public function it_autoconfigures_attribute_type_with_attribute_configuration(): void
+    {
+        $this->container->setDefinition(
+            'acme.attribute_type_with_attribute_configuration',
+            (new Definition())
+                ->setClass(AttributeTypeStub::class)
+                ->setAutoconfigured(false)
+                ->setTags(['sylius.attribute.type' => [
+                    [
+                        'attribute_type' => 'test',
+                        'label' => 'Test',
+                        'form_type' => 'SomeFormType',
+                        'priority' => 15,
+                        'configuration_form_type' => 'SomeConfigurationFormType',
+                    ]
+                ]])
+        );
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.attribute_type_with_attribute_configuration',
+            AsAttributeType::SERVICE_TAG,
+            [
+                'attribute_type' => 'test',
+                'label' => 'Test',
+                'form_type' => 'SomeFormType',
+                'priority' => 15,
+                'configuration_form_type' => 'SomeConfigurationFormType',
             ],
         );
     }


### PR DESCRIPTION
The AttributeType service has a configuration_form_type entry but the PHP AsAttributeType attribute does not.

| Q               | A
|-----------------|-----
| Branch?         | 1.14, 2.0, 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

------------

Trying to create custom attribute type I get an error trying to use AsAttributeType because it missing the configurationFormType property as the service yaml or xml declaration.

**Working**
```yaml
services:
    App\Attribute\AttributeType\EntityAttributeType:
        tags:
            - { name: sylius.attribute.type, attribute_type: entity, label: 'Entity', form_type: 'App\Form\Type\AttributeType\EntityAttributeType', configuration_form_type: 'App\Form\Type\AttributeType\Configuration\EntityAttributeConfigurationType' }
```

**Error**
```php
<?php

declare(strict_types=1);

namespace App\Attribute\AttributeType;

use App\Form\Type\AttributeType\Configuration\EntityAttributeConfigurationType;
use Sylius\Bundle\AttributeBundle\Attribute\AsAttributeType;
use Sylius\Component\Attribute\AttributeType\AttributeTypeInterface;
use Sylius\Component\Attribute\Model\AttributeValueInterface;
use Symfony\Component\Validator\Context\ExecutionContextInterface;

#[AsAttributeType(
    type: 'entity',
    label: 'Entity',
    formType: \App\Form\Type\AttributeType\EntityAttributeType::class,
    configurationFormType: EntityAttributeConfigurationType::class // Unknown named parameter 'configurationFormType'
)]
final class EntityAttributeType implements AttributeTypeInterface
{
    public const string TYPE = 'entity';

    public function getStorageType(): string
    {
        return AttributeValueInterface::STORAGE_JSON;
    }

    public function getType(): string
    {
        return self::TYPE;
    }

    public function getValue(AttributeValueInterface $attributeValue)
    {
        // Implement logic to fetch values
    }

    public function validate(AttributeValueInterface $attributeValue, ExecutionContextInterface $context, array $configuration): void
    {
        // Implement validate() method.
    }
}

```