### PR TITLE
[Admin] Missing role icon in menu

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
@@ -375,7 +375,7 @@ final class MainMenuBuilder
         $administration = $menu
             ->addChild('sylius.ui.administration')
             ->setLabel('sylius.ui.administration')
-            ->setLabelAttribute('icon', 'tabler:lock')
+            ->setLabelAttribute('icon', 'lock')
         ;
 
         $administration
@@ -383,6 +383,7 @@ final class MainMenuBuilder
             ->setUri('https://sylius.com/plus/?utm_source=product&utm_medium=placeholder&utm_campaign=rbac-placeholder')
             ->setLinkAttribute('target', '_blank')
             ->setLabel('sylius.ui.roles')
+            ->setLabelAttribute('icon', 'users')
             ->setExtra('plus_logo', true)
         ;
     }


### PR DESCRIPTION
Adding a missing menu icon next to roles
![obraz](https://github.com/user-attachments/assets/9bc3eeb3-0d76-4691-98b1-79c8ca3390ed)
