### PR TITLE
[Behat] Reuse common setup contexts in API and UI (in `shipping order` and related scenarios)

### DIFF
--- a/features/admin/order/managing_orders/order_details/being_unable_to_see_cart.feature
+++ b/features/admin/order/managing_orders/order_details/being_unable_to_see_cart.feature
@@ -7,7 +7,7 @@ Feature: Being unable to see details of a cart
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$12.00"
-        And the customer added "PHP T-Shirt" product to the cart
+        And the customer added product "PHP T-Shirt" to the cart
         And I am logged in as an administrator
 
     @api @ui

--- a/features/admin/order/managing_orders/order_details/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
+++ b/features/admin/order/managing_orders/order_details/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
@@ -11,14 +11,15 @@ Feature: Seeing payment state as paid after checkout steps if order total is zer
         And the store allows paying Offline
         And the store has promotion "Holiday promotion" with coupon "HOLIDAYPROMO"
         And the promotion gives "$10.00" discount to every order with quantity at least 1
-        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
-        And the customer bought a single "Angel T-Shirt"
-        And the customer used coupon "HOLIDAYPROMO"
-        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
-        And the customer chose "Free" shipping method
-        And I am logged in as an administrator
+        And the customer logged in
 
     @api @ui
     Scenario: Seeing payment state as paid on orders list
+        Given the customer added product "Angel T-Shirt" to the cart
+        And the customer addressed the cart
+        And the customer used coupon "HOLIDAYPROMO"
+        And the customer chose "Free" shipping method
+        And the customer confirmed the order
+        And I am logged in as an administrator
         When I browse orders
-        Then the order "#00000666" should have order payment state "Paid"
+        Then the last order should have order payment state "Paid"

--- a/features/admin/order/managing_orders/order_details/seeing_order_payment_state_as_completed_if_order_total_is_zero.feature
+++ b/features/admin/order/managing_orders/order_details/seeing_order_payment_state_as_completed_if_order_total_is_zero.feature
@@ -10,24 +10,25 @@ Feature: Seeing payment state as paid after checkout steps if order total is zer
         And the store ships everywhere for Free
         And there is a promotion "Holiday promotion"
         And the promotion gives "$10.00" discount to every order with quantity at least 1
-        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
-        And the customer bought a single "Angel T-Shirt"
-        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
+        And the customer logged in
+        And the customer added product "Angel T-Shirt" to the cart
+        And the customer addressed the cart
         And the customer chose "Free" shipping method
+        And the customer confirmed the order
         And I am logged in as an administrator
 
     @api @ui
     Scenario: Seeing payment state as paid on orders list
         When I browse orders
-        Then the order "#00000666" should have order payment state "Paid"
+        Then the last order should have order payment state "Paid"
 
     @api @no-ui
     Scenario: Seeing payment state as paid on order's summary
-        When I view the summary of the order "#00000666"
+        When I view the summary of the last order
         Then I should be informed that there are no payments
 
     @no-api @ui
     Scenario: Seeing payment state as paid on order's summary
-        When I view the summary of the order "#00000666"
+        When I view the summary of the last order
         Then I should be informed that there are no payments
         And I should not be able to refund this payment

--- a/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
+++ b/features/hybrid/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
@@ -22,8 +22,8 @@ Feature: Placing an order on multiple channels with same currency
         Given I changed my current channel to "Web"
         And I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I proceeded with "Free" shipping method and "Offline" payment method
-        And I confirm my order
+        And I chose "Free" shipping method and "Offline" payment method
+        When I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
 
     @api @ui

--- a/features/shop/cart/shopping_cart/allowing_access_only_for_correctly_logged_in_users.feature
+++ b/features/shop/cart/shopping_cart/allowing_access_only_for_correctly_logged_in_users.feature
@@ -10,103 +10,105 @@ Feature: Allowing access only for correctly logged in users
         And the store allows paying Offline
         And the store has "UPS" shipping method with "$20.00" fee
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
-        Then the visitor can see "Stark T-Shirt" product in the cart
+        Given the visitor added product "Stark T-Shirt" to the cart
+        When the visitor checks the details of their cart
+        Then the visitor should see "Stark T-Shirt" product in the cart
 
     @api @ui @javascript
     Scenario: Accessing to add address to the cart by the visitor
-        Given the visitor has product "Stark T-Shirt" in the cart
-        When the visitor specify the email as "jon.snow@example.com"
+        When the visitor adds "Stark T-Shirt" product to the cart
+        And the visitor specify the email as "jon.snow@example.com"
         And the visitor specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the visitor completes the addressing step
         Then the visitor should have checkout address step completed
 
     @api @ui @javascript
     Scenario: Accessing to add shipping method to the cart by the visitor
-        Given the visitor has product "Stark T-Shirt" in the cart
+        When the visitor adds "Stark T-Shirt" product to the cart
         And the visitor has specified the email as "jon.snow@example.com"
         And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the visitor has completed the addressing step
-        When the visitor proceed with "UPS" shipping method
+        When the visitor proceeds with "UPS" shipping method
         Then the visitor should have checkout shipping method step completed
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Accessing to add payment method to the cart by the visitor
-        Given the visitor has product "Stark T-Shirt" in the cart
+        When the visitor adds "Stark T-Shirt" product to the cart
         And the visitor has specified the email as "jon.snow@example.com"
         And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the visitor has completed the addressing step
-        And the visitor has proceeded "UPS" shipping method
-        When the visitor proceed with "Offline" payment
+        And the visitor proceeds with "UPS" shipping method
+        When the visitor proceeds with "Offline" payment method
         Then the visitor should have checkout payment step completed
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Accessing to complete the cart by the visitor
-        Given the visitor has product "Stark T-Shirt" in the cart
+        When the visitor adds "Stark T-Shirt" product to the cart
         And the visitor has specified the email as "jon.snow@example.com"
         And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the visitor has completed the addressing step
-        And the visitor has proceeded "UPS" shipping method
-        And the visitor has proceeded "Offline" payment
+        And the visitor proceeds with "UPS" shipping method
+        And the visitor proceeds with "Offline" payment method
         When the visitor confirm his order
         Then the visitor should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Accessing to increase quantity of an item in the cart by the visitor
-        Given the visitor has product "Stark T-Shirt" in the cart
-        When the visitor change product "Stark T-Shirt" quantity to 2 in his cart
+        When the visitor adds "Stark T-Shirt" product to the cart
+        And the visitor change product "Stark T-Shirt" quantity to 2 in his cart
         Then the visitor should see product "Stark T-Shirt" with quantity 2 in his cart
 
     @api @ui @javascript
     Scenario: Accessing to the cart by the logged in customer
         Given the customer logged in
         When the customer adds "Stark T-Shirt" product to the cart
-        Then the customer can see "Stark T-Shirt" product in the cart
+        Then the customer should see "Stark T-Shirt" product in the cart
 
     @api @ui @javascript
     Scenario: Accessing to add address to the cart by the customer
         Given the customer logged in
-        And the customer has product "Stark T-Shirt" in the cart
-        When the customer specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the customer completes the addressing step
+        And the customer added product "Stark T-Shirt" to the cart
+        And the customer addressed the cart
         Then the customer should have checkout address step completed
 
     @api @ui @javascript
     Scenario: Accessing to add shipping method to the cart by the customer
         Given the customer logged in
-        And the customer has product "Stark T-Shirt" in the cart
-        And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the customer has completed the addressing step
-        When the customer proceed with "UPS" shipping method
+        And the customer added product "Stark T-Shirt" to the cart
+        And the customer addressed the cart
+        When the customer proceeds with "UPS" shipping method
         Then the customer should have checkout shipping method step completed
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to add payment method to the cart by the customer
         Given the customer logged in
         And the customer has product "Stark T-Shirt" in the cart
-        And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the customer has completed the addressing step
-        And the customer has proceeded "UPS" shipping method
-        When the customer proceed with "Offline" payment
+        And the customer addressed the cart
+        And the customer chose "UPS" shipping method
+        When the customer is at the checkout payment step
+        And the customer proceeds with "Offline" payment method
         Then the customer should have checkout payment step completed
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to complete the cart by the customer
         Given the customer logged in
         And the customer has product "Stark T-Shirt" in the cart
         And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the customer has completed the addressing step
-        And the customer has proceeded "UPS" shipping method
-        And the customer has proceeded "Offline" payment
+        And the customer proceeds with "UPS" shipping method
+        And the customer proceeds with "Offline" payment method
         When the customer confirm his order
         Then the customer should see the thank you page
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Accessing to increase quantity of an item in the cart by the customer
-        Given the customer has product "Stark T-Shirt" in the cart
-        When the customer change product "Stark T-Shirt" quantity to 2 in his cart
+        Given the customer logged in
+        Given the customer added product "Stark T-Shirt" to the cart
+        When the customer checks the details of their cart
+        When I check the details of my cart
+        And the customer change product "Stark T-Shirt" quantity to 2 in his cart
         Then the customer should see product "Stark T-Shirt" with quantity 2 in his cart
 
     @api @no-ui
@@ -150,7 +152,7 @@ Feature: Allowing access only for correctly logged in users
         And the customer has product "Stark T-Shirt" in the cart
         And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the customer has completed the addressing step
-        And the customer has proceeded "UPS" shipping method
+        And the customer proceeds with "UPS" shipping method
         And the customer logged out
         Then the visitor has no access to proceed with "Offline" payment in the customer cart
 
@@ -160,8 +162,8 @@ Feature: Allowing access only for correctly logged in users
         And the customer has product "Stark T-Shirt" in the cart
         And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the customer has completed the addressing step
-        And the customer has proceeded "UPS" shipping method
-        And the customer has proceeded "Offline" payment
+        And the customer proceeds with "UPS" shipping method
+        And the customer proceeds with "Offline" payment method
         And the customer logged out
         Then the visitor has no access to confirm the customer order
 

--- a/features/shop/cart/shopping_cart/allowing_access_only_for_correctly_logged_in_users.feature
+++ b/features/shop/cart/shopping_cart/allowing_access_only_for_correctly_logged_in_users.feature
@@ -16,64 +16,65 @@ Feature: Allowing access only for correctly logged in users
         When the visitor checks the details of their cart
         Then the visitor should see "Stark T-Shirt" product in the cart
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to add address to the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
-        And the visitor specify the email as "jon.snow@example.com"
-        And the visitor specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given the visitor added product "Stark T-Shirt" to the cart
+        When the visitor specify the billing address
+        And the visitor specify the email as "guest@example.com"
         And the visitor completes the addressing step
         Then the visitor should have checkout address step completed
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to add shipping method to the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
-        And the visitor has specified the email as "jon.snow@example.com"
-        And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the visitor has completed the addressing step
-        When the visitor proceeds with "UPS" shipping method
+        Given the visitor added product "Stark T-Shirt" to the cart
+        When the visitor specify the email as "guest@example.com"
+        And the visitor specify the billing address
+        And the visitor completes the addressing step
+        And the visitor proceeds with "UPS" shipping method
         Then the visitor should have checkout shipping method step completed
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Accessing to add payment method to the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
-        And the visitor has specified the email as "jon.snow@example.com"
-        And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the visitor has completed the addressing step
-        And the visitor proceeds with "UPS" shipping method
-        When the visitor proceeds with "Offline" payment method
-        Then the visitor should have checkout payment step completed
-
-    @api @ui @mink:chromedriver
-    Scenario: Accessing to complete the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
-        And the visitor has specified the email as "jon.snow@example.com"
-        And the visitor has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And the visitor has completed the addressing step
+        Given the visitor added product "Stark T-Shirt" to the cart
+        When the visitor specify the email as "guest@example.com"
+        And the visitor specify the billing address
+        And the visitor completes the addressing step
         And the visitor proceeds with "UPS" shipping method
         And the visitor proceeds with "Offline" payment method
+        Then the visitor should have checkout payment step completed
+
+    @api @ui
+    Scenario: Accessing to complete the cart by the visitor
+        Given the visitor added product "Stark T-Shirt" to the cart
+        And the visitor addressed the cart with email "guest@example.com"
+        And the visitor chose "UPS" shipping method
+        And the visitor chose "Offline" payment method
         When the visitor confirm his order
         Then the visitor should see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui @javascript
     Scenario: Accessing to increase quantity of an item in the cart by the visitor
-        When the visitor adds "Stark T-Shirt" product to the cart
+        Given the visitor added product "Stark T-Shirt" to the cart
+        When the visitor checks the details of their cart
         And the visitor change product "Stark T-Shirt" quantity to 2 in his cart
         Then the visitor should see product "Stark T-Shirt" with quantity 2 in his cart
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to the cart by the logged in customer
         Given the customer logged in
-        When the customer adds "Stark T-Shirt" product to the cart
+        And the customer added product "Stark T-Shirt" to the cart
+        When the customer checks the details of their cart
         Then the customer should see "Stark T-Shirt" product in the cart
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to add address to the cart by the customer
         Given the customer logged in
         And the customer added product "Stark T-Shirt" to the cart
-        And the customer addressed the cart
+        When the customer specify the billing address
+        And the visitor completes the addressing step
         Then the customer should have checkout address step completed
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Accessing to add shipping method to the cart by the customer
         Given the customer logged in
         And the customer added product "Stark T-Shirt" to the cart
@@ -144,6 +145,7 @@ Feature: Allowing access only for correctly logged in users
         And the customer has specified address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And the customer has completed the addressing step
         And the customer logged out
+        When the visitor proceeds with "UPS" shipping method
         Then the visitor has no access to proceed with "UPS" shipping method in the customer cart
 
     @api @no-ui
@@ -154,6 +156,7 @@ Feature: Allowing access only for correctly logged in users
         And the customer has completed the addressing step
         And the customer proceeds with "UPS" shipping method
         And the customer logged out
+        When the customer tries to check the details of their cart
         Then the visitor has no access to proceed with "Offline" payment in the customer cart
 
     @api @no-ui
@@ -165,6 +168,7 @@ Feature: Allowing access only for correctly logged in users
         And the customer proceeds with "UPS" shipping method
         And the customer proceeds with "Offline" payment method
         And the customer logged out
+        When the customer tries to check the details of their cart
         Then the visitor has no access to confirm the customer order
 
     @api @no-ui
@@ -172,4 +176,5 @@ Feature: Allowing access only for correctly logged in users
         Given the customer logged in
         And the customer has product "Stark T-Shirt" in the cart
         And the customer logged out
+        When the customer tries to check the details of their cart
         Then the visitor has no access to change product "Stark T-Shirt" quantity to 2 in the customer cart

--- a/features/shop/checkout/accessing_order_right_after_completing_checkout.feature
+++ b/features/shop/checkout/accessing_order_right_after_completing_checkout.feature
@@ -15,6 +15,6 @@ Feature: Accessing order right after completing checkout
     Scenario: Being able to access my order right after completing checkout
         Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on delivery" payment
+        And I chose "Free" shipping method and "Cash on delivery" payment method
         When I confirm my order
         Then I should be able to access this order's details

--- a/features/shop/checkout/being_able_to_modify_remaining_steps.feature
+++ b/features/shop/checkout/being_able_to_modify_remaining_steps.feature
@@ -58,7 +58,7 @@ Feature: Changing checkout steps
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I have proceeded selecting "Free" shipping method
-        And I go back to shipping step of the checkout
+        And I go back to the shipping step
         And I select "Raven Post" shipping method
         And I complete the shipping step
         Then I should be on the checkout payment step
@@ -71,7 +71,7 @@ Feature: Changing checkout steps
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I have proceeded order with "Free" shipping method and "Offline" payment
-        And I go back to shipping step of the checkout
+        And I go back to the shipping step
         And I select "Raven Post" shipping method
         And I complete the shipping step
         Then I should be on the checkout payment step

--- a/features/shop/checkout/not_seeing_payment_method_instructions_on_thank_you_page_if_order_total_is_zero.feature
+++ b/features/shop/checkout/not_seeing_payment_method_instructions_on_thank_you_page_if_order_total_is_zero.feature
@@ -15,7 +15,8 @@ Feature: Not seeing payment method instructions on thank you page if order total
     @no-api @ui
     Scenario: Not being informed about payment instructions on thank you page
         Given I added product "PHP T-Shirt" to the cart
-        And I have proceeded through checkout process with "Free" shipping method
+        And I addressed the cart
+        And I chose "Free" shipping method
         When I confirm my order
         Then I should see the thank you page
         And I should not see any instructions about payment method

--- a/features/shop/checkout/order_promotion/order_promotion_integrity_validation.feature
+++ b/features/shop/checkout/order_promotion/order_promotion_integrity_validation.feature
@@ -12,74 +12,76 @@ Feature: Order promotions integrity
         And there is a promotion "Christmas sale"
         And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Preventing customer from completing checkout with already expired promotion
         Given this promotion gives "$10.00" discount to every order
         And this promotion is valid until tomorrow
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         And this promotion has already expired
         When I try to confirm my order
         Then I should be informed that this promotion is no longer applied
         And I should not see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Recalculating cart when promotion already expired
         Given this promotion gives "$10.00" discount to every order
         And this promotion is valid until tomorrow
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         And this promotion has already expired
         When I try to confirm my order
         And I confirm my order
         Then I should see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Being able to completing checkout with several promotions
         Given this promotion gives "12%" discount to every order
         And there is a promotion "New Year" with priority 2
         And the promotion gives "$10.00" discount to every order with items total at least "$100.00"
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount when buying items for the required total value
         Given the promotion gives "50%" discount to every order with items total at least "$80.00"
         And I added product "PHP T-Shirt" to the cart
-        When I proceed with selecting "Offline" payment method
+        And I addressed the cart
+        And I chose "Free" shipping method and "Offline" payment method
+        When I check summary of my order
         Then my order total should be "$50.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Successfully placing an order with percentage discount when buying items for the required total value
         Given the promotion gives "50%" discount to every order with items total at least "$80.00"
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Excluded tax is not taken into account into promotion integrity check
         Given the store has "VAT" tax rate of 20% for "Clothes" within the "US" zone
         And this product belongs to "Clothes" tax category
         And this promotion gives "50%" discount to every order
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         When I confirm my order
         Then I should see the thank you page
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Preventing customer from completing checkout with already archived promotion
         Given this promotion gives "$10.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceeded with "Free" shipping method and "Offline" payment method
+        And I chose "Free" shipping method and "Offline" payment method
         And the promotion "Christmas sale" is archived
         When I try to confirm my order
         Then I should be informed that this promotion is no longer applied

--- a/features/shop/checkout/paying_for_order/paying_offline_during_checkout.feature
+++ b/features/shop/checkout/paying_for_order/paying_offline_during_checkout.feature
@@ -14,16 +14,18 @@ Feature: Paying offline during checkout
     @api @ui
     Scenario: Successfully placing an order
         Given this payment method is not using Payum
-        And I have product "PHP T-Shirt" in the cart
-        And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceeded with "Free" shipping method and "Offline" payment method
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        And I chose "Free" shipping method and "Offline" payment method
+        When I check the details of my cart
         And I confirm my order
         Then I should see the thank you page
 
     @api @ui
     Scenario: Using Payum successfully placing an order
-        Given I have product "PHP T-Shirt" in the cart
-        And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceeded with "Free" shipping method and "Offline" payment method
+        Given I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
+        And I chose "Free" shipping method and "Offline" payment method
+        When I check the details of my cart
         And I confirm my order
         Then I should see the thank you page

--- a/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
+++ b/features/shop/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
@@ -18,7 +18,7 @@ Feature: Returning from payment step to one of previous steps
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I complete the shipping step
-        And I decide to change order shipping method
+        And I decide to change shipping method
         Then I should be redirected to the shipping step
         And I should be able to go to the payment step again
 

--- a/features/shop/checkout/paying_for_order/viewing_available_payment_methods_based_on_current_channel.feature
+++ b/features/shop/checkout/paying_for_order/viewing_available_payment_methods_based_on_current_channel.feature
@@ -25,7 +25,7 @@ Feature: Viewing available payment methods based on current channel
         And I am in the "United States" channel
         And I have product "PHP T-Shirt" in the cart
         When I complete addressing step with "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step
         And I should see "Bank of America" and "Offline" payment methods
         But I should not see "Bank of Poland" and "Bank of Universe" payment methods
@@ -36,7 +36,7 @@ Feature: Viewing available payment methods based on current channel
         And I am in the "Poland" channel
         And I have product "PHP T-Shirt" in the cart
         When I complete addressing step with "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step
         And I should see "Bank of Poland" and "Offline" payment methods
         But I should not see "Bank of Universe" and "Bank of America" payment methods
@@ -46,7 +46,7 @@ Feature: Viewing available payment methods based on current channel
         Given I am in the "United States" channel
         And I added product "PHP T-Shirt" to the cart
         When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step
         And I should see "Bank of America" and "Offline" payment methods
         But I should not see "Bank of Poland" and "Bank of Universe" payment methods
@@ -56,7 +56,7 @@ Feature: Viewing available payment methods based on current channel
         Given I am in the "Poland" channel
         And I added product "PHP T-Shirt" to the cart
         When I complete addressing step with email "john@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step
         And I should see "Bank of Poland" and "Offline" payment methods
         But I should not see "Bank of Universe" and "Bank of America" payment methods

--- a/features/shop/checkout/placing_an_order_after_moving_back_in_checkout.feature
+++ b/features/shop/checkout/placing_an_order_after_moving_back_in_checkout.feature
@@ -24,7 +24,7 @@ Feature: Placing an order after moving back in checkout process
     Scenario: Placing an order after moving back from the checkout summary to the shipping method step but without any shipping method modification
         Given I added product "PHP T-Shirt" to the cart
         And I was at the checkout summary step
-        When I go back to shipping step of the checkout
+        When I go back to the shipping step
         And I return to the checkout summary step
         And I confirm my order
         Then I should see the thank you page

--- a/features/shop/checkout/preventing_cart_from_being_modified_after_checkout.feature
+++ b/features/shop/checkout/preventing_cart_from_being_modified_after_checkout.feature
@@ -18,7 +18,7 @@ Feature: Preventing cart from being modified after checkout
     Scenario: Preventing from changing billing address after checkout
         Given I added product "Sig Sauer P226" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on Delivery" payment
+        And I chose "Free" shipping method and "Cash on Delivery" payment method
         And I confirmed my order
         When I try to change the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be informed that cart is no longer available
@@ -27,7 +27,7 @@ Feature: Preventing cart from being modified after checkout
     Scenario: Preventing from changing shipping method after checkout
         Given I added product "Sig Sauer P226" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on Delivery" payment
+        And I chose "Free" shipping method and "Cash on Delivery" payment method
         And I confirmed my order
         When I try to change shipping method to "UPS"
         Then I should be informed that cart is no longer available
@@ -36,7 +36,7 @@ Feature: Preventing cart from being modified after checkout
     Scenario: Preventing from adding product after checkout
         Given I added product "Sig Sauer P226" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on Delivery" payment
+        And I chose "Free" shipping method and "Cash on Delivery" payment method
         And I confirmed my order
         When I try to add product "AK-47" to the cart
         Then I should be informed that I cannot change the cart items after the checkout is completed
@@ -46,7 +46,7 @@ Feature: Preventing cart from being modified after checkout
         Given I added product "Sig Sauer P226" to the cart
         And I added product "AK-47" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on Delivery" payment
+        And I chose "Free" shipping method and "Cash on Delivery" payment method
         And I confirmed my order
         When I try to remove product "AK-47" from the cart
         Then I should be informed that cart items are no longer available
@@ -56,7 +56,7 @@ Feature: Preventing cart from being modified after checkout
         Given I added product "Sig Sauer P226" to the cart
         And I added product "AK-47" to the cart
         And I addressed the cart
-        And I proceeded with "Free" shipping method and "Cash on Delivery" payment
+        And I chose "Free" shipping method and "Cash on Delivery" payment method
         And I confirmed my order
         When I try to change product "Sig Sauer P226" quantity to 2 in my cart
         Then I should be informed that cart items are no longer available

--- a/features/shop/checkout/preventing_skipping_checkout_steps.feature
+++ b/features/shop/checkout/preventing_skipping_checkout_steps.feature
@@ -17,7 +17,7 @@ Feature: Preventing skipping checkout steps
     Scenario: Skipping shipping checkout step
         Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I want to complete checkout
+        When I try to open checkout complete page
         Then I should be on the checkout shipping step
 
     @no-api @ui
@@ -27,14 +27,14 @@ Feature: Preventing skipping checkout steps
         When I want to complete the shipping step
         And I have selected "Free" shipping method
         And I complete the shipping step
-        And I want to complete checkout
+        And I try to open checkout complete page
         Then I should be on the checkout payment step
 
     @no-api @ui
     Scenario: Skipping addressing checkout step
         Given I added product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        When I want to complete checkout
+        When I try to open checkout complete page
         Then I should be on the checkout addressing step
 
     @no-api @ui
@@ -42,7 +42,7 @@ Feature: Preventing skipping checkout steps
         Given I added product "PHP T-Shirt" to the cart
         And I have product "Paganini T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I want to complete checkout
+        When I try to open checkout complete page
         Then I should be on the checkout addressing step
 
     @no-api @ui
@@ -50,7 +50,7 @@ Feature: Preventing skipping checkout steps
         Given I added product "PHP T-Shirt" to the cart
         And I have product "Paganini T-Shirt" in the cart
         And I addressed the cart
-        When I want to complete checkout
+        When I try to open checkout complete page
         Then I should be on the checkout shipping step
 
     @no-api @ui
@@ -58,7 +58,7 @@ Feature: Preventing skipping checkout steps
         Given I added product "PHP T-Shirt" to the cart
         And I added product "Paganini T-Shirt" to the cart
         And I addressed the cart
-        When I want to complete checkout
+        When I try to open checkout complete page
         And I have selected "Free" shipping method
         And I complete the shipping step
         And I want to pay for order

--- a/features/shop/checkout/preventing_starting_checkout_with_empty_cart.feature
+++ b/features/shop/checkout/preventing_starting_checkout_with_empty_cart.feature
@@ -19,7 +19,7 @@ Feature: Preventing starting checkout with an empty cart
     @api @ui @javascript
     Scenario: Being unable to start checkout shipping step with an empty cart
         Given I added product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Joe Doe"
+        And I addressed the cart
         When I remove product "PHP T-Shirt" from the cart
         Then I should not be able to proceed checkout shipping step
         And I should be redirected to my cart summary page
@@ -27,8 +27,8 @@ Feature: Preventing starting checkout with an empty cart
     @api @ui @javascript
     Scenario: Being unable to start checkout payment step with an empty cart
         Given I added product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Joe Doe"
-        And I completed the shipping step with "Free" shipping method
+        And I addressed the cart
+        And I chose "Free" shipping method
         When I remove product "PHP T-Shirt" from the cart
         Then I should not be able to proceed checkout payment step
         And I should be redirected to my cart summary page
@@ -36,9 +36,9 @@ Feature: Preventing starting checkout with an empty cart
     @api @ui @javascript
     Scenario: Being unable to start checkout complete step with an empty cart
         Given I added product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Joe Doe"
-        And I completed the shipping step with "Free" shipping method
-        And I completed the payment step with "Offline" payment method
+        And I addressed the cart
+        And I chose "Free" shipping method
+        And I chose "Offline" payment method
         When I remove product "PHP T-Shirt" from the cart
         Then I should not be able to proceed checkout complete step
         And I should be redirected to my cart summary page

--- a/features/shop/checkout/prices_get_updated_throughout_checkout.feature
+++ b/features/shop/checkout/prices_get_updated_throughout_checkout.feature
@@ -49,7 +49,7 @@ Feature: Prices get updated when exchange rate changes during the whole checkout
         And I have selected "Pigeon Mail" shipping method
         And I complete the shipping step
         When the exchange rate of "US Dollar" to "British Pound" is 3.0
-        And I decide to change order shipping method
+        And I decide to change shipping method
         Then the subtotal of "The Pug Mug" item should be "£30.00"
 
     @no-api @ui @javascript

--- a/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
+++ b/features/shop/checkout/receiving_confirmation_email_after_completing_checkout.feature
@@ -22,6 +22,6 @@ Feature: Receiving confirmation email after finalizing checkout
     @api @ui @email
     Scenario: Receiving confirmation email after finalizing checkout in different locale than the default one
         Given I added product "Sig Sauer P226" to the cart
-        When I have proceeded through checkout process in the "Polish (Poland)" locale with email "john@example.com"
-        And I confirm my order
+        And I have proceeded through checkout process in the "Polish (Poland)" locale with email "john@example.com"
+        When I confirm my order
         Then an email with the summary of order placed by "john@example.com" should be sent to him in "Polish (Poland)" locale

--- a/features/shop/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
+++ b/features/shop/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
@@ -7,92 +7,83 @@ Feature: Preventing not available shipping method selection
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "Targaryen T-Shirt" priced at "$19.99"
-        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select disabled shipping method
         Given the store has "Raven Post" shipping method with "$10.00" fee
         And the store has disabled "Dragon Post" shipping method with "$30.00" fee
-        And I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Dragon Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select shipping method not available for my shipping address
         Given there is a zone "The Rest of the World" containing all other countries
         And the store has "Dragon Post" shipping method with "$30.00" fee for the rest of the world
         And the store has "Raven Post" shipping method with "$10.00" fee within the "US" zone
-        And I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Dragon Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select shipping method not available for order channel
         Given the store has "Raven Post" shipping method with "$10.00" fee not assigned to any channel
         And the store has "Dragon Post" shipping method with "$30.00" fee
-        And I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Raven Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Being alerted about no shipping method available
         Given there is a zone "The Rest of the World" containing all other countries
         And the store has "Dragon Post" shipping method with "$30.00" fee for the rest of the world
         And the store has disabled "Raven Post" shipping method with "$10.00" fee
-        And I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Raven Post" shipping method
         And I should not be able to select "Dragon Post" shipping method
         And I should be informed that my order cannot be shipped to this address
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select an archival shipping method
         Given the store has "Raven Post" shipping method with "$10.00" fee
         And the store has an archival "Dragon Post" shipping method with "$30.00" fee
-        And I have product "Targaryen T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Dragon Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select shipping method not available for shipping category of products in cart
         Given the store has "Over-sized" shipping category
         And product "Targaryen T-Shirt" belongs to "Over-sized" shipping category
         And the store has "Raven Post" shipping method with "$10.00" fee
         And the store has "Dragon Post" shipping method with "$30.00" fee
         And this shipping method requires that no units match to "Over-sized" shipping category
-        And I have product "Targaryen T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Dragon Post" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not being able to select shipping method not available due to shipping rules
         Given the store has "Raven Post" shipping method with "$10.00" fee
         And the store has "Dragon Post" shipping method with "$30.00" fee
         And this shipping method is only available for orders over or equal to "$100.00"
-        And I have product "Targaryen T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
         Then I should not be able to select "Dragon Post" shipping method
 
     @api @no-ui
-    Scenario: Not being able to select nonexistent shipping method
+    Scenario: Not being able to select non-existing shipping method
         Given the store has "Raven Post" shipping method with "$10.00" fee
-        And I have product "Targaryen T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
-        And I try to select "Inexistent" shipping method
-        Then I should be informed that shipping method with code "Inexistent" does not exist
+        And I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I want to complete the shipping step
+        And I try to select non-existing shipping method
+        Then I should be informed that shipping method with code "NON_EXISTING" does not exist

--- a/features/shop/checkout/shipping_order/preventing_placing_order_with_disabled_shipping_method.feature
+++ b/features/shop/checkout/shipping_order/preventing_placing_order_with_disabled_shipping_method.feature
@@ -9,20 +9,21 @@ Feature: Preventing placing an order with a disabled shipping method
         And the store has a product "Ubi T-Shirt" priced at "$19.99"
         And the store has "Raven Post" shipping method with "$4.00" fee
         And the store allows paying "Offline"
-        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Being prevented from placing an order with a shipping method that's disabled after completing the shipping method choice step
         Given I added product "Ubi T-Shirt" to the cart
-        And I have proceeded through checkout process with "Raven Post" shipping method
+        And I addressed the cart
+        And I chose "Raven Post" shipping method and "Offline" payment method
         But this shipping method has been disabled
         When I try to confirm my order
         Then I should not be able to confirm order because the "Raven Post" shipping method is not available
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Being prevented from placing an order with a shipping method that's has been disabled for the customer's country after completing the shipping method choice step
         Given I added product "Ubi T-Shirt" to the cart
-        And I have proceeded through checkout process with "Raven Post" shipping method
+        And I addressed the cart
+        And I chose "Raven Post" shipping method and "Offline" payment method
         But this shipping method has been disabled for "US Web Store" channel
         When I try to confirm my order
         Then I should not be able to confirm order because the "Raven Post" shipping method is not available

--- a/features/shop/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
+++ b/features/shop/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
@@ -11,18 +11,18 @@ Feature: Prevent shipping step completion without a selected shipping method
     Scenario: Preventing shipping step completion if there are no available shipping methods
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt"
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed the cart to "United States"
         When I check the details of my cart
         Then I should see that there is no shipment assigned
         And there should not be any shipping method available to choose
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Preventing shipping step completion if there are no available shipping methods
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt"
-        And I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart to "United States"
         When I want to complete the shipping step
         Then I should be informed that my order cannot be shipped to this address
         And I should not be able to complete the shipping step
@@ -36,12 +36,12 @@ Feature: Prevent shipping step completion without a selected shipping method
         And the store has a zone "Europe" with code "EU"
         And this zone has the "France" country member
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed the cart to "United States"
         When I try to complete the shipping step
         Then I should see that this shipping method is not available for this address
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Preventing shipping step completion if there are no available shipping methods for selected country
         Given the store operates on a channel named "Web"
         And the store operates in "United States"
@@ -50,8 +50,8 @@ Feature: Prevent shipping step completion without a selected shipping method
         And the store has a zone "Europe" with code "EU"
         And this zone has the "France" country member
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
-        And I have product "PHP T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart
         When I want to complete the shipping step
         Then I should be informed that my order cannot be shipped to this address
         And I should not be able to complete the shipping step
@@ -69,7 +69,7 @@ Feature: Prevent shipping step completion without a selected shipping method
         And this zone has the "United States" country member
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
         And the store has "UPS" shipping method with "$20.00" fee within the "AMR" zone
-        And I have product "PHP T-Shirt" in the cart
+        And I added product "PHP T-Shirt" to the cart
         And I addressed the cart to "Poland"
         When I try to complete the shipping step with "DHL" shipping method
         Then I should see that this shipping method is not available for this address

--- a/features/shop/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
+++ b/features/shop/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
@@ -10,18 +10,20 @@ Feature: Returning from shipping step to addressing step
         And the store ships everywhere for Free
         And I am a logged in customer
 
-    @no-api @ui @javascript
-    Scenario: Going back to addressing step with button
-        When I add product "Apollo 11 T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I decide to change my address
+    @no-api @ui
+    Scenario: Going back to addressing step with "Change Address" button
+        Given I added product "Apollo 11 T-Shirt" to the cart
+        And I addressed the cart
+        When I go to the shipping step
+        And I decide to change my address
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Going back to the addressing step with steps panel
-        When I add product "Apollo 11 T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I go to the addressing step
+        Given I added product "Apollo 11 T-Shirt" to the cart
+        And I addressed the cart
+        When I go to the shipping step
+        And I navigate directly to the addressing step in the checkout steps panel
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again

--- a/features/shop/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/shop/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -17,22 +17,20 @@ Feature: Seeing default shipping method selected based on shipping address
         And the store has "FedEx" shipping method with "$20.00" fee within the "UK" zone
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing default shipping method selected based on country from billing address
-        When I add product "Star Trek Ship" to the cart
-        And I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Star Trek Ship" to the cart
+        And I addressed the cart to "United States"
+        When I go to the shipping step
         Then I should be on the checkout shipping step
         And I should see selected "DHL" shipping method
         And I should not see "FedEx" shipping method
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing default shipping method selected based on country from billing address after readdressing
-        When I add product "Star Trek Ship" to the cart
-        And I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Star Trek Ship" to the cart
+        And I addressed the cart to "United States"
+        When I go to the shipping step
         And I decide to change my address
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"
         And I complete the addressing step

--- a/features/shop/checkout/shipping_order/seeing_shipping_fee.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_fee.feature
@@ -11,18 +11,20 @@ Feature: Seeing detailed shipping fee on selecting shipping method page
         And the store allows paying Offline
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing the shipping fee per shipment on selecting shipping method
         Given the store has "UPS" shipping method with "$20.00" fee
-        And I have product "The Sorting Hat" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "The Sorting Hat" to the cart
+        And I addressed the cart to "United States"
+        When I want to complete the shipping step
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$20.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing the shipping fee per unit on selecting shipping method
         Given the store has "UPS" shipping method with "$5.00" fee per unit
-        And I have product "The Sorting Hat" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "The Sorting Hat" to the cart
+        And I addressed the cart to "United States"
+        When I want to complete the shipping step
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$5.00"

--- a/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
@@ -16,20 +16,22 @@ Feature: Seeing detailed shipping fee on multiple channels with different base c
         And the store has a product "PHP T-Shirt" priced at "$12.54" available in channel "Web-US" and channel "Web-GB"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing the shipping fee per shipment on selecting method in a channel's base currency
         Given I changed my current channel to "Web-US"
-        And I have product "PHP T-Shirt" in the cart
-        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "PHP T-Shirt" to the cart
+        And I addressed the cart to "United States"
+        When I want to complete the shipping step
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$15.00"
         And I should see shipping method "FedEx" with fee "$10.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing the shipping fee on selecting shipping method on a different channel in its base currency
         Given I changed my current channel to "Web-GB"
-        When I add 2 products "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I addressed the cart to "United States"
+        When I want to complete the shipping step
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "£12.00"
         And I should see shipping method "FedEx" with fee "£16.00"

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
@@ -27,52 +27,44 @@ Feature: Seeing shipping methods which category is same as category of all my un
     Scenario: Seeing only shipping method which category is same as categories of all my units
         Given I added product "Rocket T-Shirt" to the cart
         And I added product "Picasso T-Shirt" to the cart
-        When I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
-        Then I should be on the checkout shipping step
-        And I should see "Raven Post" shipping method
+        And I addressed the cart
+        When I go to the shipping step
+        Then I should see "Raven Post" shipping method
         And I should not see "Invisible Post" shipping method
 
     @api @ui
     Scenario: Seeing shipping method which category is same as category of my unit
         Given I added product "Star Trek Ship" to the cart
-        When I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
-        Then I should be on the checkout shipping step
-        And I should see "Invisible Post" shipping method
+        And I addressed the cart
+        When I go to the shipping step
+        Then I should see "Invisible Post" shipping method
         And I should not see "Raven Post" shipping method
 
     @api @ui
     Scenario: Seeing no shipping methods if my units matches to different shipping categories
         Given I added product "Rocket T-Shirt" to the cart
         And I added product "Star Trek Ship" to the cart
-        When I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I addressed the cart
+        When I go to the shipping step
         Then there should be information about no available shipping methods
 
     @api @ui
     Scenario: Seeing no shipping methods if not all variants of my units has same shipping category
         Given the "T-Shirt banana" product's "S" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "M" size belongs to "Over-sized" shipping category
-        And I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then there should be information about no available shipping methods
 
     @api @ui
     Scenario: Seeing shipping methods if all variants of my units has same shipping category
         Given the "T-Shirt banana" product's "M" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "S" size belongs to "Standard" shipping category
-        And I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I go to the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
-        Then I should be on the checkout shipping step
-        And I should see "Raven Post" shipping method
+        And I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
+        And I addressed the cart
+        When I go to the shipping step
+        Then I should see "Raven Post" shipping method
         And I should not see "Invisible Post" shipping method

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
@@ -23,8 +23,8 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
 
     @api @ui
     Scenario: Seeing shipping methods which match to my units categories
-        Given I have product "Star Trek Ship" in the cart
-        And I have product "Picasso T-Shirt" in the cart
+        Given I added product "Star Trek Ship" to the cart
+        And I added product "Picasso T-Shirt" to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -34,7 +34,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
 
     @api @ui
     Scenario: Not seeing shipping method which not match to my units category
-        Given I have product "Star Trek Ship" in the cart
+        Given I added product "Star Trek Ship" to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -45,7 +45,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
     @api @ui
     Scenario: Seeing no shipping methods if any of them match to my units categories
         Given the store has a product "Rocket T-Shirt" priced at "$20.00"
-        And I have product "Rocket T-Shirt" in the cart
+        And I added product "Rocket T-Shirt" to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -53,8 +53,8 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
 
     @api @ui
     Scenario: Seeing no shipping methods if any of my unit has variant with shipping category matching to the shipping category of shipping method
-        Given I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
+        Given I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -64,8 +64,8 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
     Scenario: Seeing shipping methods if some of my unit has variant with shipping category matching to the shipping category of shipping method
         Given the "T-Shirt banana" product's "M" size belongs to "Standard" shipping category
         And the "T-Shirt banana" product's "S" size belongs to "Over-sized" shipping category
-        And I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
+        And I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
         When I am at the checkout addressing step
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step

--- a/features/shop/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
+++ b/features/shop/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
@@ -20,46 +20,41 @@ Feature: Seeing shipping methods which category is not same as any category of a
 
     @api @ui
     Scenario: Seeing shipping methods when all of my products fit the shipping category
-        Given I have product "Picasso T-Shirt" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Picasso T-Shirt" to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
 
     @api @ui
     Scenario: Seeing no shipping methods when all of my products are excluded from the shipping category
-        Given I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Star Trek Ship" to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then there should be information about no available shipping methods
 
     @api @ui
     Scenario: Seeing no shipping methods when any of my products is excluded from the shipping category
-        Given I have product "Picasso T-Shirt" in the cart
-        And I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Picasso T-Shirt" to the cart
+        And I added product "Star Trek Ship" to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then there should be information about no available shipping methods
 
     @api @ui
     Scenario: Seeing no shipping methods when any of my variants is excluded from the shipping category
         Given the "T-Shirt banana" product's "S" size belongs to "Over-sized" shipping category
-        And I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        And I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then there should be information about no available shipping methods
 
     @api @ui
     Scenario: Seeing shipping methods when all of my variants fit the shipping category
-        Given I have product "T-Shirt banana" with product option "Size" S in the cart
-        And I have product "T-Shirt banana" with product option "Size" M in the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "T-Shirt banana" with product option "Size" S to the cart
+        And I added product "T-Shirt banana" with product option "Size" M to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method

--- a/features/shop/checkout/shipping_order/selecting_order_shipping_method.feature
+++ b/features/shop/checkout/shipping_order/selecting_order_shipping_method.feature
@@ -13,14 +13,15 @@ Feature: Selecting order shipping method
 
     @api @ui
     Scenario: Selecting one of available shipping method
-        Given I have product "Targaryen T-Shirt" in the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I select "Raven Post" shipping method
+        Given I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I go to the shipping step
+        And I select "Raven Post" shipping method
         And I complete the shipping step
         Then I should be on the checkout payment step
 
     @api @no-ui
     Scenario: Selecting shipping method before addressing the order
-        Given I have product "Targaryen T-Shirt" in the cart
+        Given I added product "Targaryen T-Shirt" to the cart
         When I select "Raven Post" shipping method
         Then I should be notified that the order should be addressed first

--- a/features/shop/checkout/shipping_order/shipping_method_integrity_validation.feature
+++ b/features/shop/checkout/shipping_order/shipping_method_integrity_validation.feature
@@ -23,8 +23,8 @@ Feature: Order shipping method integrity
     Scenario: Validate shipping method after administrator changes shipping method requirements
         Given I added product "Westworld host" to the cart
         And I addressed the cart
-        When I have proceeded order with "DHL" shipping method and "Offline" payment
+        And I chose "DHL" shipping method and "Offline" payment method
         And product "Westworld host" shipping category has been changed to "Small stuff"
-        And I want to complete checkout
+        When I try to complete checkout
         Then I should not be able to confirm order because products do not fit "DHL" requirements
         And I should not see the thank you page

--- a/features/shop/checkout/shipping_order/sorting_shipping_method_selection.feature
+++ b/features/shop/checkout/shipping_order/sorting_shipping_method_selection.feature
@@ -12,11 +12,10 @@ Feature: Sorting shipping method selection
         And the store also allows shipping with "Pug Blimp" at position 1
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Seeing shipping methods sorted
-        When I add product "Targaryen T-Shirt" to the cart
-        When I am at the checkout addressing step
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I complete the addressing step
+        Given I added product "Targaryen T-Shirt" to the cart
+        And I addressed the cart
+        When I go to the shipping step
         Then I should have "Narwhal Submarine" shipping method available as the first choice
         And I should have "Aardvark Stagecoach" shipping method available as the last choice

--- a/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/shop/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -15,7 +15,7 @@ Feature: Skipping payment step when only one payment method is available
     Scenario: Seeing checkout completion page after shipping if only one payment method is available
         Given I added product "Guards! Guards!" to the cart
         When I complete addressing step with email "guest@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout complete step
         And my order's payment method should be "Bank transfer"
 
@@ -24,7 +24,7 @@ Feature: Skipping payment step when only one payment method is available
         Given the store has "Offline" payment method not assigned to any channel
         And I added product "Guards! Guards!" to the cart
         When I complete addressing step with email "guest@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout complete step
         And my order's payment method should be "Bank transfer"
 
@@ -34,7 +34,7 @@ Feature: Skipping payment step when only one payment method is available
         And the payment method "Offline" is disabled
         And I added product "Guards! Guards!" to the cart
         When I complete addressing step with email "guest@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout complete step
         And my order's payment method should be "Bank transfer"
 
@@ -43,5 +43,5 @@ Feature: Skipping payment step when only one payment method is available
         Given the store has disabled all payment methods
         And I added product "Guards! Guards!" to the cart
         When I complete addressing step with email "guest@example.com" and "United States" based billing address
-        And I complete the shipping step with first shipping method
+        And I complete the shipping step with the first shipping method
         Then I should be on the checkout payment step

--- a/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
+++ b/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
@@ -16,8 +16,8 @@ Feature: Reapplying promotion on cart change
         And the promotion gives "100%" discount on shipping to every order
         And I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I proceed with "DHL" shipping method
-        And I remove product "PHP T-Shirt" from the cart
+        And I chose "DHL" shipping method
+        When I remove product "PHP T-Shirt" from the cart
         Then my cart should be empty
         And there should be no shipping fee
         And there should be no discount applied
@@ -29,8 +29,8 @@ Feature: Reapplying promotion on cart change
         And the promotion gives "100%" discount on shipping to every order
         And I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I chose "DHL" shipping method
-        And I decide to change order shipping method
+        And I chose "DHL" shipping method
+        When I decide to change shipping method
         And I change shipping method to "FedEx"
         And I complete the shipping step
         And I check the details of my cart

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
@@ -45,7 +45,7 @@ Feature: Receiving fixed discount on cart
         And it gives "$10.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I proceed with selecting "DHL" shipping method
+        When I chose "DHL" shipping method
         And I check the details of my cart
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$10.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
@@ -16,7 +16,8 @@ Feature: Receiving percentage discount on shipping
     Scenario: Receiving percentage discount on shipping
         Given the promotion gives "20%" discount on shipping to every order
         And I added product "PHP T-Shirt" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$108.00"
         And my cart shipping total should be "$8.00"
@@ -25,7 +26,8 @@ Feature: Receiving percentage discount on shipping
     Scenario: Receiving free shipping
         Given the promotion gives free shipping to every order
         And I added product "PHP T-Shirt" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$0.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
@@ -22,7 +22,8 @@ Feature: Receiving percentage discount promotion on order
     Scenario: Receiving percentage discount does not affect the shipping fee
         Given the store has "DHL" shipping method with "$10.00" fee
         And I added product "PHP T-Shirt" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$90.00"
         And my cart shipping total should be "$10.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
@@ -13,19 +13,20 @@ Feature: Apply correct shipping fee on order
 
     @api @ui
     Scenario: Adding proper shipping fee
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I completed the shipping step with "DHL" shipping method
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$110.00"
         And my cart shipping total should be "$10.00"
 
     @api @ui
     Scenario: Changing shipping fee after shipping method change
-        Given I have product "PHP T-Shirt" in the cart
+        Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I completed the shipping step with "DHL" shipping method
-        When I decide to change order shipping method
+        And I chose "DHL" shipping method
+        When I want to complete the shipping step
+        When I decide to change shipping method
         And I change shipping method to "FedEx"
         And I complete the shipping step
         And I check the details of my cart
@@ -34,9 +35,9 @@ Feature: Apply correct shipping fee on order
 
     @api @ui @javascript
     Scenario: Changing per unit shipping fee after decreasing quantity of item
-        Given I have 2 products "PHP T-Shirt" in the cart
+        Given I added 2 products "PHP T-Shirt" to the cart
         And I addressed the cart
-        And I completed the shipping step with "UPS" shipping method
+        And I chose "UPS" shipping method
         When I change "PHP T-Shirt" quantity to 1
         Then my cart total should be "$105.00"
         And my cart shipping total should be "$5.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -1,6 +1,6 @@
 @applying_shipping_fee
 Feature: Apply correct shipping fee with product taxes on order
-    In order to pay proper amount for shipping and product taxes
+    In order to pay the proper amount for shipping and product taxes
     As a Customer
     I want to have correct shipping fees and all taxes applied to my order
 
@@ -22,22 +22,21 @@ Feature: Apply correct shipping fee with product taxes on order
         And I am a logged in customer
 
     @api @ui
-    Scenario: Proper shipping fee, tax and product tax
+    Scenario: Correct calculation for a US order using DHL shipping
         Given I added product "PHP T-Shirt" to the cart
-        And I addressed the cart
-        When I proceed with "DHL" shipping method
-        And I choose "Offline" payment method
-        And I check the details of my cart
+        And I addressed the cart to "United States"
+        And I chose "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$135.30"
         And my cart taxes should be "$25.30"
         And my cart shipping total should be "$12.30"
 
     @api @ui
-    Scenario: Proper shipping fee, tax and products' taxes after addressing
+    Scenario: Correct calculation for an international order using FedEx shipping after selecting Germany as billing country
         Given I have 3 products "PHP T-Shirt" in the cart
-        When I proceed with selecting "Germany" as billing country
-        And I proceed with "FedEx" shipping method
-        And I check the details of my cart
+        When I addressed the cart to "Germany"
+        And I chose "FedEx" shipping method
+        When I check the details of my cart
         Then my cart total should be "$352.00"
         And my cart taxes should be "$32.00"
         And my cart shipping total should be "$22.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
@@ -24,9 +24,8 @@ Feature: Apply correct shipping fee with taxes on order
     Scenario: Proper shipping fee and tax
         Given I added product "PHP T-Shirt" to the cart
         And I addressed the cart
-        When I proceed with "DHL" shipping method
-        And I choose "Offline" payment method
-        And I check the details of my cart
+        And I chose "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$112.30"
         And my cart taxes should be "$2.30"
         And my cart shipping total should be "$12.30"
@@ -34,9 +33,8 @@ Feature: Apply correct shipping fee with taxes on order
     @api @ui
     Scenario: Proper shipping fee and tax after addressing
         Given I added product "PHP T-Shirt" to the cart
-        When I proceed with selecting "Germany" as billing country
-        And I proceed with "DHL-World" shipping method
-        And I choose "Offline" payment method
+        And I addressed the cart to "Germany"
+        And I chose "DHL-World" shipping method
         When I check the details of my cart
         Then my cart total should be "$122.00"
         And my cart taxes should be "$2.00"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping.feature
@@ -18,7 +18,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping
         Given the store has "DHL" shipping method with "$51.06" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Symfony Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$60.55"
         And my cart taxes should be "$4.60"
@@ -28,7 +29,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping
         Given the store has "DHL" shipping method with "$51.04" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Symfony Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$60.53"
         And my cart taxes should be "$4.59"
@@ -41,7 +43,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping
         And the store has "DHL" shipping method with "$51.04" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Sonata Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$62.83"
         And my cart taxes should be "$6.89"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping_when_tax_rate_included_in_price.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping_when_tax_rate_included_in_price.feature
@@ -18,7 +18,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping when ta
         Given the store has "DHL" shipping method with "$56.95" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Symfony Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$61.25"
         And my included in price taxes should be "$4.66"
@@ -28,7 +29,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping when ta
         Given the store has "DHL" shipping method with "$56.85" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Symfony Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$61.16"
         And my included in price taxes should be "$4.65"
@@ -41,7 +43,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping when ta
         And the store has "DHL" shipping method with "$50.00" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Sonata Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$55.00"
         And my included in price taxes should be "$5.96"
@@ -54,7 +57,8 @@ Feature: Apply correct taxes for an order with a discount for a shipping when ta
         And the store has "DHL" shipping method with "$50.00" fee
         And shipping method "DHL" belongs to "Shipping" tax category
         And I added product "Sonata Mug" to the cart
-        And I proceed with selecting "DHL" shipping method
+        And I addressed the cart
+        And I chose "DHL" shipping method
         When I check the details of my cart
         Then my cart total should be "$57.30"
         And my included in price taxes should be "$4.09"

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -91,7 +91,6 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
         if ($this->sharedStorage->has('cart_token')) {
             $this->sharedStorage->set('previous_cart_token', $this->sharedStorage->get('cart_token'));
-            $this->sharedStorage->remove('cart_token');
         }
     }
 }

--- a/src/Sylius/Behat/Client/ResponseChecker.php
+++ b/src/Sylius/Behat/Client/ResponseChecker.php
@@ -273,6 +273,27 @@ final class ResponseChecker implements ResponseCheckerInterface
         return false;
     }
 
+    public function isViolationWithMessageInResponse(Response $response, string $message, ?string $property = null): bool
+    {
+        $violations = $this->getResponseContent($response)['violations'] ?? null;
+
+        if ($violations === null) {
+            throw new \InvalidArgumentException('Response expected to have violations, but it does not.');
+        }
+
+        foreach ($violations as $violation) {
+            if ($violation['message'] === $message && $property === null) {
+                return true;
+            }
+
+            if ($violation['message'] === $message && $property !== null && $violation['propertyPath'] === $property) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function getResponseContentValue(Response $response, string $key)
     {
         $content = json_decode($response->getContent(), true);

--- a/src/Sylius/Behat/Client/ResponseCheckerInterface.php
+++ b/src/Sylius/Behat/Client/ResponseCheckerInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface ResponseCheckerInterface
 {
+    public function isViolationWithMessageInResponse(Response $response, string $message, ?string $property = null): bool;
+
     public function countCollectionItems(Response $response): int;
 
     public function countTotalCollectionItems(Response $response): int;

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
@@ -15,6 +15,8 @@ namespace Sylius\Behat\Context\Api\Admin;
 
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
@@ -63,6 +65,12 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->responseChecker->getValue($response, '@id'), $this->iriConverter->getIriFromResourceInSection($order, 'admin'));
 
         $this->sharedStorage->set('order', $order);
+    }
+
+    #[When('/^I view the summary of the (last order)$/')]
+    public function iViewTheSummaryOfTheLastOrder(OrderInterface $order): void
+    {
+        $this->client->show(Resources::ORDERS, $order->getTokenValue());
     }
 
     /**
@@ -465,6 +473,17 @@ final readonly class ManagingOrdersContext implements Context
             ),
             sprintf('Order %s does not have %s payment state', $order->getTokenValue(), $paymentState),
         );
+    }
+
+    #[Then('the last order should have order payment state :orderPaymentState')]
+    public function theLastOrderShouldHavePaymentState(string $orderPaymentState): void
+    {
+        $order = $this->responseChecker->getCollection($this->client->getLastResponse())[0];
+
+        Assert::same(
+            $order['paymentState'],
+            strtolower($orderPaymentState),
+            sprintf('Order "%s" does not have "%s" payment state', $order['tokenValue'], $orderPaymentState));
     }
 
     /**
@@ -982,9 +1001,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->getTotalAsInt($tax), $totalTax);
     }
 
-    /**
-     * @Then I should be informed that there are no payments
-     */
+    #[Then('I should be informed that there are no payments')]
     public function iShouldSeeInformationAboutNoPayments(): void
     {
         Assert::same(

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -23,6 +23,7 @@ use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Behat\Service\SprintfResponseEscaper;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -58,7 +59,7 @@ final class CartContext implements Context
     }
 
     /**
-     * @When /^I see the summary of my ((?:|previous )cart)$/
+     * @When /^I see the summary of my (cart)$/
      * @When /^the visitor try to see the summary of ((?:visitor|customer)'s cart)$/
      * @When /^the (?:visitor|customer) see the summary of ((?:|their )cart)$/
      */
@@ -69,6 +70,12 @@ final class CartContext implements Context
         }
 
         $this->shopClient->show(Resources::ORDERS, $tokenValue);
+    }
+
+    #[When('/^I see the summary of my (previous cart)$/')]
+    public function iSeeTheSummaryOfMyPreviousCart(OrderInterface $cart): void
+    {
+        $this->shopClient->show(Resources::ORDERS, $cart->getTokenValue());
     }
 
     /**
@@ -313,9 +320,13 @@ final class CartContext implements Context
     /**
      * @Then /^I should not have access to the summary of my (previous cart)$/
      */
-    public function iShouldNotHaveAccessToTheSummaryOfMyCart(string $tokenValue): void
+    public function iShouldNotHaveAccessToTheSummaryOfMyCart(OrderInterface $order): void
     {
-        Assert::same($this->shopClient->show(Resources::ORDERS, $tokenValue)->getStatusCode(), Response::HTTP_NOT_FOUND);
+        Assert::same(
+            $this->shopClient->show(Resources::ORDERS, $order->getTokenValue())->getStatusCode(),
+            Response::HTTP_NOT_FOUND,
+            'The access to the summary of the previous cart should be forbidden.',
+        );
     }
 
     /**
@@ -838,6 +849,13 @@ final class CartContext implements Context
 
     private function putProductToCart(ProductInterface $product, ?string $tokenValue, int $quantity = 1): void
     {
+        // Hotfix for a bug that allowed a guest to add a product to the cart belonging to a logged-in user
+        $hasToken = $this->sharedStorage->has('token');
+        $createdAsGuest = $this->sharedStorage->has('created_as_guest') ? $this->sharedStorage->get('created_as_guest') : null;
+        if (!$hasToken && $createdAsGuest === false) {
+            $tokenValue = null;
+        }
+
         $tokenValue ??= $this->pickupCart();
 
         $request = $this->requestFactory->customItemAction(

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -243,7 +243,8 @@ final class CartContext implements Context
     }
 
     #[When('/^I check the details of my (cart)$/')]
-    #[When('/^I check details of my (cart)$/')]
+    #[When('/^the visitor checks the details of their (cart)$/')]
+    #[When('/^the customer checks the details of their (cart)$/')]
     public function iCheckDetailsOfMyCart(string $tokenValue): void
     {
         $this->shopClient->show(Resources::ORDERS, $tokenValue);
@@ -630,9 +631,9 @@ final class CartContext implements Context
     }
 
     /**
-     * @Then /^the (?:visitor|customer) can see ("[^"]+" product) in the (cart)$/
+     * @Then /^the (?:visitor|customer) should see ("[^"]+" product) in the (cart)$/
      */
-    public function theVisitorCanSeeProductInTheCart(
+    public function theVisitorShouldSeeProductInTheCart(
         ProductInterface $product,
         string $tokenValue,
         int $quantity = 1,
@@ -716,9 +717,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then I should be redirected to my cart summary page
-     */
+    #[Then('I should be redirected to my cart summary page')]
     public function iShouldBeRedirectedToMyCartSummaryPage(): void
     {
         // Intentionally left blank to fulfill context expectation

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -245,7 +245,8 @@ final class CartContext implements Context
     #[When('/^I check the details of my (cart)$/')]
     #[When('/^the visitor checks the details of their (cart)$/')]
     #[When('/^the customer checks the details of their (cart)$/')]
-    public function iCheckDetailsOfMyCart(string $tokenValue): void
+    #[When('/^the customer tries to check the details of their (cart)$/')]
+    public function iCheckTheDetailsOfMyCart(string $tokenValue): void
     {
         $this->shopClient->show(Resources::ORDERS, $tokenValue);
     }

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Context\Api\Resources;
@@ -31,9 +32,16 @@ final readonly class CheckoutCompleteContext implements Context
     ) {
     }
 
+    #[When('I check summary of my order')]
+    public function iCheckSummaryOfMyOrder(): void
+    {
+        $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+    }
+
     /**
      * @Given I have confirmed order
      */
+    #[When('I try to complete checkout')]
     public function iConfirmMyOrder(): void
     {
         $request = $this->requestFactory->customItemAction(

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
@@ -62,8 +62,8 @@ final readonly class CheckoutShippingContext implements Context
         );
     }
 
-    #[When('I complete the shipping step with first shipping method')]
-    public function iCompleteTheShippingStepWithFirstShippingMethod(): void
+    #[When('I complete the shipping step with the first shipping method')]
+    public function iCompleteTheShippingStepWithTheFirstShippingMethod(): void
     {
         /** @var ShippingMethodInterface $shippingMethod */
         $shippingMethod = $this->shippingMethodRepository->findOneBy([]);

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
@@ -162,9 +162,14 @@ final readonly class CheckoutShippingContext implements Context
 
     public function chooseShippingMethod(?ShippingMethodInterface $shippingMethod = null): void
     {
-        $content = $this->responseChecker->getResponseContent(
-            $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token'))),
-        );
+        $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+
+        // Lack of authorization
+        if (!$this->responseChecker->isShowSuccessful($response)) {
+            return;
+        }
+
+        $content = $this->responseChecker->getResponseContent($response);
 
         $this->client->requestPatch(
             uri: sprintf(

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutShippingContext.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Api\Shop\Checkout;
+
+use ApiPlatform\Metadata\IriConverterInterface;
+use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
+use Sylius\Behat\Client\ApiClientInterface;
+use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
+use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
+use Webmozart\Assert\Assert;
+
+final readonly class CheckoutShippingContext implements Context
+{
+    /** @param ShippingMethodRepositoryInterface<ShippingMethodInterface> $shippingMethodRepository */
+    public function __construct(
+        private ApiClientInterface $client,
+        private ResponseCheckerInterface $responseChecker,
+        private SharedStorageInterface $sharedStorage,
+        private IriConverterInterface $iriConverter,
+        private ShippingMethodRepositoryInterface $shippingMethodRepository,
+    ) {
+    }
+
+    #[When('I want to complete the shipping step')]
+    #[When('I go to the shipping step')]
+    #[When('the customer wants to complete the shipping step')]
+    public function iWantToCompleteTheShippingStep(): void
+    {
+        // Intentionally left blank, as this is a UI-specific action.
+    }
+
+    #[When('I try to select non-existing shipping method')]
+    public function iTryToSelectNonExistingShippingMethod(): void
+    {
+        $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+        $content = $this->responseChecker->getResponseContent($response);
+
+        $this->client->requestPatch(
+            uri: sprintf(
+                'orders/%s/shipments/%s',
+                $this->sharedStorage->get('cart_token'),
+                $content['shipments'][0]['id'],
+            ),
+            body: ['shippingMethod' => '/api/v2/shop/shipping-methods/NON_EXISTING'],
+        );
+    }
+
+    #[When('I complete the shipping step with first shipping method')]
+    public function iCompleteTheShippingStepWithFirstShippingMethod(): void
+    {
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $this->shippingMethodRepository->findOneBy([]);
+
+        $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+
+        $content = $this->responseChecker->getResponseContent($this->client->getLastResponse());
+
+        $this->client->requestPatch(
+            uri: sprintf(
+                'orders/%s/shipments/%s',
+                $this->sharedStorage->get('cart_token'),
+                $content['shipments'][0]['id'],
+            ),
+            body: ['shippingMethod' => $this->iriConverter->getIriFromResource($shippingMethod)],
+        );
+    }
+
+    #[When('I change shipping method to :shippingMethod')]
+    #[When('I proceed with :shippingMethod shipping method')]
+    #[When('I proceed with selecting :shippingMethod shipping method')]
+    #[When('I select :shippingMethod shipping method')]
+    #[When('I try to change shipping method to :shippingMethod')]
+    #[When('I try to select :shippingMethod shipping method')]
+    #[When('the customer has proceeded with :shippingMethod shipping method')]
+    #[When('the customer proceeds with :shippingMethod shipping method')]
+    #[When('the visitor has proceeded with :shippingMethod shipping method')]
+    #[When('the visitor proceeds with :shippingMethod shipping method')]
+    public function iTryToSelectShippingMethod(ShippingMethodInterface $shippingMethod): void
+    {
+        $this->chooseShippingMethod($shippingMethod);
+    }
+
+    #[Then('the checkout shipping method step should be completed')]
+    public function theCheckoutShippingMethodStepShouldBeCompleted(): void
+    {
+        Assert::same($this->getCheckoutState(), OrderCheckoutStates::STATE_SHIPPING_SELECTED);
+    }
+
+    #[Then('I should see that there is no assigned shipping method')]
+    public function iShouldSeeThatThereIsNoAssignedShippingMethod(): void
+    {
+        $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+
+        Assert::isEmpty($this->responseChecker->getValue($response, 'shipments'));
+    }
+
+    #[Then('there should not be any shipping method available to choose')]
+    public function thereShouldNotBeAnyShippingMethodAvailableToChoose(): void
+    {
+        $response = $this->client->requestGet('shipping-methods');
+
+        Assert::isEmpty($this->responseChecker->getCollection($response));
+    }
+
+    #[Then('I should not be able to select :shippingMethod shipping method')]
+    public function iShouldNotBeAbleToSelectShippingMethod(ShippingMethodInterface $shippingMethod): void
+    {
+        $this->chooseShippingMethod($shippingMethod);
+
+        Assert::same($this->client->getLastResponse()->getStatusCode(), 422);
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse($this->client->getLastResponse(), sprintf(
+            'The shipping method %s is not available for this order. Please reselect your shipping method.',
+            $shippingMethod->getName(),
+        )));
+    }
+
+    #[Then('I should see that this shipping method is not available for this address')]
+    #[Then('I should see that this shipping method is also not available for this address')]
+    public function iShouldSeeThatThisShippingMethodIsNotAvailableForThisAddress(): void
+    {
+        Assert::true(
+            $this->responseChecker->hasViolationWithMessage(
+                $this->client->getLastResponse(),
+                sprintf(
+                    'The shipping method %s is not available for this order. Please reselect your shipping method.',
+                    $this->sharedStorage->get('shipping_method'),
+                ),
+            ),
+            sprintf(
+                'Expected to see message that shipping method "%s" is not available. Got message: "%s".',
+                $this->sharedStorage->get('shipping_method'),
+                $this->responseChecker->getError($this->client->getLastResponse()),
+            ),
+        );
+    }
+
+    #[Then('I should be informed that shipping method with code :code does not exist')]
+    public function iShouldBeInformedThatShippingMethodWithCodeDoesNotExist(string $code): void
+    {
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
+            $this->client->getLastResponse(),
+            sprintf('The shipping method with %s code does not exist.', $code),
+        ));
+    }
+
+    public function chooseShippingMethod(?ShippingMethodInterface $shippingMethod = null): void
+    {
+        $content = $this->responseChecker->getResponseContent(
+            $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token'))),
+        );
+
+        $this->client->requestPatch(
+            uri: sprintf(
+                'orders/%s/shipments/%s',
+                $this->sharedStorage->get('cart_token'),
+                $content['shipments'][0]['id'],
+            ),
+            body: ['shippingMethod' => $this->iriConverter->getIriFromResource(
+                $shippingMethod ?? $this->shippingMethodRepository->findOneBy([]),
+            )],
+        );
+    }
+
+    private function getCheckoutState(): string
+    {
+        $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
+
+        $response = $this->client->getLastResponse();
+
+        return $this->responseChecker->getValue($response, 'checkoutState');
+    }
+}

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -713,19 +713,14 @@ final class CheckoutContext implements Context
         throw new \Exception(sprintf('Payment method %s not found in response.', $paymentMethod->getName()));
     }
 
-    /**
-     * @Then I should not be able to confirm order because products do not fit :shippingMethod requirements
-     */
+    #[Then('I should not be able to confirm order because products do not fit :shippingMethod requirements')]
     public function iShouldNotBeAbleToConfirmOrderBecauseDoNotBelongsToShippingCategory(
         ShippingMethodInterface $shippingMethod,
     ): void {
-        $this->iConfirmMyOrder();
-
         $response = $this->client->getLastResponse();
 
         Assert::same($response->getStatusCode(), 422);
-
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $response,
             sprintf(
                 'Product does not fit requirements for %s shipping method. Please reselect your shipping method.',
@@ -1170,7 +1165,7 @@ final class CheckoutContext implements Context
      */
     public function iShouldBeInformedThatThisProductHasBeenDisabled(ProductInterface $product): void
     {
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $this->client->getLastResponse(),
             sprintf('This product %s has been disabled.', $product->getName()),
         ));
@@ -1181,7 +1176,7 @@ final class CheckoutContext implements Context
      */
     public function iShouldBeInformedThatThisProductDoesNotExist(ProductInterface $product): void
     {
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $this->client->getLastResponse(),
             sprintf('The product %s does not exist.', $product->getName()),
         ));
@@ -1192,7 +1187,7 @@ final class CheckoutContext implements Context
      */
     public function iShouldBeInformedThatProductVariantDoesNotExist(ProductVariantInterface $productVariant): void
     {
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $this->client->getLastResponse(),
             sprintf('The product variant %s does not exist.', $productVariant->getCode()),
         ));
@@ -1203,7 +1198,7 @@ final class CheckoutContext implements Context
      */
     public function iShouldBeInformedThatProductVariantWithCodeDoesNotExist(string $code): void
     {
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $this->client->getLastResponse(),
             sprintf('The product variant %s does not exist.', $code),
         ));
@@ -1245,7 +1240,7 @@ final class CheckoutContext implements Context
 
         Assert::same($response->getStatusCode(), 422);
 
-        Assert::true($this->isViolationWithMessageInResponse(
+        Assert::true($this->responseChecker->isViolationWithMessageInResponse(
             $response,
             sprintf(
                 'This payment method %s has been disabled. Please reselect your payment method.',
@@ -1445,22 +1440,6 @@ final class CheckoutContext implements Context
             'Please select proper province.',
             sprintf('%s.%s', $addressType, 'provinceCode'),
         ));
-    }
-
-    private function isViolationWithMessageInResponse(Response $response, string $message, ?string $property = null): bool
-    {
-        $violations = $this->responseChecker->getResponseContent($response)['violations'];
-        foreach ($violations as $violation) {
-            if ($violation['message'] === $message && $property === null) {
-                return true;
-            }
-
-            if ($violation['message'] === $message && $property !== null && $violation['propertyPath'] === $property) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private function addressOrderWithCountryAndEmail(CountryInterface $country, ?string $email = null): void

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -87,7 +87,8 @@ final readonly class CartContext implements Context
      */
     #[Given('/^I added (product "[^"]+") to the (cart)$/')]
     #[Given('/^I added (this product) to the (cart)$/')]
-    #[Given('/^the customer added ("[^"]+" product) to the (cart)$/')]
+    #[Given('/^the visitor added (product "[^"]+") to the (cart)$/')]
+    #[Given('/^the customer added (product "[^"]+") to the (cart)$/')]
     public function iAddedProductToTheCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue);
@@ -114,10 +115,8 @@ final readonly class CartContext implements Context
         $this->sharedStorage->set('variant', $productVariant);
     }
 
-    /**
-     * @Given /^I have (product "[^"]+") with (product option "[^"]+") ([^"]+) in the (cart)$/
-     */
-    public function iAddThisProductWithToTheCart(
+    #[Given('/^I added (product "[^"]+") with (product option "[^"]+") ([^"]+) to the (cart)$/')]
+    public function iAddedProductWithOptionToTheCart(
         ProductInterface $product,
         ProductOptionInterface $productOption,
         string $productOptionValue,

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -171,8 +171,12 @@ final readonly class CartContext implements Context
                 /** @var CustomerInterface $customer */
                 $email = $user->getCustomer()->getEmail();
             }
+
+            $this->sharedStorage->set('created_as_guest', false);
         } else {
             file_put_contents($this->guestCartTokenFilePath, $tokenValue);
+
+            $this->sharedStorage->set('created_as_guest', true);
         }
 
         $pickupCart = new PickupCart(

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -29,20 +29,20 @@ use Sylius\Component\Core\Test\Services\DefaultChannelFactoryInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 
-final class ChannelContext implements Context
+final readonly class ChannelContext implements Context
 {
     /**
      * @param ChannelRepositoryInterface<ChannelInterface> $channelRepository
      * @param FactoryInterface<ShopBillingDataInterface> $shopBillingDataFactory
      */
     public function __construct(
-        private readonly SharedStorageInterface $sharedStorage,
-        private readonly ChannelContextSetterInterface $channelContextSetter,
-        private readonly DefaultChannelFactoryInterface $unitedStatesChannelFactory,
-        private readonly DefaultChannelFactoryInterface $defaultChannelFactory,
-        private readonly ChannelRepositoryInterface $channelRepository,
-        private readonly ObjectManager $channelManager,
-        private readonly FactoryInterface $shopBillingDataFactory,
+        private SharedStorageInterface $sharedStorage,
+        private ChannelContextSetterInterface $channelContextSetter,
+        private DefaultChannelFactoryInterface $unitedStatesChannelFactory,
+        private DefaultChannelFactoryInterface $defaultChannelFactory,
+        private ChannelRepositoryInterface $channelRepository,
+        private ObjectManager $channelManager,
+        private FactoryInterface $shopBillingDataFactory,
     ) {
     }
 
@@ -113,13 +113,11 @@ final class ChannelContext implements Context
         $this->sharedStorage->set('channel', $defaultData['channel']);
     }
 
-    /**
-     * @Given /^the store(?:| also) operates on (?:a|another) channel named "([^"]+)"$/
-     * @Given /^the store(?:| also) operates on (?:a|another) channel named "([^"]+)" in "([^"]+)" currency$/
-     * @Given /^the store(?:| also) operates on (?:a|another) channel named "([^"]+)" in "([^"]+)" currency and with hostname "([^"]+)"$/
-     * @Given the store (also) operates on a(nother) channel named :channelName with hostname :hostname
-     * @Given the store operates on a channel identified by :channelCode code
-     */
+    #[Given('/^the store(?:| also) operates on (?:a|another) channel named "([^"]+)"$/')]
+    #[Given('/^the store(?:| also) operates on (?:a|another) channel named "([^"]+)" in "([^"]+)" currency$/')]
+    #[Given('/^the store(?:| also) operates on (?:a|another) channel named "([^"]+)" in "([^"]+)" currency and with hostname "([^"]+)"$/')]
+    #[Given('the store (also) operates on a(nother) channel named :channelName with hostname :hostname')]
+    #[Given('the store operates on a channel identified by :channelCode code')]
     public function theStoreOperatesOnAChannelNamed(
         ?string $channelName = null,
         ?string $currencyCode = null,

--- a/src/Sylius/Behat/Context/Setup/Checkout/AddressContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/AddressContext.php
@@ -15,16 +15,14 @@ namespace Sylius\Behat\Context\Setup\Checkout;
 
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
+use Sylius\Behat\Service\Factory\AddressFactoryInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
-use Sylius\Component\Core\Factory\AddressFactoryInterface;
-use Sylius\Component\Core\Model\AddressInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class AddressContext implements Context
 {
-    /** @param AddressFactoryInterface<AddressInterface> $addressFactory */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private MessageBusInterface $commandBus,
@@ -35,6 +33,7 @@ final readonly class AddressContext implements Context
 
     #[Given('I addressed the cart')]
     #[Given('I addressed the cart to :countryName')]
+    #[Given('the customer addressed the cart')]
     public function iAddressedTheCart(?string $countryName = null): void
     {
         $cartToken = $this->sharedStorage->get('cart_token');
@@ -45,37 +44,20 @@ final readonly class AddressContext implements Context
             $address = $this->addressFactory->createDefaultWithCountryCode($countryCode) :
             $address = $this->addressFactory->createDefault();
 
-        $command = new UpdateCart(orderTokenValue: $cartToken, email: null, billingAddress: $address);
-        $this->commandBus->dispatch($command);
+        $this->commandBus->dispatch(new UpdateCart(
+            orderTokenValue: $cartToken,
+            billingAddress: $address,
+        ));
     }
 
-    /**
-     * @Given /^I have specified the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     */
+    #[Given('/^I have specified the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
     public function iHaveSpecifiedDefaultBillingAddressForName(): void
     {
         $cartToken = $this->sharedStorage->get('cart_token');
 
-        $command = new UpdateCart(
+        $this->commandBus->dispatch(new UpdateCart(
             orderTokenValue: $cartToken,
-            email: null,
-            billingAddress: $this->getDefaultAddress(),
-        );
-        $this->commandBus->dispatch($command);
-    }
-
-    private function getDefaultAddress(): AddressInterface
-    {
-        /** @var AddressInterface $address */
-        $address = $this->addressFactory->createNew();
-
-        $address->setCity('New York');
-        $address->setStreet('Wall Street');
-        $address->setPostcode('00-001');
-        $address->setCountryCode('US');
-        $address->setFirstName('Richy');
-        $address->setLastName('Rich');
-
-        return $address;
+            billingAddress: $this->addressFactory->createDefaultWithCountryCode('US'),
+        ));
     }
 }

--- a/src/Sylius/Behat/Context/Setup/Checkout/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/PaymentContext.php
@@ -31,6 +31,7 @@ final readonly class PaymentContext implements Context
 
     #[Given('I chose :paymentMethod payment method')]
     #[Given('the customer chose :paymentMethod payment method')]
+    #[Given('the visitor chose :paymentMethod payment method')]
     public function iChosePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->choosePaymentMethod($paymentMethod);

--- a/src/Sylius/Behat/Context/Setup/Checkout/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/PaymentContext.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Setup\Checkout;
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class PaymentContext implements Context
+{
+    public function __construct(
+        private SharedStorageInterface $sharedStorage,
+        private MessageBusInterface $commandBus,
+    ) {
+    }
+
+    #[Given('I chose :paymentMethod payment method')]
+    #[Given('the customer chose :paymentMethod payment method')]
+    public function iChosePaymentMethod(PaymentMethodInterface $paymentMethod): void
+    {
+        $this->choosePaymentMethod($paymentMethod);
+    }
+
+    public function choosePaymentMethod(PaymentMethodInterface $paymentMethod): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->sharedStorage->get('order');
+
+        $this->commandBus->dispatch(new ChoosePaymentMethod(
+            $order->getTokenValue(),
+            $order->getPayments()->first()->getId(),
+            $paymentMethod->getCode(),
+        ));
+    }
+}

--- a/src/Sylius/Behat/Context/Setup/Checkout/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/ShippingContext.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Setup\Checkout;
+
+use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class ShippingContext implements Context
+{
+    public function __construct(
+        private SharedStorageInterface $sharedStorage,
+        private MessageBusInterface $commandBus,
+    ) {
+    }
+
+    #[Given('I chose :shippingMethod shipping method')]
+    #[Given('the customer chose :shippingMethod shipping method')]
+    public function iChoseShippingMethod(ShippingMethodInterface $shippingMethod): void
+    {
+        $this->chooseShippingMethod($shippingMethod);
+    }
+
+    public function chooseShippingMethod(ShippingMethodInterface $shippingMethod): void
+    {
+        /** @var OrderInterface $order */
+        $order = $this->sharedStorage->get('order');
+
+        $this->commandBus->dispatch(new ChooseShippingMethod(
+            $order->getTokenValue(),
+            $order->getShipments()->first()->getId(),
+            $shippingMethod->getCode()
+        ));
+    }
+}

--- a/src/Sylius/Behat/Context/Setup/Checkout/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/ShippingContext.php
@@ -31,6 +31,7 @@ final readonly class ShippingContext implements Context
 
     #[Given('I chose :shippingMethod shipping method')]
     #[Given('the customer chose :shippingMethod shipping method')]
+    #[Given('the visitor chose :shippingMethod shipping method')]
     public function iChoseShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->chooseShippingMethod($shippingMethod);

--- a/src/Sylius/Behat/Context/Setup/GeographicalContext.php
+++ b/src/Sylius/Behat/Context/Setup/GeographicalContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
@@ -22,8 +23,13 @@ use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 
-final class GeographicalContext implements Context
+final readonly class GeographicalContext implements Context
 {
+    /**
+     * @param FactoryInterface<CountryInterface> $countryFactory
+     * @param FactoryInterface<ProvinceInterface> $provinceFactory
+     * @param RepositoryInterface<CountryInterface> $countryRepository
+     */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private FactoryInterface $countryFactory,
@@ -34,12 +40,10 @@ final class GeographicalContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^the store ships to "([^"]+)"$/
-     * @Given /^the store ships to "([^"]+)" and "([^"]+)"$/
-     * @Given /^the store ships to "([^"]+)", "([^"]+)" and "([^"]+)"$/
-     */
-    public function storeShipsTo(...$countriesNames)
+    #[Given('/^the store ships to "([^"]+)"$/')]
+    #[Given('/^the store ships to "([^"]+)" and "([^"]+)"$/')]
+    #[Given('/^the store ships to "([^"]+)", "([^"]+)" and "([^"]+)"$/')]
+    public function storeShipsTo(string ...$countriesNames): void
     {
         foreach ($countriesNames as $countryName) {
             $this->countryRepository->add($this->createCountryNamed(trim($countryName)));
@@ -51,7 +55,7 @@ final class GeographicalContext implements Context
      * @Given /^the store operates in "([^"]*)" and "([^"]*)"$/
      * @Given /^the store(?:| also) has country "([^"]*)"$/
      */
-    public function theStoreOperatesIn(...$countriesNames)
+    public function theStoreOperatesIn(string ...$countriesNames): void
     {
         foreach ($countriesNames as $countryName) {
             $country = $this->createCountryNamed(trim($countryName));
@@ -64,7 +68,7 @@ final class GeographicalContext implements Context
     /**
      * @Given /^the store has disabled country "([^"]*)"$/
      */
-    public function theStoreHasDisabledCountry($countryName)
+    public function theStoreHasDisabledCountry(string $countryName): void
     {
         $country = $this->createCountryNamed(trim($countryName));
         $country->disable();
@@ -77,9 +81,8 @@ final class GeographicalContext implements Context
      * @Given /^(this country)(?:| also) has the "([^"]+)" province with "([^"]+)" code$/
      * @Given /^(?:|the )(country "[^"]+") has the "([^"]+)" province with "([^"]+)" code$/
      */
-    public function theCountryHasProvinceWithCode(CountryInterface $country, $name, $code)
+    public function theCountryHasProvinceWithCode(CountryInterface $country, string $name, string $code): void
     {
-        /** @var ProvinceInterface $province */
         $province = $this->provinceFactory->createNew();
 
         $province->setName($name);
@@ -90,14 +93,8 @@ final class GeographicalContext implements Context
         $this->countryManager->flush();
     }
 
-    /**
-     * @param string $name
-     *
-     * @return CountryInterface
-     */
-    private function createCountryNamed($name)
+    private function createCountryNamed(string $name): CountryInterface
     {
-        /** @var CountryInterface $country */
         $country = $this->countryFactory->createNew();
         $country->setCode($this->countryNameConverter->convertToCode($name));
 

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -339,27 +339,6 @@ final readonly class OrderContext implements Context
     }
 
     /**
-     * @Given /^the customer chose ("[^"]+" shipping method)$/
-     */
-    public function theCustomerChoseShippingMethod(ShippingMethodInterface $shippingMethod): void
-    {
-        /** @var OrderInterface $order */
-        $order = $this->sharedStorage->get('order');
-
-        foreach ($order->getShipments() as $shipment) {
-            $shipment->setMethod($shippingMethod);
-        }
-
-        $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING);
-        $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_COMPLETE);
-        if (!$order->getPayments()->isEmpty()) {
-            $this->stateMachine->apply($order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_PAY);
-        }
-
-        $this->objectManager->flush();
-    }
-
-    /**
      * @Given /^the customer chose ("[^"]+" payment)$/
      */
     public function theCustomerChosePayment(PaymentMethodInterface $paymentMethod): void

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
@@ -102,9 +103,7 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this payment method) is not using Payum$/
-     */
+    #[Given('/^(this payment method) is not using Payum$/')]
     public function thisPaymentMethodIsNotUsingPayum(PaymentMethodInterface $paymentMethod): void
     {
         /** @var GatewayConfigInterface $gatewayConfig */

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -49,6 +49,20 @@ use Webmozart\Assert\Assert;
 
 final readonly class ProductContext implements Context
 {
+    /**
+     * @param SharedStorageInterface $sharedStorage
+     * @param ProductRepositoryInterface<ProductInterface> $productRepository
+     * @param ProductFactoryInterface<ProductInterface> $productFactory
+     * @param FactoryInterface<ProductTranslationInterface> $productTranslationFactory
+     * @param FactoryInterface<ProductVariantInterface> $productVariantFactory
+     * @param FactoryInterface<ProductVariantTranslationInterface> $productVariantTranslationFactory
+     * @param FactoryInterface<ChannelPricingInterface> $channelPricingFactory
+     * @param FactoryInterface<ProductOptionInterface> $productOptionFactory
+     * @param FactoryInterface<ProductOptionValueInterface> $productOptionValueFactory
+     * @param FactoryInterface<ProductImageInterface> $productImageFactory
+     * @param FactoryInterface<ProductTaxonInterface> $productTaxonFactory
+     * @param ProductVariantRepositoryInterface<ProductVariantInterface> $productVariantRepository
+     */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private ProductRepositoryInterface $productRepository,

--- a/src/Sylius/Behat/Context/Setup/ShippingCategoryContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingCategoryContext.php
@@ -14,14 +14,19 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 
-final class ShippingCategoryContext implements Context
+final readonly class ShippingCategoryContext implements Context
 {
+    /**
+     * @param FactoryInterface<ShippingCategoryInterface> $shippingCategoryFactory
+     * @param RepositoryInterface<ShippingCategoryInterface> $shippingCategoryRepository
+     */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private FactoryInterface $shippingCategoryFactory,
@@ -29,12 +34,12 @@ final class ShippingCategoryContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has :firstShippingCategoryName shipping category
-     * @Given the store has :firstShippingCategoryName and :secondShippingCategoryName shipping category
-     */
-    public function theStoreHasAndShippingCategory($firstShippingCategoryName, $secondShippingCategoryName = null)
-    {
+    #[Given('the store has :firstShippingCategoryName shipping category')]
+    #[Given('the store has :firstShippingCategoryName and :secondShippingCategoryName shipping category')]
+    public function theStoreHasAndShippingCategory(
+        string $firstShippingCategoryName,
+        ?string $secondShippingCategoryName = null,
+    ): void {
         $this->createShippingCategory($firstShippingCategoryName);
         (null === $secondShippingCategoryName) ?: $this->createShippingCategory($secondShippingCategoryName);
     }

--- a/src/Sylius/Behat/Context/Setup/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingContext.php
@@ -36,8 +36,14 @@ use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;
 
-final class ShippingContext implements Context
+final readonly class ShippingContext implements Context
 {
+    /**
+     * @param ShippingMethodRepositoryInterface<ShippingMethodInterface> $shippingMethodRepository
+     * @param RepositoryInterface<ZoneInterface> $zoneRepository
+     * @param ShippingMethodExampleFactory $shippingMethodExampleFactory
+     * @param FactoryInterface<ShippingMethodRuleInterface> $shippingMethodRuleFactory
+     */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -64,9 +70,7 @@ final class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given the store ships everywhere with :shippingMethodName
-     */
+    #[Given('the store ships everywhere with :shippingMethodName')]
     #[Given('the store ships everywhere for :shippingMethodName')]
     public function theStoreShipsEverywhereWith(string $shippingMethodName): void
     {
@@ -107,9 +111,7 @@ final class ShippingContext implements Context
         }
     }
 
-    /**
-     * @Given the store (also )allows shipping with :name
-     */
+    #[Given('the store (also )allows shipping with :name')]
     public function theStoreAllowsShippingMethodWithName(string $name): void
     {
         $this->saveShippingMethod($this->shippingMethodExampleFactory->create(['name' => $name, 'enabled' => true]));
@@ -198,10 +200,8 @@ final class ShippingContext implements Context
         }
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee within the ("[^"]+" zone)$/
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee for the (rest of the world)$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee within the ("[^"]+" zone)$/')]
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee for the (rest of the world)$/')]
     public function storeHasShippingMethodWithFeeAndZone(string $shippingMethodName, int $fee, ZoneInterface $zone): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -319,9 +319,7 @@ final class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has disabled "([^"]+)" shipping method with ("[^"]+") fee$/
-     */
+    #[Given('/^the store has disabled "([^"]+)" shipping method with ("[^"]+") fee$/')]
     public function storeHasDisabledShippingMethodWithFee(string $shippingMethodName, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -441,13 +439,11 @@ final class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this shipping method) requires that all units match to ("([^"]+)" shipping category)$/
-     */
+    #[Given('/^(this shipping method) requires that all units match to ("([^"]+)" shipping category)$/')]
     public function thisShippingMethodRequiresThatAllUnitsMatchToShippingCategory(
         ShippingMethodInterface $shippingMethod,
         ShippingCategoryInterface $shippingCategory,
-    ) {
+    ): void {
         $shippingMethod->setCategory($shippingCategory);
         $shippingMethod->setCategoryRequirement(ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL);
         $this->shippingMethodManager->flush();
@@ -545,10 +541,8 @@ final class ShippingContext implements Context
         $this->addRuleToShippingMethod($rule, $shippingMethod);
     }
 
-    /**
-     * @Given /^(this shipping method) has been disabled$/
-     * @Given /^(this shipping method) has been disabled for ("[^"]+" channel)$/
-     */
+    #[Given('/^(this shipping method) has been disabled$/')]
+    #[Given('/^(this shipping method) has been disabled for ("[^"]+" channel)$/')]
     public function thisShippingMethodHasBeenDisabled(ShippingMethodInterface $shippingMethod, ?ChannelInterface $channel = null): void
     {
         /** @var ShippingMethodInterface $shippingMethod */

--- a/src/Sylius/Behat/Context/Setup/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Setup/ZoneContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Factory\ZoneFactoryInterface;
@@ -22,6 +23,7 @@ use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Addressing\Model\Scope;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Addressing\Model\ZoneMemberInterface;
+use Sylius\Component\Addressing\Repository\ZoneRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -29,8 +31,13 @@ use Sylius\Resource\Factory\FactoryInterface;
 use Sylius\Resource\Model\CodeAwareInterface;
 use Symfony\Component\Intl\Countries;
 
-final class ZoneContext implements Context
+final readonly class ZoneContext implements Context
 {
+    /**
+     * @param RepositoryInterface<ZoneInterface> $zoneRepository
+     * @param ZoneFactoryInterface<ZoneInterface> $zoneFactory
+     * @param FactoryInterface<ZoneMemberInterface> $zoneMemberFactory
+     */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private RepositoryInterface $zoneRepository,
@@ -40,10 +47,8 @@ final class ZoneContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^there is a zone "The Rest of the World" containing all other countries$/
-     */
-    public function thereIsAZoneTheRestOfTheWorldContainingAllOtherCountries()
+    #[Given('there is a zone "The Rest of the World" containing all other countries')]
+    public function thereIsAZoneTheRestOfTheWorldContainingAllOtherCountries(): void
     {
         $restOfWorldCountries = Countries::getNames('en');
         unset($restOfWorldCountries['US']);
@@ -56,10 +61,8 @@ final class ZoneContext implements Context
         $this->zoneRepository->add($zone);
     }
 
-    /**
-     * @Given default tax zone is :zone
-     */
-    public function defaultTaxZoneIs(ZoneInterface $zone)
+    #[Given('default tax zone is :zone')]
+    public function defaultTaxZoneIs(ZoneInterface $zone): void
     {
         /** @var ChannelInterface $channel */
         $channel = $this->sharedStorage->get('channel');
@@ -68,10 +71,8 @@ final class ZoneContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the store does not have any zones defined
-     */
-    public function theStoreDoesNotHaveAnyZonesDefined()
+    #[Given('the store does not have any zones defined')]
+    public function theStoreDoesNotHaveAnyZonesDefined(): void
     {
         $zones = $this->zoneRepository->findAll();
 

--- a/src/Sylius/Behat/Context/Transform/CartContext.php
+++ b/src/Sylius/Behat/Context/Transform/CartContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
+use Behat\Transformation\Transform;
 use Sylius\Behat\Exception\SharedStorageElementNotFoundException;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -49,16 +50,13 @@ final readonly class CartContext implements Context
         ) ? $token : null;
     }
 
-    /**
-     * @Transform /^((?:previous|customer|customer's|visitor's|their) cart)$/
-     */
-    public function providePreviousCartToken(): ?string
+    #[Transform('/^(previous cart)$/')]
+    public function providePreviousCart(): ?OrderInterface
     {
-        if ($this->sharedStorage->has('previous_cart_token')) {
-            return $this->sharedStorage->get('previous_cart_token');
-        }
-
-        return $this->provideCartToken();
+        return $this->orderRepository->findOneBy([
+            'tokenValue' => $this->sharedStorage->get('previous_cart_token'),
+            'state' => OrderCheckoutStates::STATE_CART,
+        ]);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Transform/OrderContext.php
+++ b/src/Sylius/Behat/Context/Transform/OrderContext.php
@@ -14,24 +14,28 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
+use Behat\Transformation\Transform;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Webmozart\Assert\Assert;
 
-final class OrderContext implements Context
+final readonly class OrderContext implements Context
 {
+    /**
+     * @param CustomerRepositoryInterface<CustomerInterface> $customerRepository
+     * @param OrderRepositoryInterface<OrderInterface> $orderRepository
+     */
     public function __construct(
         private CustomerRepositoryInterface $customerRepository,
         private OrderRepositoryInterface $orderRepository,
     ) {
     }
 
-    /**
-     * @Transform :order
-     * @Transform /^"([^"]+)" order$/
-     * @Transform /^order "([^"]+)"$/
-     */
+    #[Transform(':order')]
+    #[Transform('/^"([^"]+)" order$/')]
+    #[Transform('/^order "([^"]+)"$/')]
     public function getOrderByNumber(string $orderNumber): OrderInterface
     {
         $orderNumber = $this->getOrderNumber($orderNumber);
@@ -42,9 +46,8 @@ final class OrderContext implements Context
         return $order;
     }
 
-    /**
-     * @Transform /^latest order$/
-     */
+    #[Transform('/^latest order$/')]
+    #[Transform('/^last order$/')]
     public function getLatestOrder(): OrderInterface
     {
         $orders = $this->orderRepository->findLatest(1);
@@ -54,11 +57,9 @@ final class OrderContext implements Context
         return $orders[0];
     }
 
-    /**
-     * @Transform /^this order made by "([^"]+)"$/
-     * @Transform /^order placed by "([^"]+)"$/
-     * @Transform /^the order of "([^"]+)"$/
-     */
+    #[Transform('/^this order made by "([^"]+)"$/')]
+    #[Transform('/^order placed by "([^"]+)"$/')]
+    #[Transform('/^the order of "([^"]+)"$/')]
     public function getOrderByCustomer(string $email): OrderInterface
     {
         $customer = $this->customerRepository->findOneBy(['email' => $email]);
@@ -70,13 +71,11 @@ final class OrderContext implements Context
         return end($orders);
     }
 
-    /**
-     * @Transform :orderNumber
-     * @Transform /^an order "([^"]+)"$/
-     * @Transform /^another order "([^"]+)"$/
-     * @Transform /^the order "([^"]+)"$/
-     * @Transform /^the "([^"]+)" order$/
-     */
+    #[Transform(':orderNumber')]
+    #[Transform('/^an order "([^"]+)"$/')]
+    #[Transform('/^another order "([^"]+)"$/')]
+    #[Transform('/^the order "([^"]+)"$/')]
+    #[Transform('/^the "([^"]+)" order$/')]
     public function getOrderNumber(string $orderNumber): string
     {
         return str_replace('#', '', $orderNumber);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Order\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
@@ -44,8 +46,8 @@ final readonly class ManagingOrdersContext implements Context
 
     /**
      * @Given I am browsing orders
-     * @When I browse orders
      */
+    #[When('I browse orders')]
     public function iBrowseOrders(): void
     {
         $this->indexPage->open();
@@ -58,6 +60,12 @@ final readonly class ManagingOrdersContext implements Context
      * @When /^I view the summary of the (order placed by "[^"]+")$/
      */
     public function iViewTheSummaryOfTheOrder(OrderInterface $order): void
+    {
+        $this->showPage->open(['id' => $order->getId()]);
+    }
+
+    #[When('/^I view the summary of the (last order)$/')]
+    public function iViewTheSummaryOfTheLastOrder(OrderInterface $order): void
     {
         $this->showPage->open(['id' => $order->getId()]);
     }
@@ -765,6 +773,12 @@ final readonly class ManagingOrdersContext implements Context
      * @Then /^(this order) should have order payment state "([^"]+)"$/
      */
     public function theOrderShouldHavePaymentState(OrderInterface $order, string $orderPaymentState): void
+    {
+        Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
+    }
+
+    #[Then('the last order should have order payment state :orderPaymentState')]
+    public function theLastOrderShouldHavePaymentState(string $orderPaymentState): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
     }

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -47,9 +47,11 @@ final readonly class CartContext implements Context
     ) {
     }
 
-    #[When('I check the details of my cart')]
     #[When('/^I see the summary of my (?:|previous )cart$/')]
     #[When('I check items in my cart')]
+    #[When('I check the details of my cart')]
+    #[When('the customer checks the details of their cart')]
+    #[When('the visitor checks the details of their cart')]
     public function iCheckDetailsOfMyCart(): void
     {
         $this->summaryPage->open();
@@ -280,8 +282,6 @@ final readonly class CartContext implements Context
      * @Given /^I add (this product) to the cart$/
      * @Given /^I have (product "[^"]+") added to the cart$/
      * @Given he added product :product to the cart
-     * @Given /^the visitor has (product "[^"]+") in the cart$/
-     * @Given /^the customer has (product "[^"]+") in the cart$/
      * @When /^the customer adds ("[^"]+" product) to the cart$/
      * @When /^I add ("[^"]+" product) to the (cart)$/
      * @When /^the visitor adds ("[^"]+" product) to the cart$/
@@ -364,10 +364,8 @@ final readonly class CartContext implements Context
         $this->sharedStorage->set('product', $product);
     }
 
-    /**
-     * @Then /^I should be(?: on| redirected to) my cart summary page$/
-     * @Then I should not be able to address an order with an empty cart
-     */
+    #[Then('/^I should be(?: on| redirected to) my cart summary page$/')]
+    #[Then('I should not be able to address an order with an empty cart')]
     public function shouldBeOnMyCartSummaryPage(): void
     {
         $this->summaryPage->waitForRedirect(3);
@@ -466,11 +464,9 @@ final readonly class CartContext implements Context
         Assert::same($this->summaryPage->getQuantity($productName), $quantity);
     }
 
-    /**
-     * @Then /^the customer can see "([^"]+)" product in the cart$/
-     * @Then /^the visitor can see "([^"]+)" product in the cart$/
-     */
-    public function theCustomerCanSeeProductInTheCart(string $productName): void
+    #[Then('/^the customer should see "([^"]+)" product in the cart$/')]
+    #[Then('/^the visitor should see "([^"]+)" product in the cart$/')]
+    public function theCustomerShouldSeeProductInTheCart(string $productName): void
     {
         Assert::true(
             $this->summaryPage->hasItemNamed($productName),

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -14,11 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Page\Shop\Checkout\AddressPageInterface;
 use Sylius\Behat\Page\Shop\Checkout\SelectShippingPageInterface;
+use Sylius\Behat\Service\Factory\AddressFactoryInterface;
 use Sylius\Behat\Service\Helper\JavaScriptTestHelperInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Comparator\AddressComparatorInterface;
@@ -29,11 +31,10 @@ use Webmozart\Assert\Assert;
 
 final readonly class CheckoutAddressingContext implements Context
 {
-    /** @param FactoryInterface<AddressInterface> $addressFactory */
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private AddressPageInterface $addressPage,
-        private FactoryInterface $addressFactory,
+        private AddressFactoryInterface $addressFactory,
         private AddressComparatorInterface $addressComparator,
         private SelectShippingPageInterface $selectShippingPage,
         private JavaScriptTestHelperInterface $testHelper,
@@ -192,7 +193,6 @@ final readonly class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @Given /^the customer specify the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
      * @Given /^the visitor specify the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
      * @Given /^the visitor has specified (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
      * @Given /^the customer has specified (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
@@ -200,10 +200,17 @@ final readonly class CheckoutAddressingContext implements Context
      * @When /^I specify the billing (address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
      * @When /^I (do not specify any billing address) information$/
      */
-    public function iSpecifyTheBillingAddressAs(AddressInterface $address): void
+    #[Given('/^the customer specify the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[Given('the customer specify the billing address')]
+    #[Given('the visitor specify the billing address')]
+    public function iSpecifyTheBillingAddressAs(?AddressInterface $address = null): void
     {
         if (!$this->addressPage->isOpen()) {
             $this->addressPage->open();
+        }
+
+        if ($address === null) {
+            $address = $this->addressFactory->createDefault();
         }
 
         $billingKey = sprintf(
@@ -240,7 +247,7 @@ final readonly class CheckoutAddressingContext implements Context
     public function iSpecifiedTheBillingAddress(?AddressInterface $address = null): void
     {
         if (null === $address) {
-            $address = $this->createDefaultAddress();
+            $address = $this->addressFactory->createDefault();
         }
 
         if (!$this->addressPage->isOpen()) {
@@ -316,7 +323,7 @@ final readonly class CheckoutAddressingContext implements Context
         ?string $email = null,
     ): void {
         $this->addressPage->open(['_locale' => $localeCode]);
-        $shippingAddress = $this->createDefaultAddress();
+        $shippingAddress = $this->addressFactory->createDefault();
         if (null !== $shippingCountry) {
             $shippingAddress->setCountryCode($shippingCountry->getCode());
         }
@@ -336,7 +343,7 @@ final readonly class CheckoutAddressingContext implements Context
     ): void {
         $this->addressPage->open();
         $this->addressPage->specifyEmail($email);
-        $shippingAddress = $this->createDefaultAddress();
+        $shippingAddress = $this->addressFactory->createDefault();
         if (null !== $shippingCountry) {
             $shippingAddress->setCountryCode($shippingCountry->getCode());
         }
@@ -557,21 +564,6 @@ final readonly class CheckoutAddressingContext implements Context
             $this->addressPage->isOpen(),
             'Customer should have checkout address step completed, but it is not.',
         );
-    }
-
-    private function createDefaultAddress(): AddressInterface
-    {
-        /** @var AddressInterface $address */
-        $address = $this->addressFactory->createNew();
-        $address->setFirstName('John');
-        $address->setLastName('Doe');
-        $address->setCountryCode('US');
-        $address->setCity('North Bridget');
-        $address->setPostcode('93-554');
-        $address->setStreet('0635 Myron Hollow Apt. 711');
-        $address->setPhoneNumber('321123456');
-
-        return $address;
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -26,7 +26,6 @@ use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Comparator\AddressComparatorInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
-use Sylius\Resource\Factory\FactoryInterface;
 use Webmozart\Assert\Assert;
 
 final readonly class CheckoutAddressingContext implements Context

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Page\Shop\Checkout\AddressPageInterface;
 use Sylius\Behat\Page\Shop\Checkout\SelectShippingPageInterface;
@@ -107,9 +109,7 @@ final readonly class CheckoutAddressingContext implements Context
         $this->addressPage->specifyBillingAddressProvince($provinceName);
     }
 
-    /**
-     * @When I try to open checkout addressing page
-     */
+    #[When('I try to open checkout addressing page')]
     public function iTryToOpenCheckoutAddressingPage(): void
     {
         $this->addressPage->tryToOpen();
@@ -425,18 +425,14 @@ final readonly class CheckoutAddressingContext implements Context
         Assert::false($this->addressPage->checkFormValidationMessage('This form should not contain extra fields.'), 'Found "This form should not contains extra fields." validation message');
     }
 
-    /**
-     * @Then I should be redirected to the addressing step
-     * @Then I should be on the checkout addressing step
-     */
-    public function iShouldBeRedirectedToTheAddressingStep()
+    #[Then('I should be redirected to the addressing step')]
+    #[Then('I should be on the checkout addressing step')]
+    public function iShouldBeRedirectedToTheAddressingStep(): void
     {
         $this->addressPage->verify();
     }
 
-    /**
-     * @Then I should be able to go to the shipping step again
-     */
+    #[Then('I should be able to go to the shipping step again')]
     public function iShouldBeAbleToGoToTheShippingStepAgain(): void
     {
         $this->addressPage->nextStep();

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
@@ -30,20 +30,6 @@ final readonly class CheckoutPaymentContext implements Context
     }
 
     /**
-     * @When I try to open checkout payment page
-     */
-    public function iTryToOpenCheckoutPaymentPage(): void
-    {
-        $this->selectPaymentPage->tryToOpen();
-    }
-
-    #[When('I decide to change order shipping method')]
-    public function iDecideToChangeOrderShippingMethod(): void
-    {
-        $this->selectPaymentPage->changeShippingMethod();
-    }
-
-    /**
      * @Given I completed the payment step with :paymentMethodName payment method
      * @Given the visitor has proceeded :paymentMethodName payment
      * @Given the customer has proceeded :paymentMethodName payment
@@ -51,6 +37,8 @@ final readonly class CheckoutPaymentContext implements Context
      * @Given the customer proceed with :paymentMethodName payment
      * @When /^I choose "([^"]*)" payment method$/
      */
+    #[When('the visitor proceeds with :paymentMethod payment method')]
+    #[When('the customer proceeds with :paymentMethod payment method')]
     public function iChoosePaymentMethod(string $paymentMethodName): void
     {
         $this->selectPaymentPage->selectPaymentMethod($paymentMethodName ?: 'Offline');
@@ -65,9 +53,9 @@ final readonly class CheckoutPaymentContext implements Context
         $this->selectPaymentPage->tryToOpen();
     }
 
-    /**
-     * @When I go back to payment step of the checkout
-     */
+    #[When('I am at the checkout payment step')]
+    #[When('I go back to payment step of the checkout')]
+    #[When('the customer is at the checkout payment step')]
     public function iAmAtTheCheckoutPaymentStep(): void
     {
         $this->selectPaymentPage->open();

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -72,7 +72,7 @@ final readonly class CheckoutShippingContext implements Context
 
     /**
      * @When I complete the shipping step
-     * @When I complete the shipping step with first shipping method
+     * @When I complete the shipping step with the first shipping method
      */
     public function iCompleteTheShippingStep(): void
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -15,6 +15,8 @@ namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\Then;
+use Behat\Step\When;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Page\Shop\Checkout\CompletePageInterface;
 use Sylius\Behat\Page\Shop\Checkout\SelectPaymentPageInterface;
@@ -30,17 +32,24 @@ final readonly class CheckoutShippingContext implements Context
     ) {
     }
 
+    #[When('I navigate directly to the addressing step in the checkout steps panel')]
+    public function iNavigateDirectlyToTheAddressingStepInTheCheckoutStepsPanel(): void
+    {
+        $this->selectShippingPage->changeAddressByStepLabel();
+    }
+
     /**
      * @Given the visitor has proceeded :shippingMethodName shipping method
-     * @Given the customer has proceeded :shippingMethodName shipping method
+     * @Given the customer has proceeded with :shippingMethodName shipping method
      * @Given the visitor proceed with :shippingMethodName shipping method
      * @Given the customer proceed with :shippingMethodName shipping method
-     * @Given I chose :shippingMethodName shipping method
      * @Given I completed the shipping step with :shippingMethodName shipping method
      * @Given I have proceeded with :shippingMethodName shipping method
      * @Given I have proceeded selecting :shippingMethodName shipping method
      * @When I proceed with :shippingMethodName shipping method
      */
+    #[When('the visitor proceeds with :shippingMethod shipping method')]
+    #[When('the customer proceeds with :shippingMethod shipping method')]
     public function iHaveProceededWithSelectingShippingMethod(string $shippingMethodName): void
     {
         if (!$this->selectShippingPage->isOpen()) {
@@ -62,14 +71,6 @@ final readonly class CheckoutShippingContext implements Context
     }
 
     /**
-     * @When I try to open checkout shipping page
-     */
-    public function iTryToOpenCheckoutShippingPage(): void
-    {
-        $this->selectShippingPage->tryToOpen();
-    }
-
-    /**
      * @When I complete the shipping step
      * @When I complete the shipping step with first shipping method
      */
@@ -78,34 +79,25 @@ final readonly class CheckoutShippingContext implements Context
         $this->selectShippingPage->nextStep();
     }
 
-    /**
-     * @When I decide to change my address
-     */
-    public function iDecideToChangeMyAddress()
+    #[When('I decide to change my address')]
+    public function iDecideToChangeMyAddress(): void
     {
         $this->selectShippingPage->changeAddress();
     }
 
-    /**
-     * @When I want to complete the shipping step
-     */
+    #[When('I decide to change shipping method')]
+    #[When('I go back to the shipping step')]
+    #[When('I go to the shipping step')]
+    #[When('I want to complete the shipping step')]
+    #[When('the customer wants to complete the shipping step')]
+
     public function iWantToCompleteTheShippingStep(): void
     {
         $this->selectShippingPage->open();
     }
 
-    /**
-     * @When I go back to shipping step of the checkout
-     */
-    public function iGoBackToShippingStepOfTheCheckout(): void
-    {
-        $this->selectShippingPage->open();
-    }
-
-    /**
-     * @Then I should not be able to select :shippingMethodName shipping method
-     */
-    public function iShouldNotBeAbleToSelectShippingMethod($shippingMethodName)
+    #[Then('I should not be able to select :shippingMethodName shipping method')]
+    public function iShouldNotBeAbleToSelectShippingMethod(string $shippingMethodName): void
     {
         Assert::false(in_array($shippingMethodName, $this->selectShippingPage->getShippingMethods(), true));
     }
@@ -139,10 +131,8 @@ final readonly class CheckoutShippingContext implements Context
         $this->selectShippingPage->verify();
     }
 
-    /**
-     * @Then I should be informed that my order cannot be shipped to this address
-     * @Then there should be information about no available shipping methods
-     */
+    #[Then('I should be informed that my order cannot be shipped to this address')]
+    #[Then('there should be information about no available shipping methods')]
     public function iShouldBeInformedThatMyOrderCannotBeShippedToThisAddress(): void
     {
         Assert::true($this->selectShippingPage->hasNoAvailableShippingMethodsMessage());
@@ -212,7 +202,8 @@ final readonly class CheckoutShippingContext implements Context
      * @Then the customer should have checkout shipping method step completed
      * @Then the visitor should have checkout shipping method step completed
      */
-    public function theCustomerShouldHaveCheckoutShippingMethodStepCompleted()
+    #[Then('the checkout shipping method step should be completed')]
+    public function theCustomerShouldHaveCheckoutShippingMethodStepCompleted(): void
     {
         Assert::false(
             $this->selectShippingPage->isOpen(),
@@ -220,9 +211,7 @@ final readonly class CheckoutShippingContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to proceed checkout shipping step
-     */
+    #[Then('I should not be able to proceed checkout shipping step')]
     public function iShouldNotBeAbleToProceedCheckoutShippingStep(): void
     {
         $this->selectShippingPage->tryToOpen();

--- a/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
+use Behat\Step\When;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Context\Ui\Shop\Checkout\CheckoutAddressingContext;
 use Sylius\Behat\Context\Ui\Shop\Checkout\CheckoutPaymentContext;
@@ -68,8 +70,6 @@ final readonly class CheckoutContext implements Context
 
     /**
      * @Given I have proceeded order with :shippingMethodName shipping method and :paymentMethodName payment
-     * @Given I proceeded with :shippingMethodName shipping method and :paymentMethodName payment
-     * @Given I proceeded with :shippingMethodName shipping method and :paymentMethodName payment method
      * @When I proceed with :shippingMethodName shipping method and :paymentMethodName payment
      */
     public function iProceedOrderWithShippingMethodAndPayment(string $shippingMethodName, string $paymentMethodName): void
@@ -86,8 +86,6 @@ final readonly class CheckoutContext implements Context
     }
 
     /**
-     * @Given I have proceeded through checkout process in the :localeCode locale with email :email
-     * @Given I have proceeded through checkout process
      * @When I proceed through checkout process
      * @When I proceeded through checkout process
      * @When I proceed through checkout process in the :localeCode locale
@@ -101,7 +99,6 @@ final readonly class CheckoutContext implements Context
     }
 
     /**
-     * @Given I have proceeded through checkout process with :shippingMethod shipping method
      * @When I proceed through checkout with :shippingMethod shipping method
      */
     public function iHaveProceededThroughCheckoutProcessWithShippingMethod(ShippingMethodInterface $shippingMethod): void
@@ -124,9 +121,7 @@ final readonly class CheckoutContext implements Context
         $this->shippingContext->iHaveProceededWithSelectingShippingMethod($shippingMethodName);
     }
 
-    /**
-     * @When I go to the addressing step
-     */
+    #[When('I go to the addressing step')]
     public function iGoToTheAddressingStep(): void
     {
         if ($this->selectShippingPage->isOpen()) {
@@ -148,26 +143,6 @@ final readonly class CheckoutContext implements Context
         }
 
         throw new UnexpectedPageException('It is impossible to go to addressing step from current page.');
-    }
-
-    /**
-     * @When I go to the shipping step
-     */
-    public function iGoToTheShippingStep(): void
-    {
-        if ($this->selectPaymentPage->isOpen()) {
-            $this->selectPaymentPage->changeShippingMethodByStepLabel();
-
-            return;
-        }
-
-        if ($this->completePage->isOpen()) {
-            $this->completePage->changeShippingMethod();
-
-            return;
-        }
-
-        throw new UnexpectedPageException('It is impossible to go to shipping step from current page.');
     }
 
     /**

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -75,7 +75,7 @@
         <service id="sylius.behat.context.api.shop.checkout" class="Sylius\Behat\Context\Api\Shop\CheckoutContext">
             <argument type="service" id="sylius.behat.api_platform_client.shop" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
-            <argument type="service" id="sylius.repository.shipping_method" />
+            <argument type="service" id="sylius.behat.context.api.shop.checkout.shipping"/>
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="sylius.resolver.product_variant" />
@@ -192,6 +192,14 @@
             <argument type="service" id="sylius.behat.request_factory" />
             <argument type="service" id="sylius.behat.api_platform_client.shop" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
+        </service>
+
+        <service id="sylius.behat.context.api.shop.checkout.shipping" class="Sylius\Behat\Context\Api\Shop\Checkout\CheckoutShippingContext">
+            <argument type="service" id="sylius.behat.api_platform_client.shop" />
+            <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
+            <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="sylius.repository.shipping_method" />
         </service>
 
         <service id="sylius.behat.context.api.shop.checkout.complete" class="Sylius\Behat\Context\Api\Shop\Checkout\CheckoutCompleteContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -82,6 +82,7 @@
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.behat.request_factory" />
+            <argument type="service" id="sylius.behat.factory.address" />
             <argument>%sylius.model.shipping_method.class%</argument>
             <argument>%sylius.model.payment_method.class%</argument>
         </service>

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -51,6 +51,8 @@
             <argument type="service" id="sylius.command_bus" />
             <argument type="service" id="sylius.factory.address" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.behat.context.setup.checkout.shipping"/>
+            <argument type="service" id="sylius.behat.context.setup.checkout.payment"/>
         </service>
 
         <service id="sylius.behat.context.setup.checkout.address" class="Sylius\Behat\Context\Setup\Checkout\AddressContext">
@@ -58,6 +60,16 @@
             <argument type="service" id="sylius.command_bus" />
             <argument type="service" id="sylius.factory.address" />
             <argument type="service" id="sylius.converter.country_name" />
+        </service>
+
+        <service id="sylius.behat.context.setup.checkout.shipping" class="Sylius\Behat\Context\Setup\Checkout\ShippingContext">
+            <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.command_bus" />
+        </service>
+
+        <service id="sylius.behat.context.setup.checkout.payment" class="Sylius\Behat\Context\Setup\Checkout\PaymentContext">
+            <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.command_bus" />
         </service>
 
         <service id="sylius.behat.context.setup.channel" class="Sylius\Behat\Context\Setup\ChannelContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -58,7 +58,7 @@
         <service id="sylius.behat.context.setup.checkout.address" class="Sylius\Behat\Context\Setup\Checkout\AddressContext">
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.command_bus" />
-            <argument type="service" id="sylius.factory.address" />
+            <argument type="service" id="sylius.behat.factory.address" />
             <argument type="service" id="sylius.converter.country_name" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -409,7 +409,7 @@
         <service id="sylius.behat.context.ui.shop.checkout.addressing" class="Sylius\Behat\Context\Ui\Shop\Checkout\CheckoutAddressingContext">
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.behat.page.shop.checkout.address" />
-            <argument type="service" id="sylius.factory.address" />
+            <argument type="service" id="sylius.behat.factory.address" />
             <argument type="service" id="sylius.comparator.address" />
             <argument type="service" id="sylius.behat.page.shop.checkout.select_shipping" />
             <argument type="service" id="sylius.behat.java_script_test_helper" />

--- a/src/Sylius/Behat/Resources/config/suites/api/cart/accessing_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/cart/accessing_cart.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.payment
                 - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Behat/Resources/config/suites/api/cart/accessing_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/cart/accessing_cart.yml
@@ -20,6 +20,8 @@ default:
                 - sylius.behat.context.setup.admin_api_security
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.shipping
@@ -28,6 +30,7 @@ default:
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.shipping
                 - sylius.behat.context.api.shop.login
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/api/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/checkout/checkout.yml
@@ -36,6 +36,8 @@ default:
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.payment
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.geographical
@@ -57,6 +59,8 @@ default:
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.channel
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.complete
+                - sylius.behat.context.api.shop.checkout.shipping
                 - sylius.behat.context.api.shop.order
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/api/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/checkout/paying_for_order.yml
@@ -49,6 +49,7 @@ default:
                 - sylius.behat.context.api.shop.checkout
                 - sylius.behat.context.api.shop.checkout.complete
                 - sylius.behat.context.api.shop.checkout.order_details
+                - sylius.behat.context.api.shop.checkout.shipping
                 - sylius.behat.context.api.shop.customer
                 - sylius.behat.context.api.shop.order
                 - sylius.behat.context.api.shop.payment_request

--- a/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/order/managing_orders.yml
@@ -35,6 +35,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_promotion_rules.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.customer_group
                 - sylius.behat.context.setup.order
@@ -38,6 +39,7 @@ default:
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.shipping
 
             filters:
                 tags: "@applying_promotion_rules&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/receiving_discount.yml
@@ -24,6 +24,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_fee.yml
@@ -27,6 +27,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical
@@ -41,6 +42,7 @@ default:
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.shipping
 
             filters:
                 tags: "@applying_shipping_fee&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_method_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/applying_shipping_method_rules.yml
@@ -35,6 +35,7 @@ default:
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.shipping
 
             filters:
                 tags: "@applying_shipping_method_rules&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/shipping/viewing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/shipping/viewing_shipping_methods.yml
@@ -34,6 +34,7 @@ default:
 
                 - sylius.behat.context.api.shop.cart
                 - sylius.behat.context.api.shop.checkout
+                - sylius.behat.context.api.shop.checkout.shipping
 
             filters:
                 tags: "@viewing_shipping_methods&&@api"

--- a/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
@@ -17,7 +17,10 @@ default:
                 - sylius.behat.context.transform.shipping_method
 
                 - sylius.behat.context.setup.admin_api_security
+                - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.shipping

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
@@ -20,6 +20,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.payment
                 - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
@@ -37,7 +37,10 @@ default:
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.payment
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.exchange_rate

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
@@ -29,6 +29,7 @@ default:
                 - sylius.behat.context.setup.admin_user
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout
                 - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -36,6 +36,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.customer_group
                 - sylius.behat.context.setup.order

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
@@ -16,11 +16,13 @@ default:
                 - sylius.behat.context.transform.product_variant
                 - sylius.behat.context.transform.promotion
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.taxon
 
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
@@ -21,6 +21,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.payment

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.checkout.address
+                - sylius.behat.context.setup.checkout.shipping
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Service/Factory/AddressFactoryInterface.php
+++ b/src/Sylius/Behat/Service/Factory/AddressFactoryInterface.php
@@ -16,9 +16,7 @@ namespace Sylius\Behat\Service\Factory;
 use Sylius\Component\Core\Factory\AddressFactoryInterface as BaseAddressFactoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 
-/**
- * @implements BaseAddressFactoryInterface<AddressInterface>
- */
+/** @extends BaseAddressFactoryInterface<AddressInterface> */
 interface AddressFactoryInterface extends BaseAddressFactoryInterface
 {
     public function createDefault(): AddressInterface;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Continuation of:
- https://github.com/Sylius/Sylius/pull/17785
- https://github.com/Sylius/Sylius/pull/17782
- https://github.com/Sylius/Sylius/pull/17783

Until now, the checkout-related scenarios have been set up as follows:
	•	UI – via web actions (e.g. `Given I have a product ...` actually triggered browser actions to prepare the initial step),
	•	API – a mix of messenger commands and API calls.

During the development of Sylius 2.0, with the introduction of dynamic components, all scenarios involving product-related actions had to be marked as JS to work correctly. This significantly increased build time and reduced overall stability.

This PR focuses on decoupling the Behat architecture to unify the test setup for both UI and API. The goal is to eliminate most JS tags, which should lead to greater stability. Some performance improvements are already noticeable.


This PR doesn’t yet include all refactored scenarios, but at this stage we already observe the following performance gains:
	•	For non-JS scenarios, the timing is likely similar — some JS scenarios have been converted to non-JS, but at the same time, we benefit from faster setup thanks to the refactor (using messenger commands instead of API calls or UI interactions to prepare tests).
	•	For JS scenarios executed via Chromedriver, the same applies — some Panther scenarios have been switched to Chromedriver, and performance remains comparable.

JS with Panther: **~30 min → ~20 min**