### PR TITLE
[UiBundle] Allow ResourceLivePropTrait::hydrateResource to have null $value

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Twig/Component/ResourceLivePropTrait.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/Component/ResourceLivePropTrait.php
@@ -24,7 +24,11 @@ trait ResourceLivePropTrait
 
     public function hydrateResource(mixed $value): ?ResourceInterface
     {
-        return $this->repository->find($value);
+        if (null !== $value) {
+            return :wq$this->repository->find($value);
+        }
+
+        return null;
     }
 
     public function dehydrateResource(ResourceInterface|null $resource): mixed

--- a/src/Sylius/Bundle/UiBundle/Twig/Component/ResourceLivePropTrait.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/Component/ResourceLivePropTrait.php
@@ -25,7 +25,7 @@ trait ResourceLivePropTrait
     public function hydrateResource(mixed $value): ?ResourceInterface
     {
         if (null !== $value) {
-            return :wq$this->repository->find($value);
+            return $this->repository->find($value);
         }
 
         return null;


### PR DESCRIPTION
Allow ResourceLivePropTrait::hydrateResource to have null $value

| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17911
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
