### PR TITLE
[Locale] Fix locale context in single process runtime

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
@@ -17,13 +17,14 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Locale context implementation based on Symfony Request's language negotiation (RFC 4647 based).
  *
  * @see Request::getPreferredLanguage()
  */
-final class RequestHeaderBasedLocaleContext implements LocaleContextInterface
+final class RequestHeaderBasedLocaleContext implements LocaleContextInterface, ResetInterface
 {
     private const NO_CODE_VALID_STUB = 'no_Code';
 
@@ -61,5 +62,10 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface
         }
 
         return $bestLocaleCode;
+    }
+
+    public function reset(): void
+    {
+        $this->availableLocalesCodes = [];
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17990
| License         | MIT

So, when RoadRunner is used in its default configuration, it runs a single process handling many requests. This means the whole codebase should remain stateless. However, the RequestHeaderBasedLocaleContext sets a property for optimization during runtime, which makes the service stateful. As a result, this can lead to incorrect locale selection across multiple channels.
The proposed solution comes from here: [RoadRunner Bundle - Kernel Reboots](https://github.com/Baldinof/roadrunner-bundle?tab=readme-ov-file#kernel-reboots) — it implements the ResetInterface.