### PR TITLE
[CI] Fix Panther builds by introducing secure password setup in Behat tests - 1.14 Edition

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -52,7 +52,7 @@ default:
                                 unexpectedAlertBehaviour: accept
                         options:
                             browser_arguments:
-                                - --window-size=1920,1200
+                                - --window-size=1200,1000
                                 - --headless
                                 - --no-sandbox
                                 - --disable-dev-shm-usage
@@ -66,6 +66,7 @@ default:
                                 - --disable-background-networking
                                 - --disable-dev-tools
                                 - --disable-extensions
+                                - --disable-password-manager-leak-detection
             show_auto: false
 
         FriendsOfBehat\SymfonyExtension: ~

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Client;
 
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 {
+    use SecurePasswordTrait;
+
     /** @var array<string, string|object> */
     private array $request = [];
 
@@ -48,7 +51,7 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
     public function setPassword(string $password): void
     {
-        $this->request['body']['password'] = $password;
+        $this->request['body']['password'] = $this->retrieveSecurePassword($password);
     }
 
     public function call(): void

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
@@ -20,6 +20,7 @@ use Sylius\Behat\Client\RequestBuilder;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -29,6 +30,8 @@ use Webmozart\Assert\Assert;
 
 final class ManagingAdministratorsContext implements Context
 {
+    use SecurePasswordTrait;
+
     public function __construct(
         private ApiClientInterface $client,
         private ResponseCheckerInterface $responseChecker,
@@ -107,7 +110,7 @@ final class ManagingAdministratorsContext implements Context
     public function iSpecifyItsPasswordAs(?string $password = null): void
     {
         if ($password !== null) {
-            $this->client->addRequestData('plainPassword', $password);
+            $this->client->addRequestData('plainPassword', $this->replaceWithSecurePassword($password));
         }
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
@@ -18,6 +18,7 @@ use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -27,6 +28,8 @@ use Webmozart\Assert\Assert;
 
 final class ManagingCustomersContext implements Context
 {
+    use SecurePasswordTrait;
+
     public const SORT_TYPES = ['ascending' => 'asc', 'descending' => 'desc'];
 
     public function __construct(
@@ -142,7 +145,7 @@ final class ManagingCustomersContext implements Context
     public function iSpecifyItsPasswordAs(string $password): void
     {
         $this->client->addRequestData('user', [
-            'plainPassword' => $password,
+            'plainPassword' => $this->replaceWithSecurePassword($password),
         ]);
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\RequestInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
+use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Symfony\Component\HttpFoundation\Request as HTTPRequest;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,12 +28,15 @@ use Webmozart\Assert\Assert;
 
 final class ResettingPasswordContext implements Context
 {
+    use SecurePasswordTrait;
+
     private ?RequestInterface $request = null;
 
     public function __construct(
         private ApiClientInterface $client,
         private RequestFactoryInterface $requestFactory,
         private ResponseCheckerInterface $responseChecker,
+        private SharedStorageInterface $sharedStorage,
         private string $apiUrlPrefix,
     ) {
     }
@@ -78,7 +84,7 @@ final class ResettingPasswordContext implements Context
      */
     public function iSpecifyMyNewPassword(string $password = ''): void
     {
-        $this->request->updateContent(['newPassword' => $password]);
+        $this->request->updateContent(['newPassword' => $this->replaceWithSecurePassword($password)]);
     }
 
     /**
@@ -87,7 +93,7 @@ final class ResettingPasswordContext implements Context
      */
     public function iConfirmMyNewPassword(string $password = ''): void
     {
-        $this->request->updateContent(['confirmNewPassword' => $password]);
+        $this->request->updateContent(['confirmNewPassword' => $this->confirmSecurePassword($password)]);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -20,6 +20,7 @@ use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Context\Setup\ShopSecurityContext;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
@@ -29,6 +30,8 @@ use Webmozart\Assert\Assert;
 
 final class CustomerContext implements Context
 {
+    use SecurePasswordTrait;
+
     private ?string $verificationToken = '';
 
     public function __construct(
@@ -150,9 +153,9 @@ final class CustomerContext implements Context
     public function iChangePasswordTo(string $oldPassword, string $newPassword): void
     {
         $this->client->setRequestData([
-            'currentPassword' => $oldPassword,
-            'newPassword' => $newPassword,
-            'confirmNewPassword' => $newPassword,
+            'currentPassword' => $this->retrieveSecurePassword($oldPassword),
+            'newPassword' => $this->replaceWithSecurePassword($newPassword),
+            'confirmNewPassword' => $this->confirmSecurePassword($newPassword),
         ]);
     }
 
@@ -555,7 +558,7 @@ final class CustomerContext implements Context
             'firstName' => 'First',
             'lastName' => 'Last',
             'email' => $email,
-            'password' => $password,
+            'password' => $this->replaceWithSecurePassword($password),
         ]);
 
         $this->client->executeCustomRequest($request);

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -21,6 +21,7 @@ use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\RequestInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
@@ -33,6 +34,7 @@ use Webmozart\Assert\Assert;
 
 final class LoginContext implements Context
 {
+    use SecurePasswordTrait;
     private ?RequestInterface $request = null;
 
     public function __construct(
@@ -66,7 +68,7 @@ final class LoginContext implements Context
             [],
             [],
             ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
-            json_encode(['email' => $email, 'password' => 'sylius']),
+            json_encode(['email' => $email, 'password' => $this->retrieveSecurePassword('sylius')]),
         );
 
         $response = $this->shopAuthenticationTokenClient->getResponse();
@@ -145,7 +147,7 @@ final class LoginContext implements Context
      */
     public function iSpecifyMyNewPassword(?string $password = null): void
     {
-        $this->request->updateContent(['newPassword' => $password]);
+        $this->request->updateContent(['newPassword' => $this->replaceWithSecurePassword($password)]);
     }
 
     /**
@@ -154,7 +156,7 @@ final class LoginContext implements Context
      */
     public function iConfirmMyNewPassword(?string $password = null): void
     {
-        $this->request->updateContent(['confirmNewPassword' => $password]);
+        $this->request->updateContent(['confirmNewPassword' => $this->confirmSecurePassword($password)]);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -18,6 +18,7 @@ use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Context\Api\Resources;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
@@ -25,6 +26,8 @@ use Webmozart\Assert\Assert;
 
 final class RegistrationContext implements Context
 {
+    use SecurePasswordTrait;
+
     private array $content = [];
 
     public function __construct(
@@ -87,7 +90,7 @@ final class RegistrationContext implements Context
      */
     public function iSpecifyThePasswordAs(string $password = ''): void
     {
-        $this->content['password'] = $password;
+        $this->content['password'] = $this->replaceWithSecurePassword($password);
     }
 
     /**
@@ -290,7 +293,7 @@ final class RegistrationContext implements Context
     {
         $this->content = [
             'email' => $email,
-            'password' => $password,
+            'password' => $this->replaceWithSecurePassword($password),
         ];
     }
 

--- a/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
+++ b/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Cli;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
+use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\UserPasswordHasherInterface;
@@ -24,6 +26,8 @@ use Webmozart\Assert\Assert;
 
 final class ChangeAdminPasswordContext implements Context
 {
+    use SecurePasswordTrait;
+
     private const ADMIN_USER_CHANGE_PASSWORD = 'sylius:admin-user:change-password';
 
     private Application $application;
@@ -37,6 +41,7 @@ final class ChangeAdminPasswordContext implements Context
         KernelInterface $kernel,
         private UserRepositoryInterface $adminUserRepository,
         private UserPasswordHasherInterface $userPasswordHasher,
+        private SharedStorageInterface $sharedStorage,
     ) {
         $this->application = new Application($kernel);
     }
@@ -64,7 +69,7 @@ final class ChangeAdminPasswordContext implements Context
      */
     public function iSpecifyMyNewPassword(string $password = ''): void
     {
-        $this->input['password'] = $password;
+        $this->input['password'] = $this->replaceWithSecurePassword($password);
     }
 
     /**
@@ -91,7 +96,7 @@ final class ChangeAdminPasswordContext implements Context
     {
         /** @var AdminUserInterface|null $adminUser */
         $adminUser = $this->adminUserRepository->findOneByEmail($email);
-        $adminUser->setPlainPassword($password);
+        $adminUser->setPlainPassword($this->retrieveSecurePassword($password));
 
         Assert::same($adminUser->getPassword(), $this->userPasswordHasher->hash($adminUser));
     }

--- a/src/Sylius/Behat/Context/Setup/AdminUserContext.php
+++ b/src/Sylius/Behat/Context/Setup/AdminUserContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -26,6 +27,8 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 final class AdminUserContext implements Context
 {
+    use SecurePasswordTrait;
+
     /**
      * @param UserRepositoryInterface<AdminUserInterface> $userRepository
      * @param FactoryInterface<AvatarImageInterface> $avatarImageFactory
@@ -48,7 +51,7 @@ final class AdminUserContext implements Context
     public function thereIsAnAdministratorIdentifiedBy($email, $password = 'sylius')
     {
         /** @var AdminUserInterface $adminUser */
-        $adminUser = $this->userFactory->create(['email' => $email, 'password' => $password, 'enabled' => true, 'api' => true]);
+        $adminUser = $this->userFactory->create(['email' => $email, 'password' => $this->replaceWithSecurePassword($password), 'enabled' => true, 'api' => true]);
 
         $this->userRepository->add($adminUser);
         $this->sharedStorage->set('administrator', $adminUser);

--- a/src/Sylius/Behat/Context/Setup/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
@@ -26,6 +27,8 @@ use Sylius\Resource\Factory\FactoryInterface;
 
 final class CustomerContext implements Context
 {
+    use SecurePasswordTrait;
+
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private CustomerRepositoryInterface $customerRepository,
@@ -230,7 +233,7 @@ final class CustomerContext implements Context
         $customer->setGender('m');
 
         $user->setUsername($email);
-        $user->setPlainPassword($password);
+        $user->setPlainPassword($this->replaceWithSecurePassword($password));
         $user->setEnabled($enabled);
         if (null !== $role) {
             $user->addRole($role);

--- a/src/Sylius/Behat/Context/Setup/UserContext.php
+++ b/src/Sylius/Behat/Context/Setup/UserContext.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ApiBundle\Command\Account\ChangeShopUserPassword;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
@@ -25,6 +26,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class UserContext implements Context
 {
+    use SecurePasswordTrait;
+
     public function __construct(
         private SharedStorageInterface $sharedStorage,
         private UserRepositoryInterface $userRepository,
@@ -42,7 +45,8 @@ final class UserContext implements Context
      */
     public function thereIsUserIdentifiedBy($email, $password = 'sylius')
     {
-        $user = $this->userFactory->create(['email' => $email, 'password' => $password, 'enabled' => true]);
+        /** @var ShopUserInterface $user */
+        $user = $this->userFactory->create(['email' => $email, 'password' => $this->replaceWithSecurePassword($password), 'enabled' => true]);
 
         $this->sharedStorage->set('user', $user);
 
@@ -56,7 +60,7 @@ final class UserContext implements Context
     public function theCustomerCreatedAccountWithPassword(string $email, string $password = 'sylius'): void
     {
         /** @var ShopUserInterface $user */
-        $user = $this->userFactory->create(['email' => $email, 'password' => $password, 'enabled' => true]);
+        $user = $this->userFactory->create(['email' => $email, 'password' => $this->replaceWithSecurePassword($password), 'enabled' => true]);
 
         $user->setCustomer($this->sharedStorage->get('customer'));
         $this->sharedStorage->set('user', $user);
@@ -68,7 +72,7 @@ final class UserContext implements Context
      * @Given the account of :email was deleted
      * @Given my account :email was deleted
      */
-    public function accountWasDeleted($email)
+    public function accountWasDeleted(string $email): void
     {
         /** @var ShopUserInterface $user */
         $user = $this->userRepository->findOneByEmail($email);
@@ -81,7 +85,7 @@ final class UserContext implements Context
     /**
      * @Given its account was deleted
      */
-    public function hisAccountWasDeleted()
+    public function hisAccountWasDeleted(): void
     {
         $user = $this->sharedStorage->get('user');
 
@@ -93,7 +97,7 @@ final class UserContext implements Context
      * @Given /^(this user) is not verified$/
      * @Given /^(I) have not verified my account (?:yet)$/
      */
-    public function accountIsNotVerified(UserInterface $user)
+    public function accountIsNotVerified(UserInterface $user): void
     {
         $user->setVerifiedAt(null);
 
@@ -103,7 +107,7 @@ final class UserContext implements Context
     /**
      * @Given /^(?:(I) have|(this user) has) already received a verification email$/
      */
-    public function iHaveReceivedVerificationEmail(UserInterface $user)
+    public function iHaveReceivedVerificationEmail(UserInterface $user): void
     {
         $this->prepareUserVerification($user);
     }
@@ -111,7 +115,7 @@ final class UserContext implements Context
     /**
      * @Given a verification email has already been sent to :email
      */
-    public function aVerificationEmailHasBeenSentTo($email)
+    public function aVerificationEmailHasBeenSentTo(string $email): void
     {
         $user = $this->userRepository->findOneByEmail($email);
 
@@ -121,7 +125,7 @@ final class UserContext implements Context
     /**
      * @Given /^(I) have already verified my account$/
      */
-    public function iHaveAlreadyVerifiedMyAccount(UserInterface $user)
+    public function iHaveAlreadyVerifiedMyAccount(UserInterface $user): void
     {
         $user->setVerifiedAt(new \DateTime());
 
@@ -136,7 +140,7 @@ final class UserContext implements Context
         $this->prepareUserPasswordResetToken($user);
     }
 
-    private function prepareUserVerification(UserInterface $user)
+    private function prepareUserVerification(UserInterface $user): void
     {
         $token = 'marryhadalittlelamb';
         $this->sharedStorage->set('verification_token', $token);
@@ -181,7 +185,13 @@ final class UserContext implements Context
      */
     public function iveChangedMyPasswordFromTo(UserInterface $user, string $currentPassword, string $newPassword): void
     {
-        $changeShopUserPassword = new ChangeShopUserPassword($newPassword, $newPassword, $currentPassword);
+        $currentPassword = $this->retrieveSecurePassword($currentPassword);
+
+        $changeShopUserPassword = new ChangeShopUserPassword(
+            newPassword: $this->replaceWithSecurePassword($newPassword),
+            confirmNewPassword: $this->confirmSecurePassword($newPassword),
+            currentPassword: $currentPassword,
+        );
 
         $changeShopUserPassword->setShopUserId($user->getId());
 

--- a/src/Sylius/Behat/Context/Ui/Admin/Helper/SecurePasswordTrait.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/Helper/SecurePasswordTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Ui\Admin\Helper;
+
+use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Behaviour\SpecifiesItsField;
+use Sylius\Component\Core\Formatter\StringInflector;
+use Webmozart\Assert\Assert;
+
+trait SecurePasswordTrait
+{
+    private function replaceWithSecurePassword(string $password): string
+    {
+        $this->sharedStorage->set('scenario_setup_password', $password);
+
+        // If the password is empty or less than 4 characters, use the provided password to satisfy input validation
+        $newPassword = (empty($password) || strlen($password) < 4)
+            ? $password
+            : bin2hex(random_bytes(16));
+
+        $this->sharedStorage->set('password', $newPassword);
+
+        return $newPassword;
+    }
+
+    private function confirmSecurePassword(string $password): string
+    {
+        return $password === $this->sharedStorage->get('scenario_setup_password')
+            ? $this->sharedStorage->get('password')
+            : $password
+        ;
+    }
+
+    private function retrieveSecurePassword(string $password): string
+    {
+        $scenario_setup_password = $this->sharedStorage->get('scenario_setup_password');
+
+        // If the provided password matches the scenario setup password,
+        // use the secure password generated earlier; otherwise, return the scenario setup password to cause the test to fail
+        return $scenario_setup_password === $password ? $this->sharedStorage->get('password') : $scenario_setup_password;
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\Element\Admin\Customer\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Customer\CreatePageInterface;
 use Sylius\Behat\Page\Admin\Customer\IndexPageInterface as CustomerIndexPageInterface;

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/RegistrationAfterCheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/RegistrationAfterCheckoutContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop\Checkout;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Element\Shop\Account\RegisterElementInterface;
 use Sylius\Behat\Page\Shop\Account\DashboardPageInterface;
 use Sylius\Behat\Page\Shop\Account\LoginPageInterface;
@@ -41,13 +42,10 @@ final class RegistrationAfterCheckoutContext implements Context
     ) {
     }
 
-    /**
-     * @When I specify a password as :password
-     */
+    #[When('I specify a password as :password')]
     public function iSpecifyThePasswordAs(string $password): void
     {
         $this->registerElement->specifyPassword($password);
-        $this->sharedStorage->set('password', $password);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/RegistrationContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Element\Shop\Account\RegisterElementInterface;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Shop\Account\DashboardPageInterface;
@@ -93,14 +94,16 @@ class RegistrationContext implements Context
         $this->registerElement->specifyEmail($email);
     }
 
-    /**
-     * @When I specify the password as :password
-     * @When I do not specify the password
-     */
-    public function iSpecifyThePasswordAs(?string $password = null): void
+    #[When('I specify the password as :password')]
+    public function iSpecifyThePasswordAs(string $password): void
     {
         $this->registerElement->specifyPassword($password);
-        $this->sharedStorage->set('password', $password);
+    }
+
+    #[When('I do not specify the password')]
+    public function iDoNotSpecifyThePassword(): void
+    {
+        $this->registerElement->specifyPassword('');
     }
 
     /**
@@ -111,12 +114,10 @@ class RegistrationContext implements Context
         $this->registerElement->verifyPassword($password);
     }
 
-    /**
-     * @Given I do not confirm the password
-     */
+    #[When('I do not confirm the password')]
     public function iDoNotConfirmPassword(): void
     {
-        $this->registerElement->verifyPassword(null);
+        $this->registerElement->verifyPassword('');
     }
 
     /**

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
@@ -14,11 +14,26 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
+use Sylius\Behat\Service\DriverHelper;
+use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 
 final class RegisterElement extends Element implements RegisterElementInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters = [],
+        protected ?SharedStorageInterface $sharedStorage = null,
+    )
+    {
+        parent::__construct($session, $minkParameters);
+    }
+
     public function checkValidationMessageFor(string $element, string $message): bool
     {
         $errorLabel = $this
@@ -59,9 +74,9 @@ final class RegisterElement extends Element implements RegisterElementInterface
         $this->getElement('last_name')->setValue($lastName);
     }
 
-    public function specifyPassword(?string $password): void
+    public function specifyPassword(string $password): void
     {
-        $this->getElement('password')->setValue($password);
+        $this->getElement('password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function specifyPhoneNumber(string $phoneNumber): void
@@ -69,9 +84,9 @@ final class RegisterElement extends Element implements RegisterElementInterface
         $this->getElement('phone_number')->setValue($phoneNumber);
     }
 
-    public function verifyPassword(?string $password): void
+    public function verifyPassword(string $password): void
     {
-        $this->getElement('password_verification')->setValue($password);
+        $this->getElement('password_verification')->setValue($this->confirmSecurePassword($password));
     }
 
     public function subscribeToTheNewsletter(): void

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElementInterface.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElementInterface.php
@@ -32,11 +32,11 @@ interface RegisterElementInterface
 
     public function specifyLastName(?string $lastName): void;
 
-    public function specifyPassword(?string $password): void;
+    public function specifyPassword(string $password): void;
 
     public function specifyPhoneNumber(string $phoneNumber): void;
 
-    public function verifyPassword(?string $password): void;
+    public function verifyPassword(string $password): void;
 
     public function subscribeToTheNewsletter(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
@@ -13,10 +13,25 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Account;
 
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class LoginPage extends SymfonyPage implements LoginPageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        private SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router);
+    }
+
     public function hasValidationErrorWith(string $message): bool
     {
         return $this->getElement('validation_error')->getText() === $message;
@@ -29,7 +44,7 @@ class LoginPage extends SymfonyPage implements LoginPageInterface
 
     public function specifyPassword(string $password): void
     {
-        $this->getDocument()->fillField('Password', $password);
+        $this->getDocument()->fillField('Password', $this->retrieveSecurePassword($password));
     }
 
     public function specifyUsername(string $username): void

--- a/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPage.php
@@ -14,18 +14,33 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router);
+    }
+
     public function specifyNewPassword(string $password): void
     {
-        $this->getElement('new_password')->setValue($password);
+        $this->getElement('new_password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function specifyPasswordConfirmation(string $password): void
     {
-        $this->getElement('confirm_new_password')->setValue($password);
+        $this->getElement('confirm_new_password')->setValue($this->confirmSecurePassword($password));
     }
 
     public function getValidationMessageForNewPassword(): string

--- a/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
@@ -13,10 +13,26 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Administrator;
 
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        string $routeName,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router, $routeName);
+    }
+
     public function isAvatarAttached(): bool
     {
         return $this->getElement('add_avatar')->has('css', 'img');
@@ -58,7 +74,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 
     public function specifyPassword(string $password): void
     {
-        $this->getElement('password')->setValue($password);
+        $this->getElement('password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function specifyLocale(string $localeCode): void

--- a/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
@@ -13,10 +13,26 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Administrator;
 
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        string $routeName,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router, $routeName);
+    }
+
     public function attachAvatar(string $path): void
     {
         $filesPath = $this->getParameter('files_path');
@@ -38,7 +54,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 
     public function changePassword(string $password): void
     {
-        $this->getElement('password')->setValue($password);
+        $this->getElement('password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function changeLocale(string $localeCode): void

--- a/src/Sylius/Behat/Page/Admin/Customer/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/UpdatePage.php
@@ -14,12 +14,27 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Customer;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
 use Sylius\Behat\Behaviour\Toggles;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
+    use SecurePasswordTrait;
     use Toggles;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        string $routeName,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router, $routeName);
+    }
 
     public function getFullName(): string
     {
@@ -56,7 +71,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 
     public function changePassword(string $password): void
     {
-        $this->getDocument()->fillField('Password', $password);
+        $this->getDocument()->fillField('Password', $this->replaceWithSecurePassword($password));
     }
 
     public function getPassword(): string

--- a/src/Sylius/Behat/Page/Shop/Account/ChangePasswordPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ChangePasswordPage.php
@@ -14,10 +14,25 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class ChangePasswordPage extends SymfonyPage implements ChangePasswordPageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router);
+    }
+
     public function getRouteName(): string
     {
         return 'sylius_shop_account_change_password';
@@ -36,17 +51,17 @@ class ChangePasswordPage extends SymfonyPage implements ChangePasswordPageInterf
 
     public function specifyCurrentPassword(string $password): void
     {
-        $this->getElement('current_password')->setValue($password);
+        $this->getElement('current_password')->setValue($this->retrieveSecurePassword($password));
     }
 
     public function specifyNewPassword(string $password): void
     {
-        $this->getElement('new_password')->setValue($password);
+        $this->getElement('new_password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function specifyConfirmationPassword(string $password): void
     {
-        $this->getElement('confirmation')->setValue($password);
+        $this->getElement('confirmation')->setValue($this->confirmSecurePassword($password));
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
@@ -13,10 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Service\Accessor\TableAccessorInterface;
+use Sylius\Behat\Service\DriverHelper;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class LoginPage extends SymfonyPage implements LoginPageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        protected TableAccessorInterface $tableAccessor,
+        private SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router);
+    }
+
     public function getRouteName(): string
     {
         return 'sylius_shop_login';
@@ -34,7 +52,7 @@ class LoginPage extends SymfonyPage implements LoginPageInterface
 
     public function specifyPassword(string $password): void
     {
-        $this->getElement('password')->setValue($password);
+        $this->getElement('password')->setValue($this->retrieveSecurePassword($password));
     }
 
     public function specifyUsername(string $username): void

--- a/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
@@ -14,10 +14,26 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Service\SharedStorageInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterface
 {
+    use SecurePasswordTrait;
+
+    public function __construct(
+        Session $session,
+        $minkParameters,
+        RouterInterface $router,
+        protected SharedStorageInterface $sharedStorage,
+    ) {
+        parent::__construct($session, $minkParameters, $router);
+    }
+
+
     public function getRouteName(): string
     {
         return 'sylius_shop_password_reset';
@@ -30,12 +46,12 @@ class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterfac
 
     public function specifyNewPassword(string $password): void
     {
-        $this->getElement('password')->setValue($password);
+        $this->getElement('password')->setValue($this->replaceWithSecurePassword($password));
     }
 
     public function specifyConfirmPassword(string $password): void
     {
-        $this->getElement('confirm_password')->setValue($password);
+        $this->getElement('confirm_password')->setValue($this->confirmSecurePassword($password));
     }
 
     public function checkValidationMessageFor(string $element, string $message): bool

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -17,9 +17,11 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
+use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Page\SymfonyPage;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\JQueryHelper;
+use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -27,6 +29,8 @@ use Webmozart\Assert\Assert;
 
 class AddressPage extends SymfonyPage implements AddressPageInterface
 {
+    use SecurePasswordTrait;
+
     public const TYPE_BILLING = 'billing';
 
     public const TYPE_SHIPPING = 'shipping';
@@ -35,7 +39,8 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         Session $session,
         $minkParameters,
         RouterInterface $router,
-        private AddressFactoryInterface $addressFactory,
+        protected AddressFactoryInterface $addressFactory,
+        protected SharedStorageInterface $sharedStorage,
     ) {
         parent::__construct($session, $minkParameters, $router);
     }
@@ -175,7 +180,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
     {
         $this->getDocument()->waitFor(5, fn () => $this->getElement('login_password')->isVisible());
 
-        $this->getElement('login_password')->setValue($password);
+        $this->getElement('login_password')->setValue($this->retrieveSecurePassword($password));
     }
 
     public function getItemSubtotal(string $itemName): string

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/admin.xml
@@ -286,6 +286,7 @@
             <argument type="service" id="sylius.behat.api_platform_client.shop" />
             <argument type="service" id="sylius.behat.request_factory" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
+            <argument type="service" id="sylius.behat.shared_storage" />
             <argument>%sylius.security.api_route%</argument>
         </service>
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/cli.xml
@@ -32,6 +32,7 @@
             <argument type="service" id="kernel" />
             <argument type="service" id="sylius.repository.admin_user" />
             <argument type="service" id="sylius.security.password_hasher" />
+            <argument type="service" id="sylius.behat.shared_storage"/>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/elements/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/shop.xml
@@ -18,7 +18,9 @@
     <services>
         <defaults public="true" />
 
-        <service id="sylius.behat.element.shop.account.register" class="Sylius\Behat\Element\Shop\Account\RegisterElement" parent="sylius.behat.element" public="false" />
+        <service id="sylius.behat.element.shop.account.register" class="Sylius\Behat\Element\Shop\Account\RegisterElement" parent="sylius.behat.element" public="false">
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
 
         <service id="sylius.behat.element.shop.menu" class="Sylius\Behat\Element\Shop\MenuElement" parent="sylius.behat.element" public="false" />
 

--- a/src/Sylius/Behat/Resources/config/services/pages/admin/account.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin/account.xml
@@ -19,10 +19,14 @@
     <services>
         <defaults public="true" />
 
-        <service id="sylius.behat.page.admin.login" class="Sylius\Behat\Page\Admin\Account\LoginPage" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.page.admin.login" class="Sylius\Behat\Page\Admin\Account\LoginPage" parent="sylius.behat.symfony_page" public="false">
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
 
         <service id="sylius.behat.page.admin.request_password_reset" class="Sylius\Behat\Page\Admin\Account\RequestPasswordResetPage" parent="sylius.behat.symfony_page" public="false" />
 
-        <service id="sylius.behat.page.admin.reset_password" class="%sylius.behat.page.admin.reset_password%" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.page.admin.reset_password" class="%sylius.behat.page.admin.reset_password%" parent="sylius.behat.symfony_page" public="false">
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/pages/admin/admin_user.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin/admin_user.xml
@@ -9,12 +9,14 @@
 
         <service id="sylius.behat.page.admin.administrator.create" class="Sylius\Behat\Page\Admin\Administrator\CreatePage" parent="sylius.behat.page.admin.crud.create" public="false">
             <argument type="string">sylius_admin_admin_user_create</argument>
+            <argument type="service" id="sylius.behat.shared_storage"/>
         </service>
         <service id="sylius.behat.page.admin.administrator.index" class="Sylius\Behat\Page\Admin\Crud\IndexPage" parent="sylius.behat.page.admin.crud.index" public="false">
             <argument type="string">sylius_admin_admin_user_index</argument>
         </service>
         <service id="sylius.behat.page.admin.administrator.update" class="Sylius\Behat\Page\Admin\Administrator\UpdatePage" parent="sylius.behat.page.admin.crud.update" public="false">
             <argument type="string">sylius_admin_admin_user_update</argument>
+            <argument type="service" id="sylius.behat.shared_storage"/>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/pages/admin/customer.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin/customer.xml
@@ -34,6 +34,7 @@
         </service>
         <service id="sylius.behat.page.admin.customer.update" class="%sylius.behat.page.admin.customer.update.class%" parent="sylius.behat.page.admin.crud.update" public="false">
             <argument type="string">sylius_admin_customer_update</argument>
+            <argument type="service" id="sylius.behat.shared_storage"/>
         </service>
         <service id="sylius.behat.page.admin.customer.show" class="%sylius.behat.page.admin.customer.show.class%" parent="sylius.behat.symfony_page" public="false" />
     </services>

--- a/src/Sylius/Behat/Resources/config/services/pages/shop/account.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/shop/account.xml
@@ -36,9 +36,14 @@
         <service id="sylius.behat.page.shop.account.address_book.create" class="%sylius.behat.page.shop.account.address_book.create.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.account.address_book.index" class="%sylius.behat.page.shop.account.address_book.index.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.account.address_book.update" class="%sylius.behat.page.shop.account.address_book.update.class%" parent="sylius.behat.symfony_page" public="false" />
-        <service id="sylius.behat.page.shop.account.change_password" class="%sylius.behat.page.shop.account.change_password.class%" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.page.shop.account.change_password" class="%sylius.behat.page.shop.account.change_password.class%" parent="sylius.behat.symfony_page" public="false">
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
         <service id="sylius.behat.page.shop.account.dashboard" class="%sylius.behat.page.shop.account.dashboard.class%" parent="sylius.behat.symfony_page" public="false" />
-        <service id="sylius.behat.page.shop.account.login" class="%sylius.behat.page.shop.account.login.class%" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.page.shop.account.login" class="%sylius.behat.page.shop.account.login.class%" parent="sylius.behat.symfony_page" public="false">
+            <argument type="service" id="sylius.behat.table_accessor" />
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
         <service id="sylius.behat.page.shop.account.order.index" class="%sylius.behat.page.shop.account.order.index.class%" parent="sylius.behat.symfony_page" public="false">
             <argument type="service" id="sylius.behat.table_accessor" />
         </service>
@@ -49,7 +54,9 @@
         <service id="sylius.behat.page.shop.account.register" class="%sylius.behat.page.shop.account.register.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.account.register.thank_you" class="%sylius.behat.page.shop.account.register.thank_you.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.account.request_password_reset" class="%sylius.behat.page.shop.account.request_password_reset.class%" parent="sylius.behat.symfony_page" public="false" />
-        <service id="sylius.behat.page.shop.account.reset_password" class="%sylius.behat.page.shop.account.reset_password.class%" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.page.shop.account.reset_password" class="%sylius.behat.page.shop.account.reset_password.class%" parent="sylius.behat.symfony_page" public="false">
+            <argument type="service" id="sylius.behat.shared_storage"/>
+        </service>
         <service id="sylius.behat.page.shop.account.verify" class="%sylius.behat.page.shop.account.verify.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.account.well_known_password_change" class="%sylius.behat.page.shop.account.well_known_password_change.class%" parent="sylius.behat.symfony_page" public="false" />
     </services>

--- a/src/Sylius/Behat/Resources/config/services/pages/shop/checkout.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/shop/checkout.xml
@@ -24,6 +24,7 @@
 
         <service id="sylius.behat.page.shop.checkout.address" class="%sylius.behat.page.shop.checkout.address.class%" parent="sylius.behat.symfony_page" public="false" >
             <argument type="service" id="sylius.factory.address" />
+            <argument type="service" id="sylius.behat.shared_storage"/>
         </service>
         <service id="sylius.behat.page.shop.checkout.select_payment" class="%sylius.behat.page.shop.checkout.select_payment.class%" parent="sylius.behat.symfony_page" public="false" />
         <service id="sylius.behat.page.shop.checkout.select_shipping" class="%sylius.behat.page.shop.checkout.select_shipping.class%" parent="sylius.behat.symfony_page" public="false" />


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Lately, we've been struggling with randomly failing Panther tests. For example:
```
Scenario: Placing an order as an impersonated shop user when the shop user was already logged # features/admin/placing_order_as_impersonated_shop_users.feature:28
      And I impersonate them                                                                      # features/admin/placing_order_as_impersonated_shop_users.feature:31
        Facebook\WebDriver\Exception\ElementNotInteractableException: element not interactable
          (Session info: chrome=135.0.7049.52) in vendor/php-webdriver/webdriver/lib/Exception/WebDriverException.php:98
```

What I discovered is that sometimes the browser displays a password breach warning, which makes sense since we use simple passwords in our tests. I tried disabling this pop-up, and we even have this configured in our Behat setup:
```yaml
default:
    extensions:
        Behat\MinkExtension:
            sessions:
                panther:
                    panther:
                        options:
                            browser_arguments:
                                - --window-size=1200,1000
                                - --headless
                                - --no-sandbox
                                - --disable-dev-shm-usage
                                - --disable-gpu
                                - --disable-infobars
                                - --disable-features=TranslateUI
                                - --disable-translate
                                - --disable-popup-blocking
                                - --disable-blink-features=AutomationControlled
                                - --disable-component-extensions-with-background-pages
                                - --disable-background-networking
                                - --disable-dev-tools
                                - --disable-extensions
```

However, these and other flags I tried didn’t solve the issue.

Below are two examples of the problem:
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/1fc2f5a4-9926-487b-8a3e-97178c48e23f" />
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/b15ef84e-ae6c-4de2-b5b6-87090f7e1180" />

To resolve this and avoid refactoring all Behat scenarios using static passwords, I introduced dynamic password generation. This satisfies the browser’s expectations and helps us avoid the tedious work of updating all existing scenarios.