### PR TITLE
Allow ORM 3 on Customer bundle

### DIFF
--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -36,10 +36,10 @@
     ],
     "require": {
         "php": "^8.2",
-        "doctrine/orm": "^2.18",
+        "doctrine/orm": "^2.18 || ^3.3",
         "egulias/email-validator": "^4.0",
         "sylius/customer": "^2.0",
-        "sylius/resource-bundle": "^1.12",
+        "sylius/resource-bundle": "^1.12 || ^1.13@alpha",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "webmozart/assert": "^1.11"
     },


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #17972 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Based on #17971

![image](https://github.com/user-attachments/assets/ed2587b2-cc29-48cb-aa93-8f67e2addd7a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PHP 8.3 and Symfony 7.2 in the CI pipeline.
  - Introduced a new dependency, "mozex/anthropic-php", to the State Machine Abstraction package.

- **Bug Fixes**
  - Improved handling of Doctrine ORM versions in package pipelines and CI jobs.

- **Chores**
  - Broadened dependency version constraints for several packages to support newer versions.
  - Updated Composer conflict rules to include "behat/gherkin" version ^4.13.0.
  - Changed Robo tool installation method in CI for improved reliability.
  - Adjusted CI validation step to prevent workflow failures on non-zero exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->