### PR TITLE
[API] Fix Missing root_operation in context when 'application/json' is accepted

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ShippingMethodNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ShippingMethodNormalizer.php
@@ -91,7 +91,7 @@ final class ShippingMethodNormalizer implements NormalizerInterface, NormalizerA
         }
 
         /** @var HttpOperation|null $operation */
-        $operation = $context['root_operation'] ?? null;
+        $operation = $context['root_operation'] ?? $context['operation'] ?? null;
 
         return
             $data instanceof ShippingMethodInterface &&


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #17855
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced shipping options processing to support a broader range of operational contexts, ensuring more consistent API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->