### PR TITLE
Change emitUp to emit

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Product/AddToCartFormComponent.php
@@ -104,7 +104,7 @@ class AddToCartFormComponent
         }
         $this->variant = $newVariant;
 
-        $this->emitUp(self::SYLIUS_SHOP_VARIANT_CHANGED, ['variantId' => $this->variant?->getId()]);
+        $this->emit(self::SYLIUS_SHOP_VARIANT_CHANGED, ['variantId' => $this->variant?->getId()]);
     }
 
     /** @param array<string, mixed> $routeParameters */


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Changing Add to card component event scope. Previously we had `emitUp` - only to parent. Now it is `emit` globally