### PR TITLE
Fix ZoneMatcher::match no longer finds the correct scope

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -44,6 +44,9 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
         return $this->createByAddressQueryBuilder($address, [$scope, Scope::ALL])->getQuery()->getResult();
     }
 
+    /**
+     * @param array<string> $scope
+     */
     public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -29,14 +29,9 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
     {
         $queryBuilder = $this->createByAddressQueryBuilder($address);
 
-        if (null !== $scope) {
-            $queryBuilder
-                ->andWhere($queryBuilder->expr()->eq('o.scope', ':scope'))
-                ->setParameter('scope', $scope)
-            ;
-        }
-
         $queryBuilder
+            ->andWhere($queryBuilder->expr()->eq('o.scope', ':scope'))
+            ->setParameter('scope', $scope ?? Scope::ALL)
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
             ->setParameter('type', $type)
             ->setMaxResults(1)

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -44,7 +44,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
         return $this->createByAddressQueryBuilder($address, $scope)->getQuery()->getResult();
     }
 
-    public function createByAddressQueryBuilder(AddressInterface $address, ?string $scope = null): QueryBuilder
+    public function createByAddressQueryBuilder(AddressInterface $address, ?string $scope = Scope::ALL): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->select('o', 'members')
@@ -54,7 +54,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
         if (null !== $scope) {
             $queryBuilder
                 ->andWhere($queryBuilder->expr()->in('o.scope', ':scopes'))
-                ->setParameter('scopes', array_unique([$scope, Scope::ALL]))
+                ->setParameter('scopes', $scope)
             ;
         }
 

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -29,9 +29,14 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
     {
         $queryBuilder = $this->createByAddressQueryBuilder($address);
 
+        if (null !== $scope) {
+            $queryBuilder
+                ->andWhere($queryBuilder->expr()->eq('o.scope', ':scope'))
+                ->setParameter('scope', $scope)
+            ;
+        }
+
         $queryBuilder
-            ->andWhere($queryBuilder->expr()->eq('o.scope', ':scope'))
-            ->setParameter('scope', $scope ?? Scope::ALL)
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
             ->setParameter('type', $type)
             ->setMaxResults(1)

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -27,7 +27,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
 {
     public function findOneByAddressAndType(AddressInterface $address, string $type, ?string $scope = null): ?ZoneInterface
     {
-        $queryBuilder = $this->createByAddressQueryBuilder($address, $scope);
+        $queryBuilder = $this->createByAddressQueryBuilder($address, [$scope]);
 
         $queryBuilder
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
@@ -41,10 +41,10 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
     /** @return ZoneInterface[] */
     public function findByAddress(AddressInterface $address, ?string $scope = null): array
     {
-        return $this->createByAddressQueryBuilder($address, $scope)->getQuery()->getResult();
+        return $this->createByAddressQueryBuilder($address, [$scope, Scope::ALL])->getQuery()->getResult();
     }
 
-    public function createByAddressQueryBuilder(AddressInterface $address, ?string $scope = Scope::ALL): QueryBuilder
+    public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->select('o', 'members')

--- a/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Repository/ZoneRepository.php
@@ -27,7 +27,14 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
 {
     public function findOneByAddressAndType(AddressInterface $address, string $type, ?string $scope = null): ?ZoneInterface
     {
-        $queryBuilder = $this->createByAddressQueryBuilder($address, [$scope]);
+        $queryBuilder = $this->createByAddressQueryBuilder($address);
+
+        if (null !== $scope) {
+            $queryBuilder
+                ->andWhere($queryBuilder->expr()->eq('o.scope', ':scope'))
+                ->setParameter('scope', $scope)
+            ;
+        }
 
         $queryBuilder
             ->andWhere($queryBuilder->expr()->eq('o.type', ':type'))
@@ -41,25 +48,24 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
     /** @return ZoneInterface[] */
     public function findByAddress(AddressInterface $address, ?string $scope = null): array
     {
-        return $this->createByAddressQueryBuilder($address, [$scope, Scope::ALL])->getQuery()->getResult();
+        $queryBuilder = $this->createByAddressQueryBuilder($address);
+
+        if (null !== $scope) {
+            $queryBuilder
+                ->andWhere($queryBuilder->expr()->in('o.scope', ':scopes'))
+                ->setParameter('scopes', [$scope, Scope::ALL])
+            ;
+        }
+
+        return $queryBuilder->getQuery()->getResult();
     }
 
-    /**
-     * @param array<string> $scope
-     */
-    public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder
+    public function createByAddressQueryBuilder(AddressInterface $address): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->select('o', 'members')
             ->leftJoin('o.members', 'members')
         ;
-
-        if (null !== $scope) {
-            $queryBuilder
-                ->andWhere($queryBuilder->expr()->in('o.scope', ':scopes'))
-                ->setParameter('scopes', $scope)
-            ;
-        }
 
         $orConditions = [];
 

--- a/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
+++ b/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
@@ -30,6 +30,9 @@ interface ZoneRepositoryInterface extends RepositoryInterface
     /** @return ZoneInterface[] */
     public function findByAddress(AddressInterface $address, ?string $scope = null): array;
 
+    /**
+     * @param array<string> $scope
+     */
     public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder;
 
     /**

--- a/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
+++ b/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
@@ -30,10 +30,7 @@ interface ZoneRepositoryInterface extends RepositoryInterface
     /** @return ZoneInterface[] */
     public function findByAddress(AddressInterface $address, ?string $scope = null): array;
 
-    /**
-     * @param array<string> $scope
-     */
-    public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder;
+    public function createByAddressQueryBuilder(AddressInterface $address): QueryBuilder;
 
     /**
      * @param array<ZoneInterface> $members

--- a/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
+++ b/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
@@ -30,7 +30,7 @@ interface ZoneRepositoryInterface extends RepositoryInterface
     /** @return ZoneInterface[] */
     public function findByAddress(AddressInterface $address, ?string $scope = null): array;
 
-    public function createByAddressQueryBuilder(AddressInterface $address, ?string $scope = null): QueryBuilder;
+    public function createByAddressQueryBuilder(AddressInterface $address, ?array $scope = null): QueryBuilder;
 
     /**
      * @param array<ZoneInterface> $members


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16515
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This PR fixes the issue that the zone is no longer found correctly for a specified scope.

In the logic of Sylius 1.12 it was iterated over the scopes and then the country was determined, so the specified scope was prioritized higher than the default all scope. With Sylius 1.13 this logic has been changed so that the zone is now determined by a single SQL query, therefore the scope must be clearly specified in the query so that the correct zone is still determined.
