### PR TITLE
Add `#[Attribute]` annotation to validator constraints

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraint;
 /**
  * Constraint to require a province to be valid.
  */
+#[\Attribute]
 class ProvinceAddressConstraint extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/UniqueProvinceCollection.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UniqueProvinceCollection extends Constraint
 {
     public string $message = 'sylius.country.unique_provinces';

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItself.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ZoneCannotContainItself extends Constraint
 {
     public string $message = 'sylius.zone_member.cannot_be_the_same_as_zone';

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneMemberGroup.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneMemberGroup.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ZoneMemberGroup extends Constraint
 {
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class AddingEligibleProductVariantToCart extends Constraint
 {
     public string $productNotExistMessage = 'sylius.product.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class AdminResetPasswordTokenNonExpired extends Constraint
 {
     public string $message = 'sylius.admin.expired_password_reset_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChanged.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChanged.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CanPaymentMethodBeChanged extends Constraint
 {
     public const CANNOT_CHANGE_PAYMENT_METHOD_FOR_CANCELLED_ORDER = 'sylius.payment_method.cannot_change_payment_method_for_cancelled_order';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ChangedItemQuantityInCart extends Constraint
 {
     public string $productNotExistMessage = 'sylius.product.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class CheckoutCompletion extends Constraint
 {
     public string $message = 'sylius.order.invalid_state_transition';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ChosenPaymentMethodEligibility extends Constraint
 {
     public string $notAvailable = 'sylius.payment_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /** @experimental  */
+#[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
     public string $notAvailable = 'sylius.payment_request.action_not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ChosenShippingMethodEligibility extends Constraint
 {
     public string $message = 'sylius.shipping_method.not_available';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ConfirmResetPassword extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CorrectChangeShopUserConfirmPassword extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CorrectOrderAddress extends Constraint
 {
     public string $countryCodeNotExistMessage = 'sylius.country.not_exist';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderAddressRequirement extends Constraint
 {
     public string $message = 'sylius.order.address_requirement';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderItemAvailability extends Constraint
 {
     public string $message = 'sylius.product_variant.product_variant_with_name_not_sufficient';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderNotEmpty extends Constraint
 {
     public string $message = 'sylius.order.not_empty';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
     public string $message = 'sylius.order.payment_method_eligibility';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
     public string $message = 'sylius.order.product_eligibility';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
     /**

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PlacedOrderCartItemsImmutable extends Constraint
 {
     public string $message = 'sylius.order.cart_items_immutable';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionCouponEligibility extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShipmentAlreadyShipped extends Constraint
 {
     public string $message = 'sylius.shipment.shipped';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShopUserNotVerified extends Constraint
 {
     public string $message = 'sylius.account.is_verified';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShopUserResetPasswordTokenExists extends Constraint
 {
     public string $message = 'sylius.reset_password.invalid_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShopUserResetPasswordTokenNotExpired extends Constraint
 {
     public string $message = 'sylius.reset_password.token_expired';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShopUserVerificationTokenEligibility extends Constraint
 {
     public string $message = 'sylius.account.invalid_verification_token';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class SingleValueForProductVariantOption extends Constraint
 {
     public string $message = 'sylius.product_variant.option_values.single_value';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UniqueReviewerEmail extends Constraint
 {
     public string $message = 'sylius.review.author.already_exists';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UniqueShopUserEmail extends Constraint
 {
     public string $message = 'sylius.user.email.unique';

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UpdateCartEmailNotAllowed extends Constraint
 {
     public string $message = 'sylius.checkout.email.not_changeable';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/AttributeType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class AttributeType extends Constraint
 {
     public string $unregisteredAttributeTypeMessage = 'sylius.attribute.type.unregistered';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidAttributeValue.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidAttributeValue.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class ValidAttributeValue extends Constraint
 {
     public function getTargets(): string

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidSelectAttributeConfiguration.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ValidSelectAttributeConfiguration extends Constraint
 {
     public string $messageMultiple = 'sylius.attribute.configuration.multiple';

--- a/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
+++ b/src/Sylius/Bundle/AttributeBundle/Validator/Constraints/ValidTextAttributeConfiguration.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AttributeBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ValidTextAttributeConfiguration extends Constraint
 {
     public string $message = 'sylius.attribute.configuration.max_length';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypes.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class AllowedImageMimeTypes extends Constraint
 {
     public string $message = 'sylius.image.file.allowed_mime_types';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemAvailability.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CartItemAvailability extends Constraint
 {
     public string $message;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CartItemVariantEnabled.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CartItemVariantEnabled extends Constraint
 {
     public string $message = 'sylius.cart_item.variant.not_available';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelCodeCollection.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ChannelCodeCollection extends Constraint
 {
     /** @var array<Constraint> */

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ChannelDefaultLocaleEnabled.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ChannelDefaultLocaleEnabled extends Constraint
 {
     public string $message = 'sylius.channel.default_locale.enabled';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CountryCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CountryCodeExists extends Constraint
 {
     public string $message = 'sylius.country.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CustomerGroupCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CustomerGroupCodeExists extends Constraint
 {
     public string $message = 'sylius.customer_group.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ExistingChannelCode.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ExistingChannelCode extends Constraint
 {
     public string $message = 'sylius.product_variant.channel_pricing.existing_code';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllPricesDefined.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class HasAllPricesDefined extends Constraint
 {
     public string $message = 'sylius.product_variant.channel_pricing.price.not_defined';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasAllVariantPricesDefined.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class HasAllVariantPricesDefined extends Constraint
 {
     public string $message = 'sylius.product.variants.all_prices_defined';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntity.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class HasEnabledEntity extends Constraint
 {
     public ?string $objectManager = null;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/MaxInteger.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class MaxInteger extends Constraint
 {
     public string $message = 'sylius.max_integer';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
     public string $message = 'sylius.order.payment_method_eligibility';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
     public string $message = 'sylius.order.product_eligibility';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
     /**

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProductCodeExists extends Constraint
 {
     public string $message = 'sylius.product.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductImageVariantsBelongToOwner.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProductImageVariantsBelongToOwner extends Constraint
 {
     public string $message = 'sylius.product_image.product_variant.not_belong_to_owner';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProductVariantCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProductVariantCodeExists extends Constraint
 {
     public string $message = 'sylius.product_variant.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ProvinceCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProvinceCodeExists extends Constraint
 {
     public string $message = 'sylius.province.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/RegisteredUser.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class RegisteredUser extends Constraint
 {
     public string $message = 'This email is already registered. Please log in.';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendOrderConfirmationEmailWithValidOrderState.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ResendOrderConfirmationEmailWithValidOrderState extends Constraint
 {
     public string $message = 'sylius.resend_order_confirmation_email.invalid_order_state';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ResendShipmentConfirmationEmailWithValidShipmentState.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ResendShipmentConfirmationEmailWithValidShipmentState extends Constraint
 {
     public string $message = 'sylius.resend_shipment_confirmation_email.invalid_shipment_state';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TaxonCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class TaxonCodeExists extends Constraint
 {
     public string $message = 'sylius.taxon.code.not_exist';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/TranslationForExistingLocales.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class TranslationForExistingLocales extends Constraint
 {
     public string $message = 'sylius.translation.locale_code.invalid';

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class UniqueReviewerEmail extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/ZoneCodeExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ZoneCodeExists extends Constraint
 {
     public string $message = 'sylius.zone.code.not_exist';

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/DifferentSourceTargetCurrency.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CurrencyBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class DifferentSourceTargetCurrency extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPair.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CurrencyBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 class UniqueCurrencyPair extends Constraint
 {
     /** @var string */

--- a/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
+++ b/src/Sylius/Bundle/InventoryBundle/Validator/Constraints/InStock.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\InventoryBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class InStock extends Constraint
 {
     public string $message = 'sylius.cart_item.not_available';

--- a/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
+++ b/src/Sylius/Bundle/PaymentBundle/Validator/Constraints/GatewayFactoryExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PaymentBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class GatewayFactoryExists extends Constraint
 {
     public string $invalidGatewayFactory = 'sylius.gateway_config.invalid_gateway_factory';

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantCombination.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProductVariantCombination extends Constraint
 {
     public string $message = 'sylius.product_variant.combination';

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/ProductVariantOptionValuesConfiguration.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ProductVariantOptionValuesConfiguration extends Constraint
 {
     public string $message = 'sylius.product_variant.option_values.not_configured';

--- a/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
+++ b/src/Sylius/Bundle/ProductBundle/Validator/Constraint/UniqueSimpleProductCode.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ProductBundle\Validator\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class UniqueSimpleProductCode extends Constraint
 {
     public string $message = 'sylius.simple_product.code.unique';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionGroup.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionGroup.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CatalogPromotionActionGroup extends Constraint
 {
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionActionType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CatalogPromotionActionType extends Constraint
 {
     public string $invalidType = 'sylius.catalog_promotion_action.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeGroup.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeGroup.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CatalogPromotionScopeGroup extends Constraint
 {
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CatalogPromotionScopeType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CatalogPromotionScopeType extends Constraint
 {
     public string $invalidType = 'sylius.catalog_promotion_scope.type.invalid';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/CouponPossibleGenerationAmount.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class CouponPossibleGenerationAmount extends Constraint
 {
     public string $message = 'sylius.promotion_coupon_generator_instruction.possible_generation_amount';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionGroup.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionGroup.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionActionGroup extends Constraint
 {
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionActionType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionActionType extends Constraint
 {
     public string $invalidType = 'sylius.promotion_action.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionDateRange.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionDateRange extends Constraint
 {
     public string $message = 'sylius.promotion.end_date_cannot_be_set_prior_start_date';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionNotCouponBased.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionNotCouponBased extends Constraint
 {
     public string $message = 'sylius.promotion_coupon.promotion.not_coupon_based';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleGroup.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleGroup.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionRuleGroup extends Constraint
 {
     public function validatedBy(): string

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionRuleType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionRuleType extends Constraint
 {
     public string $invalidType = 'sylius.promotion_rule.invalid_type';

--- a/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
+++ b/src/Sylius/Bundle/PromotionBundle/Validator/Constraints/PromotionSubjectCoupon.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\PromotionBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class PromotionSubjectCoupon extends Constraint
 {
     public string $message = 'sylius.promotion_coupon.is_invalid';

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodCalculatorExists.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShippingBundle\Validator\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShippingMethodCalculatorExists extends Constraint
 {
     public string $invalidShippingCalculator = 'sylius.shipping_method.calculator.invalid';

--- a/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Validator/Constraint/ShippingMethodRule.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShippingBundle\Validator\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute]
 final class ShippingMethodRule extends Constraint
 {
     public string $invalidType = 'sylius.shipping_method.rule.invalid_type';


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | kinda (DX)
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/SyliusResourceBundle/pull/1010
| License         | MIT

According to the documentation:
https://symfony.com/doc/current/validation/custom_constraint.html
`Add #[\Attribute] to the constraint class if you want to use it as an attribute in other classes.`