### PR TITLE
Allow ORM 3 on Core component

### DIFF
--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -27,6 +27,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "doctrine/common": "^3.0.3",
         "guzzlehttp/guzzle": "^7.9",
         "knplabs/gaufrette": "^0.11",
         "laminas/laminas-stdlib": "^3.19",
@@ -60,7 +61,7 @@
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "doctrine/orm": "^2.18",
+        "doctrine/orm": "^2.18 || ^3.3",
         "phpspec/phpspec": "^7.5",
         "phpunit/phpunit": "^10.5",
         "symfony/property-access": "^6.4 || ^7.2"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #17972 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
