### PR TITLE
[Behat][UI] Introduce common `SaveContext` for more flexible suite configuration management

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,3 +1,25 @@
+# UPGRADE FROM `2.0.5` TO `2.0.6`
+
+### Behat
+
+1. The context classes have been refactored. All `UI` occurrences of the following step definitions have been removed:
+
+- `@When I save my changes`
+- `@When I try to save my changes`
+
+These have been replaced by the new common context class: `Sylius\Behat\Context\Ui\SaveContext`
+identified by the id `sylius.behat.context.ui.save`.
+
+If you use any of the removed methods, please update your suite configuration to include the new context class:
+```
+your_behat_profile:
+    suites:
+        your_suite_name:
+            contexts:
+                - ...
++               - sylius.behat.context.ui.save
+```
+
 # UPGRADE FROM `2.0.2` TO `2.0.3`
 
 1. New `left` and `right` sections have been added to the following Twig hooks to improve customization:

--- a/features/admin/product/managing_product_reviews/recalculating_product_average_rating.feature
+++ b/features/admin/product/managing_product_reviews/recalculating_product_average_rating.feature
@@ -11,7 +11,7 @@ Feature: Recalculating product average rating
         And this product has a review titled "Not bad" and rated 3 with a comment "Not bad car" added by customer "specter@teamharvey.com"
         And I am logged in as an administrator
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Product's average rating is correctly recalculated after review's rate change
         When I want to modify the "Awesome" product review
         And I choose 5 as its rating

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -484,14 +484,6 @@ final readonly class ManagingProductsContext implements Context
     }
 
     /**
-     * @When I save my changes to the images
-     */
-    public function iSaveMyChangesToTheImages(): void
-    {
-        // Intentionally left blank
-    }
-
-    /**
      * @When I filter
      */
     public function iFilter(): void

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -363,14 +363,6 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::null($product->getMainTaxon());
     }
 
-    /**
-     * @When I save my changes to the images
-     */
-    public function iSaveMyChangesToTheImages(): void
-    {
-        // Intentionally left blank
-    }
-
     private function updateTranslations(string $localeCode, string $field, ?string $value = null): void
     {
         $data['translations'][$localeCode] = [];

--- a/src/Sylius/Behat/Context/Api/Common/SaveContext.php
+++ b/src/Sylius/Behat/Context/Api/Common/SaveContext.php
@@ -14,20 +14,25 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Common;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 
-final class SaveContext implements Context
+final readonly class SaveContext implements Context
 {
     public function __construct(private ApiClientInterface $client)
     {
     }
 
-    /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
+    #[When('I save my changes')]
+    #[When('I try to save my changes')]
     public function iSaveMyChanges(): void
     {
         $this->client->update();
+    }
+
+    #[When('I save my changes to the images')]
+    public function iSaveMyChangesToTheImages(): void
+    {
+        // Intentionally left blank
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
@@ -149,14 +149,6 @@ final class ManagingAdministratorsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I delete administrator with email :email
      */
     public function iDeleteAdministratorWithEmail($email)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -356,14 +356,6 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I remove its last scope
      */
     public function iRemoveItsLastScope(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -355,16 +355,6 @@ final class ManagingChannelsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     * @When I save it
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then I should be notified that channel with this code already exists
      */
     public function iShouldBeNotifiedThatChannelWithThisCodeAlreadyExists(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -105,15 +105,6 @@ final class ManagingCountriesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then /^the (country "([^"]+)") should appear in the store$/
      */
     public function countryShouldAppearInTheStore(CountryInterface $country)
@@ -277,7 +268,7 @@ final class ManagingCountriesContext implements Context
     public function iRemoveProvinceName(string $provinceName): void
     {
         $this->updatePage->removeProvinceName($provinceName);
-        $this->iSaveMyChanges();
+        $this->updatePage->saveChanges();
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
@@ -83,15 +83,6 @@ final readonly class ManagingCustomerGroupsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I check (also) the :customerGroupName customer group
      */
     public function iCheckTheCustomerGroup(string $customerGroupName): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -169,15 +169,6 @@ final class ManagingCustomersContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then /^(this customer) with name "([^"]*)" should appear in the store$/
      */
     public function theCustomerWithNameShouldAppearInTheRegistry(CustomerInterface $customer, $name)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
@@ -101,14 +101,6 @@ final readonly class ManagingExchangeRatesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I delete the exchange rate between :sourceCurrencyName and :targetCurrencyName
      */
     public function iDeleteTheExchangeRateBetweenAnd(string $sourceCurrencyName, string $targetCurrencyName): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -806,15 +806,6 @@ final readonly class ManagingOrdersContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When /^I specify their (?:|new )shipping (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
      */
     public function iSpecifyTheirShippingAddressAsFor(AddressInterface $address): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -95,15 +95,6 @@ final readonly class ManagingPaymentMethodsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I delete the :paymentMethod payment method
      * @When I try to delete the :paymentMethod payment method
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
@@ -104,15 +104,6 @@ final readonly class ManagingProductAssociationTypesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I delete the :productAssociationType product association type
      */
     public function iDeleteTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -165,15 +165,6 @@ final readonly class ManagingProductAttributesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then I should not be able to edit its code
      */
     public function iShouldNotBeAbleToEditItsCode(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -79,15 +79,6 @@ final readonly class ManagingProductOptionsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I name it :name in :language
      */
     public function iNameItInLanguage($name, $language): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
@@ -125,15 +125,6 @@ final class ManagingProductReviewsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I choose :rating as its rating
      */
     public function iChooseAsItsRating(string $rating): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -293,15 +293,6 @@ final class ManagingProductVariantsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I generate it
      * @When I try to generate it
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -594,18 +594,6 @@ final readonly class ManagingProductsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     * @When I save my changes to the images
-     */
-    public function iSaveMyChanges(): void
-    {
-        $currentPage = $this->resolveCurrentPage();
-
-        $currentPage->saveChanges();
-    }
-
-    /**
      * @When I cancel my changes
      */
     public function iCancelChanges(): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -206,14 +206,6 @@ final class ManagingPromotionCouponsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I generate it
      * @When I generate these coupons
      * @When I try to generate it

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -554,15 +554,6 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When /^I delete a ("([^"]+)" promotion)$/
      * @When /^I try to delete a ("([^"]+)" promotion)$/
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
@@ -166,14 +166,6 @@ class ManagingShippingCategoriesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I check (also) the :shippingCategoryName shipping category
      */
     public function iCheckTheShippingCategory(string $shippingCategoryName): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -239,15 +239,6 @@ final readonly class ManagingShippingMethodsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then /^I should be notified that (code) is required$/
      */
     public function iShouldBeNotifiedThatCodeIsRequired(string $field): void

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
@@ -94,15 +94,6 @@ final readonly class ManagingTaxCategoriesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Given I am browsing tax categories
      * @When I browse tax categories
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -206,15 +206,6 @@ final class ManagingTaxRateContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges()
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @Then /^(this tax rate) name should be "([^"]+)"$/
      * @Then /^(this tax rate) should still be named "([^"]+)"$/
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -163,16 +163,6 @@ final readonly class ManagingTaxonsContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     * @When I save my changes to the images
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I attach the :path image with :type type
      * @When I attach the :path image with :type type to this taxon
      * @When I attach the :path image

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -142,14 +142,6 @@ final class ManagingZonesContext implements Context
     }
 
     /**
-     * @When I save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->updatePage->saveChanges();
-    }
-
-    /**
      * @When I check (also) the :zoneName zone
      */
     public function iCheckTheZone(string $zoneName): void

--- a/src/Sylius/Behat/Context/Ui/SaveContext.php
+++ b/src/Sylius/Behat/Context/Ui/SaveContext.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Ui;
+
+use Behat\Behat\Context\Context;
+use Behat\Step\When;
+use Sylius\Behat\Element\SaveElementInterface;
+
+final readonly class SaveContext implements Context
+{
+    public function __construct(
+        private SaveElementInterface $saveElement,
+    ) {
+    }
+
+    #[When('I save my changes')]
+    #[When('I try to save my changes')]
+    #[When('I save my changes to the images')]
+    public function iSaveMyChanges(): void
+    {
+        $this->saveElement->saveChanges();
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Shop/AccountContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/AccountContext.php
@@ -88,15 +88,6 @@ final readonly class AccountContext implements Context
     }
 
     /**
-     * @When I save my changes
-     * @When I try to save my changes
-     */
-    public function iSaveMyChanges(): void
-    {
-        $this->profileUpdatePage->saveChanges();
-    }
-
-    /**
      * @Then I should be notified that it has been successfully edited
      */
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyEdited(): void

--- a/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
@@ -82,6 +82,7 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
 
         $firstSubform = $this->getFirstImageSubform();
         $firstSubform->find('css', '[data-test-image-delete]')->click();
+        $this->waitForFormUpdate();
     }
 
     public function hasImageWithType(string $type): bool

--- a/src/Sylius/Behat/Element/SaveElement.php
+++ b/src/Sylius/Behat/Element/SaveElement.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element;
+
+use Behat\Mink\Exception\ElementNotFoundException;
+use FriendsOfBehat\PageObjectExtension\Element\Element;
+
+class SaveElement extends Element implements SaveElementInterface
+{
+    public function saveChanges(): void
+    {
+        try {
+            $this->getElement('update_changes_button')->press();
+        } catch (ElementNotFoundException) {
+            // Fallback for elements with different data-test attributes
+            $this->getElement('save_changes_button')->press();
+        }
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'save_changes_button' => '[data-test-button="save-changes"]',
+            'update_changes_button' => '[data-test-update-changes-button]',
+        ]);
+    }
+}

--- a/src/Sylius/Behat/Element/SaveElementInterface.php
+++ b/src/Sylius/Behat/Element/SaveElementInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element;
+
+interface SaveElementInterface
+{
+    public function saveChanges(): void;
+}

--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -15,7 +15,7 @@
     <imports>
         <import resource="services/api.xml" />
         <import resource="services/contexts.xml" />
-        <import resource="services/elements.xml" />
+        <import resource="services/elements/**/*.xml" />
         <import resource="services/pages.xml" />
     </imports>
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -628,5 +628,9 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.behat.shared_security" />
         </service>
+
+        <service id="sylius.behat.context.ui.save" class="Sylius\Behat\Context\Ui\SaveContext">
+            <argument type="service" id="sylius.behat.element.save" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/elements/common.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/common.xml
@@ -22,5 +22,7 @@
         </service>
 
         <service id="sylius.behat.element.browser" class="Sylius\Behat\Element\BrowserElement" parent="sylius.behat.element"/>
+
+        <service id="sylius.behat.element.save" class="Sylius\Behat\Element\SaveElement" parent="sylius.behat.element"/>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/elements/common.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/common.xml
@@ -15,16 +15,12 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
-    <imports>
-        <import resource="elements/**/*.xml" />
-    </imports>
-
     <services>
-        <service id="sylius.behat.element" class="FriendsOfBehat\PageObjectExtension\Element\Element" abstract="true" public="false">
+        <service id="sylius.behat.element" class="FriendsOfBehat\PageObjectExtension\Element\Element" abstract="true">
             <argument type="service" id="behat.mink.default_session" />
             <argument type="service" id="behat.mink.parameters" />
         </service>
 
-        <service id="sylius.behat.element.browser" class="Sylius\Behat\Element\BrowserElement" parent="sylius.behat.element" public="false" />
+        <service id="sylius.behat.element.browser" class="Sylius\Behat\Element\BrowserElement" parent="sylius.behat.element"/>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.setup.shop_security
                 - sylius.behat.context.setup.user
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.address_book
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
@@ -37,6 +37,7 @@ default:
                 - sylius.behat.context.ui.browser
                 - sylius.behat.context.ui.channel
                 - sylius.behat.context.ui.email
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.account
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
@@ -19,6 +19,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_countries
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_countries&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_zones.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_zones.yml
@@ -22,6 +22,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_zones
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_zones&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
@@ -32,6 +32,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_products
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.browser
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@admin_dashboard&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/impersonating_customers.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/impersonating_customers.yml
@@ -25,6 +25,7 @@ default:
 
                 - sylius.behat.context.ui.admin.impersonating_customers
                 - sylius.behat.context.ui.admin.managing_customers
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.complete

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/locale.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/locale.yml
@@ -23,6 +23,7 @@ default:
                 - sylius.behat.context.ui.admin.login
                 - sylius.behat.context.ui.admin.managing_administrators
                 - sylius.behat.context.ui.channel
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.locale
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
@@ -21,6 +21,7 @@ default:
 
                 - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_products
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.browsing_product
                 - Sylius\Behat\Context\Ui\Admin\ProductCreationContext
                 - Sylius\Behat\Context\Ui\Admin\RemovingProductContext

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/security.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/security.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.ui.admin.login
                 - sylius.behat.context.ui.admin.managing_administrators
                 - sylius.behat.context.ui.email
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@administrator_security&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
@@ -26,6 +26,7 @@ default:
 
                 - sylius.behat.context.ui.browser
                 - sylius.behat.context.ui.channel
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout.addressing
                 - sylius.behat.context.ui.shop.checkout.complete

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -34,6 +34,7 @@ default:
 
                 - sylius.behat.context.ui.browser
                 - sylius.behat.context.ui.channel
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.currency
                 - sylius.behat.context.ui.shop.product

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
@@ -30,6 +30,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_channels
                 - sylius.behat.context.ui.admin.managing_channels_billing_data
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_channels&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
@@ -53,6 +53,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_orders
                 - sylius.behat.context.ui.channel
                 - sylius.behat.context.ui.email
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.address_book
                 - sylius.behat.context.ui.shop.authorization
                 - sylius.behat.context.ui.shop.cart

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
@@ -40,6 +40,7 @@ default:
                 - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.ui.admin.managing_payment_requests
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.account
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout

--- a/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_exchange_rates.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_exchange_rates.yml
@@ -18,6 +18,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_exchange_rates
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_exchange_rates&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
@@ -28,6 +28,7 @@ default:
 
                 - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_product_variants
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.complete

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/displaying_inventory_on_edit_product_page.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/displaying_inventory_on_edit_product_page.yml
@@ -18,6 +18,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_inventory
                 - sylius.behat.context.ui.admin.managing_products
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@inventory_on_product_page&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
@@ -32,6 +32,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_inventory
                 - sylius.behat.context.ui.admin.managing_product_variants
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_inventory&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -53,6 +53,7 @@ default:
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.channel
                 - sylius.behat.context.ui.email
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/modifying_placed_order_address.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/modifying_placed_order_address.yaml
@@ -43,9 +43,9 @@ default:
                 - sylius.behat.context.setup.user
                 - sylius.behat.context.setup.zone
 
-
                 - sylius.behat.context.ui.admin.managing_orders
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.currency
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/order_history.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/order_history.yml
@@ -29,6 +29,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_orders
                 - sylius.behat.context.ui.admin.order_history
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@order_history&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payment_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payment_methods.yml
@@ -30,6 +30,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_payment_methods
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.locale
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_association_types.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_association_types.yml
@@ -18,6 +18,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_product_association_types
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_product_association_types&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_product_attributes
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_product_attributes&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
@@ -24,6 +24,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_product_options
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_product_options&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_reviews.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_reviews.yml
@@ -22,6 +22,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_product_reviews
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.product
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
@@ -40,6 +40,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_administrator_locale
                 - sylius.behat.context.ui.admin.managing_product_variants
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.browsing_product
                 - Sylius\Behat\Context\Ui\Admin\ChannelPricingLogEntryContext
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
@@ -50,6 +50,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_products
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.browsing_product
                 - Sylius\Behat\Context\Ui\Admin\ManagingProductTaxonsContext
                 - Sylius\Behat\Context\Ui\Admin\RemovingProductContext

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history.yaml
@@ -21,6 +21,7 @@ default:
                 - Sylius\Behat\Context\Setup\CatalogPromotionContext
 
                 - sylius.behat.context.ui.admin.managing_product_variants
+                - sylius.behat.context.ui.save
                 - Sylius\Behat\Context\Ui\Admin\ChannelPricingLogEntryContext
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history_after_catalog_promotions.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history_after_catalog_promotions.yaml
@@ -21,6 +21,7 @@ default:
                 - Sylius\Behat\Context\Setup\CatalogPromotionContext
 
                 - sylius.behat.context.ui.admin.product_showpage
+                - sylius.behat.context.ui.save
                 - Sylius\Behat\Context\Ui\Admin\ChannelPricingLogEntryContext
                 - Sylius\Behat\Context\Ui\Admin\ManagingCatalogPromotionsContext
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_in_admin_panel.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_in_admin_panel.yaml
@@ -40,6 +40,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_product_attributes
                 - sylius.behat.context.ui.admin.product_showpage
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.browsing_product
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
@@ -26,6 +26,7 @@ default:
                 - sylius.behat.context.setup.taxonomy
                 - Sylius\Behat\Context\Setup\CatalogPromotionContext
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.product
                 - Sylius\Behat\Context\Ui\Admin\ManagingCatalogPromotionsContext
                 - Sylius\Behat\Context\Ui\Admin\ManagingProductTaxonsContext

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
@@ -30,6 +30,7 @@ default:
                 - sylius.behat.context.setup.shop_security
                 - sylius.behat.context.setup.taxonomy
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
@@ -33,6 +33,7 @@ default:
                 - sylius.behat.context.setup.shop_security
                 - sylius.behat.context.setup.taxonomy
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_catalog_promotions.yml
@@ -26,6 +26,7 @@ default:
 
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.product
                 - Sylius\Behat\Context\Ui\Admin\BrowsingCatalogPromotionProductVariantsContext
                 - Sylius\Behat\Context\Ui\Admin\ManagingCatalogPromotionsContext

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotion_coupons.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotion_coupons.yml
@@ -28,6 +28,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_promotion_coupons
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_promotion_coupons&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
@@ -37,6 +37,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_promotions
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.removing_taxons
+                - sylius.behat.context.ui.save
                 - Sylius\Behat\Context\Ui\Admin\RemovingProductContext
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
@@ -29,6 +29,7 @@ default:
                 - Sylius\Behat\Context\Setup\CatalogPromotionContext
 
                 - sylius.behat.context.ui.channel
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/removing_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/removing_catalog_promotions.yml
@@ -27,6 +27,7 @@ default:
                 - Sylius\Behat\Context\Setup\CatalogPromotionContext
 
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.product
                 - Sylius\Behat\Context\Ui\Admin\ManagingCatalogPromotionsContext
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
@@ -27,6 +27,7 @@ default:
                 - sylius.behat.context.setup.taxation
                 - sylius.behat.context.setup.zone
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
@@ -29,6 +29,7 @@ default:
                 - sylius.behat.context.setup.taxation
                 - sylius.behat.context.setup.zone
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_categories.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_categories.yml
@@ -15,9 +15,9 @@ default:
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.shipping_category
 
-
                 - sylius.behat.context.ui.admin.managing_shipping_categories
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_shipping_categories&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_methods.yml
@@ -34,6 +34,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_administrator_locale
                 - sylius.behat.context.ui.admin.managing_shipping_methods
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_shipping_methods&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -33,6 +33,7 @@ default:
                 - sylius.behat.context.setup.user
                 - sylius.behat.context.setup.zone
 
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout
                 - sylius.behat.context.ui.shop.checkout.addressing

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_categories.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_categories.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_tax_categories
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_tax_categories&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_rates.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_rates.yml
@@ -20,6 +20,7 @@ default:
 
                 - sylius.behat.context.ui.admin.managing_tax_rate
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_tax_rates&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
@@ -24,6 +24,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_taxons
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.removing_taxons
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_taxons&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/customer_statistics.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/customer_statistics.yml
@@ -22,6 +22,7 @@ default:
                 - sylius.behat.context.setup.user
 
                 - sylius.behat.context.ui.admin.managing_customers
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@customer_statistics&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_administrators.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_administrators.yml
@@ -22,6 +22,7 @@ default:
                 - sylius.behat.context.ui.admin.login
                 - sylius.behat.context.ui.admin.managing_administrators
                 - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_administrators&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customer_groups.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customer_groups.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_customer_groups
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
 
             filters:
                 tags: "@managing_customer_groups&&@ui"

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
@@ -35,6 +35,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_customers
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.admin.search_filter
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.login
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_users.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_users.yml
@@ -18,6 +18,7 @@ default:
                 - sylius.behat.context.ui.admin.managing_customers
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.customer
+                - sylius.behat.context.ui.save
                 - sylius.behat.context.ui.shop.login
                 - sylius.behat.context.ui.user
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Continuation of https://github.com/Sylius/Sylius/pull/17782

This proposal is motivated by the issue in Behat when suite configuration includes contexts that define the same method.
In brief, this decoupling provides more flexibility in managing suite configurations.