### PR TITLE
[Stimulus] Ease of use in real app

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
@@ -7,37 +7,15 @@
  * file that was distributed with this source code.
  */
 
+import '@sylius/admin-bundle/entrypoint';
+
 import {startStimulusApp} from '@symfony/stimulus-bridge';
-import LiveController from '@symfony/ux-live-component';
-import '@symfony/ux-live-component/styles/live.css';
-import SlugController from './controllers/SlugController';
-import TaxonSlugController from './controllers/TaxonSlugController';
-import TaxonTree from './controllers/TaxonTreeController';
-import DeleteTaxon from './controllers/DeleteTaxonController';
-import ProductAttributeAutocomplete from './controllers/ProductAttributeAutocomplete';
-import ProductTaxonTree from './controllers/ProductTaxonTreeController';
-import SavePositionsController from './controllers/SavePositionsController';
-import CompoundFormErrorsController from './controllers/CompoundFormErrorsController';
-import TabsErrorsController from './controllers/TabsErrorsController';
-import BackButtonController from './controllers/BackButtonController';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
-    '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
-    true,
-    /\.[jt]sx?$/
+  '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
+  true,
+  /\.[jt]sx?$/
 ));
-
-app.register('live', LiveController);
-app.register('slug', SlugController);
-app.register('taxon-slug', TaxonSlugController);
-app.register('taxon-tree', TaxonTree);
-app.register('delete-taxon', DeleteTaxon);
-app.register('product-attribute-autocomplete', ProductAttributeAutocomplete);
-app.register('product-taxon-tree', ProductTaxonTree);
-app.register('save-positions', SavePositionsController);
-app.register('compound-form-errors', CompoundFormErrorsController);
-app.register('tabs-errors', TabsErrorsController);
-app.register('back-button', BackButtonController);
 
 app.debug = process.env.NODE_ENV !== 'production';

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/app.js
@@ -13,9 +13,9 @@ import {startStimulusApp} from '@symfony/stimulus-bridge';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
-  '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
-  true,
-  /\.[jt]sx?$/
+    '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
+    true,
+    /\.[jt]sx?$/
 ));
 
 app.debug = process.env.NODE_ENV !== 'production';

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
@@ -23,40 +23,58 @@
     },
     "@sylius/admin-bundle": {
       "slug": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/SlugController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "taxon-slug": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/TaxonSlugController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "taxon-tree": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/TaxonTreeController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "delete-taxon": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/DeleteTaxonController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "product-attribute-autocomplete": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/ProductAttributeAutocomplete.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "product-taxon-tree": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/ProductTaxonTreeController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "save-positions": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/SavePositionsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "compound-form-errors": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/CompoundFormErrorsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       },
       "tabs-errors": {
-        "enabled": true,
-        "fetch": "lazy"
+        "main": "controllers/TabsErrorsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       }
     }
   },

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
@@ -11,6 +11,53 @@
           "tom-select/dist/css/tom-select.bootstrap5.css": false
         }
       }
+    },
+    "@symfony/ux-live-component": {
+      "live": {
+        "enabled": true,
+        "fetch": "eager",
+        "autoimport": {
+          "@symfony/ux-live-component/dist/live.min.css": true
+        }
+      }
+    },
+    "@sylius/admin-bundle": {
+      "slug": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "taxon-slug": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "taxon-tree": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "delete-taxon": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "product-attribute-autocomplete": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "product-taxon-tree": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "save-positions": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "compound-form-errors": {
+        "enabled": true,
+        "fetch": "lazy"
+      },
+      "tabs-errors": {
+        "enabled": true,
+        "fetch": "lazy"
+      }
     }
   },
   "entrypoints": []

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers.json
@@ -75,6 +75,12 @@
         "webpackMode": "lazy",
         "fetch": "lazy",
         "enabled": true
+      },
+      "back-button": {
+        "main": "controllers/BackButtonController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       }
     }
   },

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/DeleteTaxonController.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/DeleteTaxonController.js
@@ -8,7 +8,6 @@
  */
 
 import { Controller } from '@hotwired/stimulus';
-import { Modal } from 'bootstrap';
 
 export default class extends Controller {
     static targets = ['modal', 'parent', 'csrfToken'];
@@ -19,7 +18,7 @@ export default class extends Controller {
             this.modalElement = this.modalTarget;
 
             this.modalElement.closest('[data-modal-delete-taxon-target]').appendChild(this.modalElement);
-            this.modal = new Modal(this.modalElement);
+            this.modal = new window.bootstrap.Modal(this.modalElement);
             this.modal.show();
 
             this.modalElement.addEventListener(

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/ProductTaxonTreeController.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/ProductTaxonTreeController.js
@@ -55,7 +55,7 @@ export default class extends Controller {
         }
 
         const toggler = `<span class="${treeOptions.togglerClass} ${togglerClass}" style="width: ${nodeMargin}px"></span>`;
-        const checkbox = `<span class="infinite-tree-check" style="width: ${nodeMargin}px;"><input class="form-check-input" type="checkbox" data-action="product-taxon-tree#clickNode" ${indeterminate && !checked ? 'data-indeterminate' : ''} ${checked ? 'checked' : ''}></span>`;
+        const checkbox = `<span class="infinite-tree-check" style="width: ${nodeMargin}px;"><input class="form-check-input" type="checkbox" data-action="sylius--admin-bundle--product-taxon-tree#clickNode" ${indeterminate && !checked ? 'data-indeterminate' : ''} ${checked ? 'checked' : ''}></span>`;
         const treeNode = `<div class="infinite-tree-node" style="${rtl ? 'margin-right' : 'margin-left'}: ${(depth * nodeMargin)}px">${toggler}${checkbox}<span class="infinite-tree-title">${name}</span></div>`;
 
         return `<div

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
@@ -9,8 +9,6 @@
 
 import './styles/main.scss';
 
-import './app';
-
 import './scripts/bulk-delete';
 import './scripts/check-all';
 import './scripts/fullscreen';

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@sylius/admin-bundle",
+  "license": "MIT",
+  "author": "Sylius Sp. z o.o.",
+  "version": "2.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sylius/SyliusAdminBundle.git"
+  },
+  "engines": {
+    "node": "^20 || ^22"
+  },
+  "engineStrict": true,
+  "symfony": {
+    "controllers": {
+      "slug": {
+        "main": "controllers/SlugController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "taxon-slug": {
+        "main": "controllers/TaxonSlugController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "taxon-tree": {
+        "main": "controllers/TaxonTreeController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "delete-taxon": {
+        "main": "controllers/DeleteTaxonController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "product-attribute-autocomplete": {
+        "main": "controllers/ProductAttributeAutocomplete.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "product-taxon-tree": {
+        "main": "controllers/ProductTaxonTreeController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "save-positions": {
+        "main": "controllers/SavePositionsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "compound-form-errors": {
+        "main": "controllers/CompoundFormErrorsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      },
+      "tabs-errors": {
+        "main": "controllers/TabsErrorsController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      }
+    }
+  },
+  "peerDependencies": {
+    "@hotwired/stimulus": "^3.0.0"
+  },
+  "devDependencies": {
+    "@hotwired/stimulus": "^3.0.0"
+  }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/Sylius/SyliusAdminBundle.git"
   },
   "engines": {
-    "node": "^20 || ^22"
+    "node": ">=20"
   },
   "engineStrict": true,
   "symfony": {

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/package.json
@@ -66,6 +66,12 @@
         "webpackMode": "lazy",
         "fetch": "lazy",
         "enabled": true
+      },
+      "back-button": {
+        "main": "controllers/BackButtonController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
       }
     }
   },

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -11,7 +11,8 @@
         "ui",
         "admin interface",
         "admin",
-        "backend"
+        "backend",
+        "symfony-ux"
     ],
     "homepage": "https://sylius.com",
     "license": "MIT",

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -17,6 +17,7 @@ class SyliusAdmin {
      */
     static getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
+
         Encore
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'));
 

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -12,20 +12,9 @@ const Encore = require('@symfony/webpack-encore');
 
 class SyliusAdmin {
     static getWebpackConfig(rootDir) {
+        this._prepareWebpackConfig(rootDir);
         Encore
-            .setOutputPath('public/build/admin/')
-            .setPublicPath('/build/admin')
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
-            .addEntry('admin-product-entry', path.resolve(__dirname, 'Resources/assets/product-entrypoint.js'))
-            .disableSingleRuntimeChunk()
-            .cleanupOutputBeforeBuild()
-            .enableSourceMaps(!Encore.isProduction())
-            .enableVersioning(Encore.isProduction())
-            .enableSassLoader((options) => {
-                // eslint-disable-next-line no-param-reassign
-                options.additionalData = `$rootDir: '${rootDir}';`;
-            })
-            .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const adminConfig = Encore.getWebpackConfig();
 
@@ -35,6 +24,37 @@ class SyliusAdmin {
         Encore.reset();
 
         return adminConfig;
+    }
+
+    static _getInternalWebpackConfig(rootDir) {
+        this._prepareWebpackConfig(rootDir);
+        // For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
+        Encore
+            .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/app.js'))
+            .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
+        const adminConfig = Encore.getWebpackConfig();
+
+        adminConfig.externals = { ...adminConfig.externals, window: 'window', document: 'document' };
+        adminConfig.name = 'admin';
+
+        Encore.reset();
+
+        return adminConfig;
+    }
+
+    static _prepareWebpackConfig(rootDir) {
+        Encore
+            .setOutputPath('public/build/admin/')
+            .setPublicPath('/build/admin')
+            .addEntry('admin-product-entry', path.resolve(__dirname, 'Resources/assets/product-entrypoint.js'))
+            .disableSingleRuntimeChunk()
+            .cleanupOutputBeforeBuild()
+            .enableSourceMaps(!Encore.isProduction())
+            .enableVersioning(Encore.isProduction())
+            .enableSassLoader((options) => {
+                // eslint-disable-next-line no-param-reassign
+                options.additionalData = `$rootDir: '${rootDir}';`;
+            })
     }
 }
 

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -18,7 +18,7 @@ class SyliusAdmin {
     static getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         Encore
-            .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
+            .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'));
 
         const adminConfig = Encore.getWebpackConfig();
 
@@ -64,7 +64,7 @@ class SyliusAdmin {
             .enableSassLoader((options) => {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
-            })
+            });
     }
 }
 

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -11,7 +11,11 @@ const path = require('path');
 const Encore = require('@symfony/webpack-encore');
 
 class SyliusAdmin {
-    static getWebpackConfig(rootDir) {
+    /**
+     * Provide a light Webpack configuration for Sylius Admin
+     * All the stimulus stuff should be handled by the app.admin entrypoint
+     */
+    static getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         Encore
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
@@ -26,12 +30,18 @@ class SyliusAdmin {
         return adminConfig;
     }
 
-    static _getInternalWebpackConfig(rootDir) {
+    /**
+     * For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
+     * For instances started with Sylius-Standard < 2.0.4, it'll still be used unless upgrading webpack.config.js
+     * to use the method above getBaseWebpackConfig()
+     */
+    static getWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
-        // For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
+
         Encore
             .addEntry('admin-entry', path.resolve(__dirname, 'Resources/assets/app.js'))
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
+
         const adminConfig = Encore.getWebpackConfig();
 
         adminConfig.externals = { ...adminConfig.externals, window: 'window', document: 'document' };

--- a/src/Sylius/Bundle/AdminBundle/package.json
+++ b/src/Sylius/Bundle/AdminBundle/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-env": "^7.25.8",
     "@hotwired/stimulus": "^3.0.0",
     "@popperjs/core": "^2.11.8",
+    "@sylius/admin-bundle": "file:Resources/assets/",
     "@symfony/stimulus-bridge": "^3.2.0",
     "@symfony/webpack-encore": "^5.0.1",
     "@tabler/core": "^1.3.0",

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes/list.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes/list.html.twig
@@ -1,3 +1,3 @@
-<div class="row" {{ stimulus_controller('tabs-errors') }}>
+<div class="row" {{ stimulus_controller('@sylius/admin-bundle/tabs-errors') }}>
     {% hook 'list' %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes/list/item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/attributes/list/item.html.twig
@@ -7,7 +7,7 @@
                 {% set product_attribute_name = (product_attribute_value|first).vars.data.name %}
                 <div
                     class="py-2 cursor-pointer list-group-item list-group-item-action {% if loop.first %}active{% endif %}"
-                    data-tabs-errors-target="tab"
+                    {{ stimulus_target('@sylius/admin-bundle/tabs-errors', 'tab') }}
                     data-bs-toggle="tab"
                     data-bs-target="#{{ product_attribute_code }}"
                     aria-selected="{{ loop.first ? 'true' : 'false' }}"

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxonomy/product_taxons.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxonomy/product_taxons.html.twig
@@ -2,8 +2,8 @@
 
 <div {{ sylius_test_html_attribute('product-taxons') }}>
     {{ form_label(product_taxons_form) }}
-    <div {{ stimulus_controller('product-taxon-tree', {treeData: this.tree, autoOpen: hookableMetadata.configuration.auto_open}) }}>
-        {{ form_widget(product_taxons_form, {attr: {'data-product-taxon-tree-target': 'productTaxons'}}) }}
+    <div {{ stimulus_controller('@sylius/admin-bundle/product-taxon-tree', {treeData: this.tree, autoOpen: hookableMetadata.configuration.auto_open}) }}>
+        {{ form_widget(product_taxons_form, {attr: {'data-sylius--admin-bundle--product-taxon-tree-target': 'productTaxons'}}) }}
 
         <div class="pb-5">
             <div class="input-group input-group-flat mb-4">
@@ -13,21 +13,21 @@
                     {{ sylius_test_html_attribute('product-taxons-filter') }}
                 />
                 <span class="input-group-text">
-                        <a class="input-group-link link-reset" type="button" data-action="product-taxon-tree#clearFilter" >{{ 'sylius.ui.clear'|trans }}</a>
+                        <a class="input-group-link link-reset" type="button" {{ stimulus_action('@sylius/admin-bundle/product-taxon-tree', 'clearFilter') }} >{{ 'sylius.ui.clear'|trans }}</a>
                     </span>
             </div>
             <div class="d-flex flex-column gap-1">
                 <div class="d-flex gap-3 align-items-center">
-                    <a class="d-flex align-items-center gap-1 text-nowrap link-reset fs-5" type="button" data-action="product-taxon-tree#checkAll" {{ sylius_test_html_attribute('product-taxons-check-all') }}>
+                    <a class="d-flex align-items-center gap-1 text-nowrap link-reset fs-5" type="button" {{ stimulus_action('@sylius/admin-bundle/product-taxon-tree', 'checkAll') }} {{ sylius_test_html_attribute('product-taxons-check-all') }}>
                         {{ ux_icon('tabler:copy-check', {'class': 'icon m-0'}) }}
                         {{ 'sylius.ui.check_all'|trans }}
                     </a>
-                    <a class="d-flex align-items-center gap-1 text-nowrap link-reset fs-5" type="button" data-action="product-taxon-tree#uncheckAll" {{ sylius_test_html_attribute('product-taxons-uncheck-all') }}>
+                    <a class="d-flex align-items-center gap-1 text-nowrap link-reset fs-5" type="button"  {{ stimulus_action('@sylius/admin-bundle/product-taxon-tree', 'uncheckAll') }}{{ sylius_test_html_attribute('product-taxons-uncheck-all') }}>
                         {{ ux_icon('tabler:copy-x', {'class': 'icon m-0'}) }}
                         {{ 'sylius.ui.uncheck_all'|trans }}
                     </a>
                 </div>
-                <div data-product-taxon-tree-target="tree"></div>
+                <div {{ stimulus_target('@sylius/admin-bundle/product-taxon-tree', 'tree') }}></div>
             </div>
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxonomy/product_taxons.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/sections/taxonomy/product_taxons.html.twig
@@ -8,8 +8,8 @@
         <div class="pb-5">
             <div class="input-group input-group-flat mb-4">
                 <input class="form-control" placeholder="{{ 'sylius.ui.filter'|trans }}" type="text"
-                       data-product-taxon-tree-target="filter"
-                       data-action="input->product-taxon-tree#filter"
+                    {{ stimulus_target('@sylius/admin-bundle/product-taxon-tree', 'filter') }}
+                    {{ stimulus_action('@sylius/admin-bundle/product-taxon-tree', 'filter', 'input') }}
                     {{ sylius_test_html_attribute('product-taxons-filter') }}
                 />
                 <span class="input-group-text">

--- a/src/Sylius/Bundle/AdminBundle/templates/product/product_attribute_autocomplete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/product_attribute_autocomplete.html.twig
@@ -2,7 +2,7 @@
     <input
         name="product_attributes"
         data-model="selectedAttributeCodes"
-        {{ stimulus_controller('product-attribute-autocomplete', {
+        {{ stimulus_controller('@sylius/admin-bundle/product-attribute-autocomplete', {
             url: path('sylius_admin_entity_autocomplete', { alias: 'sylius_admin_product_attribute', 'extra_options': extra_options }),
             selectedAttributeCodes: selected_attribute_codes|join(','),
         }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
@@ -1,11 +1,11 @@
 <button class="btn primary"
-    {{ stimulus_controller('save-positions', {
+    {{ stimulus_controller('@sylius/admin-bundle/save-positions', {
         url: path('sylius_admin_ajax_product_taxons_update_position', {taxonId: app.request.get('taxonId')}),
         csrfToken: csrf_token('update-product-taxon-position'),
         inputSelector: '.sylius-product-taxon-position',
         dataKey: 'productTaxons',
     }) }}
-        data-action="save-positions#submit"
+        data-action="sylius--admin-bundle--save-positions#submit"
     {{ sylius_test_html_attribute('save-configuration-button') }}
 >
     {{ ux_icon(action.icon|default('tabler:check'), {'class': 'icon dropdown-item-icon' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_taxon/grid/action/update_positions.html.twig
@@ -5,7 +5,7 @@
         inputSelector: '.sylius-product-taxon-position',
         dataKey: 'productTaxons',
     }) }}
-        data-action="sylius--admin-bundle--save-positions#submit"
+    {{ stimulus_action('@sylius/admin-bundle/save-positions', 'submit') }}
     {{ sylius_test_html_attribute('save-configuration-button') }}
 >
     {{ ux_icon(action.icon|default('tabler:check'), {'class': 'icon dropdown-item-icon' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
@@ -1,11 +1,11 @@
 <button class="btn primary"
-    {{ stimulus_controller('save-positions', {
+    {{ stimulus_controller('@sylius/admin-bundle/save-positions', {
         url: path('sylius_admin_ajax_product_variants_update_position'),
         csrfToken: csrf_token('update-product-variant-position'),
         inputSelector: '.sylius-product-variant-position',
         dataKey: 'productVariants',
     }) }}
-    data-action="save-positions#submit"
+    data-action="sylius--admin-bundle--save-positions#submit"
     {{ sylius_test_html_attribute('save-configuration-button') }}
 >
         {{ ux_icon(action.icon|default('tabler:check'), {'class': 'icon dropdown-item-icon' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_variant/grid/action/update_positions.html.twig
@@ -5,7 +5,7 @@
         inputSelector: '.sylius-product-variant-position',
         dataKey: 'productVariants',
     }) }}
-    data-action="sylius--admin-bundle--save-positions#submit"
+    {{ stimulus_action('@sylius/admin-bundle/save-positions', 'submit') }}
     {{ sylius_test_html_attribute('save-configuration-button') }}
 >
         {{ ux_icon(action.icon|default('tabler:check'), {'class': 'icon dropdown-item-icon' }) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/form_theme.html.twig
@@ -8,7 +8,7 @@
     {%- else -%}
         {% set form_method = "POST" %}
     {%- endif -%}
-    <form{% if name != '' %} name="{{ name }}"{% endif %} method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{{ block('attributes') }}{% if multipart %} enctype="multipart/form-data"{% endif %} {{ stimulus_controller('compound-form-errors') }}>
+    <form{% if name != '' %} name="{{ name }}"{% endif %} method="{{ form_method|lower }}"{% if action != '' %} action="{{ action }}"{% endif %}{{ block('attributes') }}{% if multipart %} enctype="multipart/form-data"{% endif %} {{ stimulus_controller('@sylius/admin-bundle/compound-form-errors') }}>
     {%- if form_method != method -%}
         <input type="hidden" name="_method" value="{{ method }}" />
     {%- endif -%}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
@@ -83,12 +83,14 @@
 {% endmacro %}
 
 {% macro cancel(params = {}) %}
-    {% set defaultAttr = {
-        'data-controller': 'back-button',
-        'data-action': 'click->back-button#goBack',
-        'data-back-button-current-url-value': app.request.uri,
-        'data-back-button-fallback-url-value': params.fallback_url
-    } %}
+    {% set default_attr =
+        stimulus_controller('@sylius/admin-bundle/back-button')
+        |merge(stimulus_action('@sylius/admin-bundle/back-button', 'goBack', 'click'))
+        |merge({
+            'data-back-button-current-url-value': app.request.uri,
+            'data-back-button-fallback-url-value': params.fallback_url
+        })
+    %}
 
     {% set params = {
         class: null,
@@ -97,7 +99,7 @@
         attr: {}
     }
         |merge(params)
-        |merge({attr: (params.attr is defined ? params.attr : {})|merge(defaultAttr)})
+        |merge({attr: (params.attr is defined ? params.attr : {})|merge(default_attr)})
     %}
 
     {{ _self.default(params) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/button.html.twig
@@ -87,8 +87,8 @@
         stimulus_controller('@sylius/admin-bundle/back-button')
         |merge(stimulus_action('@sylius/admin-bundle/back-button', 'goBack', 'click'))
         |merge({
-            'data-back-button-current-url-value': app.request.uri,
-            'data-back-button-fallback-url-value': params.fallback_url
+            'data-sylius--admin-bundle--back-button-current-url-value': app.request.uri,
+            'data-sylius--admin-bundle--back-button-fallback-url-value': params.fallback_url
         })
     %}
 

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
@@ -8,7 +8,7 @@
             </div>
         </div>
         <div class="card-body">
-            <div class="d-none" data-taxon-tree-target="itemPrototyp">
+            <div class="d-none" {{ stimulus_target('@sylius/admin-bundle/taxon-tree', 'itemPrototyp') }}>
                 <div class="d-flex justify-content-between infinite-tree-item" {{ sylius_test_html_attribute('tree-taxon', '__TAXON_NAME__') }}>
                     <div class="infinite-tree-node">
                         <span class="infinite-tree-toggler" data-infinite-tree-toggler></span>
@@ -19,7 +19,7 @@
 
                 </div>
             </div>
-            <div data-taxon-tree-target="tree" {{ sylius_test_html_attribute('tree-taxons') }}></div>
+            <div {{ stimulus_target('@sylius/admin-bundle/taxon-tree', 'tree') }} {{ sylius_test_html_attribute('tree-taxons') }}></div>
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
@@ -1,6 +1,6 @@
 {# Rendered with \Sylius\Bundle\AdminBundle\Twig\Component\Taxon\TreeComponent #}
 
-<div {{ attributes.defaults(stimulus_controller('taxon-tree', {autoOpen: true})) }} data-taxon-tree-tree-data-value="{{ this.tree|json_encode }}">
+<div {{ attributes.defaults(stimulus_controller('@sylius/admin-bundle/taxon-tree', {autoOpen: true, treeData: this.tree|json_encode})) }}>
     <div class="card mb-5">
         <div data-loading>
             <div class="sylius-loader">

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
@@ -3,7 +3,7 @@
 {% import '@SyliusAdmin/shared/helper/button.html.twig' as button %}
 {% set id = taxon_id|default('__TAXON_ID__') %}
 
-<div {{ attributes.defaults(stimulus_controller('delete-taxon')) }}>
+<div {{ attributes.defaults(stimulus_controller('@sylius/admin-bundle/delete-taxon')) }}>
     <button
         class="dropdown-item"
         data-action="live#action:prevent"

--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree/actions/dropdown/delete.html.twig
@@ -15,8 +15,8 @@
         {{ 'sylius.ui.delete'|trans }}
     </button>
 
-    <div data-delete-taxon-target="parent">
-        <div class="modal fade" id="delete-modal-{{ id }}" tabindex="-1" aria-hidden="true" data-delete-taxon-target="modal" {{ sylius_test_html_attribute('delete-modal') }}>
+    <div {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'parent') }}>
+        <div class="modal fade" id="delete-modal-{{ id }}" tabindex="-1" aria-hidden="true" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'modal') }} {{ sylius_test_html_attribute('delete-modal') }}>
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -25,7 +25,7 @@
                     <div class="modal-footer">
                         <form action="{{ path('sylius_admin_taxon_delete', {id: id}) }}" method="post">
                             <input type="hidden" name="_method" value="DELETE">
-                            <input type="hidden" name="_csrf_token" data-delete-taxon-target="csrfToken"/>
+                            <input type="hidden" name="_csrf_token" {{ stimulus_target('@sylius/admin-bundle/delete-taxon', 'csrfToken') }}/>
 
                             {{ button.default({ text: 'sylius.ui.cancel'|trans, attr: 'data-bs-dismiss=modal' }) }}
                             {{ button.default({ text: 'sylius.ui.delete'|trans, type: 'submit', class: 'btn-danger', attr: sylius_test_html_attribute('confirm-button') }) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
@@ -7,9 +7,9 @@
  * file that was distributed with this source code.
  */
 
+import '@sylius/shop-bundle/entrypoint';
+
 import { startStimulusApp } from '@symfony/stimulus-bridge';
-import LiveController from '@symfony/ux-live-component';
-import ApiLoginController from './controllers/ApiLoginController';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
@@ -17,8 +17,5 @@ export const app = startStimulusApp(require.context(
     true,
     /\.[jt]sx?$/
 ));
-
-app.register('live', LiveController);
-app.register('api-login', ApiLoginController);
 
 app.debug = process.env.NODE_ENV !== 'production';

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers.json
@@ -1,5 +1,11 @@
 {
   "controllers": {
+    "@sylius/shop-bundle": {
+      "api-login": {
+        "enabled": true,
+        "fetch": "lazy"
+      }
+    },
     "@symfony/ux-autocomplete": {
       "autocomplete": {
         "main": "dist/controller.js",
@@ -9,6 +15,15 @@
         "autoimport": {
           "tom-select/dist/css/tom-select.default.css": false,
           "tom-select/dist/css/tom-select.bootstrap5.css": false
+        }
+      }
+    },
+    "@symfony/ux-live-component": {
+      "live": {
+        "enabled": true,
+        "fetch": "eager",
+        "autoimport": {
+          "@symfony/ux-live-component/dist/live.min.css": true
         }
       }
     }

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers.json
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers.json
@@ -2,7 +2,9 @@
   "controllers": {
     "@sylius/shop-bundle": {
       "api-login": {
+        "main": "controllers/ApiLoginController.js",
         "enabled": true,
+        "webpackMode": "lazy",
         "fetch": "lazy"
       }
     },

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/entrypoint.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/entrypoint.js
@@ -9,8 +9,6 @@
 
 import './styles/main.scss';
 
-import './app';
-
 import './scripts/bootstrap';
 import './scripts/spotlight';
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sylius/shop-bundle",
+  "license": "MIT",
+  "author": "Sylius Sp. z o.o.",
+  "version": "2.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sylius/SyliusShopBundle.git"
+  },
+  "engines": {
+    "node": "^20 || ^22"
+  },
+  "engineStrict": true,
+  "symfony": {
+    "controllers": {
+      "api-login": {
+        "main": "controllers/ApiLoginController.js",
+        "webpackMode": "lazy",
+        "fetch": "lazy",
+        "enabled": true
+      }
+    }
+  },
+  "peerDependencies": {
+    "@hotwired/stimulus": "^3.0.0"
+  },
+  "devDependencies": {
+    "@hotwired/stimulus": "^3.0.0"
+  }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/Sylius/SyliusShopBundle.git"
   },
   "engines": {
-    "node": "^20 || ^22"
+    "node": ">=20"
   },
   "engineStrict": true,
   "symfony": {

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -7,7 +7,8 @@
         "ecommerce",
         "store",
         "webshop",
-        "sylius"
+        "sylius",
+        "symfony-ux"
     ],
     "homepage": "https://sylius.com",
     "license": "MIT",

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -18,7 +18,7 @@ class SyliusShop {
     static getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         Encore
-            .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
+            .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'));
 
         const shopConfig = Encore.getWebpackConfig();
 
@@ -62,7 +62,7 @@ class SyliusShop {
             .enableSassLoader((options) => {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
-            })
+            });
     }
 }
 

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -12,19 +12,9 @@ const Encore = require('@symfony/webpack-encore');
 
 class SyliusShop {
     static getWebpackConfig(rootDir) {
+        this._prepareWebpackConfig(rootDir);
         Encore
-            .setOutputPath('public/build/shop/')
-            .setPublicPath('/build/shop')
             .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
-            .disableSingleRuntimeChunk()
-            .cleanupOutputBeforeBuild()
-            .enableSourceMaps(!Encore.isProduction())
-            .enableVersioning(Encore.isProduction())
-            .enableSassLoader((options) => {
-                // eslint-disable-next-line no-param-reassign
-                options.additionalData = `$rootDir: '${rootDir}';`;
-            })
-            .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const shopConfig = Encore.getWebpackConfig();
 
@@ -34,6 +24,36 @@ class SyliusShop {
         Encore.reset();
 
         return shopConfig;
+    }
+
+    static _getInternalWebpackConfig(rootDir) {
+        this._prepareWebpackConfig(rootDir);
+        // For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
+        Encore
+            .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/app.js'))
+            .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
+        const shopConfig = Encore.getWebpackConfig();
+
+        shopConfig.externals = { ...shopConfig.externals, window: 'window', document: 'document' };
+        shopConfig.name = 'shop';
+
+        Encore.reset();
+
+        return shopConfig;
+    }
+
+    static _prepareWebpackConfig(rootDir) {
+        Encore
+            .setOutputPath('public/build/shop/')
+            .setPublicPath('/build/shop')
+            .disableSingleRuntimeChunk()
+            .cleanupOutputBeforeBuild()
+            .enableSourceMaps(!Encore.isProduction())
+            .enableVersioning(Encore.isProduction())
+            .enableSassLoader((options) => {
+                // eslint-disable-next-line no-param-reassign
+                options.additionalData = `$rootDir: '${rootDir}';`;
+            })
     }
 }
 

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -11,7 +11,11 @@ const path = require('path');
 const Encore = require('@symfony/webpack-encore');
 
 class SyliusShop {
-    static getWebpackConfig(rootDir) {
+    /**
+     * Provide a light Webpack configuration for Sylius Admin
+     * All the stimulus stuff should be handled by the app.shop entrypoint
+     */
+    static getBaseWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         Encore
             .addEntry('shop-entry', path.resolve(__dirname, 'Resources/assets/entrypoint.js'))
@@ -26,7 +30,12 @@ class SyliusShop {
         return shopConfig;
     }
 
-    static _getInternalWebpackConfig(rootDir) {
+    /**
+     * For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
+     * For instances started with Sylius-Standard < 2.0.4, it'll still be used unless upgrading webpack.config.js
+     * to use the method above getBaseWebpackConfig()
+     */
+    static getWebpackConfig(rootDir) {
         this._prepareWebpackConfig(rootDir);
         // For a ready-to-use Stimulus bridge. Should be used only for sylius/sylius tests
         Encore

--- a/src/Sylius/Bundle/ShopBundle/package.json
+++ b/src/Sylius/Bundle/ShopBundle/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-env": "^7.25.8",
     "@hotwired/stimulus": "^3.0.0",
     "@popperjs/core": "^2.11.8",
+    "@sylius/shop-bundle": "file:Resources/assets/",
     "@symfony/stimulus-bridge": "^3.2.0",
     "@symfony/webpack-encore": "^5.0.1",
     "bootstrap": "^5.3.3",

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -3,16 +3,16 @@
 {% if form.customer is defined %}
     <div {{ stimulus_controller('@sylius/shop-bundle/api-login', {url: path('sylius_shop_json_login_check')} ) }}>
         <div class="d-none">
-            <div class="alert alert-danger" data-api-login-target="errorPrototype"></div>
+            <div class="alert alert-danger" {{ stimulus_target('@sylius/shop-bundle/api-login', 'errorPrototype') }}></div>
         </div>
         {{ form_row(form.customer.email, sylius_test_form_attribute('login-email')|sylius_merge_recursive({attr: {'data-sylius--shop-bundle--api-login-target': 'email'}})) }}
         {% if hookable_metadata.context.email_exists %}
             <div class="input-group mb-2">
-                <input type="password" class="form-control" placeholder="{{ 'sylius.ui.password'|trans }}" data-api-login-target="password" {{ sylius_test_html_attribute('password-input') }}>
-                <button class="btn btn-primary" type="button" data-action="api-login#login" {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
+                <input type="password" class="form-control" placeholder="{{ 'sylius.ui.password'|trans }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'password') }} {{ sylius_test_html_attribute('password-input') }}>
+                <button class="btn btn-primary" type="button" {{ stimulus_action('@sylius/shop-bundle/api-login', 'login') }} {{ sylius_test_html_attribute('login-button') }}>{{ 'sylius.ui.sign_in'|trans }}</button>
             </div>
-            <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" data-api-login-target="csrfToken">
-            <div data-api-login-target="error" {{ sylius_test_html_attribute('login-validation-error') }}></div>
+            <input type="hidden" name="_csrf_shop_security_token" value="{{ csrf_token('shop_authenticate') }}" {{ stimulus_target('@sylius/shop-bundle/api-login', 'csrfToken') }}>
+            <div {{ stimulus_target('@sylius/shop-bundle/api-login', 'error') }} {{ sylius_test_html_attribute('login-validation-error') }}></div>
         {% endif %}
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/user.html.twig
@@ -1,11 +1,11 @@
 {% set form = hookable_metadata.context.form %}
 
 {% if form.customer is defined %}
-    <div {{ stimulus_controller('api-login', {url: path('sylius_shop_json_login_check')} ) }}>
+    <div {{ stimulus_controller('@sylius/shop-bundle/api-login', {url: path('sylius_shop_json_login_check')} ) }}>
         <div class="d-none">
             <div class="alert alert-danger" data-api-login-target="errorPrototype"></div>
         </div>
-        {{ form_row(form.customer.email, sylius_test_form_attribute('login-email')|sylius_merge_recursive({attr: {'data-api-login-target': 'email'}})) }}
+        {{ form_row(form.customer.email, sylius_test_form_attribute('login-email')|sylius_merge_recursive({attr: {'data-sylius--shop-bundle--api-login-target': 'email'}})) }}
         {% if hookable_metadata.context.email_exists %}
             <div class="input-group mb-2">
                 <input type="password" class="form-control" placeholder="{{ 'sylius.ui.password'|trans }}" data-api-login-target="password" {{ sylius_test_html_attribute('password-input') }}>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const SyliusAdmin = require('@sylius-ui/admin');
 const SyliusShop = require('@sylius-ui/shop');
 
-const adminConfig = SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
-const shopConfig = SyliusShop.getWebpackConfig(path.resolve(__dirname));
+const adminConfig = SyliusAdmin._getInternalWebpackConfig(path.resolve(__dirname));
+const shopConfig = SyliusShop._getInternalWebpackConfig(path.resolve(__dirname));
 
 module.exports = [adminConfig, shopConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const SyliusAdmin = require('@sylius-ui/admin');
 const SyliusShop = require('@sylius-ui/shop');
 
-const adminConfig = SyliusAdmin._getInternalWebpackConfig(path.resolve(__dirname));
-const shopConfig = SyliusShop._getInternalWebpackConfig(path.resolve(__dirname));
+const adminConfig = SyliusAdmin.getWebpackConfig(path.resolve(__dirname));
+const shopConfig = SyliusShop.getWebpackConfig(path.resolve(__dirname));
 
 module.exports = [adminConfig, shopConfig];


### PR DESCRIPTION
Hello :wave: 

Adding Stimulus in v2.0 is a great step forward!

I'd like to make its usage easier in real-world applications.

This is a first PR, with a following that will target Sylius-Standard (https://github.com/Sylius/Sylius-Standard/pull/1126)

## What this PR do ? 

Mainly rewrite the webpackConfig provided by Sylius to destination of the Sylius-Standard, and move the controllers into the controllers.json for both admin and shop bundle. 

## Why ? 

When I synced the recipe of stimulus-bridge on a Sylius-Standard version, a new `assets/controllers.json` appears, loading symfony/ux-autocomplete and symfony/ux-live

It seemed to me legitimate to add this new file in my own webpack config (ie the app one, both for admin/shop). But after that, there was issue with firing double events (also noticed by @loic425 on https://github.com/Sylius/Stack/pull/253) 

Also, as I plan to create some plugins that could have stimulus controller, I want them to be added directly on the app, thanks to flex. 

## How ? 

So, in the webpackConfig classes for Admin and Shop, I created a new getBaseWebpackConfig method that **will not** include any stimulus stuff. The original method still exists, to be used by this project (sylius/sylius as standalone).

I created in both Admin and Shop a new `package.json` (named @sylius/admin-bundle and @sylius/shop-bundle) that expose the existing stimulus controllers for flex. 

WebpackEncore will be able to retrieve them in assets/controllers.json or assets/{app}/controllers.json

On the Sylius-Standard PR, I will provide a way to merge both them to load it into enableStimulusBridge

### Pros
This approach would be very beneficial for end developers who want to fully embrace the Symfony UX ecosystem.
The flex mechanism only allows to update assets/controllers.json, and it'll do after require a package, that bring already imported controllers into the final app. It'll prevent the double call that could occur and give more flexibility to devs.

### Cons
As it'll be up to the final app to having them into their controllers.json, we can't add new stimulus controllers and expect them to be automatically wired in the final app... unless we give a new breath to the PR https://github.com/Sylius/Sylius-Standard/pull/982. With it, and by requiring sylius/shop-bundle, any new controllers exposed in package.json will be updated in the final app controllers.json

### Why targeting 2.0 ?

It looks like a new feature, but IMHO, I think we should handle this as soon as possible, to help every plugin developer to expose easily stimulus controllers, and speed-up the plugin portage on v2

What do you think ? 

---

| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced fully namespaced Stimulus controllers for both Admin and Shop interfaces, enhancing modularity and integration with Symfony UX.
  - Added new JavaScript package definitions for Admin and Shop bundles, enabling improved asset management and controller configuration.

- **Refactor**
  - Updated all Stimulus controller references in templates to use fully qualified namespaced identifiers.
  - Streamlined controller registration and loading for Admin and Shop bundles, reducing manual imports and improving maintainability.
  - Modularized Webpack configuration with new base config methods and centralized common setup logic.

- **Chores**
  - Updated package and composer metadata to include Symfony UX compatibility keywords.
  - Improved Webpack configuration setup for both Admin and Shop bundles, offering simplified and modular build options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->