### PR TITLE
[Composer] Bump phparkitect to install latest behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -217,7 +217,7 @@
         "mockery/mockery": "^1.4",
         "payum/paypal-express-checkout-nvp": "^1.7.3",
         "payum/stripe": "^1.7.3",
-        "phparkitect/phparkitect": "^0.2.9",
+        "phparkitect/phparkitect": "^0.2.9 || ^0.5",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.6",

--- a/phparkitect.php
+++ b/phparkitect.php
@@ -37,7 +37,7 @@ return static function (Config $config): void
     $config->add(
         $testsClassSet,
         Rule::allClasses()
-            ->that(new HaveNameMatching('*Test$'))
+            ->that(new HaveNameMatching('*Test'))
             ->should(new IsFinal())
             ->because('Tests should not be extendable')
         ,

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -35,7 +35,7 @@
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "nelmio/alice": "^3.8",
-        "phparkitect/phparkitect": "^0.2.9",
+        "phparkitect/phparkitect": "^0.2.9 || ^0.5",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Bump phparkitect to enable installation of latest behat -> to fix failing test 😆  
