### PR TITLE
Fix dev firewall order

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -13,6 +13,10 @@ security:
     password_hashers:
         Sylius\Component\User\Model\UserInterface: argon2i
     firewalls:
+        dev:
+            pattern:  ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+
         admin:
             switch_user: true
             context: admin
@@ -95,10 +99,6 @@ security:
 
         image_resolver:
             pattern: ^/media/cache/resolve
-            security: false
-
-        dev:
-            pattern:  ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
     access_control:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

All requests from `/_profiler` and `/_wdt` are currently part of `shop` firewall instead of `dev`. It's because the `dev` firewall is defined in last position and `/_profiler` and `_wdt` are not excluded from `%sylius.security.shop_regex%`.
Defining it first fixes this issue. 

However, existing projects should also change their config, should I target 2.1 branch instead and add this change in the `UPGRADE-2.1.md` ?
