### PR TITLE
[Behat] Introduce Bad Gateway Context

### DIFF
--- a/src/Sylius/Behat/Context/Hook/BadGatewayContext.php
+++ b/src/Sylius/Behat/Context/Hook/BadGatewayContext.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Hook;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Hook\AfterStep;
+use Behat\Testwork\Tester\Result\TestResult;
+
+final class BadGatewayContext implements Context
+{
+    #[AfterStep]
+    public function checkForBadGatewayError(AfterStepScope $scope): void
+    {
+        if ($scope->getTestResult()->getResultCode() !== TestResult::FAILED) {
+            return;
+        }
+
+        $exception = $scope->getTestResult()->getException();
+        if ($exception && str_contains($exception->getMessage(), '502')) {
+            fwrite(STDERR, "Encountered Bad Gateway (502) error, aborting further tests.\n");
+            exit(1);
+        }
+    }
+}

--- a/src/Sylius/Behat/Resources/config/services/contexts/hook.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/hook.xml
@@ -43,5 +43,7 @@
         <service id="sylius.behat.context.hook.guest_cart" class="Sylius\Behat\Context\Hook\GuestCartContext">
             <argument>%sylius.behat.guest_cart_token_file%</argument>
         </service>
+
+        <service id="sylius.behat.context.hook.bad_gateway" class="Sylius\Behat\Context\Hook\BadGatewayContext"/>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/address_book.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_address_book:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/customer.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_customer_account:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.mailer

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/customer_registration.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/customer_registration.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_customer_registration:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.mailer
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/email_verification.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/email_verification.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_email_verification:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.mailer
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/account/login.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/account/login.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_customer_login:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.mailer
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_countries.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_countries:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_zones.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/addressing/managing_zones.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_zones:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/dashboard.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_dashboard:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/impersonating_customers.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/impersonating_customers.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_impersonating_customers:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/locale.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/locale.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_admin_locale:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/login.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/login.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_administrator_login:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/panel.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_panel:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/admin/security.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/admin/security.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_administrator_security:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/accessing_cart.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_accessing_cart:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_shopping_cart:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/channels.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_channels:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_channels:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/products_accessibility_in_multiple_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/products_accessibility_in_multiple_channels.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_products_accessibility_in_multiple_channels:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/theming.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/theming.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_theming:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
                 - sylius.behat.context.hook.test_theme

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/checkout.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_checkout:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.mailer

--- a/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/checkout/paying_for_order.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_paying_for_order:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/contact/requesting_contact.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/contact/requesting_contact.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_customer_requesting_contact:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.mailer
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/currency/currencies.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/currency/currencies.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_currencies:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_currencies.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_currencies.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_currencies:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_exchange_rates.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/currency/managing_exchange_rates.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_exchange_rates:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/errors/admin/error_page.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/errors/admin/error_page.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_admin_error_page:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/errors/shop/error_page.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/errors/shop/error_page.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_shop_error_page:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_homepage:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/cart_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/cart_inventory.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_cart_inventory:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_checkout_inventory:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/displaying_inventory_on_edit_product_page.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/displaying_inventory_on_edit_product_page.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_inventory_on_product_page:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_inventory:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/locale/locales.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/locale/locales.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_locales:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/locale/managing_locales.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/locale/managing_locales.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_locales:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_orders:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.calendar
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/modifying_placed_order_address.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/modifying_placed_order_address.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_modifying_placed_order_address:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/order_history.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/order_history.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_order_history:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payment_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payment_methods.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_payment_methods:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payments.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/payment/managing_payments.yml
@@ -2,6 +2,7 @@ default:
     suites:
         ui_managing_payments:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/payment_request/payment_request_notify.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/payment_request/payment_request_notify.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_payment_request_notify:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.address

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/accessing_price_history.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/accessing_price_history.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_accessing_price_history:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.channel

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/adding_product_review.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/adding_product_review.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_adding_product_review:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_association_types.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_association_types.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_product_association_types:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_attributes.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_product_attributes:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_product_options:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_reviews.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_reviews.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_product_reviews:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_product_variants:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_products:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.cache
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/navigating_between_product_show_and_edit_pages.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/navigating_between_product_show_and_edit_pages.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_navigating_between_product_show_and_edit_pages:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_price_history:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.channel

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history_after_catalog_promotions.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_price_history_after_catalog_promotions.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_price_history_after_catalog_promotions:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.channel

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_in_admin_panel.yaml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_in_admin_panel.yaml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_product_in_admin_panel:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_reviews.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_product_reviews.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_product_reviews:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/viewing_products.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_products:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_catalog_promotions:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.calendar
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_promotion_coupon:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_promotion_rules:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_catalog_promotions.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_catalog_promotions:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotion_coupons.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotion_coupons.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_promotion_coupons:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/managing_promotions.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_promotions:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_receiving_discount:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/removing_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/removing_catalog_promotions.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_removing_catalog_promotions:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.calendar
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_shipping_fee:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_method_rules.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_shipping_method_rules:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipments.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipments.yml
@@ -2,6 +2,7 @@ default:
     suites:
         ui_managing_shipments:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.calendar
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.mailer

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_categories.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_categories.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_shipping_categories:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/managing_shipping_methods.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_shipping_methods:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/viewing_shipping_methods.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/viewing_shipping_methods.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_viewing_shipping_methods:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/applying_taxes.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_applying_taxes:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.calendar
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.guest_cart

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_categories.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_categories.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_tax_categories:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_rates.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxation/managing_tax_rates.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_tax_rates:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_taxons:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/customer_statistics.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/customer_statistics.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_customer_statistics:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_administrators.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_administrators.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_administrators:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customer_groups.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customer_groups.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_customer_groups:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_customers.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_customers:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.cache
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session

--- a/src/Sylius/Behat/Resources/config/suites/ui/user/managing_users.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/user/managing_users.yml
@@ -5,6 +5,7 @@ default:
     suites:
         ui_managing_users:
             contexts:
+                - sylius.behat.context.hook.bad_gateway
                 - sylius.behat.context.hook.doctrine_orm
                 - sylius.behat.context.hook.session
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0  <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Sometimes, there’s an issue in the CI pipeline—particularly with the Chromedriver build when running on PHP 8.2. You may recall that we previously struggled to run Behat tests locally with PHP 8.2, and upgrading to 8.3 resolved the issue. Unfortunately, we can’t eliminate this combination from the testing flow entirely, but we can at least make it more reliable.

This proposed change aims to improve the developer experience by short-circuiting the execution of the JS job early if a 502 error occurs. While it doesn’t fix the root cause, it does improve the feedback loop.

BadRequestContext service in action:
<img width="1322" alt="image" src="https://github.com/user-attachments/assets/ec155fcd-0b32-4040-bd3e-ce3a6052b7a7" />

Another example:
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/1f347df1-bc6b-462b-834f-85cb3cd393cd" />
