### PR TITLE
[Shop] Handle missing icon errors

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/config/packages/ux_icons.yaml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/packages/ux_icons.yaml
@@ -1,3 +1,4 @@
 ux_icons:
     default_icon_attributes:
         'class': 'icon'
+    ignore_not_found: true


### PR DESCRIPTION
Previously, when there were any issues related to icons — such as an invalid, misspelled, or missing icon name (e.g. ux_icon('tabler:brand-instagra')) — the application would throw an IconNotFoundException, resulting in a 500 error and breaking the rendering of components like the footer.

To prevent this issue:

- Added ignore_not_found: true to the ux_icons.yaml configuration file.
- This ensures that when an icon is missing or not found, no exception is thrown, and the icon is simply not rendered.

Benefits:
Ensures that templates using icons render properly even if some icons are unavailable

![image](https://github.com/user-attachments/assets/85a7a624-df36-43d8-ae6c-975ea03ad7e2)
![image](https://github.com/user-attachments/assets/2efd0271-d3a2-4026-8a0e-d7259766cdf1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to bypass errors for missing icons, enhancing flexibility and reliability in icon management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->