### PR TITLE
Allow ORM 3 on Inventory bundle

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -28,17 +28,16 @@
     "require": {
         "php": "^8.2",
         "sylius/inventory": "^2.0",
-        "sylius/resource-bundle": "^1.12",
+        "sylius/resource-bundle": "^1.12 || ^1.13@alpha",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/validator": "^6.4 || ^7.2"
     },
     "conflict": {
-        "doctrine/orm": ">= 3.0",
         "phpstan/phpdoc-parser": ">= 2.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.13",
-        "doctrine/orm": "^2.18",
+        "doctrine/orm": "^2.18 || ^3.3",
         "phpspec/phpspec": "^7.5",
         "phpunit/phpunit": "^10.5",
         "symfony/browser-kit": "^6.4 || ^7.2",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #17972 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Based on #17971

![image](https://github.com/user-attachments/assets/fe33f44e-b74b-4cb2-96d3-bfb75562e69a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PHP 8.3, Symfony ^7.2, and Doctrine ORM ^3.3 in continuous integration testing.

- **Bug Fixes**
  - Improved workflow job naming and environment variable handling for clearer CI results.

- **Chores**
  - Updated dependency constraints to support newer versions of Sylius ResourceBundle and Doctrine ORM.
  - Declared a conflict with behat/gherkin ^4.13.0 to prevent compatibility issues.
  - Changed Robo installation method in CI for improved reliability.
  - Adjusted validation steps in CI to prevent job failures from non-critical errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->