### PR TITLE
[Behat] Decouple cart setup from interaction – `Given I added` vs `When I add`

### DIFF
--- a/features/admin/order/managing_orders/browsing_orders/seeing_orders_with_different_currency_on_index.feature
+++ b/features/admin/order/managing_orders/browsing_orders/seeing_orders_with_different_currency_on_index.feature
@@ -17,24 +17,24 @@ Feature: Seeing orders' total in their currency
         And there is a customer account "customer@example.com" identified by "sylius"
         And I am logged in as "customer@example.com"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: List of orders from only one channel
         Given I changed my current channel to "United States"
-        And I have product "Angel T-Shirt" in the cart
-        And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
+        And I added product "Angel T-Shirt" to the cart
+        And I addressed the cart
         And I proceed with "Free" shipping method and "Offline" payment
-        And I confirm my order
+        When I confirm my order
         Then the administrator should see the order with total "$20.00" in order list
 
-    @api @ui @javascript
+    @api @ui
     Scenario: List of orders from different channels
         Given I changed my current channel to "United States"
-        And I have product "Angel T-Shirt" in the cart
-        And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
-        And I proceed with "Free" shipping method and "Offline" payment
+        And I added product "Angel T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         And I changed my current channel to "Great Britain"
-        And I had product "Angel T-Shirt" in the cart
+        And I have product "Angel T-Shirt" in the cart
         And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
         And I proceed with "Free" shipping method and "Offline" payment
         When I confirm my order

--- a/features/admin/order/managing_orders/order_details/being_unable_to_see_cart.feature
+++ b/features/admin/order/managing_orders/order_details/being_unable_to_see_cart.feature
@@ -10,7 +10,7 @@ Feature: Being unable to see details of a cart
         And the customer added "PHP T-Shirt" product to the cart
         And I am logged in as an administrator
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Being unable to see the details of a cart
         When I try to view the summary of the customer's latest cart
         Then I should be informed that the order does not exist

--- a/features/hybrid/checkout/leaving_notes_on_order_during_checkout.feature
+++ b/features/hybrid/checkout/leaving_notes_on_order_during_checkout.feature
@@ -13,11 +13,11 @@ Feature: Leaving additional request notes on my order during checkout
         And there is a customer account "customer@example.com" identified by "sylius"
         And I am logged in as "customer@example.com"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Adding note on the checkout summary step
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I proceed with "Free" shipping method and "Offline" payment
-        When I provide additional note like "Code to the front gateway is #44*"
+        When I proceed with "Free" shipping method and "Offline" payment
+        And I provide additional note like "Code to the front gateway is #44*"
         And I confirm my order
         Then the administrator should know about this additional note for this order made by "customer@example.com"

--- a/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_a_single_channel_store.feature
+++ b/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_a_single_channel_store.feature
@@ -16,18 +16,18 @@ Feature: Placing an order on a single channel store
         And there is a customer account "customer@example.com" identified by "sylius"
         And I am logged in as "customer@example.com"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Placing an order in a channels base currency
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
         When I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
 
-    @no-api @ui @mink:chromedriver
+    @no-api @ui
     Scenario: Placing an order in a channels base currency displaying prices in other currency
         Given that channel also allows to shop using the "CAD" currency
-        And I had product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I changed my currency to "CAD"
         And I addressed the cart
         When I proceed with "Free" shipping method and "Offline" payment

--- a/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_different_currency.feature
+++ b/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_different_currency.feature
@@ -20,17 +20,17 @@ Feature: Placing an order on multiple channels with different currency
     @api @todo-ui
     Scenario: Placing an order in a channels base currency
         Given I changed my current channel to "United States"
-        And I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
 
     @api @todo-ui
     Scenario: Placing an order on a different channel with same currency
         Given I changed my current channel to "Colombia"
-        And I had product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        When I confirm my order
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Offline" payment
+        And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "COP" currency

--- a/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
+++ b/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
@@ -17,20 +17,20 @@ Feature: Placing an order on multiple channels with same currency
         And there is a customer account "customer@example.com" identified by "sylius"
         And I am logged in as "customer@example.com"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Placing an order in a channels base currency
         Given I changed my current channel to "Web"
-        And I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        When I proceeded with "Free" shipping method and "Offline" payment method
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Placing an order on a different channel with same currency
         Given I changed my current channel to "Mobile"
-        And I had product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        When I confirm my order
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Offline" payment
+        And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency

--- a/features/shop/account/customer_account/address_book/deleting_address_created_after_checkout.feature
+++ b/features/shop/account/customer_account/address_book/deleting_address_created_after_checkout.feature
@@ -15,7 +15,7 @@ Feature: Removing an address from my book
 
     @api @ui @javascript
     Scenario: Deleting address created after placing an order
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
         And my billing address is fulfilled automatically through default address
         When I specify the first and last name as "Mike Ross" for billing address

--- a/features/shop/account/customer_account/address_book/viewing_addresses_created_after_checkout.feature
+++ b/features/shop/account/customer_account/address_book/viewing_addresses_created_after_checkout.feature
@@ -15,7 +15,7 @@ Feature: Viewing addresses created after checkout
 
     @api @ui @javascript
     Scenario: Viewing address created after placing an order
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
         And my billing address is fulfilled automatically through default address
         When I specify the first and last name as "Mike Ross" for billing address

--- a/features/shop/account/customer_account/viewing_orders_history/order_is_always_placed_in_a_base_currency_of_a_channel.feature
+++ b/features/shop/account/customer_account/viewing_orders_history/order_is_always_placed_in_a_base_currency_of_a_channel.feature
@@ -15,13 +15,13 @@ Feature: Order is always placed in a base currency of a channel
         And the store has a product "Angel T-Shirt" priced at "$20.00"
         And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Placing an order with other than base display currency
         Given I changed my currency to "GBP"
-        And I had product "Angel T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "DHL" shipping method and "Cash on Delivery" payment
-        When I confirm my order
+        And I added product "Angel T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "DHL" shipping method and "Cash on Delivery" payment
+        And I confirm my order
         And I am viewing the summary of my last order
         Then I should see "£40.00" as order's total
         And I should see "£20.00" as order's subtotal

--- a/features/shop/cart/shopping_cart/adding_product_to_cart.feature
+++ b/features/shop/cart/shopping_cart/adding_product_to_cart.feature
@@ -45,6 +45,7 @@ Feature: Adding a simple product to the cart
 
     @api @ui @javascript
     Scenario: Increasing quantity of an item in cart by adding the product again
-        Given I have product "T-Shirt banana" in the cart
+        Given I am a logged in customer
+        And I added product "T-Shirt banana" to the cart
         When I add this product to the cart
         Then I should see "T-Shirt banana" with quantity 2 in my cart

--- a/features/shop/cart/shopping_cart/changing_display_currency_of_cart.feature
+++ b/features/shop/cart/shopping_cart/changing_display_currency_of_cart.feature
@@ -16,8 +16,8 @@ Feature: Changing display currency of the cart
 
     @no-api @ui @javascript
     Scenario: Changing the currency of my cart
-        Given I have product "The Pug Mug" in the cart
-        When I switch to the "GBP" currency
+        When I add product "The Pug Mug" to the cart
+        And I switch to the "GBP" currency
         Then my cart total should be "£32.00"
         And total price of "The Pug Mug" item should be "£20.00"
         And my cart taxes should be "£2.00"

--- a/features/shop/cart/shopping_cart/changing_quantity_of_product_in_cart.feature
+++ b/features/shop/cart/shopping_cart/changing_quantity_of_product_in_cart.feature
@@ -1,24 +1,26 @@
 @shopping_cart
 Feature: Changing quantity of a product in cart
     In order to buy chosen quantity of a specific product
-    As a Visitor
+    As a Customer
     I want to be able to change quantity of an item in my cart
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "T-Shirt banana" priced at "$12.54"
-        And I add this product to the cart
+        And I am a logged in customer
 
     @api @ui @javascript
     Scenario: Increasing quantity of an item in cart
-        Given I see the summary of my cart
-        When I change product "T-Shirt banana" quantity to 2 in my cart
+        Given I added product "T-Shirt banana" to the cart
+        When I see the summary of my cart
+        And I change product "T-Shirt banana" quantity to 2 in my cart
         Then I should see "T-Shirt banana" with quantity 2 in my cart
         And my cart items total should be "$25.08"
 
     @api @ui @javascript
     Scenario: Increasing quantity of an item in cart beyond the threshold
-        Given I see the summary of my cart
-        When I change product "T-Shirt banana" quantity to 20000 in my cart
+        Given I added product "T-Shirt banana" to the cart
+        When I see the summary of my cart
+        And I change product "T-Shirt banana" quantity to 20000 in my cart
         Then I should be notified that the quantity of the product "T-Shirt banana" must be between 1 and 9999
         And my cart items total should be "$12.54"

--- a/features/shop/cart/shopping_cart/clearing_cart_after_logging_out.feature
+++ b/features/shop/cart/shopping_cart/clearing_cart_after_logging_out.feature
@@ -11,8 +11,8 @@ Feature: Clearing cart after logging out
     @no-api @ui @mink:chromedriver
     Scenario: Clearing cart after logging out
         Given I am a logged in customer
-        And I have product "Stark T-Shirt" in the cart
-        When I log out
+        When I add product "Stark T-Shirt" to the cart
+        And I log out
         And I see the summary of my cart
         Then my cart should be empty
 

--- a/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
+++ b/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
@@ -9,17 +9,18 @@ Feature: Currency rounding edge case
         And that channel allows to shop using the "EUR" currency
         When the exchange rate of "US Dollar" to "Euro" is 0.9737
         And the store has a product "The Pug Mug" priced at "$7.00"
+        And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Changing the currency of my cart
-        When I add product "The Pug Mug" to the cart
-        And I switch to the "EUR" currency
+        Given I added product "The Pug Mug" to the cart
+        When I switch to the "EUR" currency
         Then the grand total value should be "€6.82"
         And the grand total value in base currency should be "$7.00"
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Changing the currency of my cart
-        Given I have added 2 products "The Pug Mug" to the cart
+        Given I added 2 products "The Pug Mug" to the cart
         When I switch to the "EUR" currency
         Then the grand total value in base currency should be "$14.00"
         And I should see "The Pug Mug" with unit price "€6.82" in my cart

--- a/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
+++ b/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
@@ -12,8 +12,8 @@ Feature: Currency rounding edge case
 
     @no-api @ui @javascript
     Scenario: Changing the currency of my cart
-        Given I have product "The Pug Mug" in the cart
-        When I switch to the "EUR" currency
+        When I add product "The Pug Mug" to the cart
+        And I switch to the "EUR" currency
         Then the grand total value should be "€6.82"
         And the grand total value in base currency should be "$7.00"
 

--- a/features/shop/cart/shopping_cart/maintaining_cart_after_authorization.feature
+++ b/features/shop/cart/shopping_cart/maintaining_cart_after_authorization.feature
@@ -54,8 +54,8 @@ Feature: Maintaining cart after authorization
 
     @api @ui @javascript
     Scenario: Having cart maintained after registration
-        Given I have product "Stark T-Shirt" in the cart
-        When I register with email "eddard@stak.com" and password "handOfTheKing"
+        When I add product "Stark T-Shirt" to the cart
+        And I register with email "eddard@stak.com" and password "handOfTheKing"
         And I see the summary of my cart
         Then there should be one item in my cart
         And this item should have name "Stark T-Shirt"

--- a/features/shop/cart/shopping_cart/removing_cart_item.feature
+++ b/features/shop/cart/shopping_cart/removing_cart_item.feature
@@ -7,11 +7,11 @@ Feature: Removing cart item from cart
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "T-Shirt banana" priced at "$12.54"
-        And I added product "T-Shirt banana" to the cart
 
     @api @ui @mink:chromedriver
     Scenario: Removing cart item
-        When I see the summary of my cart
+        When I add product "T-Shirt banana" to the cart
+        And I see the summary of my cart
         And I remove product "T-Shirt banana" from the cart
         Then my cart should be empty
         And my cart's total should be "$0.00"
@@ -19,15 +19,17 @@ Feature: Removing cart item from cart
     @api @ui @mink:chromedriver
     Scenario: Removing cart item when the store has defined default shipping method
         Given the store has "UPS" shipping method with "$20.00" fee
-        When I remove product "T-Shirt banana" from the cart
+        When I add product "T-Shirt banana" to the cart
+        And I remove product "T-Shirt banana" from the cart
         Then my cart should be empty
         And my cart's total should be "$0.00"
 
     @api @ui @mink:chromedriver
     Scenario: Checking cart's total after removing one item
         Given the store has a product "T-Shirt strawberry" priced at "$17.22"
-        And I added product "T-Shirt strawberry" to the cart
-        When I remove product "T-Shirt banana" from the cart
+        When I add product "T-Shirt banana" to the cart
+        And I add product "T-Shirt strawberry" to the cart
+        And I remove product "T-Shirt banana" from the cart
         Then my cart's total should be "$17.22"
 
     @api @ui @javascript
@@ -41,7 +43,8 @@ Feature: Removing cart item from cart
         And this shipping method requires at least one unit matches to "Paid" shipping category
         And the store has "UPS" shipping method with "$0.00" fee
         And this shipping method requires that all units match to "Free" shipping category
-        And I have product "T-Shirt small" in the cart
+        When I add product "T-Shirt banana" to the cart
+        And I add product "T-Shirt small" to the cart
         When I remove product "T-Shirt banana" from the cart
         And I see the summary of my cart
         Then my cart shipping total should be "$0.00"

--- a/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_based_on_method_position.feature
+++ b/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_based_on_method_position.feature
@@ -1,7 +1,7 @@
 @shopping_cart
 Feature: Viewing a cart summary with the correct default shipping method
     In order to see details about my order
-    As a Visitor
+    As a Customer
     I want to see my cart summary with the correct shipping method based on its position
 
     Background:
@@ -9,8 +9,9 @@ Feature: Viewing a cart summary with the correct default shipping method
         And the store allows shipping with "Method 1" at position 2 with "$5.00" fee
         And the store also allows shipping with "Method 2" at position 0 with "$6.00" fee
         And the store has a product "T-Shirt banana" priced at "$10.00"
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Viewing a cart summary with the correct default shipping method
         Given I added product "T-Shirt banana" to the cart
         When I see the summary of my cart

--- a/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_for_simple_products.feature
+++ b/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_for_simple_products.feature
@@ -30,6 +30,6 @@ Feature: Viewing a cart summary with correct default shipping method based on va
 
     @api @ui @javascript
     Scenario: Viewing a cart summary with correct default shipping method based on product shipping category
-        Given I have product "T-Shirt banana" in the cart
-        When I see the summary of my cart
+        When I add product "T-Shirt banana" to the cart
+        And I see the summary of my cart
         Then my cart shipping total should be "$0.00"

--- a/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_for_simple_products.feature
+++ b/features/shop/cart/shopping_cart/resolving_default_shipping_method_in_cart_summary_for_simple_products.feature
@@ -1,7 +1,7 @@
 @shopping_cart
 Feature: Viewing a cart summary with correct default shipping method based on variant applied
     In order to see details about my order
-    As a Visitor
+    As a Customer
     I want to be able to see my cart summary with the correct shipping method based on variants
 
     Background:
@@ -21,15 +21,16 @@ Feature: Viewing a cart summary with correct default shipping method based on va
         And this shipping method requires that all units match to "Free" shipping category
         And the store has a product "T-Shirt banana" priced at "$9.99"
         And this product belongs to "Free" shipping category
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Viewing a cart summary with correct default shipping method based on product shipping category
         Given I added product "Star Trek Table Linen" to the cart
         When I see the summary of my cart
         Then my cart shipping total should be "$5.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Viewing a cart summary with correct default shipping method based on product shipping category
-        When I add product "T-Shirt banana" to the cart
+        Given I added product "T-Shirt banana" to the cart
         And I see the summary of my cart
         Then my cart shipping total should be "$0.00"

--- a/features/shop/cart/shopping_cart/updating_cart_on_checkout.feature
+++ b/features/shop/cart/shopping_cart/updating_cart_on_checkout.feature
@@ -1,18 +1,19 @@
 @shopping_cart
 Feature:
     In order to avoid taking additional steps before accessing checkout
-    As a Visitor
+    As a Customer
     I want my cart to be updated on checkout
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "T-Shirt banana" priced at "$12.54"
-        And I added this product to the cart
+        And I am a logged in customer
 
     @no-api @ui @mink:chromedriver
     Scenario: Updating the cart on checkout
-        Given I am on the summary of my cart page
-        When I change product "T-Shirt banana" quantity to 2
+        Given I added product "T-Shirt banana" to the cart
+        When I check details of my cart
+        And I change product "T-Shirt banana" quantity to 2
         And I proceed to the checkout
         Then I should be on the checkout addressing page
         And the quantity of "T-Shirt banana" should be 2

--- a/features/shop/cart/shopping_cart/viewing_cart_summary.feature
+++ b/features/shop/cart/shopping_cart/viewing_cart_summary.feature
@@ -1,22 +1,23 @@
 @shopping_cart
 Feature: Viewing a cart summary
     In order to see details about my order
-    As a Visitor
+    As a Customer
     I want to be able to see my cart summary
 
     Background:
         Given the store operates on a single channel in "United States"
+        And I am a logged in customer
 
     @api @ui
     Scenario: Viewing information about empty cart
         When I see the summary of my cart
         Then my cart should be empty
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Viewing information about empty cart after clearing cookies
         Given the store has a product "T-Shirt banana" priced at "$12.54"
-        And I added this product to the cart
-        And I am on the summary of my cart page
-        But I've been gone for a long time
-        When I try to proceed to the checkout
+        And I added product "T-Shirt banana" to the cart
+        When I am on the summary of my cart page
+        And I've been gone for a long time
+        And I try to proceed to the checkout
         Then I should see an empty cart

--- a/features/shop/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
+++ b/features/shop/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
@@ -1,7 +1,7 @@
 @shopping_cart
 Feature: Viewing a cart summary in many channels
     In order to see details about my order in selected channel
-    As a Visitor
+    As a Customer
     I want to see different carts in different channels
 
     Background:
@@ -9,6 +9,7 @@ Feature: Viewing a cart summary in many channels
         And there is product "Banana" available in this channel
         And the store operates on a channel named "Poland" in "PLN" currency
         And there is product "Onion" available in this channel
+        And I am a logged in customer
 
     @no-api @ui
     Scenario: Viewing information about empty cart after channel switching
@@ -18,7 +19,7 @@ Feature: Viewing a cart summary in many channels
         And I see the summary of my cart
         Then my cart should be empty
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Viewing item in cart after switching channels
         Given I changed my current channel to "Poland"
         And I added product "Onion" to the cart

--- a/features/shop/checkout/ability_to_change_email_during_checkout.feature
+++ b/features/shop/checkout/ability_to_change_email_during_checkout.feature
@@ -13,8 +13,8 @@ Feature: Changing email during checkout with registered email
 
     @api @ui @javascript
     Scenario: Being able to change the email when checking out as a guest
-        Given I have product "Mantis blade" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "Mantis blade" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I go back to addressing step of the checkout
         And I complete addressing step with email "new-email@example.com" and "United States" based billing address
         Then I should be checking out as "new-email@example.com"

--- a/features/shop/checkout/ability_to_checkout_as_guest_with_a_registered_email.feature
+++ b/features/shop/checkout/ability_to_checkout_as_guest_with_a_registered_email.feature
@@ -13,8 +13,8 @@ Feature: Checking out as guest with a registered email
 
     @api @ui @javascript
     Scenario: Successfully placing an order
-        Given I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I select "Free" shipping method
         And I complete the shipping step
         And I choose "Offline" payment method
@@ -23,8 +23,8 @@ Feature: Checking out as guest with a registered email
 
     @api @ui @javascript
     Scenario: Placing an order using email with mixed case
-        Given I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "JOhn@example.COM" and "United States" based billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "JOhn@example.COM" and "United States" based billing address
         And I select "Free" shipping method
         And I complete the shipping step
         And I choose "Offline" payment method

--- a/features/shop/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
+++ b/features/shop/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
@@ -15,9 +15,9 @@ Feature: Ability to confirm an order with a promotion on shipping
 
     @api @ui @javascript
     Scenario: Successfully placing an order
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "DHL" shipping method and "Offline" payment
+        And I proceed with "DHL" shipping method and "Offline" payment
         And I confirm my order
         Then I should see the thank you page

--- a/features/shop/checkout/accessing_order_right_after_completing_checkout.feature
+++ b/features/shop/checkout/accessing_order_right_after_completing_checkout.feature
@@ -9,13 +9,12 @@ Feature: Accessing order right after completing checkout
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store allows paying "Cash on delivery"
         And the store ships everywhere for Free
-        And there is a user "john@example.com"
-        And I am logged in as "john@example.com"
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Being able to access my order right after completing checkout
         Given I added product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I addressed the cart
         And I proceeded with "Free" shipping method and "Cash on delivery" payment
         When I confirm my order
         Then I should be able to access this order's details

--- a/features/shop/checkout/adding_product_with_promotion_that_makes_the_order_free.feature
+++ b/features/shop/checkout/adding_product_with_promotion_that_makes_the_order_free.feature
@@ -15,8 +15,8 @@ Feature: Buying product with promotion that makes the order Free
 
     @api @ui @javascript
     Scenario: Buying product with promotion that makes the order Free
-        Given I have product "T-Shirt banana" in the cart
+        When I add product "T-Shirt banana" to the cart
         And I am at the checkout addressing step
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "DHL" shipping method
+        And I proceed with "DHL" shipping method
         Then my order total should be "$0.00"

--- a/features/shop/checkout/addressing_order/changing_address_during_checkout.feature
+++ b/features/shop/checkout/addressing_order/changing_address_during_checkout.feature
@@ -11,9 +11,9 @@ Feature: Changing address during checkout
 
     @no-api @ui @javascript
     Scenario: Going back to addressing step with and changing email
-        Given I have product "T-Shirt banana" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "jon.snow@example.com"
+        When I add product "T-Shirt banana" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "jon.snow@example.com"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I decide to change my address

--- a/features/shop/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature
+++ b/features/shop/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature
@@ -17,29 +17,29 @@ Feature: Choosing an address from address book
 
     @api @ui @javascript
     Scenario: Choosing billing address from address book
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Seaside Fwy" street for billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I choose "Seaside Fwy" street for billing address
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as billing address
 
     @api @ui @javascript
     Scenario: Choosing shipping address from address book
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Seaside Fwy" street for shipping address
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I choose "Seaside Fwy" street for shipping address
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as shipping address
 
     @api @ui @javascript
     Scenario: Choosing billing address which contains a country with provinces from my address book
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Upper Barkly Street" street for billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I choose "Upper Barkly Street" street for billing address
         Then address "Fletcher Ren", "Upper Barkly Street", "3377", "Ararat", "Australia", "Victoria" should be filled as billing address
 
     @api @ui @javascript
     Scenario: Choosing billing address from address book and proceed to the next step
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Seaside Fwy" street for billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I choose "Seaside Fwy" street for billing address
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/shop/checkout/addressing_order/choosing_province_for_country.feature
+++ b/features/shop/checkout/addressing_order/choosing_province_for_country.feature
@@ -14,28 +14,28 @@ Feature: Choosing province for country
 
     @api @ui @javascript
     Scenario: Address an order with country and its province
-        Given I have product "The Dark Knight T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
+        When I add product "The Dark Knight T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
         And I specify billing country province as "New York"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @api @ui @mink:chromedriver
     Scenario: Address an order with country and its province and specify country without province for different billing address
-        Given I have product "The Dark Knight T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "The Dark Knight T-Shirt" to the cart
+        And I go to the checkout addressing step
         And I specify the billing address as "Nanda Parbat", "League of Assassins House", "11-333", "Nepal" for "Ra's al Ghul"
-        When I specify the shipping address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
+        And I specify the shipping address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
         And I specify shipping country province as "New York"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @api @ui @javascript
     Scenario: Address an order with country and its province and specify country with province for different billing address
-        Given I have product "The Dark Knight T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
+        When I add product "The Dark Knight T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
         And I specify billing country province as "New York"
         And I specify the shipping address as "Metropolis", "Clinton Str.", "344", "United States" for "Clark Kent"
         And I specify shipping country province as "New York"
@@ -44,9 +44,9 @@ Feature: Choosing province for country
 
     @api @no-ui
     Scenario: Being unable to address an order with country without provinces and province from other country
-        Given I have product "The Dark Knight T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Nanda Parbat", "League of Assassins House", "11-333", "Nepal" for "Ra's al Ghul"
+        When I add product "The Dark Knight T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Nanda Parbat", "League of Assassins House", "11-333", "Nepal" for "Ra's al Ghul"
         And I specify billing country province as "New York"
         And I complete the addressing step
         Then I should be notified that selected province is invalid for billing address

--- a/features/shop/checkout/addressing_order/filling_billing_and_shipping_address_details.feature
+++ b/features/shop/checkout/addressing_order/filling_billing_and_shipping_address_details.feature
@@ -12,17 +12,17 @@ Feature: Addressing an order
 
     @api @ui @javascript
     Scenario: Address an order without different shipping address
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @api @ui @mink:chromedriver
     Scenario: Address an order with different shipping address
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/shop/checkout/addressing_order/filling_shipping_address_details_as_guest_with_existing_account.feature
+++ b/features/shop/checkout/addressing_order/filling_shipping_address_details_as_guest_with_existing_account.feature
@@ -12,9 +12,9 @@ Feature: Addressing an order and signing in
 
     @no-api @ui @javascript
     Scenario: Addressing an order and signing in
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "francis@underwood.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "francis@underwood.com"
         And I specify the password as "whitehouse"
         And I sign in
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/checkout/addressing_order/filling_shipping_and_billing_address_details_as_guest.feature
+++ b/features/shop/checkout/addressing_order/filling_shipping_and_billing_address_details_as_guest.feature
@@ -11,18 +11,18 @@ Feature: Addressing an order
 
     @api @ui @javascript
     Scenario: Address an order without different shipping address
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "jon.snow@example.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "jon.snow@example.com"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @api @ui @mink:chromedriver
     Scenario: Address an order with different shipping address
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "eddard.stark@example.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "eddard.stark@example.com"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
         And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -31,8 +31,8 @@ Feature: Addressing an order
     @api @ui @javascript
     Scenario: Address an order using existing email
         Given the store has customer "eddard.stark@example.com"
-        And I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
         When I specify the email as "eddard.stark@example.com"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step

--- a/features/shop/checkout/addressing_order/having_default_address_preselected.feature
+++ b/features/shop/checkout/addressing_order/having_default_address_preselected.feature
@@ -15,12 +15,12 @@ Feature: Having a default address preselected
     @no-api @ui @javascript
     Scenario: Having a default address preselected on checkout addressing step
         When I add product "PHP T-Shirt" to the cart
-        And I am at the checkout addressing step
+        And I go to the checkout addressing step
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as billing address
 
     @no-api @ui @javascript
     Scenario: Not modifying a default address in address book after modifying it on addressing step
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I am browsing my address book
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should still be marked as my default address

--- a/features/shop/checkout/addressing_order/having_only_possible_country_preselected.feature
+++ b/features/shop/checkout/addressing_order/having_only_possible_country_preselected.feature
@@ -13,12 +13,12 @@ Feature: Having only possible country preselected
     @no-api @ui @javascript
     Scenario: Having the only country preselected on addressing form
         When I add product "PHP T-Shirt" to the cart
-        And I am at the checkout addressing step
+        And I go to the checkout addressing step
         Then I should have "United States" selected as country
 
     @no-api @ui @javascript
     Scenario: Having no country selected if there is more than one country available
         Given the store operates in "United Kingdom"
         When I add product "PHP T-Shirt" to the cart
-        And I am at the checkout addressing step
+        And I go to the checkout addressing step
         Then I should have no country selected

--- a/features/shop/checkout/addressing_order/preventing_xss_attack_during_checkout.feature
+++ b/features/shop/checkout/addressing_order/preventing_xss_attack_during_checkout.feature
@@ -1,19 +1,19 @@
 @checkout
 Feature: Preventing a potential XSS attack during updating the address in the checkout
     In order to keep my information safe
-    As a Visitor
+    As a Customer
     I want to be protected against the potential XSS attacks
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
-        And I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
 
     @no-api @ui @mink:chromedriver
     Scenario: Preventing a potential XSS attack during updating the address in the checkout
-        When I specify the email as "john.doe@example.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "john.doe@example.com"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Doe"
         And I specify the province name manually as '<img """><script>alert("XSS")</script>">' for billing address
         And I complete the addressing step

--- a/features/shop/checkout/addressing_order/returning_from_addressing_step_to_shop_homepage.feature
+++ b/features/shop/checkout/addressing_order/returning_from_addressing_step_to_shop_homepage.feature
@@ -12,7 +12,7 @@ Feature: Returning from addressing step to shop homepage
 
     @no-api @ui @javascript
     Scenario: Returning to shop from addressing step
-        Given I have product "The Stick of Truth" in the cart
-        And I am at the checkout addressing step
-        When I go back to store
+        When I add product "The Stick of Truth" to the cart
+        And I go to the checkout addressing step
+        And I go back to store
         Then I should be redirected to the homepage

--- a/features/shop/checkout/addressing_order/returning_to_addressing_step_with_a_different_shipping_address.feature
+++ b/features/shop/checkout/addressing_order/returning_to_addressing_step_with_a_different_shipping_address.feature
@@ -11,9 +11,9 @@ Feature: Returning to addressing step with a different shipping address
 
     @no-api @ui @mink:chromedriver
     Scenario: Going back to addressing step after submitting a different shipping address
-        Given I have product "Summer T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "john.doe@example.com"
+        When I add product "Summer T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "john.doe@example.com"
         And I specify the billing address as "Brooklyn", "9036 Country Club Ave.", "11230", "United States" for "John Doe"
         And I specify the shipping address as "Brooklyn", "70 Joy Ridge St", "11225", "United States" for "Jane Doe"
         And I complete the addressing step
@@ -22,9 +22,9 @@ Feature: Returning to addressing step with a different shipping address
 
     @no-api @ui @javascript
     Scenario: Going back to addressing step after not submitting a different shipping address
-        Given I have product "Summer T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "john.doe@example.com"
+        When I add product "Summer T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "john.doe@example.com"
         And I specify the billing address as "Brooklyn", "9036 Country Club Ave.", "11230", "United States" for "John Doe"
         And I complete the addressing step
         And I decide to change my address
@@ -32,9 +32,9 @@ Feature: Returning to addressing step with a different shipping address
 
     @no-api @ui @mink:chromedriver
     Scenario: Going back to addressing step after submitting a different shipping address
-        Given I have product "Summer T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "john.doe@example.com"
+        When I add product "Summer T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "john.doe@example.com"
         And I specify the billing address as "Brooklyn", "9036 Country Club Ave.", "11230", "United States" for "John Doe"
         And I specify the shipping address as "Brooklyn", "70 Joy Ridge St", "11225", "United States" for "Jane Doe"
         And I complete the addressing step
@@ -43,9 +43,9 @@ Feature: Returning to addressing step with a different shipping address
 
     @no-api @ui @javascript
     Scenario: Going back to addressing step after not submitting a different shipping address
-        Given I have product "Summer T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the email as "john.doe@example.com"
+        When I add product "Summer T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the email as "john.doe@example.com"
         And I specify the billing address as "Brooklyn", "9036 Country Club Ave.", "11230", "United States" for "John Doe"
         And I complete the addressing step
         And I decide to change my address

--- a/features/shop/checkout/addressing_order/shipping_and_billing_address_validation.feature
+++ b/features/shop/checkout/addressing_order/shipping_and_billing_address_validation.feature
@@ -12,9 +12,9 @@ Feature: Order addressing validation
 
     @api @ui @javascript
     Scenario: Address an order without name, city and street
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I do not specify any shipping address information
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I do not specify any shipping address information
         And I try to complete the addressing step
         Then I should be notified that the "first name" and the "last name" in shipping details are required
         And I should also be notified that the "city" and the "street" in shipping details are required
@@ -22,9 +22,9 @@ Feature: Order addressing validation
 
     @api @ui @javascript
     Scenario: Address an order's billing address without name, city and street
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I do not specify any billing address information
         And I try to complete the addressing step
         Then I should be notified that the "first name" and the "last name" in billing details are required

--- a/features/shop/checkout/addressing_order/sign_in_during_addressing_step.feature
+++ b/features/shop/checkout/addressing_order/sign_in_during_addressing_step.feature
@@ -11,15 +11,15 @@ Feature: Sign in to the store during checkout
 
     @no-api @ui @javascript
     Scenario: Displaying login form if the customer has an account
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
         When I specify the email as "francis@underwood.com"
         Then I should be able to log in
 
     @no-api @ui @javascript
     Scenario: Successful sign in
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
         When I specify the email as "francis@underwood.com"
         And I specify the password as "whitehouse"
         And I sign in
@@ -27,8 +27,8 @@ Feature: Sign in to the store during checkout
 
     @no-api @ui @javascript
     Scenario: Failure sign in
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
         When I specify the email as "francis@underwood.com"
         And I specify the password as "francis"
         And I sign in
@@ -36,9 +36,9 @@ Feature: Sign in to the store during checkout
 
     @no-api @ui @mink:chromedriver
     Scenario: Successful sign in after omitting fill the email field
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address for "Jon Snow" from "Ankh Morpork", "Frost Alley", "90210", "United States", "Texas"
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address for "Jon Snow" from "Ankh Morpork", "Frost Alley", "90210", "United States", "Texas"
         And I try to complete the addressing step
         And I specify the email as "francis@underwood.com"
         And I specify the password as "whitehouse"

--- a/features/shop/checkout/being_able_to_modify_remaining_steps.feature
+++ b/features/shop/checkout/being_able_to_modify_remaining_steps.feature
@@ -15,59 +15,59 @@ Feature: Changing checkout steps
 
     @no-api @ui @javascript
     Scenario: Changing address of my order
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I go back to addressing step of the checkout
+        And I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @no-api @ui @javascript
     Scenario: Addressing my order after selecting payment method
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
-        When I go back to addressing step of the checkout
+        And I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @no-api @ui @javascript
     Scenario: Addressing my order after selecting shipping method
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded selecting "Free" shipping method
-        When I go back to addressing step of the checkout
+        And I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @no-api @ui @javascript
     Scenario: Changing shipping method of my order
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded selecting "Free" shipping method
-        When I go back to shipping step of the checkout
+        And I go back to shipping step of the checkout
         And I select "Raven Post" shipping method
         And I complete the shipping step
         Then I should be on the checkout payment step
 
     @no-api @ui @javascript
     Scenario: Selecting shipping method after selecting payment method
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
-        When I go back to shipping step of the checkout
+        And I go back to shipping step of the checkout
         And I select "Raven Post" shipping method
         And I complete the shipping step
         Then I should be on the checkout payment step
 
     @no-api @ui @javascript
     Scenario: Selecting payment method after complete checkout
-        Given I had product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
-        When I go back to payment step of the checkout
+        And I go back to payment step of the checkout
         And I select "Bank transfer" payment method
         And I complete the payment step
         Then I should be on the checkout summary step

--- a/features/shop/checkout/emptying_the_cart_after_checkout.feature
+++ b/features/shop/checkout/emptying_the_cart_after_checkout.feature
@@ -13,8 +13,8 @@ Feature: Emptying the cart after checkout
 
     @no-api @ui @javascript
     Scenario: Cart is emptied after the checkout
-        Given I have product "Sig Sauer P226" in the cart
+        When I add product "Sig Sauer P226" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
-        When I confirm my order
+        And I confirm my order
         Then my cart should be empty

--- a/features/shop/checkout/emptying_the_cart_after_checkout.feature
+++ b/features/shop/checkout/emptying_the_cart_after_checkout.feature
@@ -11,7 +11,7 @@ Feature: Emptying the cart after checkout
         And the store allows paying with "Cash on Delivery"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @no-api @ui @javascript
     Scenario: Cart is emptied after the checkout
         Given I have product "Sig Sauer P226" in the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/checkout/having_registration_account_form_prefilled_after_checkout.feature
+++ b/features/shop/checkout/having_registration_account_form_prefilled_after_checkout.feature
@@ -12,7 +12,7 @@ Feature: Having registration form prefilled after checkout
 
     @no-api @ui @javascript
     Scenario: Having prefilled registration form after checkout
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
@@ -20,11 +20,11 @@ Feature: Having registration form prefilled after checkout
         And I should be able to proceed to the registration
         And the registration form should be prefilled with "john@example.com" email
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Not being able to create an account if customer is logged in
         Given I am a logged in customer
-        And I have product "PHP T-Shirt" in the cart
-        And I complete addressing step with "United States" based billing address
+        And I added product "PHP T-Shirt" to the cart
+        When I complete addressing step with "United States" based billing address
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then I should see the thank you page

--- a/features/shop/checkout/not_seeing_payment_method_instructions_on_thank_you_page_if_order_total_is_zero.feature
+++ b/features/shop/checkout/not_seeing_payment_method_instructions_on_thank_you_page_if_order_total_is_zero.feature
@@ -12,9 +12,9 @@ Feature: Not seeing payment method instructions on thank you page if order total
         And the promotion gives "$10.00" discount to every order with quantity at least 1
         And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Not being informed about payment instructions on thank you page
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I have proceeded through checkout process with "Free" shipping method
         When I confirm my order
         Then I should see the thank you page

--- a/features/shop/checkout/order_promotion/order_promotion_integrity_validation.feature
+++ b/features/shop/checkout/order_promotion/order_promotion_integrity_validation.feature
@@ -12,7 +12,7 @@ Feature: Order promotions integrity
         And there is a promotion "Christmas sale"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Preventing customer from completing checkout with already expired promotion
         Given this promotion gives "$10.00" discount to every order
         And this promotion is valid until tomorrow
@@ -24,7 +24,7 @@ Feature: Order promotions integrity
         Then I should be informed that this promotion is no longer applied
         And I should not see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Recalculating cart when promotion already expired
         Given this promotion gives "$10.00" discount to every order
         And this promotion is valid until tomorrow
@@ -36,7 +36,7 @@ Feature: Order promotions integrity
         And I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Being able to completing checkout with several promotions
         Given this promotion gives "12%" discount to every order
         And there is a promotion "New Year" with priority 2
@@ -47,14 +47,14 @@ Feature: Order promotions integrity
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Receiving percentage discount when buying items for the required total value
         Given the promotion gives "50%" discount to every order with items total at least "$80.00"
         And I added product "PHP T-Shirt" to the cart
         When I proceed with selecting "Offline" payment method
         Then my order total should be "$50.00"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Successfully placing an order with percentage discount when buying items for the required total value
         Given the promotion gives "50%" discount to every order with items total at least "$80.00"
         And I added product "PHP T-Shirt" to the cart
@@ -63,7 +63,7 @@ Feature: Order promotions integrity
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Excluded tax is not taken into account into promotion integrity check
         Given the store has "VAT" tax rate of 20% for "Clothes" within the "US" zone
         And this product belongs to "Clothes" tax category
@@ -74,7 +74,7 @@ Feature: Order promotions integrity
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Preventing customer from completing checkout with already archived promotion
         Given this promotion gives "$10.00" discount to every order
         And I added product "PHP T-Shirt" to the cart

--- a/features/shop/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
+++ b/features/shop/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
@@ -11,7 +11,7 @@ Feature: Having good number of items in changing payment method page
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct quantity on payment retry page
         When I add 2 products "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address

--- a/features/shop/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
+++ b/features/shop/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
@@ -13,9 +13,9 @@ Feature: Having good number of items in changing payment method page
 
     @no-api @ui @javascript
     Scenario: Seeing correct quantity on payment retry page
-        Given I have added 2 products "PHP T-Shirt" to the cart
+        When I add 2 products "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded selecting "Cash on delivery" payment method
         And I have confirmed order
-        When I go to the change payment method page
+        And I go to the change payment method page
         Then I should see 2 as number of items

--- a/features/shop/checkout/paying_for_order/changing_offline_payment_method_after_order_confirmation.feature
+++ b/features/shop/checkout/paying_for_order/changing_offline_payment_method_after_order_confirmation.feature
@@ -11,7 +11,7 @@ Feature: Changing the offline payment method after order confirmation
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for Free
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Retrying the payment with different Offline payment
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
@@ -21,7 +21,7 @@ Feature: Changing the offline payment method after order confirmation
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Retrying the payment with different Offline payment works correctly together with inventory
         Given there is 1 unit of product "PHP T-Shirt" available in the inventory
         And this product is tracked by the inventory
@@ -33,7 +33,7 @@ Feature: Changing the offline payment method after order confirmation
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
-    @todo-api @ui @javascript
+    @todo-api @ui @mink:chromedriver
     Scenario: Being unable to pay for my order if my chosen payment method gets disabled
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
@@ -44,7 +44,7 @@ Feature: Changing the offline payment method after order confirmation
         And I try to pay for my order
         Then I should be notified to choose a payment method
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Retrying the payment with different payment method after order confirmation when the original is disabled
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
@@ -55,7 +55,7 @@ Feature: Changing the offline payment method after order confirmation
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
-    @todo-api @ui @javascript
+    @todo-api @ui @mink:chromedriver
     Scenario: Being unable to pay for my order if no methods are available
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address

--- a/features/shop/checkout/paying_for_order/changing_offline_payment_method_after_order_confirmation.feature
+++ b/features/shop/checkout/paying_for_order/changing_offline_payment_method_after_order_confirmation.feature
@@ -13,11 +13,11 @@ Feature: Changing the offline payment method after order confirmation
 
     @api @ui @javascript
     Scenario: Retrying the payment with different Offline payment
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded selecting "Free" shipping method
-        And I have proceeded selecting "Cash on delivery" payment method
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
+        And I proceed with selecting "Cash on delivery" payment method
+        And I confirm my order
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
@@ -25,43 +25,43 @@ Feature: Changing the offline payment method after order confirmation
     Scenario: Retrying the payment with different Offline payment works correctly together with inventory
         Given there is 1 unit of product "PHP T-Shirt" available in the inventory
         And this product is tracked by the inventory
-        When I added product "PHP T-Shirt" to the cart
+        When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded selecting "Free" shipping method
-        And I have proceeded selecting "Cash on delivery" payment method
-        And I have confirmed order
+        And I proceed with selecting "Free" shipping method
+        And I proceed with selecting "Cash on delivery" payment method
+        And I confirm my order
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
     @todo-api @ui @javascript
     Scenario: Being unable to pay for my order if my chosen payment method gets disabled
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded selecting "Free" shipping method
-        And I have proceeded selecting "Cash on delivery" payment method
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
+        And I proceed with selecting "Cash on delivery" payment method
+        And I confirm my order
         And the payment method "Cash on delivery" gets disabled
         And I try to pay for my order
         Then I should be notified to choose a payment method
 
     @api @ui @javascript
     Scenario: Retrying the payment with different payment method after order confirmation when the original is disabled
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded selecting "Free" shipping method
-        And I have proceeded selecting "Cash on delivery" payment method
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
+        And I proceed with selecting "Cash on delivery" payment method
+        And I confirm my order
         And the payment method "Cash on delivery" gets disabled
         And I retry the payment with "Offline" payment method
         Then I should have chosen "Offline" payment method
 
     @todo-api @ui @javascript
     Scenario: Being unable to pay for my order if no methods are available
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded selecting "Free" shipping method
-        And I have proceeded selecting "Cash on delivery" payment method
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
+        And I proceed with selecting "Cash on delivery" payment method
+        And I confirm my order
         And the payment method "Cash on delivery" gets disabled
         And the payment method "Offline" gets disabled
         And I want to pay for my order
@@ -69,9 +69,9 @@ Feature: Changing the offline payment method after order confirmation
 
     @api @no-ui
     Scenario: Changing chosen Offline payment method to another Offline payment method after checkout
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I proceed with "Free" shipping method
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
         And I proceed with selecting "Cash on delivery" payment method
         And I confirm my order
         And I change payment method to "Offline" after checkout
@@ -81,9 +81,9 @@ Feature: Changing the offline payment method after order confirmation
     Scenario: Changing the payment method to a different Offline payment method works correctly together with inventory
         Given there is 1 unit of product "PHP T-Shirt" available in the inventory
         And this product is tracked by the inventory
-        When I added product "PHP T-Shirt" to the cart
+        When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I proceed with "Free" shipping method
+        And I proceed with selecting "Free" shipping method
         And I proceed with selecting "Cash on delivery" payment method
         And I confirm my order
         And I change payment method to "Offline" after checkout
@@ -91,9 +91,9 @@ Feature: Changing the offline payment method after order confirmation
 
     @api @no-ui
     Scenario: Changing chosen Offline payment method to another Offline payment method after checkout when the original is disabled
-        Given I added product "PHP T-Shirt" to the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I proceed with "Free" shipping method
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with selecting "Free" shipping method
         And I proceed with selecting "Cash on delivery" payment method
         And I confirm my order
         And the payment method "Cash on delivery" gets disabled

--- a/features/shop/checkout/paying_for_order/informing_customer_about_order_total_changes.feature
+++ b/features/shop/checkout/paying_for_order/informing_customer_about_order_total_changes.feature
@@ -12,8 +12,17 @@ Feature: Informing customer about any order total changes during checkout proces
         And the store ships everywhere for Free
         And the store allows paying Offline
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Informing customer about order total change due to product price change
+        Given I am a logged in customer
+        And I added product "PHP T-Shirt" to the cart
+        And I proceeded through checkout process
+        And this product price has been changed to "$25.00"
+        And I confirm my order
+        Then my order should not be placed due to changed order total
+
+    @api @ui
+    Scenario: Being able to confirm order after information appears
         Given I am a logged in customer
         And I added product "PHP T-Shirt" to the cart
         And I proceeded through checkout process
@@ -21,16 +30,7 @@ Feature: Informing customer about any order total changes during checkout proces
         When I confirm my order
         Then my order should not be placed due to changed order total
 
-    @api @ui @javascript
-    Scenario: Being able to confirm order after information appears
-        Given I am a logged in customer
-        And I added product "PHP T-Shirt" to the cart
-        And I proceeded through checkout process
-        And this product price has been changed to "$25.00"
-        And I have confirmed order
-        Then my order should not be placed due to changed order total
-
-    @api @ui @javascript
+    @api @ui
     Scenario: Informing customer about order total change due to tax change
         Given I am a logged in customer
         And I added product "PHP T-Shirt" to the cart
@@ -42,9 +42,9 @@ Feature: Informing customer about any order total changes during checkout proces
     @api @ui @javascript
     Scenario: Informing customer about order total change due to shipping method fee change
         Given the store has "UPS" shipping method with "$20.00" fee
-        And I added product "PHP T-Shirt" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
-        And I have proceeded order with "UPS" shipping method and "Offline" payment
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "guest@example.com" and "United States" based billing address
+        And I proceed with "UPS" shipping method and "Offline" payment
         And the shipping fee for "UPS" shipping method has been changed to "$30.00"
-        When I confirm my order
+        And I confirm my order
         Then my order should not be placed due to changed order total

--- a/features/shop/checkout/paying_for_order/informing_customer_about_order_total_changes.feature
+++ b/features/shop/checkout/paying_for_order/informing_customer_about_order_total_changes.feature
@@ -39,7 +39,7 @@ Feature: Informing customer about any order total changes during checkout proces
         When I confirm my order
         Then my order should not be placed due to changed order total
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Informing customer about order total change due to shipping method fee change
         Given the store has "UPS" shipping method with "$20.00" fee
         When I add product "PHP T-Shirt" to the cart

--- a/features/shop/checkout/paying_for_order/paying_offline_during_checkout.feature
+++ b/features/shop/checkout/paying_for_order/paying_offline_during_checkout.feature
@@ -10,7 +10,7 @@ Feature: Paying offline during checkout
         And the store ships everywhere for Free
         And the store allows paying Offline
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Successfully placing an order
         Given I am a logged in customer
         And this payment method is not using Payum
@@ -20,7 +20,7 @@ Feature: Paying offline during checkout
         And I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Using Payum successfully placing an order
         Given I am a logged in customer
         And I have product "PHP T-Shirt" in the cart

--- a/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
+++ b/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
@@ -11,7 +11,7 @@ Feature: Paying Offline during checkout as guest
         And the store ships everywhere for Free
         And the store allows paying Offline
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Successfully placing an order
         Given this payment method is not using Payum
         When I add product "PHP T-Shirt" to the cart
@@ -21,7 +21,7 @@ Feature: Paying Offline during checkout as guest
         And I confirm my order
         Then I should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Using Payum successfully placing an order
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john@example.com" and "United States" based billing address
@@ -30,7 +30,7 @@ Feature: Paying Offline during checkout as guest
         And I confirm my order
         Then I should see the thank you page
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Successfully placing an order using custom locale
         Given this payment method is not using Payum
         When I add product "PHP T-Shirt" to the cart
@@ -38,7 +38,7 @@ Feature: Paying Offline during checkout as guest
         And I confirm my order
         Then I should see the thank you page in "French (France)"
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Using Payum successfully placing an order using custom locale
         When I add product "PHP T-Shirt" to the cart
         And I proceed through checkout process in the "French (France)" locale with email "john@example.com"

--- a/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
+++ b/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
@@ -23,8 +23,8 @@ Feature: Paying Offline during checkout as guest
 
     @api @ui @javascript
     Scenario: Using Payum successfully placing an order
-        Given I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I proceed with "Free" shipping method
         And I choose "Offline" payment method
         And I confirm my order
@@ -40,8 +40,8 @@ Feature: Paying Offline during checkout as guest
 
     @no-api @ui @javascript
     Scenario: Using Payum successfully placing an order using custom locale
-        Given I have product "PHP T-Shirt" in the cart
-        When I proceed through checkout process in the "French (France)" locale with email "john@example.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I proceed through checkout process in the "French (France)" locale with email "john@example.com"
         And I confirm my order
         Then I should see the thank you page in "French (France)"
 

--- a/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
+++ b/features/shop/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
@@ -14,8 +14,8 @@ Feature: Paying Offline during checkout as guest
     @api @ui @javascript
     Scenario: Successfully placing an order
         Given this payment method is not using Payum
-        And I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I proceed with "Free" shipping method
         And I choose "Offline" payment method
         And I confirm my order
@@ -33,8 +33,8 @@ Feature: Paying Offline during checkout as guest
     @no-api @ui @javascript
     Scenario: Successfully placing an order using custom locale
         Given this payment method is not using Payum
-        And I have product "PHP T-Shirt" in the cart
-        When I proceed through checkout process in the "French (France)" locale with email "john@example.com"
+        When I add product "PHP T-Shirt" to the cart
+        And I proceed through checkout process in the "French (France)" locale with email "john@example.com"
         And I confirm my order
         Then I should see the thank you page in "French (France)"
 
@@ -48,16 +48,16 @@ Feature: Paying Offline during checkout as guest
     @api @no-ui
     Scenario: Successfully placing an order using custom locale
         Given this payment method is not using Payum
-        And I pick up cart in the "French (France)" locale
+        When I pick up cart in the "French (France)" locale
         And I add product "PHP T-Shirt" to the cart
-        When I proceed through checkout process
+        And I proceed through checkout process
         And I confirm my order
         Then my order's locale should be "French (France)"
 
     @api @no-ui
     Scenario: Using Payum successfully placing an order using custom locale
         Given I pick up cart in the "French (France)" locale
-        And I add product "PHP T-Shirt" to the cart
-        When I proceed through checkout process
+        When I add product "PHP T-Shirt" to the cart
+        And I proceed through checkout process
         And I confirm my order
         Then my order's locale should be "French (France)"

--- a/features/shop/checkout/paying_for_order/payment_method_integrity_validation.feature
+++ b/features/shop/checkout/paying_for_order/payment_method_integrity_validation.feature
@@ -13,7 +13,7 @@ Feature: Order payment method integrity
 
     @api @ui @javascript
     Scenario: Preventing customer from completing checkout with no longer available payment method
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I have proceeded selecting "Offline" payment method
         But the payment method "Offline" is disabled
         When I confirm my order

--- a/features/shop/checkout/paying_for_order/payment_method_integrity_validation.feature
+++ b/features/shop/checkout/paying_for_order/payment_method_integrity_validation.feature
@@ -11,7 +11,7 @@ Feature: Order payment method integrity
         And the store allows paying Offline
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Preventing customer from completing checkout with no longer available payment method
         When I add product "PHP T-Shirt" to the cart
         And I have proceeded selecting "Offline" payment method

--- a/features/shop/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
+++ b/features/shop/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
@@ -12,7 +12,7 @@ Feature: Preventing not available payment method selection
         And the store ships everywhere for Free
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Not being able to select disabled payment method
         Given the payment method "Offline" is disabled
         And I have product "PHP T-Shirt" in the cart
@@ -23,7 +23,7 @@ Feature: Preventing not available payment method selection
         And I complete the shipping step
         Then I should not be able to select "Offline" payment method
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Not being able to select payment method not available for order channel
         Given the store has "Cash on delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart

--- a/features/shop/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
+++ b/features/shop/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
@@ -37,9 +37,9 @@ Feature: Preventing not available payment method selection
 
     @api @no-ui
     Scenario: Preventing customer from selecting nonexistent payment method
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step

--- a/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
+++ b/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
@@ -19,7 +19,7 @@ Feature: Preventing payment step completion without a selected method
         Then I should see that no payment method is assigned
         And there should not be any payment methods available for selection
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Preventing payment step completion if there are no available methods
         When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -37,7 +37,7 @@ Feature: Preventing payment step completion without a selected method
         Then I should see that no payment method is assigned
         And there should not be any payment methods available for selection
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Preventing payment step completion if there are no available methods for a channel
         Given the store has "Cash on Delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart
@@ -58,7 +58,7 @@ Feature: Preventing payment step completion without a selected method
         Then I should see that no payment method is assigned
         And there should not be any payment methods available for selection
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Preventing payment step completion if a payment method is disabled
         Given the store has a payment method "Offline" with a code "Offline"
         And this payment method is disabled
@@ -81,7 +81,7 @@ Feature: Preventing payment step completion without a selected method
         Then I should see that no payment method is assigned
         And there should not be any payment methods available for selection
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Preventing payment step completion if a payment method is disabled or not assigned to a channel
         Given the store has a payment method "Offline" with a code "Offline"
         And this payment method is disabled

--- a/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
+++ b/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
@@ -12,17 +12,17 @@ Feature: Preventing payment step completion without a selected method
 
     @api @no-ui
     Scenario: Preventing payment step completion if there are no available methods
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I have addressed the cart to "United States"
         And I proceed with selecting "Free" shipping method
-        When I check the details of my cart
+        And I check the details of my cart
         Then I should see that no payment method is assigned
         And there should not be any payment methods available for selection
 
     @no-api @ui @javascript
     Scenario: Preventing payment step completion if there are no available methods
-        Given I have product "PHP T-Shirt" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "PHP T-Shirt" to the cart
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with selecting "Free" shipping method
         Then I should not be able to complete the payment step
         And there should be information about no payment methods available for my order

--- a/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
+++ b/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
@@ -13,27 +13,27 @@ Feature: Returning from payment step to one of previous steps
 
     @no-api @ui @javascript
     Scenario: Going back to shipping step with button
-        Given I have product "Hulk Mug" in the cart
+        When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
-        When I decide to change order shipping method
+        And I decide to change order shipping method
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 
     @no-api @ui @javascript
     Scenario: Going back to shipping step with steps panel
-        Given I have product "Hulk Mug" in the cart
+        When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
-        When I go to the shipping step
+        And I go to the shipping step
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 
     @no-api @ui @javascript
     Scenario: Going back to addressing step with steps panel
-        Given I have product "Hulk Mug" in the cart
+        When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
-        When I go to the addressing step
+        And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again

--- a/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
+++ b/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
@@ -11,7 +11,7 @@ Feature: Returning from payment step to one of previous steps
         And the store allows paying with "Bank transfer"
         And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Going back to shipping step with button
         When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -20,7 +20,7 @@ Feature: Returning from payment step to one of previous steps
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Going back to shipping step with steps panel
         When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -29,7 +29,7 @@ Feature: Returning from payment step to one of previous steps
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Going back to addressing step with steps panel
         When I add product "Hulk Mug" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/checkout/paying_for_order/seeing_payment_method_instructions_after_checkout.feature
+++ b/features/shop/checkout/paying_for_order/seeing_payment_method_instructions_after_checkout.feature
@@ -11,7 +11,7 @@ Feature: Seeing payment method instructions after checkout
         And the store has a payment method "Offline" with a code "OFFLINE"
         And it has instructions "Account number: 0000 1111 2222 3333"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Being informed about payment instructions
         Given I am a logged in customer
         And this payment method is not using Payum
@@ -20,7 +20,7 @@ Feature: Seeing payment method instructions after checkout
         And I confirm my order
         Then I should be informed with "Offline" payment method instructions
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Using Payum being informed about payment instructions
         Given I am a logged in customer
         And I have product "PHP T-Shirt" in the cart

--- a/features/shop/checkout/paying_for_order/selecting_order_payment_method.feature
+++ b/features/shop/checkout/paying_for_order/selecting_order_payment_method.feature
@@ -24,10 +24,10 @@ Feature: Selecting an order payment method
 
     @api @ui @javascript
     Scenario: Using Payum selecting a payment method
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I select "Free" shipping method
         And I complete the shipping step
-        When I select "Bank transfer" payment method
+        And I select "Bank transfer" payment method
         And I complete the payment step
         Then I should be on the checkout complete step

--- a/features/shop/checkout/paying_for_order/selecting_order_payment_method.feature
+++ b/features/shop/checkout/paying_for_order/selecting_order_payment_method.feature
@@ -11,7 +11,7 @@ Feature: Selecting an order payment method
         And the store allows paying with "Bank transfer"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Selecting a payment method
         Given this payment method is not using Payum
         And I have product "PHP T-Shirt" in the cart
@@ -22,7 +22,7 @@ Feature: Selecting an order payment method
         And I complete the payment step
         Then I should be on the checkout complete step
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Using Payum selecting a payment method
         When I add product "PHP T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/checkout/paying_for_order/sorting_payment_method_selection.feature
+++ b/features/shop/checkout/paying_for_order/sorting_payment_method_selection.feature
@@ -13,7 +13,7 @@ Feature: Sorting payment method selection
         And the store allows paying with "Offline" at position 1
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing payment methods sorted
         When I add product "Targaryen T-Shirt" to the cart
         And I am at the checkout addressing step

--- a/features/shop/checkout/paying_for_order/sorting_payment_method_selection.feature
+++ b/features/shop/checkout/paying_for_order/sorting_payment_method_selection.feature
@@ -15,8 +15,8 @@ Feature: Sorting payment method selection
 
     @api @ui @javascript
     Scenario: Seeing payment methods sorted
-        Given I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
+        When I add product "Targaryen T-Shirt" to the cart
+        And I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Aardvark Stagecoach" shipping method

--- a/features/shop/checkout/paying_for_order/viewing_available_payment_methods_based_on_current_channel.feature
+++ b/features/shop/checkout/paying_for_order/viewing_available_payment_methods_based_on_current_channel.feature
@@ -19,7 +19,7 @@ Feature: Viewing available payment methods based on current channel
         And this product is also priced at "$25.00" in "Poland" channel
         And the store ships everywhere for free for all channels
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing payment methods that are available in channel as a logged in customer
         Given I am a logged in customer
         And I am in the "United States" channel
@@ -30,7 +30,7 @@ Feature: Viewing available payment methods based on current channel
         And I should see "Bank of America" and "Offline" payment methods
         But I should not see "Bank of Poland" and "Bank of Universe" payment methods
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing shipping methods that are available in another channel as an logged in customer
         Given I am a logged in customer
         And I am in the "Poland" channel
@@ -41,20 +41,20 @@ Feature: Viewing available payment methods based on current channel
         And I should see "Bank of Poland" and "Offline" payment methods
         But I should not see "Bank of Universe" and "Bank of America" payment methods
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing payment methods that are available in channel as a guest
         Given I am in the "United States" channel
-        And I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I complete the shipping step with first shipping method
         Then I should be on the checkout payment step
         And I should see "Bank of America" and "Offline" payment methods
         But I should not see "Bank of Poland" and "Bank of Universe" payment methods
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing shipping methods that are available in another channel as a guest
         Given I am in the "Poland" channel
-        And I have product "PHP T-Shirt" in the cart
+        And I add product "PHP T-Shirt" to the cart
         When I complete addressing step with email "john@example.com" and "United States" based billing address
         And I complete the shipping step with first shipping method
         Then I should be on the checkout payment step

--- a/features/shop/checkout/placing_an_order_after_moving_back_in_checkout.feature
+++ b/features/shop/checkout/placing_an_order_after_moving_back_in_checkout.feature
@@ -11,27 +11,27 @@ Feature: Placing an order after moving back in checkout process
         And the store allows paying Offline
         And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Placing an order after moving back from the checkout summary to the addressing step but without any address modification
-        Given I had product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I was at the checkout summary step
         When I go back to addressing step of the checkout
         And I return to the checkout summary step
         And I confirm my order
         Then I should see the thank you page
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Placing an order after moving back from the checkout summary to the shipping method step but without any shipping method modification
-        Given I had product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I was at the checkout summary step
         When I go back to shipping step of the checkout
         And I return to the checkout summary step
         And I confirm my order
         Then I should see the thank you page
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Placing an order after moving back from the checkout summary to the payment method step but without any payment method modification
-        Given I had product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I was at the checkout summary step
         When I go back to payment step of the checkout
         And I return to the checkout summary step

--- a/features/shop/checkout/preventing_from_claiming_cart_of_wrong_user.feature
+++ b/features/shop/checkout/preventing_from_claiming_cart_of_wrong_user.feature
@@ -36,7 +36,7 @@ Feature: Preventing from claiming cart of a wrong user
 
     @no-api @ui @mink:chromedriver
     Scenario: Preventing anonymous user from claiming cart of logged in user
-        Given I have product "PHP T-Shirt" in the cart
+        Given I add the product "PHP T-Shirt" to the cart
         When I sign in with email "robb@stark.com" and password "KingInTheNorth"
         And I log out
         And an anonymous user in another browser adds products "PHP T-Shirt" and "Kotlin T-Shirt" to the cart
@@ -50,8 +50,8 @@ Feature: Preventing from claiming cart of a wrong user
     @no-api @ui @mink:chromedriver
     Scenario: Preventing anonymous user from claiming cart of logged in user
         Given on this channel account verification is not required
-        And I have product "PHP T-Shirt" in the cart
-        When I register with email "eddard@stark.com" and password "handOfTheKing"
+        When I add product "PHP T-Shirt" to the cart
+        And I register with email "eddard@stark.com" and password "handOfTheKing"
         And I log out
         And an anonymous user in another browser adds products "PHP T-Shirt" and "Kotlin T-Shirt" to the cart
         And they complete addressing step with email "robb@stark.com" and "United States" based billing address
@@ -65,8 +65,8 @@ Feature: Preventing from claiming cart of a wrong user
     Scenario: Preventing logged in user from claiming cart of anonymous user
         Given an anonymous user added product "Kotlin T-Shirt" to the cart
         And they have completed addressing step with email "robb@stark.com" and "United States" based billing address
-        When I log in as "robb@stark.com"
-        And I add product "Sylius T-Shirt" to the cart
+        And I am logged in as "robb@stark.com"
+        When I add product "Sylius T-Shirt" to the cart
         And I view my cart in the previous session
         Then there should be one item in my cart
         And my cart total should be "$150.00"

--- a/features/shop/checkout/preventing_skipping_checkout_steps.feature
+++ b/features/shop/checkout/preventing_skipping_checkout_steps.feature
@@ -14,51 +14,53 @@ Feature: Preventing skipping checkout steps
         And the store allows paying Offline
         And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Skipping shipping checkout step
-        Given I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
         When I want to complete checkout
         Then I should be on the checkout shipping step
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Skipping payment checkout step
-        Given I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I have selected "Free" shipping method
         And I complete the shipping step
-        When I want to complete checkout
+        And I want to complete checkout
         Then I should be on the checkout payment step
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Skipping addressing checkout step
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
         When I want to complete checkout
         Then I should be on the checkout addressing step
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Skipping addressing checkout step when order total is zero
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I have product "Paganini T-Shirt" in the cart
         And I am at the checkout addressing step
         When I want to complete checkout
         Then I should be on the checkout addressing step
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Not being able to skip the checkout shipping selection step when order total is zero
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I have product "Paganini T-Shirt" in the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I want to complete checkout
         Then I should be on the checkout shipping step
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Not being able go to payment checkout step when order total is zero and payments not exists
-        Given I have product "PHP T-Shirt" in the cart
-        And I have product "Paganini T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "Paganini T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete checkout
         And I have selected "Free" shipping method
         And I complete the shipping step
-        When I want to pay for order
+        And I want to pay for order
         Then I should be on the checkout complete step

--- a/features/shop/checkout/product_integrity_validation.feature
+++ b/features/shop/checkout/product_integrity_validation.feature
@@ -16,7 +16,7 @@ Feature: Order products integrity
 
     @api @ui @javascript
     Scenario: Preventing customer from completing checkout with no longer available products
-        Given I have product "PHP T-Shirt" added to the cart
+        When I add product "PHP T-Shirt" to the cart
         And I have proceeded through checkout process
         But the product "PHP T-Shirt" has been disabled
         When I try to confirm my order

--- a/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
+++ b/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
@@ -13,15 +13,15 @@ Feature: Receiving confirmation email after finalizing checkout
 
     @api @ui @mink:chromedriver @email
     Scenario: Receiving confirmation email after finalizing checkout
-        Given I have product "Sig Sauer P226" in the cart
+        When I add product "Sig Sauer P226" to the cart
         And I have completed addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded order with "Free" shipping method and "Offline" payment
-        When I confirm my order
+        And I confirm my order
         Then an email with the summary of order placed by "john@example.com" should be sent to him
 
     @api @ui @mink:chromedriver @email
     Scenario: Receiving confirmation email after finalizing checkout in different locale than the default one
-        Given I have product "Sig Sauer P226" in the cart
+        When I add product "Sig Sauer P226" to the cart
         And I have proceeded through checkout process in the "Polish (Poland)" locale with email "john@example.com"
-        When I confirm my order
+        And I confirm my order
         Then an email with the summary of order placed by "john@example.com" should be sent to him in "Polish (Poland)" locale

--- a/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
+++ b/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
@@ -14,8 +14,8 @@ Feature: Receiving confirmation email after finalizing checkout
     @api @ui @mink:chromedriver @email
     Scenario: Receiving confirmation email after finalizing checkout
         When I add product "Sig Sauer P226" to the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded order with "Free" shipping method and "Offline" payment
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then an email with the summary of order placed by "john@example.com" should be sent to him
 

--- a/features/shop/checkout/registering_account_after_checkout.feature
+++ b/features/shop/checkout/registering_account_after_checkout.feature
@@ -13,10 +13,10 @@ Feature: Registering a new account after checkout
     @no-api @ui @javascript
     Scenario: Displaying thank you page after registration
         Given on this channel account verification is required
-        And I have product "PHP T-Shirt" in the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded order with "Free" shipping method and "Offline" payment
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with "Free" shipping method and "Offline" payment
+        And I confirm my order
         When I proceed to the registration
         And I specify a password as "sylius"
         And I confirm this password
@@ -26,10 +26,10 @@ Feature: Registering a new account after checkout
     @no-api @ui @javascript
     Scenario: Registering a new account after checkout when channel has enabled registration verification
         Given on this channel account verification is required
-        And I have product "PHP T-Shirt" in the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded order with "Free" shipping method and "Offline" payment
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with "Free" shipping method and "Offline" payment
+        And I confirm my order
         When I proceed to the registration
         And I specify a password as "sylius"
         And I confirm this password
@@ -40,10 +40,10 @@ Feature: Registering a new account after checkout
     @no-api @ui @javascript
     Scenario: Registering a new account after checkout when channel has disabled registration verification
         Given on this channel account verification is not required
-        And I have product "PHP T-Shirt" in the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based billing address
-        And I have proceeded order with "Free" shipping method and "Offline" payment
-        And I have confirmed order
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I proceed with "Free" shipping method and "Offline" payment
+        And I confirm my order
         When I proceed to the registration
         And I specify a password as "sylius"
         And I confirm this password

--- a/features/shop/checkout/returning_from_order_summary_page_to_one_of_previous_steps.feature
+++ b/features/shop/checkout/returning_from_order_summary_page_to_one_of_previous_steps.feature
@@ -13,60 +13,66 @@ Feature: Returning from order summary page to one of previous steps
         And the store ships everywhere for Free
         And the store allows paying with "Cash on Delivery"
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to payment step
-        Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
+        Given I am a logged in customer
+        And I have product "Stark Robe" in the cart
+        And I addressed the cart
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I decide to change the payment method
         Then I should be redirected to the payment step
         And I should be able to go to the summary page again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to shipping step with steps panel
-        Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
-        And I proceed with "Free" shipping method and "Cash on Delivery" payment
-        When I go to the shipping step
+        Given I am a logged in customer
+        And I added product "Stark Robe" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Cash on Delivery" payment
+        And I go to the shipping step
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to addressing step with steps panel
-        Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
-        And I proceed with "Free" shipping method and "Cash on Delivery" payment
-        When I go to the addressing step
+        Given I am a logged in customer
+        And I added product "Stark Robe" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Cash on Delivery" payment
+        And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to addressing step with steps panel when used an email of customer which had placed an order before
         Given the store has customer "jon@snow.wall"
         And this customer has a "United States" based address in their address book
-        And I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
-        And I proceed with "Free" shipping method and "Cash on Delivery" payment
-        When I go to the addressing step
+        And I am a logged in customer
+        And I added product "Stark Robe" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method and "Cash on Delivery" payment
+        And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to shipping step with steps panel when order total is zero
-        Given I have product "Stark Robe" in the cart
-        And I have product "Paganini T-Shirt" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
-        And I proceed with "Free" shipping method
-        When I go to the shipping step
+        Given I am a logged in customer
+        And I added product "Stark Robe" to the cart
+        And I added product "Paganini T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method
+        And I go to the shipping step
         Then I should be redirected to the shipping step
         And I should be able to go to the complete step again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to addressing step with steps panel when order total is zero
-        Given I have product "Stark Robe" in the cart
-        And I have product "Paganini T-Shirt" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
-        And I proceed with "Free" shipping method
-        When I go to the addressing step
+        Given I am a logged in customer
+        And I added product "Stark Robe" to the cart
+        And I added product "Paganini T-Shirt" to the cart
+        And I addressed the cart
+        When I proceed with "Free" shipping method
+        And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again

--- a/features/shop/checkout/seeing_order_summary/seeing_addresses_on_order_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_addresses_on_order_summary_page.feature
@@ -13,17 +13,17 @@ Feature: Seeing order addresses on order summary page
 
     @api @ui @javascript
     Scenario: Seeing the same shipping and billing address on order summary
-        Given I have product "Lannister Coat" in the cart
+        When I add product "Lannister Coat" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
-        Then I should be on the checkout summary step
+        And I should be on the checkout summary step
         And address to "Jon Snow" should be used for both shipping and billing of my order
 
     @api @ui @mink:chromedriver
     Scenario: Seeing different shipping and billing address on order summary
-        Given I have product "Lannister Coat" in the cart
+        When I add product "Lannister Coat" to the cart
         And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
         And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Cash on Delivery" payment

--- a/features/shop/checkout/seeing_order_summary/seeing_current_prices_of_products_after_catalog_promotion_becomes_ineligible.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_current_prices_of_products_after_catalog_promotion_becomes_ineligible.feature
@@ -13,11 +13,11 @@ Feature: Seeing current prices of products after catalog promotion becomes ineli
         And there is a catalog promotion "Winter sale" available in "United States" channel that reduces price by "25%" and applies on "PHP T-Shirt" variant
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Processing order with valid prices after catalog promotion becomes ineligibly
         Given I have "PHP T-Shirt" variant of this product in the cart
-        When the "Winter sale" catalog promotion is no longer available
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed through checkout process
+        And the "Winter sale" catalog promotion is no longer available
+        And I addressed the cart
+        When I proceed through checkout process
         Then I should be on the checkout summary step
         And I should see product "T-Shirt" with unit price "$20.00"

--- a/features/shop/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
@@ -15,9 +15,9 @@ Feature: Seeing a order item discount
 
     @api @ui @javascript
     Scenario: Seeing a discounted price on order item
-        Given I have product "Lannister Coat" in the cart
+        When I add product "Lannister Coat" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
+        And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And the "Lannister Coat" product should have unit price discounted by "$10.00"
         And my order total should be "$90.00"

--- a/features/shop/checkout/seeing_order_summary/seeing_order_locale.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_order_locale.feature
@@ -21,8 +21,8 @@ Feature: Seeing order locale on order summary page
 
     @no-api @ui @javascript
     Scenario: Seeing order locale on the order summary page after change channel locale
-        Given I have product "Stark T-Shirt" in the cart
-        When I proceed through checkout process in the "French (France)" locale
+        When I add product "Stark T-Shirt" to the cart
+        And I proceed through checkout process in the "French (France)" locale
         Then I should be on the checkout summary step
         And my order's locale should be "French (France)"
 

--- a/features/shop/checkout/seeing_order_summary/seeing_shipping_discount_on_order_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_shipping_discount_on_order_summary_page.feature
@@ -15,10 +15,10 @@ Feature: Seeing shipping discount on order summary
 
     @api @ui @javascript
     Scenario: Seeing order shipping discount on the order summary page
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "DHL" shipping method and "Offline" payment
+        And I proceed with "DHL" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And "Holiday promotion" should be applied to my order shipping
         And this promotion should give "-$5.00" discount on shipping

--- a/features/shop/checkout/seeing_order_summary/seeing_shipping_method_and_payment_method_on_order_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_shipping_method_and_payment_method_on_order_summary_page.feature
@@ -13,8 +13,8 @@ Feature: Seeing an order shipping method and payment method details on summary p
 
     @api @ui @javascript
     Scenario: Seeing shipping method and payment method
-        Given I have product "Lannister Coat" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "Lannister Coat" to the cart
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Cash on delivery" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order's shipping method should be "Cash on delivery"

--- a/features/shop/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
@@ -29,9 +29,9 @@ Feature: Seeing a summary of the order with free product
 
     @api @ui @javascript
     Scenario: Seeing order with both Free and paid products
-        Given I have product "Greyjoy Coat" in the cart
-        And I have product "Lannister Coat" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "Greyjoy Coat" to the cart
+        And I add product "Lannister Coat" to the cart
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "DHL" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order total should be "$104.50"

--- a/features/shop/checkout/seeing_order_summary/seeing_total_discount_on_order_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_total_discount_on_order_summary_page.feature
@@ -17,9 +17,9 @@ Feature: Seeing order promotion total on order summary page
 
     @api @ui @javascript
     Scenario: Seeing the total discount on order summary page
-        Given I have product "The Sorting Hat" in the cart
+        When I add product "The Sorting Hat" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
+        And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order promotion total should be "-$9.00"
         And "Holiday promotion" should be applied to my order

--- a/features/shop/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
+++ b/features/shop/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
@@ -15,8 +15,8 @@ Feature: Seeing tax total on order summary page
 
     @api @ui @javascript
     Scenario: Seeing the total tax on order summary page
-        Given I have product "The Sorting Hat" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "The Sorting Hat" to the cart
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my tax total should be "$23.00"

--- a/features/shop/checkout/seeing_purchaser_identifier_in_checkout_page.feature
+++ b/features/shop/checkout/seeing_purchaser_identifier_in_checkout_page.feature
@@ -1,7 +1,7 @@
 @checkout
 Feature: Seeing purchaser identifier in checkout page
     In order to improve checkout experience
-    As a customer
+    As a Customer
     I want to see my name or email in checkout header
 
     Background:
@@ -13,8 +13,8 @@ Feature: Seeing purchaser identifier in checkout page
 
     @no-api @ui @javascript
     Scenario: Seeing email in checkout header as a guest
-        Given I have product "Gaming chair" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "Gaming chair" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         Then I should be making an order as "john@example.com"
 
     @no-api @ui @javascript

--- a/features/shop/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
+++ b/features/shop/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
@@ -12,7 +12,7 @@ Feature: Returning from shipping step to addressing step
 
     @no-api @ui @javascript
     Scenario: Going back to addressing step with button
-        Given I have product "Apollo 11 T-Shirt" in the cart
+        When I add product "Apollo 11 T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I decide to change my address
         Then I should be redirected to the addressing step
@@ -20,8 +20,8 @@ Feature: Returning from shipping step to addressing step
 
     @no-api @ui @javascript
     Scenario: Going back to the addressing step with steps panel
-        Given I have product "Apollo 11 T-Shirt" in the cart
+        When I add product "Apollo 11 T-Shirt" to the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I go to the addressing step
+        And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again

--- a/features/shop/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/shop/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -19,9 +19,9 @@ Feature: Seeing default shipping method selected based on shipping address
 
     @api @ui @javascript
     Scenario: Seeing default shipping method selected based on country from billing address
-        Given I have product "Star Trek Ship" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "Star Trek Ship" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see selected "DHL" shipping method
@@ -29,9 +29,9 @@ Feature: Seeing default shipping method selected based on shipping address
 
     @api @ui @javascript
     Scenario: Seeing default shipping method selected based on country from billing address after readdressing
-        Given I have product "Star Trek Ship" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add product "Star Trek Ship" to the cart
+        And I go to the checkout addressing step
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I decide to change my address
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"

--- a/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
@@ -28,7 +28,7 @@ Feature: Seeing detailed shipping fee on multiple channels with different base c
     @api @ui @javascript
     Scenario: Seeing the shipping fee on selecting shipping method on a different channel in its base currency
         Given I changed my current channel to "Web-GB"
-        And I have added 2 products "PHP T-Shirt" in the cart
+        And I added 2 products "PHP T-Shirt" in the cart
         When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "£12.00"

--- a/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
@@ -28,8 +28,8 @@ Feature: Seeing detailed shipping fee on multiple channels with different base c
     @api @ui @javascript
     Scenario: Seeing the shipping fee on selecting shipping method on a different channel in its base currency
         Given I changed my current channel to "Web-GB"
-        And I added 2 products "PHP T-Shirt" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I add 2 products "PHP T-Shirt" to the cart
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "£12.00"
         And I should see shipping method "FedEx" with fee "£16.00"

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
@@ -23,54 +23,54 @@ Feature: Seeing shipping methods which category is same as category of all my un
         And this shipping method requires that all units match to "Over-sized" shipping category
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing only shipping method which category is same as categories of all my units
-        Given I have product "Rocket T-Shirt" in the cart
-        And I have product "Picasso T-Shirt" in the cart
-        When I am at the checkout addressing step
+        Given I added product "Rocket T-Shirt" to the cart
+        And I added product "Picasso T-Shirt" to the cart
+        When I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Raven Post" shipping method
         And I should not see "Invisible Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping method which category is same as category of my unit
-        Given I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
+        Given I added product "Star Trek Ship" to the cart
+        When I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
         And I should not see "Raven Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing no shipping methods if my units matches to different shipping categories
-        And I have product "Rocket T-Shirt" in the cart
-        And I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
+        Given I added product "Rocket T-Shirt" to the cart
+        And I added product "Star Trek Ship" to the cart
+        When I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing no shipping methods if not all variants of my units has same shipping category
         Given the "T-Shirt banana" product's "S" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "M" size belongs to "Over-sized" shipping category
         And I have product "T-Shirt banana" with product option "Size" S in the cart
         And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I am at the checkout addressing step
+        When I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing shipping methods if all variants of my units has same shipping category
         Given the "T-Shirt banana" product's "M" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "S" size belongs to "Standard" shipping category
         And I have product "T-Shirt banana" with product option "Size" S in the cart
         And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I am at the checkout addressing step
+        When I go to the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
@@ -21,7 +21,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And this shipping method requires at least one unit matches to "Over-sized" shipping category
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods which match to my units categories
         Given I have product "Star Trek Ship" in the cart
         And I have product "Picasso T-Shirt" in the cart
@@ -32,7 +32,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And I should see "Raven Post" shipping method
         And I should see "Invisible Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not seeing shipping method which not match to my units category
         Given I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
@@ -42,7 +42,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And I should see "Invisible Post" shipping method
         And I should not see "Raven Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing no shipping methods if any of them match to my units categories
         Given the store has a product "Rocket T-Shirt" priced at "$20.00"
         And I have product "Rocket T-Shirt" in the cart
@@ -51,7 +51,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing no shipping methods if any of my unit has variant with shipping category matching to the shipping category of shipping method
         Given I have product "T-Shirt banana" with product option "Size" S in the cart
         And I have product "T-Shirt banana" with product option "Size" M in the cart
@@ -60,7 +60,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing shipping methods if some of my unit has variant with shipping category matching to the shipping category of shipping method
         Given the "T-Shirt banana" product's "M" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "S" size belongs to "Over-sized" shipping category

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
@@ -18,7 +18,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And this shipping method requires that no units match to "Over-sized" shipping category
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods when all of my products fit the shipping category
         Given I have product "Picasso T-Shirt" in the cart
         When I am at the checkout addressing step
@@ -27,7 +27,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing no shipping methods when all of my products are excluded from the shipping category
         Given I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
@@ -35,7 +35,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing no shipping methods when any of my products is excluded from the shipping category
         Given I have product "Picasso T-Shirt" in the cart
         And I have product "Star Trek Ship" in the cart
@@ -44,7 +44,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing no shipping methods when any of my variants is excluded from the shipping category
         Given the "T-Shirt banana" product's "S" size belongs to "Over-sized" shipping category
         And I have product "T-Shirt banana" with product option "Size" S in the cart
@@ -54,7 +54,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Seeing shipping methods when all of my variants fit the shipping category
         Given I have product "T-Shirt banana" with product option "Size" S in the cart
         And I have product "T-Shirt banana" with product option "Size" M in the cart

--- a/features/shop/checkout/shipping_order/selecting_order_shipping_method.feature
+++ b/features/shop/checkout/shipping_order/selecting_order_shipping_method.feature
@@ -11,7 +11,7 @@ Feature: Selecting order shipping method
         And the store has "Dragon Post" shipping method with "$30.00" fee
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Selecting one of available shipping method
         Given I have product "Targaryen T-Shirt" in the cart
         And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/checkout/shipping_order/shipping_method_integrity_validation.feature
+++ b/features/shop/checkout/shipping_order/shipping_method_integrity_validation.feature
@@ -1,7 +1,7 @@
 @checkout
 Feature: Order shipping method integrity
     In order to have valid shipping method on my order
-    As a Visitor
+    As a Customer
     I want to have valid order
 
     Background:
@@ -17,13 +17,14 @@ Feature: Order shipping method integrity
         And this product belongs to "Heavy stuff" shipping category
         And the store has a product "T-Shirt Breaking Bad" priced at "$12.54"
         And this product belongs to "Small stuff" shipping category
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Validate shipping method after administrator changes shipping method requirements
         Given I added product "Westworld host" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
-        And I have proceeded order with "DHL" shipping method and "Offline" payment
+        And I addressed the cart
+        When I have proceeded order with "DHL" shipping method and "Offline" payment
         And product "Westworld host" shipping category has been changed to "Small stuff"
-        When I want to complete checkout
+        And I want to complete checkout
         Then I should not be able to confirm order because products do not fit "DHL" requirements
         And I should not see the thank you page

--- a/features/shop/checkout/shipping_order/sorting_shipping_method_selection.feature
+++ b/features/shop/checkout/shipping_order/sorting_shipping_method_selection.feature
@@ -14,7 +14,7 @@ Feature: Sorting shipping method selection
 
     @api @ui @javascript
     Scenario: Seeing shipping methods sorted
-        Given I have product "Targaryen T-Shirt" in the cart
+        When I add product "Targaryen T-Shirt" to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step

--- a/features/shop/checkout/skipping_payment_step_when_order_total_is_zero.feature
+++ b/features/shop/checkout/skipping_payment_step_when_order_total_is_zero.feature
@@ -15,9 +15,9 @@ Feature: Skipping payment selection when order total is zero
 
     @api @ui @javascript
     Scenario: Seeing order summary after shipping selection when order total is zero
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step
@@ -26,9 +26,9 @@ Feature: Skipping payment selection when order total is zero
 
     @api @ui @javascript
     Scenario: Seeing payment selection after shipping selection when order total is not zero
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "SHL" shipping method
         And I complete the shipping step

--- a/features/shop/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
+++ b/features/shop/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
@@ -16,10 +16,10 @@ Feature: Skipping payment selection when order total is zero after applying coup
 
     @no-api @ui @javascript
     Scenario: Seeing order summary after shipping selection when order total is zero
-        Given I have product "PHP T-Shirt" in the cart
+        When I add product "PHP T-Shirt" to the cart
         And I use coupon with code "HOLIDAYPROMO"
         And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step

--- a/features/shop/inventory/cart_inventory/prevent_buying_more_products_than_available_in_a_stock.feature
+++ b/features/shop/inventory/cart_inventory/prevent_buying_more_products_than_available_in_a_stock.feature
@@ -1,7 +1,7 @@
 @cart_inventory
 Feature: Prevent buying more products than available in a stock
     In order to buy only available items
-    As a Visitor
+    As a Customer
     I want to be prevented from adding items over the available amount
 
     Background:
@@ -9,6 +9,7 @@ Feature: Prevent buying more products than available in a stock
         And the store has a product "T-Shirt Mononoke" priced at "$12.54"
         And "T-Shirt Mononoke" product is tracked by the inventory
         And there are 5 units of product "T-Shirt Mononoke" available in the inventory
+        And I am a logged in customer
 
     @api @ui @javascript
     Scenario: Preventing from adding more items to the cart than it's available in stock

--- a/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
+++ b/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
@@ -16,14 +16,14 @@ Feature: Verifying inventory quantity on cart summary
 
     @api @ui @javascript
     Scenario: Being unable to save a cart with product that is out of stock
-        Given I have added 3 products "Iron Maiden T-Shirt" to the cart
+        Given I added 3 products "Iron Maiden T-Shirt" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 6 in my cart
         Then I should be notified that this product has insufficient stock
 
     @no-api @ui @javascript
     Scenario: Preventing the cart recalculation when the form has errors
-        Given I have added 3 products "Iron Maiden T-Shirt" to the cart
-        And I have added 1 product "Black Dress" to the cart
+        Given I added 3 products "Iron Maiden T-Shirt" to the cart
+        And I added product "Black Dress" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 4 in my cart
         And I change product "Black Dress" quantity to 11 in my cart
         Then I should be notified that this product has insufficient stock
@@ -33,6 +33,6 @@ Feature: Verifying inventory quantity on cart summary
 
     @api @ui @javascript
     Scenario: Placing an order with products that have sufficient quantity
-        Given I have added 3 products "Iron Maiden T-Shirt" in the cart
+        Given I added 3 products "Iron Maiden T-Shirt" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 5 in my cart
         Then I should not be notified that this product cannot be updated

--- a/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
+++ b/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
@@ -12,6 +12,7 @@ Feature: Verifying inventory quantity on cart summary
         And the store has a product "Black Dress" priced at "€50.20"
         And this product is tracked by the inventory
         And there are 10 units of product "Black Dress" available in the inventory
+        And I am a logged in customer
 
     @api @ui @javascript
     Scenario: Being unable to save a cart with product that is out of stock

--- a/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
+++ b/features/shop/inventory/cart_inventory/verify_inventory_quantity_when_updating_cart_summary.feature
@@ -14,13 +14,13 @@ Feature: Verifying inventory quantity on cart summary
         And there are 10 units of product "Black Dress" available in the inventory
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Being unable to save a cart with product that is out of stock
         Given I added 3 products "Iron Maiden T-Shirt" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 6 in my cart
         Then I should be notified that this product has insufficient stock
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Preventing the cart recalculation when the form has errors
         Given I added 3 products "Iron Maiden T-Shirt" to the cart
         And I added product "Black Dress" to the cart
@@ -31,7 +31,7 @@ Feature: Verifying inventory quantity on cart summary
         And I should see "Black Dress" with quantity 11 in my cart
         And the cart total should be "$100.36"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Placing an order with products that have sufficient quantity
         Given I added 3 products "Iron Maiden T-Shirt" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 5 in my cart

--- a/features/shop/promotion/applying_promotion_coupon/removing_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/removing_promotion_coupon.feature
@@ -1,7 +1,7 @@
 @applying_promotion_coupon
 Feature: Removing promotion coupon
     In order to be able to make my mind if I want to use the promotion code or not
-    As a Visitor
+    As a Customer
     I want to have possibility to remove once requested coupon code
 
     Background:
@@ -9,11 +9,13 @@ Feature: Removing promotion coupon
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
         And this promotion gives "$10.00" discount to every order
-        And I have product "PHP T-Shirt" in the cart
-        And this cart has promotion applied with coupon "SANTA2016"
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Removing coupon code from cart
-        When I remove coupon from my cart
+        Given I added product "PHP T-Shirt" to the cart
+        And this cart has promotion applied with coupon "SANTA2016"
+        When I check details of my cart
+        And I remove coupon from my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
+++ b/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
@@ -14,23 +14,23 @@ Feature: Reapplying promotion on cart change
     Scenario: Not receiving discount on shipping after removing last item from cart
         Given the store has "DHL" shipping method with "$10.00" fee
         And the promotion gives "100%" discount on shipping to every order
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed it
-        When I proceed with selecting "DHL" shipping method
+        When I proceed with "DHL" shipping method
         And I remove product "PHP T-Shirt" from the cart
-        Then cart should be empty with no value
+        Then my cart should be empty
         And there should be no shipping fee
         And there should be no discount applied
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving discount on shipping after shipping method change
         Given the store has "DHL" shipping method with "$10.00" fee
         And the store has "FedEx" shipping method with "$30.00" fee
         And the promotion gives "100%" discount on shipping to every order
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed it
-        And I chose "DHL" shipping method
-        When I decide to change order shipping method
+        When I chose "DHL" shipping method
+        And I decide to change order shipping method
         And I change shipping method to "FedEx"
         And I complete the shipping step
         Then my cart total should be "$100.00"
@@ -40,9 +40,9 @@ Feature: Reapplying promotion on cart change
     Scenario: Receiving discount after removing an item from the cart and then adding another one
         Given the store has a product "Symfony T-Shirt" priced at "$150.00"
         And the promotion gives "$10.00" discount to every order
-        And I had product "PHP T-Shirt" in the cart
-        But I removed product "PHP T-Shirt" from the cart
-        When I add product "Symfony T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I remove product "PHP T-Shirt" from the cart
+        And I add product "Symfony T-Shirt" to the cart
         Then my cart total should be "$140.00"
         And my discount should be "-$10.00"
 

--- a/features/shop/promotion/complex_promotions.feature
+++ b/features/shop/promotion/complex_promotions.feature
@@ -15,62 +15,65 @@ Feature: Receiving a discount based on a configured promotion
         And this product belongs to "Dresses"
         And the store has a product "Rammstein bow tie" priced at "$10.00"
         And this product belongs to "Formal attire"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on the first order
         Given there is a promotion "First order promotion"
         And it gives "20%" off on the customer's 1st order
-        And I am a logged in customer
-        When I add product "Metallica dress" to the cart
+        And I added product "Metallica dress" to the cart
+        When I check details of my cart
         Then my cart total should be "$40.00"
         And my discount should be "-$10.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving a discount on items and shipping from one promotion based on items total
         Given the store has "DHL" shipping method with "$10.00" fee
         And there is a promotion "Jackets and shipping discount"
         And it gives "$10.00" off on every product classified as "Jackets" and a free shipping to every order with items total equal at least "$500.00"
-        And I am a logged in customer
-        When I add 7 products "Black Sabbath jacket" to the cart
+        And I added 7 products "Black Sabbath jacket" to the cart
         And I addressed the cart
-        And I proceed with selecting "DHL" shipping method
+        When I proceed with "DHL" shipping method
         Then theirs subtotal price should be decreased by "$70.00"
         And my cart total should be "$630.00"
         And my cart shipping total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on products from a specific taxon if an order contains products from an another taxon
         Given there is a promotion "Jacket-trousers pack"
         And it gives "10%" off on every product classified as "Jackets" if order contains any product classified as "Trousers"
-        When I add product "Iron Maiden trousers" to the cart
-        And I add product "Black Sabbath jacket" to the cart
+        And I added products "Iron Maiden trousers" and "Black Sabbath jacket" to the cart
+        When I check details of my cart
         Then product "Black Sabbath jacket" price should be discounted by "$10.00"
         And my cart total should be "$170.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on items and the whole order from one promotion based on items total
         Given there is a promotion "Greatest promotion"
         And it gives "20%" off on every product classified as "Jackets" and a "$50.00" discount to every order with items total equal at least "$500.00"
-        When I add 7 products "Black Sabbath jacket" to the cart
+        And I added 7 products "Black Sabbath jacket" to the cart
+        When I check details of my cart
         Then theirs subtotal price should be decreased by "$140.00"
         And my cart total should be "$510.00"
         And my discount should be "-$190.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on products from multiple taxons based on products from different taxons
         Given there is a promotion "Formal attire pack"
         And it gives "10%" off on every product classified as "Formal attire" or "Dresses" if order contains any product classified as "Trousers" or "Jackets"
-        When I add products "Rammstein bow tie", "Metallica dress" and "Iron Maiden trousers" to the cart
+        And I added products "Rammstein bow tie", "Metallica dress" and "Iron Maiden trousers" to the cart
+        When I check details of my cart
         Then product "Metallica dress" price should be discounted by "$5.00"
         And product "Rammstein bow tie" price should be discounted by "$1.00"
         And my cart total should be "$134.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on products from a specific taxon together with fixed discount on order
         Given there is a promotion "Jacket-trousers pack"
         And it gives "10%" off on every product classified as "Jackets" and "$20.00" discount on every order
-        When I add product "Iron Maiden trousers" to the cart
-        And I add product "Black Sabbath jacket" to the cart
+        And I added product "Iron Maiden trousers" to the cart
+        And I added product "Black Sabbath jacket" to the cart
+        When I check details of my cart
         Then product "Black Sabbath jacket" price should be discounted by "$10.00"
         And my discount should be "-$30.00"
         And my cart total should be "$150.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
@@ -8,41 +8,44 @@ Feature: Receiving fixed discount on cart
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has a product "PHP Mug" priced at "$6.00"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount for my cart
         Given there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
         Given there is a promotion "Christmas Sale"
         And it gives "$106.00" discount to every order
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check details of my cart
         Then my cart total should be "$0.00"
         And my discount should be "-$106.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
         Given there is a promotion "Thanksgiving sale"
         And it gives "$200.00" discount to every order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$0.00"
         And my discount should be "-$100.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving fixed discount does not affect the shipping fee
         Given the store has "DHL" shipping method with "$10.00" fee
         And there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
-        And I am a logged in customer
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed it
-        And I proceed with selecting "DHL" shipping method
+        When I proceed with selecting "DHL" shipping method
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$10.00"
         And my discount should be "-$10.00"

--- a/features/shop/promotion/reverting_discount/reverting_previously_applied_discount_on_cart.feature
+++ b/features/shop/promotion/reverting_discount/reverting_previously_applied_discount_on_cart.feature
@@ -9,12 +9,13 @@ Feature: Reverting previously applied discount on cart
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has a product "PHP Mug" priced at "$20.00"
         And there is a promotion "Christmas promotion"
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Reverting discount applied from total item quantity based promotion
         Given this promotion gives "$10.00" discount to every order with quantity at least 2
-        And I have product "PHP Mug" in the cart
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
         When I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$20.00"
         And there should be no discount applied
@@ -22,7 +23,7 @@ Feature: Reverting previously applied discount on cart
     @api @ui @mink:chromedriver
     Scenario: Reverting discount applied from total item cost based promotion
         Given this promotion gives "10%" off on every product when the item total is at least "$100.00"
-        And I have 8 products "PHP Mug" in the cart
+        And I added 8 products "PHP Mug" to the cart
         When I change product "PHP Mug" quantity to 4
         Then product "PHP Mug" price should not be decreased
         And my cart total should be "$80.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
@@ -12,7 +12,7 @@ Feature: Apply correct shipping fee on order
         And the store has "UPS" shipping method with "$5.00" fee per unit for "United States" channel
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Adding proper shipping fee
         Given I have product "PHP T-Shirt" in the cart
         And I addressed the cart
@@ -21,7 +21,7 @@ Feature: Apply correct shipping fee on order
         Then my cart total should be "$110.00"
         And my cart shipping total should be "$10.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Changing shipping fee after shipping method change
         Given I have product "PHP T-Shirt" in the cart
         And I addressed the cart

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -21,17 +21,17 @@ Feature: Apply correct shipping fee with product taxes on order
         And the store allows paying Offline
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper shipping fee, tax and product tax
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I proceed with selecting "DHL" shipping method
+        When I proceed with "DHL" shipping method
         And I choose "Offline" payment method
         Then my cart total should be "$135.30"
         And my cart taxes should be "$25.30"
         And my cart shipping total should be "$12.30"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper shipping fee, tax and products' taxes after addressing
         Given I have 3 products "PHP T-Shirt" in the cart
         When I proceed with selecting "Germany" as billing country

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
@@ -20,19 +20,19 @@ Feature: Apply correct shipping fee with taxes on order
         And the store allows paying Offline
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper shipping fee and tax
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I proceed with selecting "DHL" shipping method
+        When I proceed with "DHL" shipping method
         And I choose "Offline" payment method
         Then my cart total should be "$112.30"
         And my cart taxes should be "$2.30"
         And my cart shipping total should be "$12.30"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper shipping fee and tax after addressing
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         When I proceed with selecting "Germany" as billing country
         And I proceed with "DHL-World" shipping method
         And I choose "Offline" payment method

--- a/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
@@ -14,12 +14,14 @@ Feature: Seeing estimated shipping costs based on items total
         And this shipping method is only available for orders under or equal to "$29.99"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a value over minimum price configured on the shipping method
-        When I add product "Expensive Jacket" to the cart
+        Given I added product "Expensive Jacket" to the cart
+        When I check details of my cart
         Then my cart estimated shipping cost should be "$1.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a value under maximum price configured on the shipping method
-        When I add product "Cheap Jacket" to the cart
+        Given I added product "Cheap Jacket" to the cart
+        When I check details of my cart
         Then my cart estimated shipping cost should be "$10.00"

--- a/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
@@ -16,12 +16,14 @@ Feature: Seeing estimated shipping costs based on total weight
         And this shipping method is only available for orders with a total weight less or equal to 1.0
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a total weight over minimum total weight configured on the shipping method
-        When I add product "Jacket for the Lochness Monster" to the cart
+        Given I added product "Jacket for the Lochness Monster" to the cart
+        When I check details of my cart
         Then my cart estimated shipping cost should be "$200.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a total weight under maximum total weight configured on the shipping method
-        When I add product "T-Shirt for Tinkerbell" to the cart
+        Given I added product "T-Shirt for Tinkerbell" to the cart
+        When I check details of my cart
         Then my cart estimated shipping cost should be "$2.00"

--- a/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total.feature
@@ -15,29 +15,29 @@ Feature: Viewing available shipping methods based on items total
         And the store has "DHL" shipping method with "$20.00" fee
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle expensive goods
-        Given I have product "Expensive Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "Expensive Jacket" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Above $50" shipping method
         And I should not see "Below $29.99" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle cheap goods
-        Given I have product "Cheap Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "Cheap Jacket" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Below $29.99" shipping method
         And I should not see "Above $50" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle all goods
-        Given I have 2 products "Cheap Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added 2 products "Cheap Jacket" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should not see "Above $50" shipping method
         And I should not see "Below $29.99" shipping method

--- a/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total_with_taxes_and_promotions.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_items_total_with_taxes_and_promotions.feature
@@ -25,29 +25,29 @@ Feature: Viewing available shipping methods based on items total
         And it gives "$5.00" off on a "Expensive Jacket" product
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle expensive goods
-        Given I have product "Expensive Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "Expensive Jacket" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Above $50" shipping method
         And I should not see "Below $29.99" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle cheap goods
-        Given I have product "Cheap Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "Cheap Jacket" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Below $29.99" shipping method
         And I should not see "Above $50" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle all goods
         Given I have 2 products "Cheap Jacket" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should not see "Above $50" shipping method
         And I should not see "Below $29.99" shipping method

--- a/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/viewing_available_shipping_methods_based_on_total_weight.feature
@@ -17,30 +17,30 @@ Feature: Viewing available shipping methods based on total weight
         And this shipping method is only available for orders with a total weight less or equal to 1.0
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle heavy goods
-        Given I have product "Jacket for the Lochness Monster" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "Jacket for the Lochness Monster" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Heavy Duty Courier" shipping method
         And I should not see "Fairytale Delivery Service" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle light goods
-        Given I have product "T-Shirt for Tinkerbell" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "T-Shirt for Tinkerbell" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should see "Fairytale Delivery Service" shipping method
         And I should not see "Heavy Duty Courier" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that handle all goods
-        Given I have product "T-Shirt for Tinkerbell" in the cart
-        And I add 11 of them to my cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        Given I added product "T-Shirt for Tinkerbell" to the cart
+        And I added 11 of them to my cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "DHL" shipping method
         And I should not see "Fairytale Delivery Service" shipping method
         And I should not see "Heavy Duty Courier" shipping method

--- a/features/shop/shipping/viewing_shipping_methods/viewing_available_shipping_methods_based_on_channel_as_a_shop_user.feature
+++ b/features/shop/shipping/viewing_shipping_methods/viewing_available_shipping_methods_based_on_channel_as_a_shop_user.feature
@@ -1,7 +1,7 @@
 @viewing_shipping_methods
-Feature: Viewing available shipping methods based on channel as a Shop User
+Feature: Viewing available shipping methods based on channel
     In order to only see applicable shipping methods
-    As a Shop User
+    As a Customer
     I want to see the shipping methods that are available to my order based on the channel
 
     Background:
@@ -16,20 +16,20 @@ Feature: Viewing available shipping methods based on channel as a Shop User
         And the store has a product "T-Shirt" priced at "$20.00" available in channel "United Kingdom" and channel "United States"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that are available in channel as an logged in customer
         Given I changed my current channel to "United States"
-        And I have product "T-Shirt" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        And I added product "T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "ultra fast" shipping method
         And I should not see "uber speedy" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods that are available in another channel as an logged in customer
         Given I changed my current channel to "United Kingdom"
-        And I have product "T-Shirt" in the cart
-        When I specified the billing address
-        Then I should be on the checkout shipping step
+        And I added product "T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         And I should see "uber speedy" shipping method
         And I should not see "ultra fast" shipping method

--- a/features/shop/shipping/viewing_shipping_methods/viewing_available_shipping_methods_based_on_channel_as_a_visitor.feature
+++ b/features/shop/shipping/viewing_shipping_methods/viewing_available_shipping_methods_based_on_channel_as_a_visitor.feature
@@ -18,8 +18,8 @@ Feature: Viewing available shipping methods based on channel as a Visitor
     @api @ui @javascript
     Scenario: Seeing shipping methods that are available in channel
         Given I changed my current channel to "United States"
-        And I have product "T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         Then I should be on the checkout shipping step
         And I should see "ultra fast" shipping method
         And I should not see "uber speedy" shipping method
@@ -27,8 +27,8 @@ Feature: Viewing available shipping methods based on channel as a Visitor
     @api @ui @javascript
     Scenario: Seeing shipping methods that are available in another channel
         Given I changed my current channel to "United Kingdom"
-        And I have product "T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        When I add product "T-Shirt" to the cart
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         Then I should be on the checkout shipping step
         And I should see "uber speedy" shipping method
         And I should not see "ultra fast" shipping method

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_items_with_the_same_tax_rate.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_items_with_the_same_tax_rate.feature
@@ -1,7 +1,7 @@
 @applying_taxes
 Feature: Apply correct taxes for items with the same tax rate
     In order to pay proper amount when buying goods from the same tax category
-    As a Visitor
+    As a Customer
     I want to have correct taxes applied to my order
 
     Background:
@@ -12,38 +12,43 @@ Feature: Apply correct taxes for items with the same tax rate
         And it belongs to "Clothes" tax category
         And the store has a product "Symfony Hat" priced at "$30.00"
         And it belongs to "Clothes" tax category
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes for taxed product
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes for multiple same products with the same tax rate
-        When I add 3 products "PHP T-Shirt" to the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes for multiple different products with the same tax rate
-        When I add 3 products "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony Hat" to the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
+        When I check details of my cart
         Then my cart total should be "$442.80"
         And my cart taxes should be "$82.80"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Proper taxes after removing one of the item
-        Given I have 3 products "PHP T-Shirt" in the cart
-        And I have 2 products "Symfony Hat" in the cart
-        When I remove product "PHP T-Shirt" from the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
+        When I check details of my cart
+        And I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$73.80"
         And my cart taxes should be "$13.80"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Proper taxes after changing item quantity
-        Given I have 3 products "PHP T-Shirt" in the cart
-        And I have 2 products "Symfony Hat" in the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
         When I change product "PHP T-Shirt" quantity to 1 in my cart
         Then my cart total should be "$196.80"
         And my cart taxes should be "$36.80"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
@@ -27,7 +27,7 @@ Feature: Apply correct taxes for products with different tax rates for different
 
     @api @ui @javascript
     Scenario: Displaying correct tax after specifying billing address
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         When I proceed with selecting "Germany" as billing country
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
@@ -48,7 +48,7 @@ Feature: Apply correct taxes for products with different tax rates for different
 
     @api @ui @javascript
     Scenario: Displaying correct taxes for multiple products from different zones after specifying billing address
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I have 2 products "Symfony Mug" in the cart
         When I proceed with selecting "Germany" as billing country
         Then my cart total should be "$223.00"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
@@ -23,7 +23,7 @@ Feature: Apply correct taxes on visitor cart
 
     @api @ui @javascript
     Scenario: Proper taxes after specifying billing address
-        Given I have product "PHP T-Shirt" in the cart
-        When I proceed as guest "john@example.com" with "Austria" as billing country
+        When I add product "PHP T-Shirt" to the cart
+        And I proceed as guest "john@example.com" with "Austria" as billing country
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"

--- a/features/shop/taxation/applying_taxes_based_on_order_item_units_calculation_strategy/applying_correct_taxes_for_item_units_with_the_same_tax_rate.feature
+++ b/features/shop/taxation/applying_taxes_based_on_order_item_units_calculation_strategy/applying_correct_taxes_for_item_units_with_the_same_tax_rate.feature
@@ -1,7 +1,7 @@
 @applying_taxes
 Feature: Applying correct taxes for item units with the same tax rate
     In order to pay proper amount when buying goods from the same tax category
-    As a Visitor
+    As a Customer
     I want to have correct taxes applied to my order
 
     Background:
@@ -13,38 +13,44 @@ Feature: Applying correct taxes for item units with the same tax rate
         And it belongs to "Clothes" tax category
         And the store has a product "Symfony Hat" priced at "$30.00"
         And it belongs to "Clothes" tax category
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Applying correct taxes for a single unit
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Applying correct taxes for multiple units of the same product
-        When I add 3 products "PHP T-Shirt" to the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check details of my cart
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Applying correct taxes for multiple units of different products
-        When I add 3 products "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony Hat" to the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
+        When I check details of my cart
         Then my cart total should be "$442.80"
         And my cart taxes should be "$82.80"
 
     @api @ui @javascript
     Scenario: Applying correct taxes after removing one of the item
-        Given I have 3 products "PHP T-Shirt" in the cart
-        And I have 2 products "Symfony Hat" in the cart
-        When I remove product "PHP T-Shirt" from the cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
+        When I check details of my cart
+        And I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$73.80"
         And my cart taxes should be "$13.80"
 
     @api @ui @javascript
     Scenario: Applying correct taxes after changing item quantity
-        Given I have 3 products "PHP T-Shirt" in the cart
-        And I have 2 products "Symfony Hat" in the cart
-        When I change product "PHP T-Shirt" quantity to 1 in my cart
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Hat" to the cart
+        When I check details of my cart
+        And I change product "PHP T-Shirt" quantity to 1 in my cart
         Then my cart total should be "$196.80"
         And my cart taxes should be "$36.80"

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -91,7 +91,7 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
         if ($this->sharedStorage->has('cart_token')) {
             $this->sharedStorage->set('previous_cart_token', $this->sharedStorage->get('cart_token'));
-            $this->sharedStorage->set('cart_token', null);
+            $this->sharedStorage->remove('cart_token');
         }
     }
 }

--- a/src/Sylius/Behat/Context/Api/EmailContext.php
+++ b/src/Sylius/Behat/Context/Api/EmailContext.php
@@ -109,7 +109,7 @@ final class EmailContext implements Context
             sprintf(
                 '%s %s %s',
                 $this->translator->trans('sylius.email.order_confirmation.your_order_number', [], null, $localeCode),
-                $order->getNumber(),
+                $order->getNumber() ?? $this->sharedStorage->get('order_number'),
                 $this->translator->trans('sylius.email.order_confirmation.has_been_successfully_placed', [], null, $localeCode),
             ),
             $recipient,

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -118,7 +118,6 @@ final class CartContext implements Context
     /**
      * @When /^I add ("[^"]+" variant) of (this product) to the (cart)$/
      * @When /^I add ("[^"]+" variant) of (product "[^"]+") to the (cart)$/
-     * @When /^I have ("[^"]+" variant) of (product "[^"]+") in the (cart)$/
      */
     public function iAddVariantOfThisProductToTheCart(
         ProductVariantInterface $productVariant,

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -380,16 +380,15 @@ final class CartContext implements Context
     }
 
     /**
-     * @Then /^my (cart) should be empty$/
-     * @Then /^(cart) should be empty with no value$/
+     * @Then my cart should be empty
      */
-    public function myCartShouldBeEmpty(string $tokenValue): void
+    public function myCartShouldBeEmpty(): void
     {
-        $response = $this->shopClient->show(Resources::ORDERS, $tokenValue);
+        $tokenValue = $this->sharedStorage->get('cart_token');
 
-        Assert::true(
-            $this->responseChecker->isShowSuccessful($response),
-            SprintfResponseEscaper::provideMessageWithEscapedResponseContent('Cart has not been created.', $response),
+        Assert::isEmpty(
+            $this->responseChecker->getValue($this->shopClient->show(Resources::ORDERS, $tokenValue), 'items'),
+            'Cart is not empty.',
         );
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -207,7 +207,6 @@ final class CartContext implements Context
     }
 
     /**
-     * @Given /^I removed (product "[^"]+") from the (cart)$/
      * @When /^I remove (product "[^"]+") from the (cart)$/
      */
     public function iRemoveProductFromTheCart(ProductInterface $product, string $tokenValue): void

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -23,6 +23,7 @@ use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Behat\Service\SprintfResponseEscaper;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -40,6 +41,7 @@ final class CartContext implements Context
         private IriConverterInterface $iriConverter,
         private RequestFactoryInterface $requestFactory,
         private string $apiUrlPrefix,
+        private OrderRepositoryInterface $orderRepository,
     ) {
     }
 
@@ -50,7 +52,7 @@ final class CartContext implements Context
     {
         $this->shopClient->delete(Resources::ORDERS, $tokenValue);
 
-        $this->sharedStorage->set('cart_token', null);
+        $this->sharedStorage->remove('cart_token');
     }
 
     /**
@@ -844,6 +846,7 @@ final class CartContext implements Context
             'created_as_guest',
             $this->responseChecker->getValue($this->shopClient->getLastResponse(), 'customer') === null,
         );
+        $this->sharedStorage->set('order', $this->orderRepository->findOneBy(['tokenValue' => $tokenValue]));
 
         return $tokenValue;
     }

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
@@ -38,6 +38,7 @@ final class CheckoutOrderDetailsContext implements Context
     public function iWantToBrowseOrderDetailsForThisOrder(OrderInterface $order): void
     {
         $this->sharedStorage->set('cart_token', $order->getTokenValue());
+        $this->sharedStorage->set('order', $order);
         $this->client->show(Resources::ORDERS, $order->getTokenValue());
     }
 

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -440,6 +440,7 @@ final class CheckoutContext implements Context
             'order_number',
             $this->responseChecker->getValue($response, 'number'),
         );
+        $this->sharedStorage->set('order', $this->orderRepository->findOneByNumber($this->sharedStorage->get('order_number')));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -1252,7 +1252,7 @@ final class CheckoutContext implements Context
     /**
      * @When /^I try to add (product "[^"]+") to the (cart)$/
      */
-    public function iTryToAddProductToCart(ProductInterface $product, string $tokenValue): void
+    public function iTryToAddProductToCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->putProductToCart($product, $tokenValue);
     }
@@ -1297,7 +1297,7 @@ final class CheckoutContext implements Context
     /**
      * @When /^I try to remove (product "[^"]+") from the (cart)$/
      */
-    public function iTryToRemoveProductFromTheCart(ProductInterface $product, string $tokenValue): void
+    public function iTryToRemoveProductFromTheCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->removeOrderItemFromCart($product->getId(), $tokenValue);
     }
@@ -1305,7 +1305,7 @@ final class CheckoutContext implements Context
     /**
      * @When /^I try to change quantity to (\d+) of (product "[^"]+") from the (cart)$/
      */
-    public function iTryToChangeQuantityToOfProductFromTheCart(int $quantity, ProductInterface $product, string $tokenValue): void
+    public function iTryToChangeQuantityToOfProductFromTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->putProductToCart($product, $tokenValue, $quantity);
     }

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -331,6 +332,12 @@ final class CheckoutContext implements Context
 
         $this->content['billingAddress']['firstName'] = $names[0];
         $this->content['billingAddress']['lastName'] = $names[1];
+    }
+
+    #[When('I want to complete the shipping step')]
+    public function iWantToCompleteTheShippingStep(): void
+    {
+        // Intentionally left blank, as this is a UI-specific action.
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -1251,11 +1251,11 @@ final class CheckoutContext implements Context
     }
 
     /**
-     * @When /^I try to add (product "[^"]+") to the (cart)$/
+     * @When /^I try to add (product "[^"]+") to the cart$/
      */
-    public function iTryToAddProductToCart(ProductInterface $product, ?string $tokenValue): void
+    public function iTryToAddProductToCart(ProductInterface $product): void
     {
-        $this->putProductToCart($product, $tokenValue);
+        $this->putProductToCart($product, $this->sharedStorage->get('cart_token'));
     }
 
     /**
@@ -1296,11 +1296,11 @@ final class CheckoutContext implements Context
     }
 
     /**
-     * @When /^I try to remove (product "[^"]+") from the (cart)$/
+     * @When /^I try to remove (product "[^"]+") from the cart$/
      */
-    public function iTryToRemoveProductFromTheCart(ProductInterface $product, ?string $tokenValue): void
+    public function iTryToRemoveProductFromTheCart(ProductInterface $product): void
     {
-        $this->removeOrderItemFromCart($product->getId(), $tokenValue);
+        $this->removeOrderItemFromCart($product->getId(), $this->sharedStorage->get('cart_token'));
     }
 
     /**
@@ -1669,7 +1669,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    private function putProductToCart(ProductInterface $product, string $tokenValue, int $quantity = 1): void
+    private function putProductToCart(ProductInterface $product, ?string $tokenValue, int $quantity = 1): void
     {
         Assert::notNull($productVariant = $this->productVariantResolver->getVariant($product));
         Assert::isInstanceOf($productVariant, ProductVariantInterface::class);
@@ -1677,7 +1677,7 @@ final class CheckoutContext implements Context
         $this->putVariantToCart($productVariant, $tokenValue, $quantity);
     }
 
-    private function putVariantToCart(ProductVariantInterface $productVariant, string $tokenValue, int $quantity = 1): void
+    private function putVariantToCart(ProductVariantInterface $productVariant, ?string $tokenValue, int $quantity = 1): void
     {
         $request = $this->requestFactory->customItemAction(
             'shop',
@@ -1694,7 +1694,7 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('response', $this->client->executeCustomRequest($request));
     }
 
-    private function removeOrderItemFromCart(int $orderItemId, string $tokenValue): void
+    private function removeOrderItemFromCart(int $orderItemId, ?string $tokenValue): void
     {
         $request = $this->requestFactory->customItemAction(
             'shop',

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -80,6 +80,7 @@ final readonly class OrderContext implements Context
     {
         $this->shopClient->show(Resources::ORDERS, $order->getTokenValue());
 
+        $this->sharedStorage->set('order', $order);
         $this->sharedStorage->set('cart_token', $order->getTokenValue());
     }
 

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -57,6 +57,7 @@ final readonly class CartContext implements Context
     /**
      * @Given /^I have(?:| added) (\d+) (product(?:|s) "[^"]+") (?:to|in) the (cart)$/
      * @Given /^I added(?:| again) (\d+) (products "[^"]+") to the (cart)$/
+     * @Given /^I added (\d+) of (them) to (?:the|my) (cart)$/
      */
     public function iAddedGivenQuantityOfProductsToTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
@@ -78,7 +79,7 @@ final readonly class CartContext implements Context
 
     /**
      * @Given /^I added (product "[^"]+") to the (cart)$/
-     * @Given /^I (?:have|had) (product "[^"]+") in the (cart)$/
+     * @Given /^I have (product "[^"]+") in the (cart)$/
      * @Given /^I have (product "[^"]+") added to the (cart)$/
      * @Given /^the (?:customer|visitor) has (product "[^"]+") in the (cart)$/
      * @Given /^the (?:customer|visitor) added ("[^"]+" product) to the (cart)$/
@@ -117,7 +118,7 @@ final readonly class CartContext implements Context
         ?string $tokenValue,
     ): void {
         if ($tokenValue === null) {
-            $tokenValue = $this->pickupCart();
+            $tokenValue = $this->pickupCart($tokenValue);
         }
 
         $this->commandBus->dispatch(new AddItemToCart(

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -95,7 +95,7 @@ final readonly class CartContext implements Context
      */
     public function iHaveVariantOfProductInTheCart(ProductVariantInterface $productVariant, ?string $tokenValue): void
     {
-        if ($tokenValue === null) {
+        if ($tokenValue === null || !$this->doesCartWithTokenExist($tokenValue)) {
             $tokenValue = $this->pickupCart();
         }
 

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -107,6 +107,7 @@ final readonly class CartContext implements Context
         ));
 
         $this->sharedStorage->set('product', $productVariant->getProduct());
+        $this->sharedStorage->set('variant', $productVariant);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -56,10 +56,24 @@ final readonly class CartContext implements Context
 
     /**
      * @Given /^I have(?:| added) (\d+) (product(?:|s) "[^"]+") (?:to|in) the (cart)$/
+     * @Given /^I added(?:| again) (\d+) (products "[^"]+") to the (cart)$/
      */
-    public function iHaveAddedProductsToTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
+    public function iAddedGivenQuantityOfProductsToTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue, $quantity);
+    }
+
+    /**
+     * @Given /^I added (products "([^"]+)" and "([^"]+)") to the (cart)$/
+     * @Given /^I added (products "([^"]+)", "([^"]+)" and "([^"]+)") to the (cart)$/
+     *
+     * @param ProductInterface[] $products
+     */
+    public function iAddedProductsAndToTheCart(array $products, ?string $tokenValue): void
+    {
+        foreach ($products as $product) {
+            $this->addProductToCart($product, $tokenValue);
+        }
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -91,6 +91,7 @@ final readonly class CartContext implements Context
     }
 
     /**
+     * @Given /^I have ("[^"]+" variant of product "[^"]+") in the (cart)$/
      * @Given /^I have ("[^"]+" variant of this product) in the (cart)$/
      */
     public function iHaveVariantOfProductInTheCart(ProductVariantInterface $productVariant, ?string $tokenValue): void

--- a/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
@@ -14,27 +14,30 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Sylius\Behat\Service\SecurityServiceInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Webmozart\Assert\Assert;
 
 final readonly class ShopSecurityContext implements Context
 {
+    /** @param UserRepositoryInterface<ShopUserInterface> $userRepository */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private SecurityServiceInterface $securityService,
         private ExampleFactoryInterface $userFactory,
         private UserRepositoryInterface $userRepository,
+        private JWTTokenManagerInterface $jwtTokenManager,
     ) {
     }
 
-    /**
-     * @Given I am logged in as :email
-     * @Given the customer logged in as :email
-     * @When I log in as :email
-     */
+    #[Given('I am logged in as :email')]
+    #[Given('the customer logged in as :email')]
     public function iAmLoggedInAs(string $email): void
     {
         $user = $this->userRepository->findOneByEmail($email);
@@ -43,16 +46,16 @@ final readonly class ShopSecurityContext implements Context
         $this->securityService->logIn($user);
 
         $this->sharedStorage->set('user', $user);
+
+        $this->storeUserToken($user);
     }
 
-    /**
-     * @Given I am a logged in customer with name :fullName
-     * @Given I am a logged in customer
-     * @Given the customer logged in
-     */
+    #[Given('I am a logged in customer')]
+    #[Given('I am a logged in customer with name :fullName')]
+    #[Given('the customer logged in')]
     public function iAmLoggedInCustomer(?string $fullName = null): void
     {
-        $userData = ['email' => 'sylius@example.com', 'password' => 'sylius', 'enabled' => true];
+        $userData = ['email' => 'shop@example.com', 'password' => 'sylius', 'enabled' => true];
 
         if ($fullName !== null) {
             $names = explode(' ', $fullName);
@@ -67,11 +70,11 @@ final readonly class ShopSecurityContext implements Context
         $this->securityService->logIn($user);
 
         $this->sharedStorage->set('user', $user);
+
+        $this->storeUserToken($user);
     }
 
-    /**
-     * @Given I am a logged in customer by using remember me option
-     */
+    #[Given('I am a logged in customer by using remember me option')]
     public function iAmLoggedInCustomerByUsingRememberMeOption(): void
     {
         $userData = ['email' => 'sylius@example.com', 'password' => 'sylius', 'enabled' => true];
@@ -80,5 +83,13 @@ final readonly class ShopSecurityContext implements Context
         $this->userRepository->add($user);
 
         $this->securityService->logInWithRememberMe($user);
+
+        $this->storeUserToken($user);
+    }
+
+    /** Set the token in the shared storage to have access both in UI and API to resources created in the setup context */
+    private function storeUserToken(UserInterface $user): void
+    {
+        $this->sharedStorage->set('token', $this->jwtTokenManager->create($user));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -303,9 +303,9 @@ final readonly class CartContext implements Context
      * @Given /^I (?:add|added) (this product) to the cart$/
      * @Given /^I have (product "[^"]+") added to the cart$/
      * @Given he added product :product to the cart
-     * @Given /^the customer (?:added|adds) ("[^"]+" product) to the cart$/
      * @Given /^the visitor has (product "[^"]+") in the cart$/
      * @Given /^the customer has (product "[^"]+") in the cart$/
+     * @When /^the customer adds ("[^"]+" product) to the cart$/
      * @When /^I add ("[^"]+" product) to the (cart)$/
      * @When /^the visitor adds ("[^"]+" product) to the cart$/
      * @When I add product :product to the cart

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -76,7 +76,6 @@ final readonly class CartContext implements Context
     /**
      * @Then my cart should be empty
      * @Then my cart should be cleared
-     * @Then cart should be empty with no value
      */
     public function iShouldBeNotifiedThatMyCartIsEmpty(): void
     {
@@ -305,7 +304,6 @@ final readonly class CartContext implements Context
      * @Given /^I (?:add|added) (this product) to the cart$/
      * @Given /^I have (product "[^"]+") added to the cart$/
      * @Given he added product :product to the cart
-     * @Given /^I had (product "[^"]+") in the cart$/
      * @Given /^the customer (?:added|adds) ("[^"]+" product) to the cart$/
      * @Given /^the visitor has (product "[^"]+") in the cart$/
      * @Given /^the customer has (product "[^"]+") in the cart$/
@@ -455,7 +453,6 @@ final readonly class CartContext implements Context
 
     /**
      * @Given I have :product with :productOption :productOptionValue in the cart
-     * @Given I have product :product with product option :productOption :productOptionValue in the cart
      * @When I add :product with :productOption :productOptionValue to the cart
      */
     public function iAddThisProductWithToTheCart(

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -348,8 +348,6 @@ final readonly class CartContext implements Context
     }
 
     /**
-     * @Given I have :variantName variant of product :product in the cart
-     * @Given /^I have "([^"]+)" variant of (this product) in the cart$/
      * @When I add :variantName variant of product :product to the cart
      * @When /^I add "([^"]+)" variant of (this product) to the cart$/
      */

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -548,7 +548,6 @@ final readonly class CartContext implements Context
 
     /**
      * @Given I use coupon with code :couponCode
-     * @Given this cart has promotion applied with coupon :couponCode
      */
     public function iUseCouponWithCode(string $couponCode): void
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -85,7 +85,6 @@ final readonly class CartContext implements Context
     }
 
     /**
-     * @Given I removed product :productName from the cart
      * @When I remove product :productName from the cart
      */
     public function iRemoveProductFromTheCart(string $productName): void

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -304,13 +304,12 @@ final readonly class CartContext implements Context
      * @Given /^an anonymous user added (product "([^"]+)") to the cart$/
      * @Given /^I (?:add|added) (this product) to the cart$/
      * @Given /^I have (product "[^"]+") added to the cart$/
-     * @Given I added product :product to the cart
      * @Given he added product :product to the cart
-     * @Given /^I (?:have|had) (product "[^"]+") in the cart$/
+     * @Given /^I had (product "[^"]+") in the cart$/
      * @Given /^the customer (?:added|adds) ("[^"]+" product) to the cart$/
-     * @Given /^I (?:add|added) ("[^"]+" product) to the (cart)$/
      * @Given /^the visitor has (product "[^"]+") in the cart$/
      * @Given /^the customer has (product "[^"]+") in the cart$/
+     * @When /^I add ("[^"]+" product) to the (cart)$/
      * @When /^the visitor adds ("[^"]+" product) to the cart$/
      * @When I add product :product to the cart
      * @When I add the product :product to the cart
@@ -383,8 +382,7 @@ final readonly class CartContext implements Context
     }
 
     /**
-     * @Given /^I have(?:| added) (\d+) (product(?:|s) "([^"]+)") (?:to|in) the cart$/
-     * @When /^I add(?:|ed)(?:| again) (\d+) (products "([^"]+)") to the cart$/
+     * @When /^I add(?:| again) (\d+) (products "([^"]+)") to the cart$/
      */
     public function iAddProductsToTheCart(string $quantity, ProductInterface $product): void
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -39,17 +39,6 @@ final readonly class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @Given I addressed the cart
-     * @Given I addressed it
-     */
-    public function iAddressedTheCart(): void
-    {
-        $this->addressPage->open();
-        $this->addressPage->specifyBillingAddress($this->createDefaultAddress());
-        $this->addressPage->nextStep();
-    }
-
-    /**
      * @Given the visitor has completed the addressing step
      * @Given the customer has completed the addressing step
      * @When the customer completes the addressing step
@@ -238,7 +227,6 @@ final readonly class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @Given /^I have specified the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
      * @When I specified the billing address
      * @When /^I specified the billing (address as "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/
      * @When /^I define the billing (address as "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -44,7 +44,7 @@ final readonly class CheckoutShippingContext implements Context
     public function iHaveProceededWithSelectingShippingMethod(string $shippingMethodName): void
     {
         if (!$this->selectShippingPage->isOpen()) {
-            throw new UnexpectedPageException(sprintf('Shipping method "%s" cannot be selected because checkout shipping page is not open.', $shippingMethodName));
+            $this->selectShippingPage->open();
         }
 
         $this->selectShippingPage->selectShippingMethod($shippingMethodName);

--- a/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
@@ -74,6 +74,10 @@ final readonly class CheckoutContext implements Context
      */
     public function iProceedOrderWithShippingMethodAndPayment(string $shippingMethodName, string $paymentMethodName): void
     {
+        if (!$this->selectShippingPage->isOpen()) {
+            $this->selectShippingPage->open();
+        }
+
         $this->selectShippingPage->selectShippingMethod($shippingMethodName);
         $this->selectShippingPage->nextStep();
 

--- a/src/Sylius/Behat/Exception/SharedStorageElementNotFoundException.php
+++ b/src/Sylius/Behat/Exception/SharedStorageElementNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Exception;
+
+final class SharedStorageElementNotFoundException extends \InvalidArgumentException
+{
+    public function __construct(string $key = "", int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            sprintf('No element found in shared storage with key "%s"', $key),
+            $code,
+            $previous,
+        );
+    }
+}

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -47,6 +47,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.request_factory" />
             <argument>%sylius.security.api_route%</argument>
+            <argument type="service" id="sylius.repository.order"/>
         </service>
 
         <service id="sylius.behat.context.api.shop.customer" class="Sylius\Behat\Context\Api\Shop\CustomerContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -244,6 +244,7 @@
             <argument type="service" id="sylius.behat.shop_security" />
             <argument type="service" id="sylius.fixture.example_factory.shop_user" />
             <argument type="service" id="sylius.repository.shop_user" />
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager" />
         </service>
 
         <service id="sylius.behat.context.setup.shop_api_security" class="Sylius\Behat\Context\Setup\ShopSecurityContext">
@@ -251,6 +252,7 @@
             <argument type="service" id="sylius.behat.api_shop_security" />
             <argument type="service" id="sylius.fixture.example_factory.shop_user" />
             <argument type="service" id="sylius.repository.shop_user" />
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager" />
         </service>
 
         <service id="sylius.behat.context.setup.shipping" class="Sylius\Behat\Context\Setup\ShippingContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -431,6 +431,8 @@
             <argument type="service" id="sylius.behat.page.shop.checkout.complete" />
             <argument type="service" id="sylius.behat.notification_checker.shop" />
             <argument type="service" id="sylius.behat.page.shop.order.thank_you" />
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
 
         <service id="sylius.behat.context.ui.shop.checkout.registration_after_checkout" class="Sylius\Behat\Context\Ui\Shop\Checkout\RegistrationAfterCheckoutContext">

--- a/src/Sylius/Behat/Resources/config/suites/api/account/address_book.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/account/address_book.yml
@@ -22,6 +22,7 @@ default:
                 - sylius.behat.context.setup.address
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment
@@ -31,6 +32,7 @@ default:
                 - sylius.behat.context.setup.user
 
                 - sylius.behat.context.api.shop.address
+                - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
                 - sylius.behat.context.api.shop.save
 

--- a/src/Sylius/Behat/Resources/config/suites/api/inventory/cart_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/inventory/cart_inventory.yml
@@ -15,6 +15,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shop_security
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.product

--- a/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
@@ -33,6 +33,7 @@ default:
                 - sylius.behat.context.setup.calendar
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical
@@ -50,6 +51,7 @@ default:
 
                 - sylius.behat.context.api.admin.managing_orders
                 - sylius.behat.context.api.email                
+                - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/receiving_discount.yml
@@ -20,6 +20,7 @@ default:
                 - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.taxon
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_method_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_method_rules.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.setup.address
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/viewing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/viewing_shipping_methods.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.setup.address
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
@@ -16,6 +16,7 @@ default:
                 - sylius.behat.context.transform.user
 
                 - sylius.behat.context.setup.address
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
@@ -22,7 +22,9 @@ default:
                 - sylius.behat.context.transform.user
                 - sylius.behat.context.transform.zone
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -19,6 +19,7 @@ default:
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.zone
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.exchange_rate

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
@@ -33,7 +33,9 @@ default:
 
                 - sylius.behat.context.setup.address
                 - sylius.behat.context.setup.admin_user
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.exchange_rate

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
@@ -10,6 +10,7 @@ default:
                 - sylius.behat.context.hook.session
 
                 - sylius.behat.context.transform.address
+                - sylius.behat.context.transform.cart
                 - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.currency

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.admin_user
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.transform.order
                 - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.product_variant
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.tax_category
@@ -27,6 +28,7 @@ default:
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.locale

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/cart_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/cart_inventory.yml
@@ -12,8 +12,10 @@ default:
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shop_security
 
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.product

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -32,7 +32,9 @@ default:
                 - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.calendar
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
@@ -20,6 +20,7 @@ default:
                 - sylius.behat.context.transform.taxon
                 - sylius.behat.context.transform.user
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.order
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
@@ -21,7 +21,9 @@ default:
                 - sylius.behat.context.transform.taxon
                 - sylius.behat.context.transform.user
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.customer_group
                 - sylius.behat.context.setup.order

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
@@ -17,7 +17,9 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.taxon
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
@@ -17,7 +17,9 @@ default:
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.zone
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
@@ -18,7 +18,9 @@ default:
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.zone
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/viewing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/viewing_shipping_methods.yml
@@ -18,7 +18,9 @@ default:
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.zone
 
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.calendar
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer

--- a/src/Sylius/Behat/Service/SharedStorage.php
+++ b/src/Sylius/Behat/Service/SharedStorage.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service;
 
+use Sylius\Behat\Exception\SharedStorageElementNotFoundException;
+
 class SharedStorage implements SharedStorageInterface
 {
     private array $clipboard = [];
@@ -22,7 +24,7 @@ class SharedStorage implements SharedStorageInterface
     public function get(string $key)
     {
         if (!isset($this->clipboard[$key])) {
-            throw new \InvalidArgumentException(sprintf('There is no current resource for "%s"!', $key));
+            throw new SharedStorageElementNotFoundException($key);
         }
 
         return $this->clipboard[$key];

--- a/src/Sylius/Behat/Service/SharedStorageInterface.php
+++ b/src/Sylius/Behat/Service/SharedStorageInterface.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service;
 
+use Sylius\Behat\Exception\SharedStorageElementNotFoundException;
+
 interface SharedStorageInterface
 {
+    /** @throws SharedStorageElementNotFoundException */
     public function get(string $key);
 
     public function has(string $key): bool;

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/common/steps.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/common/steps.html.twig
@@ -40,9 +40,9 @@
 
 <div class="steps steps-{{ active_step }} mb-5">
     {% for step in steps|filter(step => step.required) %}
-        <div class="steps-item steps-item-{{ step.state }}" {{ sylius_test_html_attribute(step.test_attribute) }}>
+        <div class="steps-item steps-item-{{ step.state }}">
             {% if step.state != 'disabled' %}
-                <a href="{{ path(step.route) }}" >
+                <a href="{{ path(step.route) }}" {{ sylius_test_html_attribute(step.test_attribute) }}>
                     {{ step.label|trans }}
                 </a>
             {% else %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Continuation of:
- https://github.com/Sylius/Sylius/pull/17782
- https://github.com/Sylius/Sylius/pull/17783

Until now, the checkout-related scenarios have been set up as follows:
	•	UI – via web actions (e.g. `Given I have a product ...` actually triggered browser actions to prepare the initial step),
	•	API – a mix of messenger commands and API calls.

During the development of Sylius 2.0, with the introduction of dynamic components, all scenarios involving product-related actions had to be marked as JS to work correctly. This significantly increased build time and reduced overall stability.

This PR focuses on decoupling the Behat architecture to unify the test setup for both UI and API. The goal is to eliminate most JS tags, which should lead to greater stability. Some performance improvements are already noticeable.


This PR doesn’t yet include all refactored scenarios, but at this stage we already observe the following performance gains:
	•	For non-JS scenarios, the timing is likely similar — some JS scenarios have been converted to non-JS, but at the same time, we benefit from faster setup thanks to the refactor (using messenger commands instead of API calls or UI interactions to prepare tests).
	•	For JS scenarios executed via Chromedriver, the same applies — some Panther scenarios have been switched to Chromedriver, and performance remains comparable.

JS with Panther: **~30 min → ~20 min**