### PR TITLE
[Channel] Fix missing channel tab in web profiler

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -70,7 +70,7 @@ final class ChannelCollector extends DataCollector
 
     public function getName(): string
     {
-        return 'sylius.channel_collector';
+        return 'sylius.collector.channel';
     }
 
     private function pluckChannel(ChannelInterface $channel): array


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | Follow up of #17828 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

As mentioned in #17828, the debug bar doesn't display the channel tab. This PR fixes this issue which is present since 2.0