### PR TITLE
[Shop] Change buttons placement in address book

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -7,5 +7,9 @@
 1. The `sylius_admin.dashboard.index.content.latest_statistics.new_customers` hook has been deprecated and disabled. 
    It has been replaced by the `sylius_admin.dashboard.index.content.latest_statistics.pending_actions`.
 1. The `tabler` package has been updated to version `^1.3.0`. Please pay attention to the accordion element in final applications, as its implementation has changed.
+
 ### Twig hooks
-1. The `history`, `cancel` and `resend_confirmation_email` hookables from `'sylius_admin.order.show.content.header.title_block.actions'` hook have been deprecated and disabled. Now these templates are located in `'sylius_admin.order.show.content.header.title_block.actions.list'` hook.
+
+- The `history`, `cancel` and `resend_confirmation_email` hookables from `'sylius_admin.order.show.content.header.title_block.actions'` hook have been deprecated and disabled. Now these templates are located in `'sylius_admin.order.show.content.header.title_block.actions.list'` hook.
+- `'sylius_shop.account.address_book.index.content.main.buttons'` hook has been deprecated and disabled. Content of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header'`section.
+- `'sylius_shop.account.address_book.index.content.main.buttons.add_address'` hook has been deprecated and disabled. Content of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header.buttons.add_address'` section.

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,15 +1,23 @@
 # UPGRADE FROM `2.0` TO `2.1`
 
+### General
+
 1. The `sylius_admin_customer_orders_statistics` route has been deprecated.
 
 1. The minimum version of Symfony 7 packages has been bumped from Symfony `^7.1` to `^7.2`
 
-1. The `sylius_admin.dashboard.index.content.latest_statistics.new_customers` hook has been deprecated and disabled. 
-   It has been replaced by the `sylius_admin.dashboard.index.content.latest_statistics.pending_actions`.
 1. The `tabler` package has been updated to version `^1.3.0`. Please pay attention to the accordion element in final applications, as its implementation has changed.
 
-### Twig hooks
+### Twig Hooks
 
-- The `history`, `cancel` and `resend_confirmation_email` hookables from `'sylius_admin.order.show.content.header.title_block.actions'` hook have been deprecated and disabled. Now these templates are located in `'sylius_admin.order.show.content.header.title_block.actions.list'` hook.
-- `'sylius_shop.account.address_book.index.content.main.buttons'` hook has been deprecated and disabled. Content of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header'`section.
-- `'sylius_shop.account.address_book.index.content.main.buttons.add_address'` hook has been deprecated and disabled. Content of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header.buttons.add_address'` section.
+1. The `sylius_admin.dashboard.index.content.latest_statistics.new_customers` hook has been deprecated and disabled.
+   It has been replaced by the `sylius_admin.dashboard.index.content.latest_statistics.pending_actions`.
+
+1. The `history`, `cancel` and `resend_confirmation_email` hookables from `'sylius_admin.order.show.content.header.title_block.actions'` 
+   hook have been deprecated and disabled. Now these templates are located in `'sylius_admin.order.show.content.header.title_block.actions.list'` hook.
+
+1. `'sylius_shop.account.address_book.index.content.main.buttons'` hook has been deprecated and disabled. Content 
+   of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header'` section.
+
+1. `'sylius_shop.account.address_book.index.content.main.buttons.add_address'` hook has been deprecated and disabled. 
+   Content of this hook has been moved to `'sylius_shop.account.address_book.index.content.main.header.buttons.add_address'` section.

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
@@ -12,9 +12,6 @@ sylius_twig_hooks:
                 priority: 0
 
         'sylius_shop.account.address_book.index.content.main':
-            buttons:
-                template: '@SyliusShop/account/address_book/index/content/main/buttons.html.twig'
-                priority: 100
             addresses:
                 template: '@SyliusShop/account/address_book/index/content/main/addresses.html.twig'
                 priority: 0
@@ -22,12 +19,15 @@ sylius_twig_hooks:
         'sylius_shop.account.address_book.index.content.main.header':
             title:
                 template: '@SyliusShop/account/address_book/index/content/main/header/title.html.twig'
-                priority: 100
+                priority: 200
             subtitle:
                 template: '@SyliusShop/account/address_book/index/content/main/header/subtitle.html.twig'
+                priority: 100
+            buttons:
+                template: '@SyliusShop/account/address_book/index/content/main/header/buttons.html.twig'
                 priority: 0
 
-        'sylius_shop.account.address_book.index.content.main.buttons':
+        'sylius_shop.account.address_book.index.content.main.header.buttons':
             add_address:
                 template: '@SyliusShop/account/address_book/index/content/main/buttons/add_address.html.twig'
                 priority: 0

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
@@ -12,6 +12,10 @@ sylius_twig_hooks:
                 priority: 0
 
         'sylius_shop.account.address_book.index.content.main':
+            buttons:
+                template: '@SyliusShop/account/address_book/index/content/main/buttons.html.twig'
+                priority: 100
+                enabled: false
             addresses:
                 template: '@SyliusShop/account/address_book/index/content/main/addresses.html.twig'
                 priority: 0
@@ -27,9 +31,15 @@ sylius_twig_hooks:
                 template: '@SyliusShop/account/address_book/index/content/main/header/buttons.html.twig'
                 priority: 0
 
-        'sylius_shop.account.address_book.index.content.main.header.buttons':
+        'sylius_shop.account.address_book.index.content.main.buttons':
             add_address:
                 template: '@SyliusShop/account/address_book/index/content/main/buttons/add_address.html.twig'
+                priority: 0
+                enabled: false
+        
+        'sylius_shop.account.address_book.index.content.main.header.buttons':
+            add_address:
+                template: '@SyliusShop/account/address_book/index/content/main/header/buttons/add_address.html.twig'
                 priority: 0
 
         'sylius_shop.account.address_book.index.content.main.addresses':

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/twig_hooks/account/address_book/index.yaml
@@ -23,13 +23,13 @@ sylius_twig_hooks:
         'sylius_shop.account.address_book.index.content.main.header':
             title:
                 template: '@SyliusShop/account/address_book/index/content/main/header/title.html.twig'
-                priority: 200
+                priority: 100
             subtitle:
                 template: '@SyliusShop/account/address_book/index/content/main/header/subtitle.html.twig'
-                priority: 100
+                priority: 0
             buttons:
                 template: '@SyliusShop/account/address_book/index/content/main/header/buttons.html.twig'
-                priority: 0
+                priority: -100
 
         'sylius_shop.account.address_book.index.content.main.buttons':
             add_address:

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form/buttons.html.twig
@@ -1,3 +1,3 @@
-<div class="d-flex gap-2">
+<div class="d-flex gap-2 flex-wrap">
     {% hook 'buttons' %}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form/buttons/cancel.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/common/main/form/buttons/cancel.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.default(path('sylius_shop_account_address_book_index'), 'sylius.ui.cancel'|trans, null, null, 'btn-outline-gray') }}
+{{ buttons.default(path('sylius_shop_account_address_book_index'), 'sylius.ui.cancel'|trans, null, null, 'btn-outline-gray col-12 col-md-auto mb-2') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/create/content/main/form/buttons/add.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/create/content/main/form/buttons/add.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.submit('sylius.ui.add'|trans, 'add-address', null, 'btn-primary') }}
+{{ buttons.submit('sylius.ui.add'|trans, 'add-address', null, 'btn-primary col-12 col-md-auto mb-2') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/buttons.html.twig
@@ -1,0 +1,5 @@
+{% deprecated 'The "buttons.html.twig" template is deprecated. Content has been moved to header section.' %}
+
+<div class="text-end my-4">
+    {% hook 'buttons' %}
+</div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/buttons/add_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/buttons/add_address.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.primary(path('sylius_shop_account_address_book_create'), 'sylius.ui.add_address'|trans, null, null, 'btn-primary') }}
+{{ buttons.default(path('sylius_shop_account_address_book_create'), 'sylius.ui.add_address'|trans, null, null, 'btn-primary col-12 col-md-auto mb-2') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/header/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/header/buttons.html.twig
@@ -1,3 +1,3 @@
-<div class="text-end mb-4">
+<div class="text-end my-4">
     {% hook 'buttons' %}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/header/buttons/add_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/index/content/main/header/buttons/add_address.html.twig
@@ -1,5 +1,3 @@
-{% deprecated 'The "add_address.html.twig" template is deprecated. Content has been moved to header section.' %}
-
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
 {{ buttons.default(path('sylius_shop_account_address_book_create'), 'sylius.ui.add_address'|trans, null, null, 'btn-primary col-12 col-md-auto mb-2') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/address_book/update/content/main/form/buttons/save.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/address_book/update/content/main/form/buttons/save.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary') }}
+{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary col-12 col-md-auto') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/change_password/update/content/main/form/buttons/submit.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/change_password/update/content/main/form/buttons/submit.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary') }}
+{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary col-12 col-md-auto') }}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons.html.twig
@@ -1,4 +1,4 @@
-<div class="d-flex flex-wrap gap-3 justify-content-end mb-3">
+<div class="d-flex flex-wrap gap-2 mb-3">
     {% hook 'buttons' %}
 </div>
 

--- a/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/order/show/content/main/header/buttons/pay.html.twig
@@ -3,5 +3,5 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
 {% if order.paymentState == constant('Sylius\\Component\\Core\\OrderPaymentStates::STATE_AWAITING_PAYMENT') %}
-    {{ buttons.primary(path('sylius_shop_order_show', {'tokenValue': order.tokenValue}), 'sylius.ui.pay', null, 'tabler:credit-card', 'green') }}
+    {{ buttons.default(path('sylius_shop_order_show', {'tokenValue': order.tokenValue}), 'sylius.ui.pay', null, 'tabler:credit-card', 'btn-primary') }}
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/account/profile_update/update/content/main/form/buttons/submit.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/account/profile_update/update/content/main/form/buttons/submit.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusShop/shared/buttons.html.twig' as buttons %}
 
-{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary') }}
+{{ buttons.submit('sylius.ui.save_changes'|trans, 'save-changes', null, 'btn-primary col-12 col-md-auto') }}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/368fac68-91bd-4e41-bbb1-93e2b85431dc)
![image](https://github.com/user-attachments/assets/189a0ba1-608f-451f-af94-29d6c321f12b)



![image](https://github.com/user-attachments/assets/bcacd970-668c-419f-ac4c-bb4931e585c4)
![image](https://github.com/user-attachments/assets/90027ad2-c894-422c-b41b-4838fecdabb4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Moved address book buttons to the header section for improved layout and deprecated old button hooks.

- **Style**
  - Enhanced button styling with responsive Bootstrap classes across address book, profile, password change, and order pages.
  - Updated spacing and margin utilities for consistent vertical and horizontal alignment.

- **Documentation**
  - Added upgrade notes about deprecated address book button hooks and their new locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->