### PR TITLE
[PHPSpec to PHPUnit] Customer Component Fix

### DIFF
--- a/src/Sylius/Component/Customer/tests/Model/CustomerGroupTest.php
+++ b/src/Sylius/Component/Customer/tests/Model/CustomerGroupTest.php
@@ -27,12 +27,12 @@ final class CustomerGroupTest extends TestCase
         $this->customerGroup = new CustomerGroup();
     }
 
-    public function testShouldImplementsCustomerGroupInterface(): void
+    public function testImplementsCustomerGroupInterface(): void
     {
         $this->assertInstanceOf(CustomerGroupInterface::class, $this->customerGroup);
     }
 
-    public function testShouldHasNoNameByDefault(): void
+    public function testHasNoNameByDefault(): void
     {
         self::assertNull($this->customerGroup->getName());
     }

--- a/src/Sylius/Component/Customer/tests/Model/CustomerTest.php
+++ b/src/Sylius/Component/Customer/tests/Model/CustomerTest.php
@@ -28,7 +28,7 @@ final class CustomerTest extends TestCase
         $this->customer = new Customer();
     }
 
-    public function testShouldImplementCustomerInterface(): void
+    public function testImplementCustomerInterface(): void
     {
         self::assertInstanceOf(CustomerInterface::class, $this->customer);
     }
@@ -51,7 +51,7 @@ final class CustomerTest extends TestCase
         self::assertSame('Thatch', $this->customer->getLastName());
     }
 
-    public function testFullNameShoudBeMutable(): void
+    public function testFullNameShouldBeMutable(): void
     {
         $this->customer->setFirstName('Edward');
         $this->customer->setLastName('Kenway');
@@ -90,7 +90,7 @@ final class CustomerTest extends TestCase
         self::assertTrue($this->customer->isMale());
     }
 
-    public function testShouldHasNoGroupByDefault(): void
+    public function testHasNoGroupByDefault(): void
     {
         self::assertNull($this->customer->getGroup());
     }

--- a/src/Sylius/Component/Customer/tests/Model/CustomerTest.php
+++ b/src/Sylius/Component/Customer/tests/Model/CustomerTest.php
@@ -28,7 +28,7 @@ final class CustomerTest extends TestCase
         $this->customer = new Customer();
     }
 
-    public function testImplementCustomerInterface(): void
+    public function testImplementsCustomerInterface(): void
     {
         self::assertInstanceOf(CustomerInterface::class, $this->customer);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | OP-571
| License         | MIT

This is a fix to  [PHPSpec to PHPUnit] Customer Component #18003  -Fixing function names

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Improved clarity and consistency of test method names for customer and customer group tests. No changes to test behavior or results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->