### PR TITLE
Allow ORM 3 on Channel bundle

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -27,12 +27,12 @@
     "require": {
         "php": "^8.2",
         "sylius/channel": "^2.0",
-        "sylius/resource-bundle": "^1.12",
+        "sylius/resource-bundle": "^1.12 || ^1.13@alpha",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13",
-        "doctrine/orm": "^2.18",
+        "doctrine/orm": "^2.18 || ^3.3",
         "matthiasnoback/symfony-dependency-injection-test": "^5.1",
         "phpspec/phpspec": "^7.5",
         "phpunit/phpunit": "^10.5",
@@ -40,9 +40,6 @@
         "symfony/dependency-injection": "^6.4.1 || ^7.2",
         "symfony/form": "^6.4.1 || ^7.2",
         "twig/twig": "^3.14"
-    },
-    "conflict": {
-        "doctrine/orm": ">= 3.0"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #17972 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Based on #17971 

![image](https://github.com/user-attachments/assets/0dfc58c5-b326-46c6-9b16-2ff55aafc009)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PHP 8.3 and Symfony 7.2 in the test environments.
  - Introduced a new dependency, mozex/anthropic-php, to the state machine abstraction package.

- **Dependency Updates**
  - Expanded compatibility for sylius/resource-bundle and doctrine/orm in AddressingBundle and ChannelBundle.
  - Updated conflict and require sections in composer.json files to reflect new compatibility and restrictions.
  - Declared new conflict with behat/gherkin package.

- **Chores**
  - Improved workflow job labeling and environment variable handling for test jobs.
  - Changed Robo installation method in CI workflows.
  - Adjusted workflow step to ignore failures in package version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->