### PR TITLE
[CI] Bump Symfony to `7.3.x-dev` in Unstable Workflow

### DIFF
--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -25,11 +25,7 @@ jobs:
                 include:
                     -
                         php: "8.3"
-                        symfony: "~7.2.0-RC1"
-                        mysql: "8.4"
-                    -
-                        php: "8.4"
-                        symfony: "~7.1.0"
+                        symfony: "7.3.x-dev"
                         mysql: "8.4"
 
         env:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | https://github.com/Sylius/Sylius/pull/17830
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the continuous integration configuration by consolidating dependency version selections, resulting in a more consistent and modern testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->