### PR TITLE
[Behat] Decouple cart setup from interaction – `Given I added` vs `When I add` - Promotion & Some other scenarios

### DIFF
--- a/features/shop/cart/shopping_cart/adding_product_with_variants_with_discounted_catalog_price_to_cart.feature
+++ b/features/shop/cart/shopping_cart/adding_product_with_variants_with_discounted_catalog_price_to_cart.feature
@@ -18,6 +18,6 @@ Feature: Adding a product with selected variant with discounted catalog price to
     Scenario: Adding multiple product variants with discounted price by catalog promotion catalog to the cart
         When I add "PHP T-Shirt" variant of product "T-Shirt" to the cart
         And I add "RGB Keyboard" variant of product "Keyboard" to the cart
-        And I check details of my cart
+        And I check the details of my cart
         Then I should see "T-Shirt" with unit price "$15.00" in my cart
         And I should see "Keyboard" with unit price "$40.00" in my cart

--- a/features/shop/cart/shopping_cart/changing_display_currency_of_cart.feature
+++ b/features/shop/cart/shopping_cart/changing_display_currency_of_cart.feature
@@ -1,7 +1,7 @@
 @shopping_cart
 Feature: Changing display currency of the cart
     In order to know estimated price for foreign currencies
-    As a Visitor
+    As a Customer
     I want to see every cash amount rounded to my chosen currency
 
     Background:
@@ -13,11 +13,13 @@ Feature: Changing display currency of the cart
         And the store has "Pugs" tax rate of 10% for "Mugs" within the "US" zone
         And the store has a product "The Pug Mug" priced at "$10.00"
         And it belongs to "Mugs" tax category
+        And I am a logged in customer
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Changing the currency of my cart
-        When I add product "The Pug Mug" to the cart
-        And I switch to the "GBP" currency
+        Given I added product "The Pug Mug" to the cart
+        When I switch to the "GBP" currency
+        And I check the details of my cart
         Then my cart total should be "£32.00"
         And total price of "The Pug Mug" item should be "£20.00"
         And my cart taxes should be "£2.00"

--- a/features/shop/cart/shopping_cart/clearing_cart.feature
+++ b/features/shop/cart/shopping_cart/clearing_cart.feature
@@ -1,16 +1,17 @@
 @shopping_cart
 Feature: Clearing cart
     In order to quick start shopping again
-    As a Visitor
+    As a Customer
     I want to be able to clear my cart
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "T-Shirt banana" priced at "$12.54"
-        And I added this product to the cart
+        And I am a logged in customer
 
     @api @ui @javascript
     Scenario: Clearing cart
-        Given I see the summary of my cart
-        When I clear my cart
+        Given I added product "T-Shirt banana" to the cart
+        When I check the details of my cart
+        And I clear my cart
         Then my cart should be cleared

--- a/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
+++ b/features/shop/cart/shopping_cart/currency_rounding_edge_case.feature
@@ -1,7 +1,7 @@
 @shopping_cart
 Feature: Currency rounding edge case
     In order to pay proper value of my cart
-    As a Visitor
+    As a Customer
     I want to have total value of my cart items rounded properly
 
     Background:
@@ -15,6 +15,7 @@ Feature: Currency rounding edge case
     Scenario: Changing the currency of my cart
         Given I added product "The Pug Mug" to the cart
         When I switch to the "EUR" currency
+        And I check the details of my cart
         Then the grand total value should be "€6.82"
         And the grand total value in base currency should be "$7.00"
 
@@ -22,6 +23,7 @@ Feature: Currency rounding edge case
     Scenario: Changing the currency of my cart
         Given I added 2 products "The Pug Mug" to the cart
         When I switch to the "EUR" currency
+        And I check the details of my cart
         Then the grand total value in base currency should be "$14.00"
         And I should see "The Pug Mug" with unit price "€6.82" in my cart
         But the grand total value should be "€13.63"

--- a/features/shop/cart/shopping_cart/maintaining_last_picked_up_cart.feature
+++ b/features/shop/cart/shopping_cart/maintaining_last_picked_up_cart.feature
@@ -11,5 +11,5 @@ Feature: Maintaining a last picked up cart
     Scenario: Having access to a last picked up cart
         When I pick up my cart
         And I pick up my cart again
-        And I check details of my cart
+        And I check the details of my cart
         Then I should have empty cart

--- a/features/shop/cart/shopping_cart/seeing_detailed_information_about_cart.feature
+++ b/features/shop/cart/shopping_cart/seeing_detailed_information_about_cart.feature
@@ -17,5 +17,5 @@ Feature: Seeing detailed information of cart
     @api @ui @javascript
     Scenario: Viewing items total of my cart
         When I add 5 of them to my cart
-        And I check details of my cart
+        And I check the details of my cart
         Then my cart should have "$62.70" items total

--- a/features/shop/cart/shopping_cart/updating_cart_on_checkout.feature
+++ b/features/shop/cart/shopping_cart/updating_cart_on_checkout.feature
@@ -12,7 +12,7 @@ Feature:
     @no-api @ui @mink:chromedriver
     Scenario: Updating the cart on checkout
         Given I added product "T-Shirt banana" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         And I change product "T-Shirt banana" quantity to 2
         And I proceed to the checkout
         Then I should be on the checkout addressing page

--- a/features/shop/cart/shopping_cart/viewing_cart_summary.feature
+++ b/features/shop/cart/shopping_cart/viewing_cart_summary.feature
@@ -17,7 +17,7 @@ Feature: Viewing a cart summary
     Scenario: Viewing information about empty cart after clearing cookies
         Given the store has a product "T-Shirt banana" priced at "$12.54"
         And I added product "T-Shirt banana" to the cart
-        When I am on the summary of my cart page
+        When I check the details of my cart
         And I've been gone for a long time
         And I try to proceed to the checkout
         Then I should see an empty cart

--- a/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
+++ b/features/shop/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
@@ -13,7 +13,7 @@ Feature: Preventing payment step completion without a selected method
     @api @no-ui
     Scenario: Preventing payment step completion if there are no available methods
         When I add product "PHP T-Shirt" to the cart
-        And I have addressed the cart to "United States"
+        And I addressed the cart to "United States"
         And I proceed with selecting "Free" shipping method
         And I check the details of my cart
         Then I should see that no payment method is assigned
@@ -31,7 +31,7 @@ Feature: Preventing payment step completion without a selected method
     Scenario: Preventing payment step completion if there are no available methods for a channel
         Given the store has "Cash on Delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart
-        And I have addressed the cart to "United States"
+        And I addressed the cart to "United States"
         And I proceed with selecting "Free" shipping method
         When I check the details of my cart
         Then I should see that no payment method is assigned

--- a/features/shop/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
+++ b/features/shop/checkout/picking_up_the_cart_with_the_locale_other_than_the_default.feature
@@ -13,17 +13,17 @@ Feature: Picking up the cart with the locale other than the default
     @api @no-ui
     Scenario: Picking up the cart with the locale other than default
         When I pick up cart in the "English (United States)" locale
-        And I check details of my cart
+        And I check the details of my cart
         Then my cart's locale should be "English (United States)"
 
     @api @no-ui
     Scenario: Picking up the cart without specified locale
         When I pick up cart without specifying locale
-        And I check details of my cart
+        And I check the details of my cart
         Then my cart's locale should be "French (France)"
 
     @api @no-ui
     Scenario: Picking up the cart with non valid locale
         When I pick up cart using wrong locale
-        And I check details of my cart
+        And I check the details of my cart
         Then my cart's locale should be "French (France)"

--- a/features/shop/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
+++ b/features/shop/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
@@ -12,7 +12,7 @@ Feature: Prevent shipping step completion without a selected shipping method
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt"
         And I have product "PHP T-Shirt" in the cart
-        And I have addressed the cart to "United States"
+        And I addressed the cart to "United States"
         When I check the details of my cart
         Then I should see that there is no shipment assigned
         And there should not be any shipping method available to choose
@@ -37,7 +37,7 @@ Feature: Prevent shipping step completion without a selected shipping method
         And this zone has the "France" country member
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
         And I have product "PHP T-Shirt" in the cart
-        And I have addressed the cart to "United States"
+        And I addressed the cart to "United States"
         When I try to complete the shipping step
         Then I should see that this shipping method is not available for this address
 
@@ -70,7 +70,7 @@ Feature: Prevent shipping step completion without a selected shipping method
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
         And the store has "UPS" shipping method with "$20.00" fee within the "AMR" zone
         And I have product "PHP T-Shirt" in the cart
-        And I have addressed the cart to "Poland"
+        And I addressed the cart to "Poland"
         When I try to complete the shipping step with "DHL" shipping method
         Then I should see that this shipping method is not available for this address
         When I try to complete the shipping step with "UPS" shipping method

--- a/features/shop/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_products_with_options.feature
+++ b/features/shop/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_products_with_options.feature
@@ -15,7 +15,7 @@ Feature: Seeing applied catalog promotions on products configured with the optio
         And there is a catalog promotion "Winter sale" that reduces price by "50%" and applies on "T-Shirt-Variant-1" variant
         And there is another catalog promotion "Surprise sale" that reduces price by "25%" and applies on "T-Shirt-Variant-3" variant
 
-    @no-api @ui @javascript
+    @no-api @ui
     Scenario: Seeing applied catalog promotion on the product with default option
         When I view product "T-Shirt"
         Then I should see this product is discounted from "$20.00" to "$10.00" with "Winter sale" promotion

--- a/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon.feature
@@ -1,7 +1,7 @@
 @applying_promotion_coupon
 Feature: Applying promotion coupon
     In order to pay proper amount after using the promotion coupon
-    As a Visitor
+    As a Customer
     I want to have promotion coupon's discounts applied to my cart
 
     Background:
@@ -9,10 +9,12 @@ Feature: Applying promotion coupon
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
         And this promotion gives "$10.00" discount to every order
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Receiving fixed discount for my cart
-        When I add the product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"

--- a/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
@@ -1,7 +1,7 @@
 @applying_promotion_coupon
 Feature: Applying promotion coupon with an expiration date
     In order to pay proper amount after using the promotion coupon
-    As a Visitor
+    As a Customer
     I want to have promotion coupon's discounts applied to my cart only if the given promotion coupon is valid
 
     Background:
@@ -9,11 +9,13 @@ Feature: Applying promotion coupon with an expiration date
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
         And this promotion gives "$10.00" discount to every order
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Receiving discount from valid coupon with an expiration date
         Given this coupon is valid until tomorrow
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -21,7 +23,8 @@ Feature: Applying promotion coupon with an expiration date
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount from expired coupon
         Given this coupon has already expired
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_full_percentage.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_full_percentage.feature
@@ -1,7 +1,7 @@
 @applying_promotion_coupon
 Feature: Applying promotion coupon
     In order to pay proper amount after using the promotion coupon
-    As a Visitor
+    As a Customer
     I want to have promotion coupon's discounts applied to my cart when it is a promotion that provides 100% discount
 
     Background:
@@ -9,10 +9,12 @@ Feature: Applying promotion coupon
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
         And this promotion gives "100%" discount to every order
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Receiving full percentage discount for my cart
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$0.00"
         And my discount should be "-$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
@@ -17,7 +17,8 @@ Feature: Applying promotion coupon with per customer usage limit
 
     @api @ui @mink:chromedriver
     Scenario: Receiving discount from valid coupon with a per customer usage limit as a logged in customer
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -28,7 +29,8 @@ Feature: Applying promotion coupon with per customer usage limit
         And I bought a "PHP T-Shirt" and a "PHP Socks"
         And I used "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -39,7 +41,8 @@ Feature: Applying promotion coupon with per customer usage limit
         And I placed an order "#00000022"
         And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"
@@ -52,7 +55,8 @@ Feature: Applying promotion coupon with per customer usage limit
         And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         But I cancelled this order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -65,7 +69,8 @@ Feature: Applying promotion coupon with per customer usage limit
         And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         But I cancelled this order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_usage_limit.feature
+++ b/features/shop/promotion/applying_promotion_coupon/applying_promotion_coupon_with_usage_limit.feature
@@ -16,7 +16,8 @@ Feature: Applying promotion coupon with usage limit
     @api @ui @mink:chromedriver
     Scenario: Receiving discount from valid coupon with a usage limit
         Given this coupon can be used 5 times
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -24,7 +25,8 @@ Feature: Applying promotion coupon with usage limit
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount from valid coupon that has reached its usage limit
         Given this coupon has already reached its usage limit
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"
@@ -37,7 +39,8 @@ Feature: Applying promotion coupon with usage limit
         And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         But I cancelled this order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
@@ -50,7 +53,8 @@ Feature: Applying promotion coupon with usage limit
         And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
         And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         But I cancelled this order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/denying_usage_of_unexisting_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/denying_usage_of_unexisting_promotion_coupon.feature
@@ -1,7 +1,7 @@
 @applying_promotion_coupon
 Feature: Denying usage of nonexistent promotion coupon
     In order to pay proper amount after using the promotion coupon
-    As a Visitor
+    As a Customer
     I want to have promotion coupon's discounts applied to my cart only if the given promotion coupon is valid
 
     Background:
@@ -9,10 +9,12 @@ Feature: Denying usage of nonexistent promotion coupon
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
         And this promotion gives "$10.00" discount to every order
+        And I am a logged in customer
 
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount from nonexistent coupon
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2011"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/shop/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -16,7 +16,8 @@ Feature: Receiving no discount if coupon promotion is not eligible
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount if promotion for the applied coupon is not enabled in the current channel
         Given this promotion is not available in any channel
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
@@ -25,7 +26,8 @@ Feature: Receiving no discount if coupon promotion is not eligible
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount if promotion for the applied coupon has not started yet
         Given this promotion starts tomorrow
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
@@ -34,7 +36,8 @@ Feature: Receiving no discount if coupon promotion is not eligible
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount if promotion for the applied coupon has already expired
         Given this promotion has already expired
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
@@ -44,7 +47,8 @@ Feature: Receiving no discount if coupon promotion is not eligible
     Scenario: Receiving no discount if promotion's usage for the applied coupon is already exceeded
         Given this promotion has usage limit equal to 100
         And this promotion usage limit is already reached
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
@@ -52,7 +56,8 @@ Feature: Receiving no discount if coupon promotion is not eligible
 
     @api @ui @mink:chromedriver
     Scenario: Receiving no discount if promotion's rules for the applied coupon are not fulfilled
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"

--- a/features/shop/promotion/applying_promotion_coupon/removing_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/removing_promotion_coupon.feature
@@ -15,7 +15,7 @@ Feature: Removing promotion coupon
     Scenario: Removing coupon code from cart
         Given I added product "PHP T-Shirt" to the cart
         And this cart has promotion applied with coupon "SANTA2016"
-        When I check details of my cart
+        When I check the details of my cart
         And I remove coupon from my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
+++ b/features/shop/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
@@ -15,7 +15,7 @@ Feature: Reapplying promotion on cart change
         Given the store has "DHL" shipping method with "$10.00" fee
         And the promotion gives "100%" discount on shipping to every order
         And I added product "PHP T-Shirt" to the cart
-        And I addressed it
+        And I addressed the cart
         When I proceed with "DHL" shipping method
         And I remove product "PHP T-Shirt" from the cart
         Then my cart should be empty
@@ -28,13 +28,14 @@ Feature: Reapplying promotion on cart change
         And the store has "FedEx" shipping method with "$30.00" fee
         And the promotion gives "100%" discount on shipping to every order
         And I added product "PHP T-Shirt" to the cart
-        And I addressed it
+        And I addressed the cart
         When I chose "DHL" shipping method
         And I decide to change order shipping method
         And I change shipping method to "FedEx"
         And I complete the shipping step
+        And I check the details of my cart
         Then my cart total should be "$100.00"
-        And my cart shipping should be for Free
+        And my cart shipping should be for free
 
     @api @ui @mink:chromedriver
     Scenario: Receiving discount after removing an item from the cart and then adding another one
@@ -49,7 +50,7 @@ Feature: Reapplying promotion on cart change
     @api @ui @mink:chromedriver
     Scenario: Not receiving discount when cart does not meet the required total value after removing an item
         Given the promotion gives "$10.00" discount to every order with items total at least "$120.00"
-        And I have 2 products "PHP T-Shirt" in the cart
+        And I added 2 products "PHP T-Shirt" to the cart
         When I change product "PHP T-Shirt" quantity to 1
         Then my cart total should be "$100.00"
         And there should be no discount applied
@@ -57,7 +58,7 @@ Feature: Reapplying promotion on cart change
     @api @ui @mink:chromedriver
     Scenario: Not receiving discount when cart does not meet the required quantity after removing an item
         Given the promotion gives "$10.00" discount to every order with quantity at least 3
-        And I have 3 products "PHP T-Shirt" in the cart
+        And I added 3 products "PHP T-Shirt" to the cart
         When I change product "PHP T-Shirt" quantity to 1
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_cart_quantity.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_cart_quantity.feature
@@ -1,40 +1,45 @@
 @applying_promotion_rules
 Feature: Receiving discount based on cart quantity
     In order to pay decreased amount for my order during promotion
-    As a Visitor
+    As a Customer
     I want to have promotion applied to my cart when my cart quantity qualifies
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying more than required quantity
         Given the promotion gives "$10.00" discount to every order with quantity at least 3
-        When I add 4 products "PHP T-Shirt" to the cart
+        And I added 4 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$390.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying the required quantity
         Given the promotion gives "$10.00" discount to every order with quantity at least 4
-        When I add 4 products "PHP T-Shirt" to the cart
+        And I added 4 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$390.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Not receiving discount when buying less than required quantity
         Given the promotion gives "$10.00" discount to every order with quantity at least 5
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$200.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying different products with the required quantity
         Given the store has a product "Symfony T-Shirt" priced at "$50.00"
         And the promotion gives "$10.00" discount to every order with quantity at least 3
-        When I add 2 products "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$290.00"
         And my discount should be "-$10.00"

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_chosen_product.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_chosen_product.feature
@@ -9,22 +9,26 @@ Feature: Receiving discount based on chosen product
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "T-Shirts promotion"
         And the promotion gives "$20.00" off if order contains a "PHP T-Shirt" product
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying promoted product
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying promoted product
-        When I add 2 products "PHP T-Shirt" to the cart
+        Given I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$180.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount on order while buying product different then discounted
         Given the store has a product "PHP Mug" priced at "$20.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$20.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_customer_group.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_customer_group.feature
@@ -1,7 +1,7 @@
 @applying_promotion_rules
 Feature: Receiving discount based on customer group
     In order to apply discount only for selected customer group
-    As a Visitor
+    As a Customer
     I want to have a discount applied when I belong to a specific customer group
 
     Background:
@@ -17,21 +17,23 @@ Feature: Receiving discount based on customer group
         Then my cart total should be "$80.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discounts when belonging to a specific customer group
         Given there is a customer account "wholesale@sylius.com"
         And the customer belongs to group "Wholesale"
         And I am logged in as "wholesale@sylius.com"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$72.00"
         And my discount should be "-$8.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Not receiving discount when belonging to a different customer group that specified in the promotion
         Given the store has a customer group "Retail"
         And there is a customer account "retail@sylius.com"
         And the customer belongs to group "Retail"
         And I am logged in as "retail@sylius.com"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_items_from_specific_taxons.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_items_from_specific_taxons.feature
@@ -12,41 +12,47 @@ Feature: Receiving discount based on products from specific taxon
         And the store has a product "PHP Mug" priced at "$20.00"
         And it belongs to "Mugs"
         And there is a promotion "T-Shirts promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying product from promoted taxon
         Given the promotion gives "$20.00" off if order contains products classified as "T-Shirts"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount on order while buying product from different than promoted taxon
         Given the promotion gives "$20.00" off if order contains products classified as "T-Shirts"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         And my cart total should be "$20.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying product from one of promoted taxon
         Given the promotion gives "$20.00" off if order contains products classified as "T-Shirts" or "Mugs"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying multiple products from promoted taxon
         Given the promotion gives "$50.00" off if order contains products classified as "T-Shirts"
-        When I add 3 products "PHP T-Shirt" to the cart
+        And I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         And my cart total should be "$250.00"
         And my discount should be "-$50.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying product from both of promoted taxon
         Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts"
         And there is a promotion "Mugs promotion"
         And this promotion gives "$5.00" off if order contains products classified as "Mugs"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         And my cart total should be "$105.00"
         And my discount should be "-$15.00"

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_items_total.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_items_total.feature
@@ -1,40 +1,45 @@
 @applying_promotion_rules
 Feature: Receiving discount based on items total
     In order to pay decreased amount for my order during promotion
-    As a Visitor
+    As a Customer
     I want to have promotion applied when my items total is qualified
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$80.00"
         And there is a promotion "Holiday promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying items for the required total value
         Given the promotion gives "$10.00" discount to every order with items total at least "$80.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$70.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying items for more than required total value
         Given the promotion gives "$10.00" discount to every order with items total at least "$90.00"
-        When I add 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$150.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Not receiving discount when buying items for less than required total value
         Given the promotion gives "$10.00" discount to every order with items total at least "$100.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying different products for more than the required total value
         Given the store has a product "Symfony T-Shirt" priced at "$60.00"
         And the promotion gives "$10.00" discount to every order with items total at least "$200.00"
-        When I add 2 products "PHP T-Shirt" to the cart
-        And I add product "Symfony T-Shirt" to the cart
+        And I added 2 products "PHP T-Shirt" to the cart
+        And I added product "Symfony T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$210.00"
         And my discount should be "-$10.00"

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order.feature
@@ -13,24 +13,27 @@ Feature: Receiving discount based on nth order
         And it gives "$20.00" off customer's 5th order
         And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on an order if it's nth order placed
         Given I have already placed 4 orders choosing "PHP T-Shirt" product, "Free" shipping method to "United States" with "Cash on Delivery" payment
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount on an order if it's not nth order placed
         Given I have already placed 3 orders choosing "PHP T-Shirt" product, "Free" shipping method to "United States" with "Cash on Delivery" payment
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount on 6th order when 5th one was cancelled
         Given I have already placed 5 orders choosing "PHP T-Shirt" product, "Free" shipping method to "United States" with "Cash on Delivery" payment
         But I cancelled my last order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
@@ -1,7 +1,7 @@
 @applying_promotion_rules
 Feature: Receiving discount based on nth order
     In order to pay less while placing an order
-    As a Visitor
+    As a Customer
     I want to receive a discount for my purchase
 
     Background:
@@ -10,12 +10,13 @@ Feature: Receiving discount based on nth order
         And the store ships everywhere for Free
         And the store allows paying "Cash on Delivery"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving a discount on an first order
         Given there is a promotion "1st order promotion"
         And it gives "$20.00" off customer's 1st order
-        When I add product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
+        And I am a logged in customer
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
@@ -28,14 +29,16 @@ Feature: Receiving discount based on nth order
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         When I add product "PHP T-Shirt" to the cart
         And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
+        And I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving no discount on an order if I placed more than one order
         Given there is a promotion "2nd order promotion"
         And it gives "$10.00" off customer's 2nd order
-        When I add product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
+        And I am a logged in customer
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_total_of_items_from_specific_taxon.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_total_of_items_from_specific_taxon.feature
@@ -12,41 +12,47 @@ Feature: Receiving discount based on total of items from specific taxon
         And the store has a product "PHP Mug" priced at "$20.00"
         And it belongs to "Mugs"
         And there is a promotion "T-Shirts promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying product from promoted taxon which fits price criteria
         Given the promotion gives "$20.00" off if order contains products classified as "T-Shirts" with a minimum value of "$50.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount on order while buying product from different than promoted taxon
         Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$15.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$20.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount on order while buying product from promoted taxon which not fits price criteria
         Given the promotion gives "$20.00" off if order contains products classified as "Mugs" with a minimum value of "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$20.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying multiple products from promoted taxon which fit price criteria
         Given the promotion gives "$20.00" off if order contains products classified as "Mugs" with a minimum value of "$50.00"
-        When I add 3 products "PHP Mug" to the cart
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$40.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount on order while buying products from both of promoted taxons which fits price criteria
         Given the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$50.00"
         And there is a promotion "Mugs promotion"
         And the promotion gives "$5.00" off if order contains products classified as "Mugs" with a minimum value of "$30.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add 2 products "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added 2 products "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$125.00"
         And my discount should be "-$15.00"

--- a/features/shop/promotion/complex_promotions.feature
+++ b/features/shop/promotion/complex_promotions.feature
@@ -22,7 +22,7 @@ Feature: Receiving a discount based on a configured promotion
         Given there is a promotion "First order promotion"
         And it gives "20%" off on the customer's 1st order
         And I added product "Metallica dress" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$40.00"
         And my discount should be "-$10.00"
 
@@ -34,7 +34,8 @@ Feature: Receiving a discount based on a configured promotion
         And I added 7 products "Black Sabbath jacket" to the cart
         And I addressed the cart
         When I proceed with "DHL" shipping method
-        Then theirs subtotal price should be decreased by "$70.00"
+        And I check the details of my cart
+        Then its subtotal price should be decreased by "$70.00"
         And my cart total should be "$630.00"
         And my cart shipping total should be "$0.00"
 
@@ -43,7 +44,7 @@ Feature: Receiving a discount based on a configured promotion
         Given there is a promotion "Jacket-trousers pack"
         And it gives "10%" off on every product classified as "Jackets" if order contains any product classified as "Trousers"
         And I added products "Iron Maiden trousers" and "Black Sabbath jacket" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then product "Black Sabbath jacket" price should be discounted by "$10.00"
         And my cart total should be "$170.00"
 
@@ -52,7 +53,7 @@ Feature: Receiving a discount based on a configured promotion
         Given there is a promotion "Greatest promotion"
         And it gives "20%" off on every product classified as "Jackets" and a "$50.00" discount to every order with items total equal at least "$500.00"
         And I added 7 products "Black Sabbath jacket" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then theirs subtotal price should be decreased by "$140.00"
         And my cart total should be "$510.00"
         And my discount should be "-$190.00"
@@ -62,7 +63,7 @@ Feature: Receiving a discount based on a configured promotion
         Given there is a promotion "Formal attire pack"
         And it gives "10%" off on every product classified as "Formal attire" or "Dresses" if order contains any product classified as "Trousers" or "Jackets"
         And I added products "Rammstein bow tie", "Metallica dress" and "Iron Maiden trousers" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then product "Metallica dress" price should be discounted by "$5.00"
         And product "Rammstein bow tie" price should be discounted by "$1.00"
         And my cart total should be "$134.00"
@@ -73,7 +74,7 @@ Feature: Receiving a discount based on a configured promotion
         And it gives "10%" off on every product classified as "Jackets" and "$20.00" discount on every order
         And I added product "Iron Maiden trousers" to the cart
         And I added product "Black Sabbath jacket" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then product "Black Sabbath jacket" price should be discounted by "$10.00"
         And my discount should be "-$30.00"
         And my cart total should be "$150.00"

--- a/features/shop/promotion/receiving_discount/applying_only_promotions_enabled_for_given_channel.feature
+++ b/features/shop/promotion/receiving_discount/applying_only_promotions_enabled_for_given_channel.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Applying only promotions enabled for given channel
     In order to place a valid order
-    As a Visitor
+    As a Customer
     I want to have only available promotions applied to my cart
 
     Background:
@@ -9,16 +9,19 @@ Feature: Applying only promotions enabled for given channel
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount for my cart
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Not receiving discount when promotion is disabled for current channel
         Given the promotion was disabled for the channel "Web"
-        When I add product "PHP T-Shirt" to the cart
+        When I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/receiving_discount/applying_promotion_with_expiration_date.feature
+++ b/features/shop/promotion/receiving_discount/applying_promotion_with_expiration_date.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Applying promotion with an expiration date
     In order to pay proper amount after using the promotion
-    As a Visitor
+    As a Customer
     I want to have promotion's discounts applied to my cart only if the given promotion is valid
 
     Background:
@@ -9,31 +9,36 @@ Feature: Applying promotion with an expiration date
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Christmas sale"
         And this promotion gives "$10.00" discount to every order
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount from an ongoing promotion
         Given this promotion is valid until tomorrow
-        When I add the product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount from an expired promotion
         Given this promotion has already expired
-        When I add the product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving a discount from a promotion that has already started
         Given this promotion started yesterday
-        When I add the product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving no discount from a promotion that has not started yet
         Given this promotion starts tomorrow
-        When I add the product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no discount applied

--- a/features/shop/promotion/receiving_discount/receiving_discount_from_promotion_with_multiple_actions.feature
+++ b/features/shop/promotion/receiving_discount/receiving_discount_from_promotion_with_multiple_actions.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving discount from a promotion with multiple actions
     In order to pay less while buying goods
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -12,23 +12,26 @@ Feature: Receiving discount from a promotion with multiple actions
         And the store has a product "PHP Mug" priced at "$20.00"
         And it belongs to "Mugs"
         And there is a promotion "Christmas promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discounts only on items that fit action filters
         Given this promotion gives "$10.00" off on every product with minimum price at "$50.00"
         And this promotion gives another "$5.00" off on every product classified as "T-Shirts"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$15.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$105.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discounts only on items that fit action filters
         Given this promotion gives "20%" off on every product priced between "$30.00" and "$150.00"
         And this promotion gives another "10%" off every product classified as "T-Shirts"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$30.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$90.00"

--- a/features/shop/promotion/receiving_discount/receiving_discount_in_order_of_promotions_priority.feature
+++ b/features/shop/promotion/receiving_discount/receiving_discount_in_order_of_promotions_priority.feature
@@ -1,45 +1,50 @@
 @receiving_discount
 Feature: Receiving discount in the order defined by promotions' priorities
     In order to pay proper amount while buying promoted goods
-    As a Visitor
+    As a Customer
     I want to have promotions applied in prioritized fashion
 
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "The Pug Mug" priced at "$100.00"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount first when priority is higher
         Given there is a promotion "Cebula Deal" with priority 1
         And it gives "$10.00" discount to every order
         And there is a promotion "Santa's Gift" with priority 4
         And it gives "20%" discount to every order
-        When I add product "The Pug Mug" to the cart
+        And I added product "The Pug Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$70.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount first when priority is higher
         Given there is a promotion "Cebula Deal" with priority 5
         And it gives "$10.00" discount to every order
         And there is a promotion "Santa's Gift" with priority 2
         And it gives "20%" discount to every order
-        When I add product "The Pug Mug" to the cart
+        And I added product "The Pug Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$72.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount from exclusive promotion even if their priority is lower than that of a regular one
         Given there is a promotion "Cebula Deal" with priority 5
         And it gives "$10.00" discount to every order
         And there is an exclusive promotion "Golden Pug Market" with priority 1
         And it gives "20%" discount to every order
-        When I add product "The Pug Mug" to the cart
+        And I added product "The Pug Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount from an exclusive promotion with higher priority
         Given there is an exclusive promotion "Golden Pug Market" with priority 2
         And it gives "20%" discount to every order
         And there is an exclusive promotion "Sloth's Agility" with priority 5
         And it gives "$10.00" discount to every order
-        When I add product "The Pug Mug" to the cart
+        And I added product "The Pug Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"

--- a/features/shop/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
+++ b/features/shop/promotion/receiving_discount/receiving_discounts_with_product_minimum_price_specified.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving discounts with product minimum price specified
     In order to avoid paying less than product minimum price
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase up to product minimum price
 
     Background:
@@ -14,59 +14,67 @@ Feature: Receiving discounts with product minimum price specified
         And the "PHP T-Shirt" variant has minimum price of "$45.00" in the "United States" channel
         And the store has a product "Symfony Mug" priced at "$40.00"
         And the store has a product "PHP Mug" priced at "$20.00"
+        And I am a logged in customer
         And there is a promotion "Christmas sale"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item fulfilling minimum price criteria
         Given this promotion gives "50%" off on every product with minimum price at "$50.00"
-        When I add product "T-Shirt" to the cart
+        And I added product "T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$5.00"
         And my cart total should be "$45.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount for my cart
         Given there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
-        When I add product "T-Shirt" to the cart
+        And I added product "T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$45.00"
         And my discount should be "-$5.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item fulfilling range price criteria
         Given this promotion gives "50%" off on every product priced between "$15.00" and "$50.00"
-        When I add product "T-Shirt" to the cart
+        And I added product "T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$5.00"
         And my cart total should be "$45.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Distributing fixed discount promotion
         And this promotion gives "$10.00" off on every product with minimum price at "$10.00"
-        When I add product "T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "T-Shirt" price should be decreased by "$5.00"
         And product "PHP Mug" price should be decreased by "$10.00"
         And my cart total should be "$55.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount for my cart
         And the promotion gives "$10.00" discount to every order with items total at least "$20.00"
-        When I add product "T-Shirt" to the cart
+        And I added product "T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$45.00"
         And my discount should be "-$5.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving discount when buying more than required quantity
         Given there is a promotion "T-Shirts promotion"
         And the promotion gives "$50.00" discount to every order with quantity at least 2
-        When I add 2 products "T-Shirt" to the cart
+        And I added 2 products "T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
     @api @no-ui
     Scenario: Distributing fixed order discount promotion
         Given the promotion gives "$20.00" discount to every order with quantity at least 2
-        When I add product "T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "T-Shirt" price should be decreased by "$5.00"
         And product "PHP Mug" price should be decreased by "$15.00"
         And my cart total should be "$50.00"
@@ -74,8 +82,9 @@ Feature: Receiving discounts with product minimum price specified
     @api @no-ui
     Scenario: Distributing percentage order discount promotion
         Given it gives "20%" discount to every order
-        When I add product "T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "T-Shirt" price should be decreased by "$5.00"
         And product "PHP Mug" price should be decreased by "$9.00"
         And my cart total should be "$56.00"
@@ -83,34 +92,28 @@ Feature: Receiving discounts with product minimum price specified
     @api @no-ui
     Scenario: Distributing discount evenly between different products when one has minimum price specified
         Given it gives "$25.00" discount to every order
-        And I add product "T-Shirt" to the cart
-        And I add 3 products "PHP Mug" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added product "T-Shirt" to the cart
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
         And the "T-Shirt" product should have unit price discounted by "$5.00"
         And the "PHP Mug" product should have unit prices discounted by "$6.67", "$6.67" and "$6.66"
 
     @api @no-ui
     Scenario: Distributing discount evenly between different products when one has minimum price specified
         Given it gives "$20.00" discount to every order
-        And I add 2 products "T-Shirt" to the cart
-        And I add 3 products "PHP Mug" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added 2 products "T-Shirt" to the cart
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
         And the "T-Shirt" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "PHP Mug" product should have unit prices discounted by "$3.34", "$3.33" and "$3.33"
 
     @api @no-ui
     Scenario: Distributing discount proportionally between different products when one has minimum price specified
         Given it gives "$27.00" discount to every order
-        And I add 2 products "T-Shirt" to the cart
-        And I add 2 products "PHP Mug" to the cart
-        And I add product "Symfony Mug" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added 2 products "T-Shirt" to the cart
+        And I added 2 products "PHP Mug" to the cart
+        And I added product "Symfony Mug" to the cart
+        When I check the details of my cart
         And the "T-Shirt" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "PHP Mug" product should have unit prices discounted by "$4.25" and "$4.25"
         And the "Symfony Mug" product should have unit price discounted by "$8.50"
@@ -123,13 +126,11 @@ Feature: Receiving discounts with product minimum price specified
         And the "RGB Keyboard" variant has minimum price of "$15.00" in the "United States" channel
         And the store has a product "Mouse" priced at "$30.00"
         And the store has a product "Cup" priced at "$10.00"
-        When I add 2 products "T-Shirt" to the cart
-        And I add 2 products "Keyboard" to the cart
-        And I add product "Mouse" to the cart
-        And I add product "Cup" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added 2 products "T-Shirt" to the cart
+        And I added 2 products "Keyboard" to the cart
+        And I added product "Mouse" to the cart
+        And I added product "Cup" to the cart
+        When I check the details of my cart
         And the "T-Shirt" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "Keyboard" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "Mouse" product should have unit price discounted by "$12.00"
@@ -148,13 +149,11 @@ Feature: Receiving discounts with product minimum price specified
         And the store has a "Headphones" configurable product
         And this product has "RGB Headphones" variant priced at "$30.00"
         And the "RGB Headphones" variant has minimum price of "$29.00" in the "United States" channel
-        When I add product "Cup" to the cart
-        And I add product "Keyboard" to the cart
-        And I add product "Mouse" to the cart
-        And I add product "Headphones" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added product "Cup" to the cart
+        And I added product "Keyboard" to the cart
+        And I added product "Mouse" to the cart
+        And I added product "Headphones" to the cart
+        When I check the details of my cart
         And the "Cup" product should have unit price discounted by "$10.00"
         And the "Keyboard" product should have unit price discounted by "$1.00"
         And the "Mouse" product should have unit price discounted by "$0.00"
@@ -173,13 +172,11 @@ Feature: Receiving discounts with product minimum price specified
         And the store has a "Headphones" configurable product
         And this product has "RGB Headphones" variant priced at "$30.00"
         And the "RGB Headphones" variant has minimum price of "$26.00" in the "United States" channel
-        When I add product "Cup" to the cart
-        And I add product "Keyboard" to the cart
-        And I add product "Mouse" to the cart
-        And I add product "Headphones" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added product "Cup" to the cart
+        And I added product "Keyboard" to the cart
+        And I added product "Mouse" to the cart
+        And I added product "Headphones" to the cart
+        When I check the details of my cart
         And the "Cup" product should have unit price discounted by "$7.00"
         And the "Keyboard" product should have unit price discounted by "$1.00"
         And the "Mouse" product should have unit price discounted by "$0.00"
@@ -198,13 +195,11 @@ Feature: Receiving discounts with product minimum price specified
         And the store has a "Headphones" configurable product
         And this product has "RGB Headphones" variant priced at "$30.00"
         And the "RGB Headphones" variant has minimum price of "$26.00" in the "United States" channel
-        When I add product "Cup" to the cart
-        And I add product "Keyboard" to the cart
-        And I add product "Mouse" to the cart
-        And I add product "Headphones" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added product "Cup" to the cart
+        And I added product "Keyboard" to the cart
+        And I added product "Mouse" to the cart
+        And I added product "Headphones" to the cart
+        When I check the details of my cart
         And the "Cup" product should have unit price discounted by "$10.00"
         And the "Keyboard" product should have unit price discounted by "$1.00"
         And the "Mouse" product should have unit price discounted by "$0.00"
@@ -215,12 +210,10 @@ Feature: Receiving discounts with product minimum price specified
         Given this promotion does not apply on discounted products
         And it gives "$27.00" discount to every order
         And there is a catalog promotion "Fixed T-Shirt sale" that reduces price by fixed "$2.50" in the "United States" channel and applies on "PHP Mug" product
-        And I add 2 products "T-Shirt" to the cart
-        And I add 2 products "PHP Mug" to the cart
-        And I add product "Symfony Mug" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        When I proceed with "Free" shipping method and "Offline" payment
-        Then I should be on the checkout summary step
+        And I added 2 products "T-Shirt" to the cart
+        And I added 2 products "PHP Mug" to the cart
+        And I added product "Symfony Mug" to the cart
+        When I check the details of my cart
         And the "T-Shirt" product should have unit prices discounted by "$5.00" and "$5.00"
         And the "PHP Mug" product should have unit prices discounted by "$2.50" and "$2.50"
         And the "Symfony Mug" product should have unit price discounted by "$17.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_dependent_on_channel.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_dependent_on_channel.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving fixed discount dependent on channel on cart
     In order to pay proper amount while buying promoted goods in different channels
-    As a Visitor
+    As a Customer
     I want to have promotions applied to my cart
 
     Background:
@@ -11,17 +11,20 @@ Feature: Receiving fixed discount dependent on channel on cart
         And this product is also priced at "£80.00" in "Web-GB" channel
         And there is a promotion "Holiday promotion"
         And this promotion gives "$10.00" discount to every order in the "Web-US" channel and "£12.00" discount to every order in the "Web-GB" channel
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount in proper currency for channel
-        When I change my current channel to "Web-US"
-        And I add product "PHP T-Shirt" to the cart
+        Given I changed my current channel to "Web-US"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount in proper currency after channel change
-        When I change my current channel to "Web-GB"
-        And I add product "PHP T-Shirt" to the cart
+        Given I changed my current channel to "Web-GB"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "£68.00"
         And my discount should be "-£12.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_from_cart_promotions_only_on_non_discounted_products.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_from_cart_promotions_only_on_non_discounted_products.feature
@@ -1,8 +1,8 @@
 @receiving_discount
 Feature: Receiving fixed discount from cart promotions only on non discounted products
-    In order not to combine cart and catalog promotions
-    As a Store Owner
-    I want to apply discount only on products that are non discounted
+    In order to avoid combining cart promotions with catalog promotions,
+    As a Customer
+    I want to receive a fixed discount on my order only for those products that are not already discounted by a catalog promotion
 
     Background:
         Given the store operates on a single channel in "United States"
@@ -10,23 +10,26 @@ Feature: Receiving fixed discount from cart promotions only on non discounted pr
         And the store has a product "T-Shirt" priced at "$20.00"
         And the store has a product "Cap" priced at "$10.00"
         And there is a catalog promotion "Winter sale" that reduces price by "25%" and applies on "T-Shirt" product
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving product discount from cart promotions also on discounted products
         Given there is a promotion "Christmas sale" that applies to discounted products
         And this promotion gives "$10.00" off on every product priced between "$10.00" and "$50.00"
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$5.00" in the cart
         And the product "Mug" should have discounted unit price "$30.00" in the cart
         And my cart total should be "$35.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving product discount from cart promotions only on non discounted products
         Given there is a promotion "Christmas sale" that does not apply to discounted products
         And this promotion gives "$10.00" off on every product priced between "$10.00" and "$50.00"
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
+        When I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$15.00" in the cart
         And the product "Mug" should have discounted unit price "$30.00" in the cart
         And the cart total should be "$45.00"
@@ -35,9 +38,10 @@ Feature: Receiving fixed discount from cart promotions only on non discounted pr
     Scenario: Receiving order discount from cart promotions distributed only on non discounted products
         Given there is a promotion "Christmas sale" that does not apply to discounted products
         And this promotion gives "$10.00" discount to every order
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
-        And the customer adds "Cap" product to the cart
+        When I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        And I added product "Cap" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$15.00" in the cart
         And the product "Mug" should have total price "$32.00" in the cart
         And the product "Cap" should have total price "$8.00" in the cart

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving fixed discount on cart
     In order to pay proper amount while buying promoted goods
-    As a Visitor
+    As a Customer
     I want to have promotions applied to my cart
 
     Background:
@@ -15,7 +15,7 @@ Feature: Receiving fixed discount on cart
         Given there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
@@ -25,7 +25,7 @@ Feature: Receiving fixed discount on cart
         And it gives "$106.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
         And I added product "PHP Mug" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$0.00"
         And my discount should be "-$106.00"
 
@@ -34,7 +34,7 @@ Feature: Receiving fixed discount on cart
         Given there is a promotion "Thanksgiving sale"
         And it gives "$200.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$0.00"
         And my discount should be "-$100.00"
 
@@ -44,8 +44,9 @@ Feature: Receiving fixed discount on cart
         And there is a promotion "Holiday promotion"
         And it gives "$10.00" discount to every order
         And I added product "PHP T-Shirt" to the cart
-        And I addressed it
+        And I addressed the cart
         When I proceed with selecting "DHL" shipping method
+        And I check the details of my cart
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$10.00"
         And my discount should be "-$10.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_items_on_price_range.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_items_on_price_range.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving fixed discount on products from specific price range
     In order to pay less while buying goods from specific price range
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -10,96 +10,109 @@ Feature: Receiving fixed discount on products from specific price range
         And the store has a product "PHP Mug" priced at "$20.00"
         And the store has a product "PHP Sticker" priced at "$5.00"
         And there is a promotion "Christmas promotion"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item fulfilling minimum price criteria
         Given the promotion gives "$10.00" off on every product with minimum price at "$50.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter minimum criteria
         Given the promotion gives "$10.00" off on every product with minimum price at "$100.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item fulfilling maximum price criteria
         Given the promotion gives "$10.00" off on every product with maximum price at "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter maximum criteria
         Given the promotion gives "$10.00" off on every product with minimum price at "$20.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item fulfilling range price criteria
         Given the promotion gives "$10.00" off on every product priced between "$15.00" and "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter range minimum criteria
         Given the promotion gives "$10.00" off on every product priced between "$20.00" and "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter range maximum criteria
         Given the promotion gives "$10.00" off on every product priced between "$15.00" and "$20.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on multiple items fulfilling range price criteria
         Given the promotion gives "$10.00" off on every product priced between "$50.00" and "$150.00"
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$30.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$30.00"
         And my cart total should be "$270.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
         Given the promotion gives "$20.00" off on every product priced between "$10.00" and "$50.00"
-        When I add 3 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$60.00"
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$60.00"
         And my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
         Given the promotion gives "$30.00" off on every product priced between "$10.00" and "$50.00"
-        When I add 2 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$40.00"
+        And I added 2 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$40.00"
         Then my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount only on items that fit price range criteria
         Given the promotion gives "$10.00" off on every product priced between "$30.00" and "$150.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$110.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on items from different price ranges
         Given the promotion gives "$10.00" off on every product with minimum price at "$80.00"
         And there is a promotion "Mugs promotion"
         And it gives "$5.00" off on every product priced between "$10.00" and "$50.00"
         And there is a promotion "Stickers promotion"
         And it gives "$1.00" off on every product with maximum price at "$10.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
-        And I add product "PHP Sticker" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        And I added product "PHP Sticker" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should be decreased by "$5.00"
         And product "PHP Sticker" price should be decreased by "$1.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_products_from_specific_taxon.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_products_from_specific_taxon.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving fixed discount on products from specific taxon
     In order to pay less while buying goods from promoted taxons
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -13,49 +13,56 @@ Feature: Receiving fixed discount on products from specific taxon
         And it belongs to "Mugs"
         And there is a promotion "T-Shirts promotion"
         And it gives "$10.00" off on every product classified as "T-Shirts"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item from specific taxon
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a multiple items from specific taxon
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$30.00"
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$30.00"
         And my cart total should be "$270.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
         Given there is a promotion "Christmas Sale"
         And it gives "$20.00" off on every product classified as "Mugs"
-        When I add 3 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$60.00"
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$60.00"
         And my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
         Given there is a promotion "Christmas Sale"
         And it gives "$30.00" off on every product classified as "Mugs"
-        When I add 2 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$40.00"
+        And I added 2 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$40.00"
         And my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount only on items from specific taxon
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$110.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on items from different taxons
         Given there is a promotion "Mugs promotion"
         And it gives "$2.00" off on every product classified as "Mugs"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should be decreased by "$2.00"
         And my cart total should be "$108.00"

--- a/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_specific_products.feature
+++ b/features/shop/promotion/receiving_discount/receiving_fixed_discount_on_specific_products.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving fixed discount on specific products
     In order to buy specific product with a discount
-    As a Visitor
+    As a Customer
     I want to receive discount on each unit of promoted product
 
     Background:
@@ -10,55 +10,63 @@ Feature: Receiving fixed discount on specific products
         And the store has a product "PHP Mug" priced at "$20.00"
         And there is a promotion "T-Shirts promotion"
         And it gives "$10.00" off on a "PHP T-Shirt" product
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a single item
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Not receiving fixed discount on another item
-        When I add product "PHP Mug" to the cart
+        Given I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP Mug" price should not be decreased
         And my cart total should be "$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount on a multiple items
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$30.00"
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$30.00"
         And my cart total should be "$270.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
         Given there is a promotion "Christmas Sale"
         And it gives "$20.00" off on a "PHP Mug" product
-        When I add 3 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$60.00"
+        And I added 3 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$60.00"
         And my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
         Given there is a promotion "Christmas Sale"
         And it gives "$30.00" off on a "PHP Mug" product
-        When I add 2 products "PHP Mug" to the cart
-        Then theirs price should be decreased by "$40.00"
+        And I added 2 products "PHP Mug" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$40.00"
         And my cart total should be "$0.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving fixed discount only on specified product
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$110.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on different items
         Given there is a promotion "Mugs promotion"
         And it gives "$2.00" off on a "PHP Mug" product
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should be decreased by "$2.00"
         And my cart total should be "$108.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_from_cart_promotions_only_on_non_discounted_products.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_from_cart_promotions_only_on_non_discounted_products.feature
@@ -1,8 +1,8 @@
 @receiving_discount
-Feature: Receiving percentage discount from cart promotions only on non discounted products
-    In order not to combine cart and catalog promotions
-    As a Store Owner
-    I want to apply discount only on products that are non discounted
+Feature: Receiving percentage discount from cart promotions on non-discounted products only
+    In order to avoid receiving stacked discounts on the same product
+    As a Customer
+    I want to see cart promotions applied only to products that are not already discounted
 
     Background:
         Given the store operates on a single channel in "United States"
@@ -10,23 +10,26 @@ Feature: Receiving percentage discount from cart promotions only on non discount
         And the store has a product "T-Shirt" priced at "$20.00"
         And the store has a product "Cap" priced at "$10.00"
         And there is a catalog promotion "Winter sale" that reduces price by "25%" and applies on "T-Shirt" product
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving product discount from cart promotions also on discounted products
         Given there is a promotion "Christmas sale" that applies to discounted products
         And this promotion gives "50%" off on every product priced between "$10.00" and "$50.00"
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$7.50" in the cart
         And the product "Mug" should have discounted unit price "$20.00" in the cart
         And my cart total should be "$27.50"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving product discount from cart promotions only on non discounted products
         Given there is a promotion "Christmas sale" that does not apply to discounted products
         And this promotion gives "50%" off on every product priced between "$10.00" and "$50.00"
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$15.00" in the cart
         And the product "Mug" should have discounted unit price "$20.00" in the cart
         And the cart total should be "$35.00"
@@ -35,9 +38,10 @@ Feature: Receiving percentage discount from cart promotions only on non discount
     Scenario: Receiving order discount from cart promotions distributed only on non discounted products
         Given there is a promotion "Christmas sale" that does not apply to discounted products
         And this promotion gives "50%" discount to every order
-        When the customer adds "T-Shirt" product to the cart
-        And the customer adds "Mug" product to the cart
-        And the customer adds "Cap" product to the cart
+        And I added product "T-Shirt" to the cart
+        And I added product "Mug" to the cart
+        And I added product "Cap" to the cart
+        When I check the details of my cart
         Then the product "T-Shirt" should have discounted unit price "$15.00" in the cart
         And the product "Mug" should have total price "$20.00" in the cart
         And the product "Cap" should have total price "$5.00" in the cart

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_items_on_price_range.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_items_on_price_range.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving percentage discount on products from specific price range
     In order to pay less while buying goods from specific price range
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -10,82 +10,93 @@ Feature: Receiving percentage discount on products from specific price range
         And the store has a product "PHP Mug" priced at "$20.00"
         And the store has a product "PHP Sticker" priced at "$5.00"
         And there is a promotion "Christmas sale"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item fulfilling minimum price criteria
         Given this promotion gives "10%" off on every product with minimum price at "$50.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter minimum criteria
         Given this promotion gives "10%" off on every product with minimum price at "$100.00"
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$90.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item fulfilling maximum price criteria
         Given this promotion gives "10%" off on every product with maximum price at "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$2.00"
         And my cart total should be "$18.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter maximum criteria
         Given this promotion gives "10%" off on every product with maximum price at "$20.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$2.00"
         And my cart total should be "$18.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item fulfilling range price criteria
         Given this promotion gives "50%" off on every product priced between "$15.00" and "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter range minimum criteria
         Given this promotion gives "50%" off on every product priced between "$20.00" and "$50.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter range maximum criteria
         Given this promotion gives "50%" off on every product priced between "$15.00" and "$20.00"
-        When I add product "PHP Mug" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$10.00"
         And my cart total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on multiple items fulfilling range price criteria
         Given this promotion gives "50%" off on every product priced between "$50.00" and "$150.00"
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$150.00"
+        And I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$150.00"
         And my cart total should be "$150.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount only on items that fit price range criteria
         Given this promotion gives "25%" off on every product priced between "$30.00" and "$150.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$25.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$95.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on items from different price ranges
         Given this promotion gives "10%" off on every product with minimum price at "$80.00"
         And there is a promotion "Mugs promotion"
         And it gives "90%" off on every product priced between "$10.00" and "$90.00"
         And there is a promotion "Stickers promotion"
         And it gives "20%" off on every product with maximum price at "$10.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
-        And I add product "PHP Sticker" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        And I added product "PHP Sticker" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$10.00"
         And product "PHP Mug" price should be decreased by "$18.00"
         And product "PHP Sticker" price should be decreased by "$1.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_products_from_specific_taxon.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_products_from_specific_taxon.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving percentage discount on products from specific taxon
     In order to pay less while buying goods from promoted taxons
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -13,33 +13,38 @@ Feature: Receiving percentage discount on products from specific taxon
         And it belongs to "Mugs"
         And there is a promotion "T-Shirts promotion"
         And it gives "20%" off every product classified as "T-Shirts"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item from specific taxon
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$20.00"
         And my cart total should be "$80.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a multiple items from specific taxon
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$60.00"
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$60.00"
         And my cart total should be "$240.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount only on items from specific taxon
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$20.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$100.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on items from different taxons
         Given there is a promotion "Mugs promotion"
         And it gives "50%" off every product classified as "Mugs"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$20.00"
         And product "PHP Mug" price should be decreased by "$10.00"
         And my cart total should be "$90.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
@@ -12,62 +12,65 @@ Feature: Receiving percentage discount on shipping
         And there is a promotion "Holiday promotion"
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving percentage discount on shipping
         Given the promotion gives "20%" discount on shipping to every order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$108.00"
         And my cart shipping total should be "$8.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving free shipping
         Given the promotion gives free shipping to every order
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$0.00"
 
     @api @ui @javascript
     Scenario: Receiving free shipping after changing the quantity of a product in the cart
         Given the promotion gives free shipping to every order over "$70.00"
-        When I add product "PHP Mug" to the cart
-        And I change product "PHP Mug" quantity to 4 in my cart
+        And I added product "PHP Mug" to the cart
+        When I change product "PHP Mug" quantity to 4 in my cart
         Then my cart total should be "$80.00"
         And my cart shipping total should be "$0.00"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Not receiving free shipping after changing the quantity of a product in the cart
         Given the promotion gives free shipping to every order over "$70.00"
-        When I add product "PHP Mug" to the cart
-        And I change product "PHP Mug" quantity to 4 in my cart
+        And I added product "PHP Mug" to the cart
+        When I change product "PHP Mug" quantity to 4 in my cart
         And I change product "PHP Mug" quantity to 2 in my cart
         Then my cart total should be "$50.00"
         And my cart shipping total should be "$10.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not receiving negative discount on shipping
         Given the promotion gives free shipping to every order over "$70.00"
         And there is a promotion "Shipping promotion"
         And this promotion gives free shipping to every order over "$50.00"
-        When I add 4 products "PHP Mug" to the cart
+        And I added 4 products "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my cart shipping total should be "$0.00"
 
     @api @ui @javascript
     Scenario: Still receiving free shipping after removing the product from the cart
         Given the promotion gives free shipping to every order over "$70.00"
-        When I add product "PHP Mug" to the cart
-        And I add product "PHP T-Shirt" to the cart
-        And I remove product "PHP Mug" from the cart
+        And I added product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I remove product "PHP Mug" from the cart
         Then my cart total should be "$100.00"
         And my cart shipping total should be "$0.00"
 
     @api @ui @javascript
     Scenario: Not receiving free shipping after removing the product from the cart
         Given the promotion gives free shipping to every order over "$70.00"
-        When I add product "PHP Mug" to the cart
-        And I add product "PHP T-Shirt" to the cart
-        And I remove product "PHP T-Shirt" from the cart
+        And I added product "PHP Mug" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        When I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$30.00"
         And my cart shipping total should be "$10.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_specific_products.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_on_specific_products.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving percentage discount on specific products
     In order to buy specific product with a discount
-    As a Visitor
+    As a Customer
     I want to receive discount on each unit of promoted product
 
     Background:
@@ -10,33 +10,38 @@ Feature: Receiving percentage discount on specific products
         And the store has a product "PHP Mug" priced at "$20.00"
         And there is a promotion "T-Shirts promotion"
         And it gives "20%" off on a "PHP T-Shirt" product
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a single item
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then its price should be decreased by "$20.00"
         And my cart total should be "$80.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount on a multiple items
-        When I add 3 products "PHP T-Shirt" to the cart
-        Then theirs price should be decreased by "$60.00"
+        Given I added 3 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
+        Then its price should be decreased by "$60.00"
         And my cart total should be "$240.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount only on specified items
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$20.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "$100.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving different discounts on different items
         Given there is a promotion "Mugs promotion"
         And it gives "50%" off on a "PHP Mug" product
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "PHP Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then product "PHP T-Shirt" price should be decreased by "$20.00"
         And product "PHP Mug" price should be decreased by "$10.00"
         And my cart total should be "$90.00"

--- a/features/shop/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
+++ b/features/shop/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
@@ -9,35 +9,39 @@ Feature: Receiving percentage discount promotion on order
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"
         And it gives "20%" discount to every order
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount for my cart
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Receiving percentage discount does not affect the shipping fee
         Given the store has "DHL" shipping method with "$10.00" fee
-        And I am a logged in customer
-        When I add product "PHP T-Shirt" to the cart
+        And I added product "PHP T-Shirt" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$90.00"
         And my cart shipping total should be "$10.00"
         And my discount should be "-$20.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount is correct for two items with different price
         Given the store has a product "Vintage Watch" priced at "$1,000.00"
-        When I add product "PHP T-Shirt" to the cart
-        And I add product "Vintage Watch" to the cart
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "Vintage Watch" to the cart
+        When I check the details of my cart
         Then my cart total should be "$880.00"
         And my discount should be "-$220.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving percentage discount is proportional to items values
         Given the store has a product "Symfony T-Shirt" priced at "$100.00"
-        When I add 11 products "PHP T-Shirt" to the cart
-        And I add product "Symfony T-Shirt" to the cart
+        And I added 11 products "PHP T-Shirt" to the cart
+        And I added product "Symfony T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$960.00"
         And my discount should be "-$240.00"

--- a/features/shop/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
+++ b/features/shop/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
@@ -1,7 +1,7 @@
 @receiving_discount
 Feature: Receiving stacked promotion with changing context
     In order to pay proper amount while buying promoted goods
-    As a Visitor
+    As a Customer
     I want to receive discount for my purchase
 
     Background:
@@ -12,17 +12,20 @@ Feature: Receiving stacked promotion with changing context
         And it gives "50%" discount to every order
         And there is a promotion "Free shiping over" with priority 0
         And it gives free shipping to every order over "$100.00"
+        And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving only the "Holiday promotion"
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$70.00"
         And my discount should be "-$60.00"
         And my cart shipping total should be "$10.00"
 
-    @api @ui @mink:chromedriver
+    @api @ui
     Scenario: Receiving the "Holiday promotion" and the Free shipping discount
-        When I add 2 products "PHP T-Shirt" to the cart
+        Given I added 2 products "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$120.00"
         And my discount should be "-$120.00"
         And my cart shipping total should be "$0.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
@@ -17,7 +17,7 @@ Feature: Apply correct shipping fee on order
         Given I have product "PHP T-Shirt" in the cart
         And I addressed the cart
         And I completed the shipping step with "DHL" shipping method
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$110.00"
         And my cart shipping total should be "$10.00"
 
@@ -29,6 +29,7 @@ Feature: Apply correct shipping fee on order
         When I decide to change order shipping method
         And I change shipping method to "FedEx"
         And I complete the shipping step
+        And I check the details of my cart
         Then my cart total should be "$130.00"
         And my cart shipping total should be "$30.00"
 

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -27,6 +27,7 @@ Feature: Apply correct shipping fee with product taxes on order
         And I addressed the cart
         When I proceed with "DHL" shipping method
         And I choose "Offline" payment method
+        And I check the details of my cart
         Then my cart total should be "$135.30"
         And my cart taxes should be "$25.30"
         And my cart shipping total should be "$12.30"
@@ -36,6 +37,7 @@ Feature: Apply correct shipping fee with product taxes on order
         Given I have 3 products "PHP T-Shirt" in the cart
         When I proceed with selecting "Germany" as billing country
         And I proceed with "FedEx" shipping method
+        And I check the details of my cart
         Then my cart total should be "$352.00"
         And my cart taxes should be "$32.00"
         And my cart shipping total should be "$22.00"

--- a/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shop/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
@@ -26,6 +26,7 @@ Feature: Apply correct shipping fee with taxes on order
         And I addressed the cart
         When I proceed with "DHL" shipping method
         And I choose "Offline" payment method
+        And I check the details of my cart
         Then my cart total should be "$112.30"
         And my cart taxes should be "$2.30"
         And my cart shipping total should be "$12.30"
@@ -36,6 +37,7 @@ Feature: Apply correct shipping fee with taxes on order
         When I proceed with selecting "Germany" as billing country
         And I proceed with "DHL-World" shipping method
         And I choose "Offline" payment method
+        When I check the details of my cart
         Then my cart total should be "$122.00"
         And my cart taxes should be "$2.00"
         And my cart shipping total should be "$22.00"

--- a/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_items_total.feature
@@ -17,11 +17,11 @@ Feature: Seeing estimated shipping costs based on items total
     @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a value over minimum price configured on the shipping method
         Given I added product "Expensive Jacket" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart estimated shipping cost should be "$1.00"
 
     @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a value under maximum price configured on the shipping method
         Given I added product "Cheap Jacket" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart estimated shipping cost should be "$10.00"

--- a/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
+++ b/features/shop/shipping/applying_shipping_method_rules/seeing_estimated_shipping_cost_based_on_total_weight.feature
@@ -19,11 +19,11 @@ Feature: Seeing estimated shipping costs based on total weight
     @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a total weight over minimum total weight configured on the shipping method
         Given I added product "Jacket for the Lochness Monster" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart estimated shipping cost should be "$200.00"
 
     @api @ui
     Scenario: Seeing valid estimated shipping cost for the cart with a total weight under maximum total weight configured on the shipping method
         Given I added product "T-Shirt for Tinkerbell" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart estimated shipping cost should be "$2.00"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_based_on_customer_data.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_based_on_customer_data.feature
@@ -15,25 +15,28 @@ Feature: Apply correct taxes based on customer data
         And it belongs to "Clothes" tax category
         And there is user "john@example.com" with "Germany" as shipping country
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes for logged in Customer
-        Given I am logged in as "john@example.com"
-        When I add product "PHP T-Shirt" to the cart
+        Given I logged in as "john@example.com"
+        And I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes after specifying shipping address
         Given I am a logged in customer
-        When I add product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I added product "PHP T-Shirt" to the cart
+        When I define the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I check the details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Proper taxes after specifying shipping address
         Given I am a logged in customer
-        When I add product "PHP T-Shirt" to the cart
-        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Jon Snow"
+        And I added product "PHP T-Shirt" to the cart
+        When I define the billing address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Jon Snow"
+        And I check the details of my cart
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_items_with_the_same_tax_rate.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_items_with_the_same_tax_rate.feature
@@ -17,14 +17,14 @@ Feature: Apply correct taxes for items with the same tax rate
     @api @ui
     Scenario: Proper taxes for taxed product
         Given I added product "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
     @api @ui
     Scenario: Proper taxes for multiple same products with the same tax rate
         Given I added 3 products "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
@@ -32,7 +32,7 @@ Feature: Apply correct taxes for items with the same tax rate
     Scenario: Proper taxes for multiple different products with the same tax rate
         Given I added 3 products "PHP T-Shirt" to the cart
         And I added 2 products "Symfony Hat" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$442.80"
         And my cart taxes should be "$82.80"
 
@@ -40,7 +40,7 @@ Feature: Apply correct taxes for items with the same tax rate
     Scenario: Proper taxes after removing one of the item
         Given I added 3 products "PHP T-Shirt" to the cart
         And I added 2 products "Symfony Hat" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         And I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$73.80"
         And my cart taxes should be "$13.80"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_an_item_in_order.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_an_item_in_order.feature
@@ -1,7 +1,7 @@
 @applying_taxes
 Feature: Apply correct taxes for an order with a discount for an item in it
     In order to pay proper amount when buying goods
-    As a Visitor
+    As a Customer
     I want to have correct taxes applied to my order when it has a discount
 
     Background:
@@ -19,29 +19,34 @@ Feature: Apply correct taxes for an order with a discount for an item in it
         And the promotion gives "$10.10" off on a "Symfony Mug" product
         And there is a promotion "PHP promotion"
         And the promotion gives "$10.10" off on a "PHP Mug" product
+        And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded up tax for single product
-        When I add product "Symfony Mug" to the cart
+        Given I added product "Symfony Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$50.55"
         And my cart taxes should be "$4.60"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded down tax for single product
-        When I add product "PHP Mug" to the cart
+        Given I added product "PHP Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$50.53"
         And my cart taxes should be "$4.59"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded taxes for order with multiple products without discount
-        When I add 2 products "PHP T-Shirt" to the cart
-        And I add product "Symfony Mug" to the cart
+        Given I added 2 products "PHP T-Shirt" to the cart
+        And I added product "Symfony Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$75.15"
         And my cart taxes should be "$9.20"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded taxes for order with multiple products with discount
-        When I add 2 products "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony Mug" to the cart
+        Given I added 2 products "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$125.69"
         And my cart taxes should be "$13.79"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping.feature
@@ -13,32 +13,35 @@ Feature: Apply correct taxes for an order with a discount for a shipping
         And the promotion gives "10%" discount on shipping to every order
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded up tax
         Given the store has "DHL" shipping method with "$51.06" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Symfony Mug" in the cart
+        And I added product "Symfony Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$60.55"
         And my cart taxes should be "$4.60"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded down tax
         Given the store has "DHL" shipping method with "$51.04" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Symfony Mug" in the cart
+        And I added product "Symfony Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$60.53"
         And my cart taxes should be "$4.59"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly calculated taxes when item belongs to different tax category
         Given the store has "Standard VAT" tax rate of 23% for "Mugs" within the "US" zone
         And the store has a product "Sonata Mug" priced at "$10.00"
         And it belongs to "Mugs" tax category
         And the store has "DHL" shipping method with "$51.04" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Sonata Mug" in the cart
+        And I added product "Sonata Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$62.83"
         And my cart taxes should be "$6.89"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping_when_tax_rate_included_in_price.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_order_with_discount_for_shipping_when_tax_rate_included_in_price.feature
@@ -1,7 +1,7 @@
 @applying_taxes
 Feature: Apply correct taxes for an order with a discount for a shipping when tax rates are included in price
     In order to pay proper amount when buying goods
-    As a Visitor
+    As a Customer
     I want to have correct taxes applied to my order with a discount and tax rates are included in products prices
 
     Background:
@@ -13,45 +13,49 @@ Feature: Apply correct taxes for an order with a discount for a shipping when ta
         And the promotion gives "10%" discount on shipping to every order
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded up tax
         Given the store has "DHL" shipping method with "$56.95" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Symfony Mug" in the cart
+        And I added product "Symfony Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$61.25"
         And my included in price taxes should be "$4.66"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly rounded down tax
         Given the store has "DHL" shipping method with "$56.85" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Symfony Mug" in the cart
+        And I added product "Symfony Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$61.16"
         And my included in price taxes should be "$4.65"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly calculated taxes when item belongs to different tax category and has tax included in price
         Given the store has included in price "Standard VAT" tax rate of 23% for "Mugs" within the "US" zone
         And the store has a product "Sonata Mug" priced at "$10.00"
         And it belongs to "Mugs" tax category
         And the store has "DHL" shipping method with "$50.00" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Sonata Mug" in the cart
+        And I added product "Sonata Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$55.00"
         And my included in price taxes should be "$5.96"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Properly calculated taxes when item belongs to different tax category and not has tax included in price
         Given the store has "Standard VAT" tax rate of 23% for "Mugs" within the "US" zone
         And the store has a product "Sonata Mug" priced at "$10.00"
         And it belongs to "Mugs" tax category
         And the store has "DHL" shipping method with "$50.00" fee
         And shipping method "DHL" belongs to "Shipping" tax category
-        And I have product "Sonata Mug" in the cart
+        And I added product "Sonata Mug" to the cart
         And I proceed with selecting "DHL" shipping method
+        When I check the details of my cart
         Then my cart total should be "$57.30"
         And my included in price taxes should be "$4.09"
         And my cart taxes should be "$2.30"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
@@ -19,37 +19,42 @@ Feature: Apply correct taxes for products with different tax rates for different
         And it belongs to "Mugs" tax category
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Displaying correct tax before specifying shipping address
-        When I add product "PHP T-Shirt" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        When I check the details of my cart
         Then my cart total should be "$100.00"
         And there should be no taxes charged
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Displaying correct tax after specifying billing address
         Given I added product "PHP T-Shirt" to the cart
-        When I proceed with selecting "Germany" as billing country
+        And I addressed the cart to "Germany"
+        When I check the details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Displaying correct taxes for multiple products after specifying billing address
-        Given I have 3 products "PHP T-Shirt" in the cart
-        When I proceed with selecting "Germany" as billing country
+        Given I added 3 products "PHP T-Shirt" to the cart
+        And I addressed the cart to "Germany"
+        When I check the details of my cart
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Displaying correct taxes for multiple products from different zones before specifying shipping address
-        When I add product "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony Mug" to the cart
+        Given I added product "PHP T-Shirt" to the cart
+        And I added 2 products "Symfony Mug" to the cart
+        When I check the details of my cart
         Then my cart total should be "$205.00"
         And my cart taxes should be "$5.00"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Displaying correct taxes for multiple products from different zones after specifying billing address
         Given I added product "PHP T-Shirt" to the cart
-        And I have 2 products "Symfony Mug" in the cart
-        When I proceed with selecting "Germany" as billing country
+        And I added 2 products "Symfony Mug" to the cart
+        And I addressed the cart to "Germany"
+        When I check the details of my cart
         Then my cart total should be "$223.00"
         And my cart taxes should be "$23.00"

--- a/features/shop/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
+++ b/features/shop/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
@@ -25,5 +25,6 @@ Feature: Apply correct taxes on visitor cart
     Scenario: Proper taxes after specifying billing address
         When I add product "PHP T-Shirt" to the cart
         And I proceed as guest "john@example.com" with "Austria" as billing country
+        When I check the details of my cart
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"

--- a/features/shop/taxation/applying_taxes_based_on_order_item_units_calculation_strategy/applying_correct_taxes_for_item_units_with_the_same_tax_rate.feature
+++ b/features/shop/taxation/applying_taxes_based_on_order_item_units_calculation_strategy/applying_correct_taxes_for_item_units_with_the_same_tax_rate.feature
@@ -18,14 +18,14 @@ Feature: Applying correct taxes for item units with the same tax rate
     @api @ui
     Scenario: Applying correct taxes for a single unit
         Given I added product "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
     @api @ui
     Scenario: Applying correct taxes for multiple units of the same product
         Given I added 3 products "PHP T-Shirt" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
@@ -33,7 +33,7 @@ Feature: Applying correct taxes for item units with the same tax rate
     Scenario: Applying correct taxes for multiple units of different products
         Given I added 3 products "PHP T-Shirt" to the cart
         And I added 2 products "Symfony Hat" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         Then my cart total should be "$442.80"
         And my cart taxes should be "$82.80"
 
@@ -41,7 +41,7 @@ Feature: Applying correct taxes for item units with the same tax rate
     Scenario: Applying correct taxes after removing one of the item
         Given I added 3 products "PHP T-Shirt" to the cart
         And I added 2 products "Symfony Hat" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         And I remove product "PHP T-Shirt" from the cart
         Then my cart total should be "$73.80"
         And my cart taxes should be "$13.80"
@@ -50,7 +50,7 @@ Feature: Applying correct taxes for item units with the same tax rate
     Scenario: Applying correct taxes after changing item quantity
         Given I added 3 products "PHP T-Shirt" to the cart
         And I added 2 products "Symfony Hat" to the cart
-        When I check details of my cart
+        When I check the details of my cart
         And I change product "PHP T-Shirt" quantity to 1 in my cart
         Then my cart total should be "$196.80"
         And my cart taxes should be "$36.80"

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -15,6 +15,8 @@ namespace Sylius\Behat\Context\Api\Shop;
 
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -78,8 +80,8 @@ final class CartContext implements Context
     }
 
     /**
-     * @When /^I (?:add|added)(?:| the) (this product) to the (cart)$/
-     * @When /^I (?:add|added)(?:| the) ("[^"]+" product) to the (cart)$/
+     * @When /^I add(?:| the) (this product) to the (cart)$/
+     * @When /^I add(?:| the) ("[^"]+" product) to the (cart)$/
      * @When /^I add(?:| the) (product "[^"]+") to the (cart)$/
      * @When /^the (?:visitor|customer) adds(?:| the) ("[^"]+" product) to the (cart)$/
      */
@@ -205,9 +207,7 @@ final class CartContext implements Context
         $this->changeQuantityOfOrderItem((string) $itemResponse['id'], $quantity, $tokenValue);
     }
 
-    /**
-     * @When /^I remove (product "[^"]+") from the (cart)$/
-     */
+    #[When('/^I remove (product "[^"]+") from the (cart)$/')]
     public function iRemoveProductFromTheCart(ProductInterface $product, string $tokenValue): void
     {
         $itemResponse = $this->getOrderItemResponseFromProductInCart($product, $tokenValue);
@@ -242,10 +242,8 @@ final class CartContext implements Context
         $this->pickupCart('not_valid');
     }
 
-    /**
-     * @When /^I check details of my (cart)$/
-     * @When /^I check the details of my (cart)$/
-     */
+    #[When('/^I check the details of my (cart)$/')]
+    #[When('/^I check details of my (cart)$/')]
     public function iCheckDetailsOfMyCart(string $tokenValue): void
     {
         $this->shopClient->show(Resources::ORDERS, $tokenValue);
@@ -333,11 +331,9 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^my (cart)'s total should be ("[^"]+")$/
-     * @Then /^my (cart) total should be ("[^"]+")$/
-     * @Then /^the (cart) total should be ("[^"]+")$/
-     */
+    #[Then('/^my (cart)\'s total should be ("[^"]+")$/')]
+    #[Then('/^my (cart) total should be ("[^"]+")$/')]
+    #[Then('/^the (cart) total should be ("[^"]+")$/')]
     public function myCartTotalShouldBe(string $tokenValue, int $total): void
     {
         $response = $this->shopClient->show(Resources::ORDERS, $tokenValue);
@@ -559,10 +555,8 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^(its|theirs) price should be decreased by ("[^"]+")$/
-     * @Then /^(product "[^"]+") price should be decreased by ("[^"]+")$/
-     */
+    #[Then('/^(its) price should be decreased by ("[^"]+")$/')]
+    #[Then('/^(product "[^"]+") price should be decreased by ("[^"]+")$/')]
     public function itsPriceShouldBeDecreasedBy(ProductInterface $product, int $amount): void
     {
         $pricing = $this->getExpectedPriceOfProductTimesQuantity($product);
@@ -590,9 +584,7 @@ final class CartContext implements Context
         $this->compareItemPrice($product->getName(), $pricing - $amount, 'subtotal');
     }
 
-    /**
-     * @Then product :product price should not be decreased
-     */
+    #[Then('product :product price should not be decreased')]
     public function productPriceShouldNotBeDecreased(ProductInterface $product): void
     {
         $this->compareItemPrice($product->getName(), $this->getExpectedPriceOfProductTimesQuantity($product));
@@ -711,13 +703,11 @@ final class CartContext implements Context
         Assert::true($this->hasItemWithNameAndQuantity($response, $product->getName(), $quantity));
     }
 
-    /**
-     * @Then /^my cart shipping total should be ("[^"]+")$/
-     * @Then I should not see shipping total for my cart
-     * @Then /^my cart estimated shipping cost should be ("[^"]+")$/
-     * @Then there should be no shipping fee
-     * @Then my cart shipping should be for Free
-     */
+    #[Then('/^my cart shipping total should be ("[^"]+")$/')]
+    #[Then('I should not see shipping total for my cart')]
+    #[Then('/^my cart estimated shipping cost should be ("[^"]+")$/')]
+    #[Then('there should be no shipping fee')]
+    #[Then('my cart shipping should be for free')]
     public function myCartShippingFeeShouldBe(int $shippingTotal = 0): void
     {
         $response = $this->shopClient->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -460,9 +461,7 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('response', $response);
     }
 
-    /**
-     * @When I decide to change order shipping method
-     */
+    #[When('I decide to change order shipping method')]
     public function iDecideToChangeOrderShippingMethod(): void
     {
         // This step is relevant only for the UI
@@ -1074,10 +1073,8 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then /^my discount should be ("[^"]+")$/
-     * @Then there should be no discount applied
-     */
+    #[Then('/^my discount should be ("[^"]+")$/')]
+    #[Then('there should be no discount applied')]
     public function myDiscountShouldBe(int $discount = 0): void
     {
         if ($this->sharedStorage->has('cart_token')) {

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
@@ -29,10 +30,8 @@ final class PromotionContext implements Context
     ) {
     }
 
-    /**
-     * @When I use coupon with code :couponCode
-     * @When I remove coupon from my cart
-     */
+    #[When('I use coupon with code :couponCode')]
+    #[When('I remove coupon from my cart')]
     public function iUseCouponWithCode(?string $couponCode = null): void
     {
         $this->useCouponCode($couponCode);

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart;
 use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
@@ -56,9 +57,9 @@ final readonly class CartContext implements Context
 
     /**
      * @Given /^I have(?:| added) (\d+) (product(?:|s) "[^"]+") (?:to|in) the (cart)$/
-     * @Given /^I added(?:| again) (\d+) (products "[^"]+") to the (cart)$/
      * @Given /^I added (\d+) of (them) to (?:the|my) (cart)$/
      */
+    #[Given('/^I added (\d+) (products "[^"]+") to the (cart)$/')]
     public function iAddedGivenQuantityOfProductsToTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue, $quantity);
@@ -78,13 +79,14 @@ final readonly class CartContext implements Context
     }
 
     /**
-     * @Given /^I added (product "[^"]+") to the (cart)$/
      * @Given /^I have (product "[^"]+") in the (cart)$/
      * @Given /^I have (product "[^"]+") added to the (cart)$/
      * @Given /^the (?:customer|visitor) has (product "[^"]+") in the (cart)$/
-     * @Given /^the (?:customer|visitor) added ("[^"]+" product) to the (cart)$/
      * @When /^the (?:customer|visitor) try to add (product "[^"]+") in the customer (cart)$/
      */
+    #[Given('/^I added (product "[^"]+") to the (cart)$/')]
+    #[Given('/^I added (this product) to the (cart)$/')]
+    #[Given('/^the customer added ("[^"]+" product) to the (cart)$/')]
     public function iAddedProductToTheCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue);

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -507,9 +508,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is(?: a| another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" product)$/
-     */
+    #[Given('/^there is(?: a| another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" product)$/')]
     public function thereIsACatalogPromotionThatReducesPriceByAndAppliesOnProduct(
         string $name,
         float $discount,

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -71,9 +71,7 @@ final class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given the store operates on a single channel in "United States"
-     */
+    #[Given('the store operates on a single channel in "United States"')]
     public function storeOperatesOnASingleChannelInUnitedStates(): void
     {
         $defaultData = $this->unitedStatesChannelFactory->create();
@@ -82,9 +80,7 @@ final class ChannelContext implements Context
         $this->sharedStorage->set('channel', $defaultData['channel']);
     }
 
-    /**
-     * @Given the store operates on a single channel in the "United States" named :channelName
-     */
+    #[Given('the store operates on a single channel in the "United States" named :channelName')]
     public function storeOperatesOnASingleChannelInTheUnitedStatesNamed(string $channelName): void
     {
         $channelCode = StringInflector::nameToLowercaseCode($channelName);
@@ -293,12 +289,12 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @Given /^I changed (?:|back )my current (channel to "([^"]+)")$/
      * @When /^I change (?:|back )my current (channel to "([^"]+)")$/
      * @When customer view shop on :channel channel
-     * @When I am in the :channel channel
      */
-    public function iChangeMyCurrentChannelTo(ChannelInterface $channel): void
+    #[Given('/^I changed my current (channel to "([^"]+)")$/')]
+    #[Given('I am in the :channel channel')]
+    public function iChangedMyCurrentChannelTo(ChannelInterface $channel): void
     {
         $this->sharedStorage->set('channel', $channel);
         $this->sharedStorage->set('hostname', $channel->getHostname());

--- a/src/Sylius/Behat/Context/Setup/Checkout/AddressContext.php
+++ b/src/Sylius/Behat/Context/Setup/Checkout/AddressContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup\Checkout;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
@@ -32,11 +33,8 @@ final readonly class AddressContext implements Context
     ) {
     }
 
-    /**
-     * @Given I addressed the cart
-     * @Given I addressed it
-     * @Given I have addressed the cart to :countryName
-     */
+    #[Given('I addressed the cart')]
+    #[Given('I addressed the cart to :countryName')]
     public function iAddressedTheCart(?string $countryName = null): void
     {
         $cartToken = $this->sharedStorage->get('cart_token');

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -214,9 +215,7 @@ final readonly class OrderContext implements Context
         $this->sharedStorage->set('cart', $cart);
     }
 
-    /**
-     * @Given /^(I) placed (an order "[^"]+")$/
-     */
+    #[Given('/^(I) placed (an order "[^"]+")$/')]
     public function iPlacedAnOrder(ShopUserInterface $user, string $orderNumber): void
     {
         /** @var CustomerInterface $customer */
@@ -482,9 +481,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(I) have already placed (\d+) orders choosing ("[^"]+" product), ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/
-     */
+    #[Given('/^(I) have already placed (\d+) orders choosing ("[^"]+" product), ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/')]
     public function iHaveAlreadyPlacedOrderNthTimes(
         ShopUserInterface $user,
         int $numberOfOrders,

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Setup;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Event\ProductUpdated;
@@ -46,7 +47,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 
-final class ProductContext implements Context
+final readonly class ProductContext implements Context
 {
     public function __construct(
         private SharedStorageInterface $sharedStorage,
@@ -72,14 +73,12 @@ final class ProductContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has a product :productName
-     * @Given the store has a :productName product
-     * @Given I added a product :productName
-     * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+")$/
-     * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") in ("[^"]+" channel)$/
-     */
-    public function storeHasAProductPricedAt($productName, int $price = 100, ?ChannelInterface $channel = null): void
+    #[Given('/^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+")$/')]
+    #[Given('the store has a product :productName')]
+    #[Given('the store has a :productName product')]
+    #[Given('I added a product :productName')]
+    #[Given('/^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") in ("[^"]+" channel)$/')]
+    public function storeHasAProductPricedAt(string $productName, int $price = 100, ?ChannelInterface $channel = null): void
     {
         $product = $this->createProduct($productName, $price, $channel);
 

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
@@ -57,11 +58,9 @@ final readonly class PromotionContext implements Context
     ) {
     }
 
-    /**
-     * @Given there is (also) a promotion :name
-     * @Given there is a promotion :name that applies to discounted products
-     * @Given there is a promotion :name identified by :code code
-     */
+    #[Given('there is (also) a promotion :name')]
+    #[Given('there is a promotion :name that applies to discounted products')]
+    #[Given('there is a promotion :name identified by :code code')]
     public function thereIsPromotion(string $name, ?string $code = null): void
     {
         $this->createPromotion(
@@ -147,9 +146,7 @@ final readonly class PromotionContext implements Context
         $this->thereIsAPromotionWithContainsProductRuleConfiguredWithProducts($name, [$product]);
     }
 
-    /**
-     * @Given /^there is a promotion "([^"]+)" with priority ([^"]+)$/
-     */
+    #[Given('/^there is a promotion "([^"]+)" with priority ([^"]+)$/')]
     public function thereIsAPromotionWithPriority(string $promotionName, int $priority): void
     {
         $this->createPromotion(
@@ -188,9 +185,9 @@ final readonly class PromotionContext implements Context
     }
 
     /**
-     * @Given the store has promotion :promotionName with coupon :couponCode
      * @Given the store has a promotion :promotionName with a coupon :couponCode that is limited to :usageLimit usages
      */
+    #[Given('the store has promotion :promotionName with coupon :couponCode')]
     public function thereIsPromotionWithCoupon(string $promotionName, string $couponCode, ?int $usageLimit = null): void
     {
         $promotion = $this->createPromotion(
@@ -209,9 +206,7 @@ final readonly class PromotionContext implements Context
         $this->sharedStorage->set('coupon', $promotion->getCoupons()->first());
     }
 
-    /**
-     * @Given there is a promotion :name that does not apply to discounted products
-     */
+    #[Given('there is a promotion :name that does not apply to discounted products')]
     public function thereIsAPromotionThatDoesNotApplyToDiscountedProducts(string $name): void
     {
         $this->createPromotion(
@@ -307,9 +302,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) is valid until tomorrow$/
-     */
+    #[Given('/^(this coupon) is valid until tomorrow$/')]
     public function thisCouponIsValidUntilTomorrow(PromotionCouponInterface $coupon): void
     {
         $coupon->setExpiresAt(new \DateTime('tomorrow'));
@@ -359,9 +352,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) can be used twice per customer$/
-     */
+    #[Given('/^(this coupon) can be used twice per customer$/')]
     public function thisCouponCanBeUsedTwicePerCustomer(PromotionCouponInterface $coupon): void
     {
         $coupon->setPerCustomerUsageLimit(2);
@@ -425,9 +416,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order$/')]
     public function itGivesFixedDiscountToEveryOrder(PromotionInterface $promotion, int $discount): void
     {
         $this->createFixedPromotion($promotion, $discount);
@@ -493,17 +482,13 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") discount to every order$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") discount to every order$/')]
     public function itGivesPercentageDiscountToEveryOrder(PromotionInterface $promotion, float $discount): void
     {
         $this->createPercentagePromotion($promotion, $discount);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order with quantity at least ([^"]+)$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order with quantity at least ([^"]+)$/')]
     public function itGivesFixedDiscountToEveryOrderWithQuantityAtLeast(
         PromotionInterface $promotion,
         int $discount,
@@ -514,9 +499,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order with items total at least ("[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order with items total at least ("[^"]+")$/')]
     public function itGivesFixedDiscountToEveryOrderWithItemsTotalAtLeast(
         PromotionInterface $promotion,
         int $discount,
@@ -542,9 +525,7 @@ final readonly class PromotionContext implements Context
         $this->createPercentagePromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product when the item total is at least ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product when the item total is at least ("(?:€|£|\$)[^"]+")$/')]
     public function itGivesOffOnEveryItemWhenItemTotalExceeds(
         PromotionInterface $promotion,
         float $discount,
@@ -556,9 +537,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitPercentagePromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") discount on shipping to every order$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") discount on shipping to every order$/')]
     public function itGivesPercentageDiscountOnShippingToEveryOrder(PromotionInterface $promotion, float $discount): void
     {
         $action = $this->actionFactory->createShippingPercentageDiscount($discount);
@@ -575,9 +554,7 @@ final readonly class PromotionContext implements Context
         $this->itGivesPercentageDiscountOnShippingToEveryOrder($promotion, 1);
     }
 
-    /**
-     * @Given /^([^"]+) gives(?:| another) ("[^"]+%") off every product (classified as "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives(?:| another) ("[^"]+%") off every product (classified as "[^"]+")$/')]
     public function itGivesPercentageOffEveryProductClassifiedAs(
         PromotionInterface $promotion,
         float $discount,
@@ -586,9 +563,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitPercentagePromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
     }
 
-    /**
-     * @Given /^([^"]+) gives(?:| another) ("(?:€|£|\$)[^"]+") off on every product (classified as "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives(?:| another) ("(?:€|£|\$)[^"]+") off on every product (classified as "[^"]+")$/')]
     public function itGivesFixedOffEveryProductClassifiedAs(
         PromotionInterface $promotion,
         int $discount,
@@ -597,9 +572,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitFixedPromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product with minimum price at ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product with minimum price at ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionGivesOffOnEveryProductWithMinimumPriceAt(
         PromotionInterface $promotion,
         int $discount,
@@ -623,9 +596,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product priced between ("(?:€|£|\$)[^"]+") and ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product priced between ("(?:€|£|\$)[^"]+") and ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionGivesOffOnEveryProductPricedBetween(
         PromotionInterface $promotion,
         int $discount,
@@ -639,9 +610,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product with minimum price at ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product with minimum price at ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionPercentageGivesOffOnEveryProductWithMinimumPriceAt(
         PromotionInterface $promotion,
         float $discount,
@@ -650,9 +619,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitPercentagePromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product with maximum price at ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product with maximum price at ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionPercentageGivesOffOnEveryProductWithMaximumPriceAt(
         PromotionInterface $promotion,
         float $discount,
@@ -665,9 +632,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product priced between ("(?:€|£|\$)[^"]+") and ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product priced between ("(?:€|£|\$)[^"]+") and ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionPercentageGivesOffOnEveryProductPricedBetween(
         PromotionInterface $promotion,
         float $discount,
@@ -681,9 +646,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+")$/')]
     public function thePromotionGivesOffIfOrderContainsProductsClassifiedAs(
         PromotionInterface $promotion,
         int $discount,
@@ -709,9 +672,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+") with a minimum value of ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+") with a minimum value of ("(?:€|£|\$)[^"]+")$/')]
     public function thePromotionGivesOffIfOrderContainsProductsClassifiedAsAndPricedAt(
         PromotionInterface $promotion,
         int $discount,
@@ -734,9 +695,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on the customer's (\d)(?:st|nd|rd|th) order$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on the customer\'s (\d)(?:st|nd|rd|th) order$/')]
     public function itGivesPercentageOffCustomersNthOrder(PromotionInterface $promotion, float $discount, int $nth): void
     {
         $rule = $this->ruleFactory->createNthOrder($nth);
@@ -757,9 +716,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $orderDiscount);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product classified as "[^"]+" and a free shipping to every order with items total equal at least ("[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product classified as "[^"]+" and a free shipping to every order with items total equal at least ("[^"]+")$/')]
     public function itGivesOffOnEveryProductClassifiedAsAndAFreeShippingToEveryOrderWithItemsTotalEqualAtLeast(
         PromotionInterface $promotion,
         int $discount,
@@ -871,9 +828,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains (?:a|an) ("[^"]+" product)$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains (?:a|an) ("[^"]+" product)$/')]
     public function thePromotionGivesOffIfOrderContainsProducts(PromotionInterface $promotion, $discount, ProductInterface $product): void
     {
         $rule = $this->ruleFactory->createContainsProduct($product->getCode());
@@ -881,20 +836,17 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off on a ("[^"]*" product)$/
-     */
-    public function itGivesFixedDiscountOffOnAProduct(PromotionInterface $promotion, $discount, ProductInterface $product): void
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off on a ("[^"]*" product)$/')]
+
+    public function itGivesFixedDiscountOffOnAProduct(PromotionInterface $promotion, int $discount, ProductInterface $product): void
     {
         $this->createUnitFixedPromotion($promotion, $discount, $this->getProductsFilterConfiguration([$product->getCode()]));
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on a ("[^"]*" product)$/
-     */
-    public function itGivesPercentageDiscountOffOnAProduct(PromotionInterface $promotion, $discount, ProductInterface $product): void
+    #[Given('/^([^"]+) gives ("[^"]+%") off on a ("[^"]*" product)$/')]
+    public function itGivesPercentageDiscountOffOnAProduct(PromotionInterface $promotion, float $percentage, ProductInterface $product): void
     {
-        $this->createUnitPercentagePromotion($promotion, $discount, $this->getProductsFilterConfiguration([$product->getCode()]));
+        $this->createUnitPercentagePromotion($promotion, $percentage, $this->getProductsFilterConfiguration([$product->getCode()]));
     }
 
     /**
@@ -928,9 +880,7 @@ final readonly class PromotionContext implements Context
         $this->persistPromotion($promotion, $action, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives free shipping to every order over ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives free shipping to every order over ("(?:€|£|\$)[^"]+")$/')]
     public function itGivesFreeShippingToEveryOrderOver(PromotionInterface $promotion, int $itemTotal): void
     {
         $this->itGivesDiscountOnShippingToEveryOrderOver($promotion, 1, $itemTotal);
@@ -962,9 +912,7 @@ final readonly class PromotionContext implements Context
         $this->generateCoupons($amount, $promotion, $codeLength, null, $suffix);
     }
 
-    /**
-     * @Given /^(this promotion) is not available in any channel$/
-     */
+    #[Given('/^(this promotion) is not available in any channel$/')]
     public function thisPromotionIsNotAvailableInAnyChannel(PromotionInterface $promotion): void
     {
         /** @var ChannelInterface $channel */
@@ -1099,7 +1047,7 @@ final readonly class PromotionContext implements Context
 
     private function createUnitPercentagePromotion(
         PromotionInterface $promotion,
-        float $discount,
+        float $percentage,
         array $configuration = [],
         ?PromotionRuleInterface $rule = null,
     ): void {
@@ -1107,7 +1055,7 @@ final readonly class PromotionContext implements Context
 
         $this->persistPromotion(
             $promotion,
-            $this->actionFactory->createUnitPercentageDiscount($discount, $channelCode),
+            $this->actionFactory->createUnitPercentageDiscount($percentage, $channelCode),
             [$channelCode => $configuration],
             $rule,
         );

--- a/src/Sylius/Behat/Context/Setup/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ShippingMethodExampleFactory;
@@ -64,9 +65,9 @@ final class ShippingContext implements Context
     }
 
     /**
-     * @Given the store ships everywhere for :shippingMethodName
      * @Given the store ships everywhere with :shippingMethodName
      */
+    #[Given('the store ships everywhere for :shippingMethodName')]
     public function theStoreShipsEverywhereWith(string $shippingMethodName): void
     {
         /** @var ZoneInterface $zone */
@@ -218,9 +219,7 @@ final class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee$/')]
     public function storeHasShippingMethodWithFee(string $shippingMethodName, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');

--- a/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
@@ -22,7 +22,6 @@ use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Webmozart\Assert\Assert;
 
 final readonly class ShopSecurityContext implements Context
 {
@@ -37,11 +36,16 @@ final readonly class ShopSecurityContext implements Context
     }
 
     #[Given('I am logged in as :email')]
+    #[Given('I logged in as :email')]
     #[Given('the customer logged in as :email')]
     public function iAmLoggedInAs(string $email): void
     {
         $user = $this->userRepository->findOneByEmail($email);
-        Assert::notNull($user);
+
+        if ($user === null) {
+            $user = $this->userFactory->create(['email' => $email, 'password' => 'sylius', 'enabled' => true]);
+            $this->userRepository->add($user);
+        }
 
         $this->securityService->logIn($user);
 
@@ -53,6 +57,7 @@ final readonly class ShopSecurityContext implements Context
     #[Given('I am a logged in customer')]
     #[Given('I am a logged in customer with name :fullName')]
     #[Given('the customer logged in')]
+    #[Given('I logged in')]
     public function iAmLoggedInCustomer(?string $fullName = null): void
     {
         $userData = ['email' => 'shop@example.com', 'password' => 'sylius', 'enabled' => true];

--- a/src/Sylius/Behat/Context/Transform/LexicalContext.php
+++ b/src/Sylius/Behat/Context/Transform/LexicalContext.php
@@ -14,12 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
+use Behat\Transformation\Transform;
 
 final class LexicalContext implements Context
 {
-    /**
-     * @Transform /^"(\-)?(?:€|£|￥|\$)([0-9,]+(\.[0-9]*)?)"$/
-     */
+    #[Transform('/^"(\-)?(?:€|£|￥|\$)([0-9,]+(\.[0-9]*)?)"$/')]
     public function getPriceFromString(string $sign, string $price): int
     {
         $this->validatePriceString($price);
@@ -34,17 +33,13 @@ final class LexicalContext implements Context
         return $price;
     }
 
-    /**
-     * @Transform /^"((?:\d+\.)?\d+)%"$/
-     */
+    #[Transform('/^"((?:\d+\.)?\d+)%"$/')]
     public function getPercentageFromString(string $percentage): float
     {
         return (float) $percentage / 100;
     }
 
-    /**
-     * @throws \InvalidArgumentException
-     */
+    /** @throws \InvalidArgumentException */
     private function validatePriceString(string $price): void
     {
         if (!preg_match('/^.*\.\d{2}$/', $price)) {

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -15,6 +15,8 @@ namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Sylius\Behat\Element\BrowserElementInterface;
 use Sylius\Behat\Element\Shop\CartWidgetElementInterface;
 use Sylius\Behat\Element\Shop\CheckoutSubtotalElementInterface;
@@ -45,12 +47,9 @@ final readonly class CartContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am on the summary of my cart page
-     * @When /^I see the summary of my (?:|previous )cart$/
-     * @When I check details of my cart
-     * @When I check items in my cart
-     */
+    #[When('I check the details of my cart')]
+    #[When('/^I see the summary of my (?:|previous )cart$/')]
+    #[When('I check items in my cart')]
     public function iCheckDetailsOfMyCart(): void
     {
         $this->summaryPage->open();
@@ -84,9 +83,7 @@ final readonly class CartContext implements Context
         Assert::true($this->summaryPage->cartIsEmpty());
     }
 
-    /**
-     * @When I remove product :productName from the cart
-     */
+    #[When('I remove product :productName from the cart')]
     public function iRemoveProductFromTheCart(string $productName): void
     {
         $this->summaryPage->open();
@@ -121,26 +118,18 @@ final readonly class CartContext implements Context
         $this->summaryPage->changeQuantity($productName, $quantity);
     }
 
-    /**
-     * @Then the grand total value should be :total
-     * @Then my cart total should be :total
-     * @Then the cart total should be :total
-     * @Then their cart total should be :total
-     */
+    #[Then('the grand total value should be :total')]
+    #[Then('my cart total should be :total')]
+    #[Then('the cart total should be :total')]
+    #[Then('their cart total should be :total')]
     public function myCartTotalShouldBe(string $total): void
     {
-        $this->summaryPage->open();
-
         Assert::same($this->summaryPage->getGrandTotal(), $total);
     }
 
-    /**
-     * @Then the grand total value in base currency should be :total
-     */
+    #[Then('the grand total value in base currency should be :total')]
     public function myBaseCartTotalShouldBe(string $total): void
     {
-        $this->summaryPage->open();
-
         Assert::same($this->summaryPage->getBaseGrandTotal(), $total);
     }
 
@@ -184,11 +173,9 @@ final readonly class CartContext implements Context
         Assert::false($this->summaryPage->areTaxesCharged());
     }
 
-    /**
-     * @Then my cart shipping total should be :shippingTotal
-     * @Then my cart shipping should be for free
-     * @Then my cart estimated shipping cost should be :shippingTotal
-     */
+    #[Then('my cart shipping total should be :shippingTotal')]
+    #[Then('my cart shipping should be for free')]
+    #[Then('my cart estimated shipping cost should be :shippingTotal')]
     public function myCartShippingFeeShouldBe(string $shippingTotal = '$0.00'): void
     {
         if (!$this->summaryPage->isOpen()) {
@@ -210,9 +197,7 @@ final readonly class CartContext implements Context
         Assert::false($this->summaryPage->hasShippingTotal());
     }
 
-    /**
-     * @Then my discount should be :promotionsTotal
-     */
+    #[Then('my discount should be :promotionsTotal')]
     public function myDiscountShouldBe(string $promotionsTotal): void
     {
         $this->summaryPage->open();
@@ -236,9 +221,7 @@ final readonly class CartContext implements Context
         throw new \DomainException('Get shipping total should throw an exception!');
     }
 
-    /**
-     * @Then there should be no discount applied
-     */
+    #[Then('there should be no discount applied')]
     public function thereShouldBeNoDiscountApplied(): void
     {
         $this->summaryPage->open();
@@ -252,15 +235,11 @@ final readonly class CartContext implements Context
         throw new \DomainException('Get promotion total should throw an exception!');
     }
 
-    /**
-     * @Then /^(its|theirs) price should be decreased by ("[^"]+")$/
-     * @Then /^(its|theirs) subtotal price should be decreased by ("[^"]+")$/
-     * @Then /^(product "[^"]+") price should be decreased by ("[^"]+")$/
-     */
+    #[Then('/^(its) price should be decreased by ("[^"]+")$/')]
+    #[Then('/^(its|theirs) subtotal price should be decreased by ("[^"]+")$/')]
+    #[Then('/^(product "[^"]+") price should be decreased by ("[^"]+")$/')]
     public function itsPriceShouldBeDecreasedBy(ProductInterface $product, int $amount): void
     {
-        $this->summaryPage->open();
-
         $quantity = $this->summaryPage->getQuantity($product->getName());
         $itemTotal = $this->summaryPage->getItemTotal($product->getName());
         $regularUnitPrice = $this->summaryPage->getItemUnitRegularPrice($product->getName());
@@ -288,9 +267,7 @@ final readonly class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^(product "[^"]+") price should not be decreased$/
-     */
+    #[Then('/^(product "[^"]+") price should not be decreased$/')]
     public function productPriceShouldNotBeDecreased(ProductInterface $product): void
     {
         $this->summaryPage->open();
@@ -300,7 +277,7 @@ final readonly class CartContext implements Context
 
     /**
      * @Given /^an anonymous user added (product "([^"]+)") to the cart$/
-     * @Given /^I (?:add|added) (this product) to the cart$/
+     * @Given /^I add (this product) to the cart$/
      * @Given /^I have (product "[^"]+") added to the cart$/
      * @Given he added product :product to the cart
      * @Given /^the visitor has (product "[^"]+") in the cart$/
@@ -544,9 +521,7 @@ final readonly class CartContext implements Context
         Assert::same($this->summaryPage->getItemOptionValue($product->getName(), $optionName), $optionValue);
     }
 
-    /**
-     * @Given I use coupon with code :couponCode
-     */
+    #[When('I use coupon with code :couponCode')]
     public function iUseCouponWithCode(string $couponCode): void
     {
         $this->summaryPage->applyCoupon($couponCode);

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\When;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
 use Sylius\Behat\Page\Shop\Checkout\CompletePageInterface;
 use Sylius\Behat\Page\Shop\Checkout\SelectPaymentPageInterface;
@@ -36,9 +37,7 @@ final readonly class CheckoutPaymentContext implements Context
         $this->selectPaymentPage->tryToOpen();
     }
 
-    /**
-     * @When I decide to change order shipping method
-     */
+    #[When('I decide to change order shipping method')]
     public function iDecideToChangeOrderShippingMethod(): void
     {
         $this->selectPaymentPage->changeShippingMethod();

--- a/src/Sylius/Behat/Context/Ui/Shop/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CurrencyContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Page\Shop\HomePageInterface;
 use Webmozart\Assert\Assert;
 
@@ -33,8 +34,8 @@ final readonly class CurrencyContext implements Context
 
     /**
      * @Given I changed my currency to :currencyCode
-     * @When I switch to the :currencyCode currency
      */
+    #[When('I switch to the :currencyCode currency')]
     public function iSwitchTheCurrencyToTheCurrency(string $currencyCode): void
     {
         $this->homePage->open();

--- a/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/taxation/applying_taxes.yml
@@ -23,6 +23,7 @@ default:
                 - sylius.behat.context.setup.calendar
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -23,6 +23,7 @@ default:
                 - sylius.behat.context.setup.calendar
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.customer
                 - sylius.behat.context.setup.geographical


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Continuation of:
- https://github.com/Sylius/Sylius/pull/17785
- https://github.com/Sylius/Sylius/pull/17782
- https://github.com/Sylius/Sylius/pull/17783

Until now, the checkout-related scenarios have been set up as follows:
	•	UI – via web actions (e.g. `Given I have a product ...` actually triggered browser actions to prepare the initial step),
	•	API – a mix of messenger commands and API calls.

During the development of Sylius 2.0, with the introduction of dynamic components, all scenarios involving product-related actions had to be marked as JS to work correctly. This significantly increased build time and reduced overall stability.

This PR focuses on decoupling the Behat architecture to unify the test setup for both UI and API. The goal is to eliminate most JS tags, which should lead to greater stability. Some performance improvements are already noticeable.


This PR doesn’t yet include all refactored scenarios, but at this stage we already observe the following performance gains:
	•	For non-JS scenarios, the timing is likely similar — some JS scenarios have been converted to non-JS, but at the same time, we benefit from faster setup thanks to the refactor (using messenger commands instead of API calls or UI interactions to prepare tests).
	•	For JS scenarios executed via Chromedriver, the same applies — some Panther scenarios have been switched to Chromedriver, and performance remains comparable.

JS with Panther: **~30 min → ~20 min**