### PR TITLE
Allow ORM 3 on Currency bundle

### DIFF
--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -27,16 +27,13 @@
     "require": {
         "php": "^8.2",
         "sylius/currency": "^2.0",
-        "sylius/resource-bundle": "^1.12",
+        "sylius/resource-bundle": "^1.12 || ^1.13@alpha",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/intl": "^6.4 || ^7.2"
     },
-    "conflict": {
-        "doctrine/orm": ">= 3.0"
-    },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13",
-        "doctrine/orm": "^2.18",
+        "doctrine/orm": "^2.18 || ^3.3",
         "matthiasnoback/symfony-dependency-injection-test": "^5.1",
         "phpspec/phpspec": "^7.5",
         "phpunit/phpunit": "^10.5",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #17972 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Based on #17971

![image](https://github.com/user-attachments/assets/038c5fa1-5f99-4179-a8e9-746c2cb397aa)
