### PR TITLE
[Taxonomy] Fix static analysis in component tests

### DIFF
--- a/src/Sylius/Component/Taxonomy/tests/Model/TaxonTest.php
+++ b/src/Sylius/Component/Taxonomy/tests/Model/TaxonTest.php
@@ -114,7 +114,7 @@ final class TaxonTest extends TestCase
     public function testShouldReturnAnEmptyListOfAncestorsIfCalledOnRootTaxon(): void
     {
         $this->assertTrue($this->taxon->isRoot());
-        $this->assertEmpty($this->taxon->getAncestors());
+        $this->assertTrue($this->taxon->getAncestors()->isEmpty());
     }
 
     public function testShouldBeUnnamedByDefault(): void
@@ -230,7 +230,7 @@ final class TaxonTest extends TestCase
     public function testShouldHaveNoChildrenByDefault(): void
     {
         $this->assertFalse($this->taxon->hasChildren());
-        $this->assertEmpty($this->taxon->getChildren());
+        $this->assertTrue($this->taxon->getChildren()->isEmpty());
     }
 
     public function testShouldHaveChildrenWhenChildrenHasBeenAdded(): void


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17962
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test assertions to use the `isEmpty()` method for verifying empty ancestor and children collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->