### PR TITLE
Narrowing return types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,7 +37,6 @@ parameters:
     ignoreErrors:
         - identifier: missingType.generics # This need to be fixed, too many classes are using generics without PHPDoc type
         - identifier: varTag.nativeType
-        - identifier: return.unusedType
         - '/(Interface|Class) [a-zA-Z\\]+ specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior, we are basing on Psalm for generics checks        - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'
         - '/Method Sylius\\Bundle\\(Admin|Shop)Bundle\\Twig\\Component\\[a-zA-Z\\]+\:\:getDataModelValue\(\) is unused./'
         - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -35,7 +35,7 @@ final class LocaleExtension extends AbstractExtension
         ];
     }
 
-    public function convertCodeToName(string $code, ?string $localeCode = null): ?string
+    public function convertCodeToName(string $code, ?string $localeCode = null): string
     {
         try {
             return $this->localeConverter->convertCodeToName($code, $this->getLocaleCode($localeCode));

--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/MoneyIntToLocalizedStringTransformer.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedString
 
 final class MoneyIntToLocalizedStringTransformer extends MoneyToLocalizedStringTransformer
 {
-    public function reverseTransform(mixed $value): float|int|null
+    public function reverseTransform(mixed $value): ?int
     {
         if (!is_numeric($value)) {
             return null;

--- a/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/PercentFloatToLocalizedStringTransformer.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/DataTransformer/PercentFloatToLocalizedStringTransformer.php
@@ -23,12 +23,10 @@ final class PercentFloatToLocalizedStringTransformer extends PercentToLocalizedS
      *
      * @param string $value Percentage value
      *
-     * @return float Normalized value
-     *
      * @throws TransformationFailedException if the given value is not a string or
      *                                       if the value could not be transformed
      */
-    public function reverseTransform(mixed $value): float|int|null
+    public function reverseTransform(mixed $value): ?float
     {
         if (!is_numeric($value)) {
             return null;

--- a/src/Sylius/Component/Core/Payment/Provider/OrderPaymentProvider.php
+++ b/src/Sylius/Component/Core/Payment/Provider/OrderPaymentProvider.php
@@ -33,7 +33,7 @@ final class OrderPaymentProvider implements OrderPaymentProviderInterface
     ) {
     }
 
-    public function provideOrderPayment(OrderInterface $order, string $targetState): ?PaymentInterface
+    public function provideOrderPayment(OrderInterface $order, string $targetState): PaymentInterface
     {
         /** @var PaymentInterface $payment */
         $payment = $this->paymentFactory->createWithAmountAndCurrencyCode(


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #17963
| License         | MIT

Removing types that are impossible to reach from the return type or the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated several method return types to be more specific and non-nullable, improving consistency and reliability of returned values across locale and promotion functionalities.

- **Chores**
  - Adjusted static analysis configuration to report unused return type issues, leading to more accurate code analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->