### PR TITLE
[PHPSpec to PHPUnit] Attribute Component Fix

### DIFF
--- a/src/Sylius/Component/Attribute/tests/AttributeType/FloatAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/FloatAttributeTypeTest.php
@@ -63,13 +63,9 @@ class FloatAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -84,16 +80,17 @@ class FloatAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -108,8 +105,8 @@ class FloatAttributeTypeTest extends TestCase
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/AttributeType/FloatAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/FloatAttributeTypeTest.php
@@ -81,31 +81,20 @@ class FloatAttributeTypeTest extends TestCase
             ->willReturn($constraintViolationList);
 
         $constraintViolationList->expects(self::once())->method('rewind');
-
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
-
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/IntegerAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/IntegerAttributeTypeTest.php
@@ -65,9 +65,7 @@ class IntegerAttributeTypeTest extends TestCase
 
         $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -87,27 +85,17 @@ class IntegerAttributeTypeTest extends TestCase
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
-
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/IntegerAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/IntegerAttributeTypeTest.php
@@ -63,9 +63,7 @@ class IntegerAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
         $context->expects(self::once())
             ->method('getValidator')
@@ -84,16 +82,17 @@ class IntegerAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -109,8 +108,7 @@ class IntegerAttributeTypeTest extends TestCase
             ->with('value')
             ->willReturn($constraintViolationBuilder);
 
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/AttributeType/PercentAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/PercentAttributeTypeTest.php
@@ -16,7 +16,6 @@ namespace Tests\Sylius\Component\Attribute\AttributeType;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Attribute\AttributeType\AttributeTypeInterface;
 use Sylius\Component\Attribute\AttributeType\PercentAttributeType;
-use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -57,7 +56,6 @@ class PercentAttributeTypeTest extends TestCase
 
     public function testChecksIfAttributeValueIsValid(): void
     {
-        $attribute = $this->createMock(AttributeInterface::class);
         $attributeValue = $this->createMock(AttributeValueInterface::class);
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraintViolation = $this->createMock(ConstraintViolationInterface::class);
@@ -65,13 +63,9 @@ class PercentAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -86,20 +80,19 @@ class PercentAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
 
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
+        $constraintViolationList->expects(self::once())->method('next');
+
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
 
         $context->expects(self::once())
             ->method('buildViolation')
@@ -110,8 +103,8 @@ class PercentAttributeTypeTest extends TestCase
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/AttributeType/PercentAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/PercentAttributeTypeTest.php
@@ -81,29 +81,20 @@ class PercentAttributeTypeTest extends TestCase
             ->willReturn($constraintViolationList);
 
         $constraintViolationList->expects(self::once())->method('rewind');
-
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
         $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
-
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/SelectAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/SelectAttributeTypeTest.php
@@ -81,31 +81,20 @@ class SelectAttributeTypeTest extends TestCase
             ->willReturn($constraintViolationList);
 
         $constraintViolationList->expects(self::once())->method('rewind');
-
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
-
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/SelectAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/SelectAttributeTypeTest.php
@@ -16,7 +16,6 @@ namespace Tests\Sylius\Component\Attribute\AttributeType;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Attribute\AttributeType\AttributeTypeInterface;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
-use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -57,7 +56,6 @@ class SelectAttributeTypeTest extends TestCase
 
     public function testChecksIfAttributeValueIsValid(): void
     {
-        $attribute = $this->createMock(AttributeInterface::class);
         $attributeValue = $this->createMock(AttributeValueInterface::class);
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraintViolation = $this->createMock(ConstraintViolationInterface::class);
@@ -65,13 +63,9 @@ class SelectAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -86,16 +80,17 @@ class SelectAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -105,12 +100,13 @@ class SelectAttributeTypeTest extends TestCase
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
+
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/AttributeType/TextAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/TextAttributeTypeTest.php
@@ -141,31 +141,20 @@ class TextAttributeTypeTest extends TestCase
             ->willReturn($constraintViolationList);
 
         $constraintViolationList->expects(self::once())->method('rewind');
-
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
-
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/TextAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/TextAttributeTypeTest.php
@@ -58,7 +58,6 @@ class TextAttributeTypeTest extends TestCase
 
     public function testChecksIfAttributeValueIsValidAccordingToMinAndMaxConstraint(): void
     {
-        $attribute = $this->createMock(AttributeInterface::class);
         $attributeValue = $this->createMock(AttributeValueInterface::class);
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraintViolation = $this->createMock(ConstraintViolationInterface::class);
@@ -66,13 +65,9 @@ class TextAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn('X');
+        $attributeValue->expects(self::once())->method('getValue')->willReturn('X');
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -87,16 +82,17 @@ class TextAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -106,12 +102,13 @@ class TextAttributeTypeTest extends TestCase
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
+
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['min' => 2, 'max' => 255]);
     }
@@ -126,13 +123,9 @@ class TextAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -147,16 +140,17 @@ class TextAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -166,12 +160,13 @@ class TextAttributeTypeTest extends TestCase
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
+
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/AttributeType/TextareaAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/TextareaAttributeTypeTest.php
@@ -81,31 +81,20 @@ class TextareaAttributeTypeTest extends TestCase
             ->willReturn($constraintViolationList);
 
         $constraintViolationList->expects(self::once())->method('rewind');
-
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
-
-        $constraintViolationList->expects(self::once())
-            ->method('current')
-            ->willReturn($constraintViolation);
-
+        $constraintViolationList->expects(self::once())->method('current')->willReturn($constraintViolation);
         $constraintViolationList->expects(self::once())->method('next');
-
-        $constraintViolation->expects(self::once())
-            ->method('getMessage')
-            ->willReturn('error message');
-
+        $constraintViolation->expects(self::once())->method('getMessage')->willReturn('error message');
         $context->expects(self::once())
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-
         $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);

--- a/src/Sylius/Component/Attribute/tests/AttributeType/TextareaAttributeTypeTest.php
+++ b/src/Sylius/Component/Attribute/tests/AttributeType/TextareaAttributeTypeTest.php
@@ -16,7 +16,6 @@ namespace Tests\Sylius\Component\Attribute\AttributeType;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Attribute\AttributeType\AttributeTypeInterface;
 use Sylius\Component\Attribute\AttributeType\TextareaAttributeType;
-use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -57,7 +56,6 @@ class TextareaAttributeTypeTest extends TestCase
 
     public function testChecksIfAttributeValueIsValid(): void
     {
-        $attribute = $this->createMock(AttributeInterface::class);
         $attributeValue = $this->createMock(AttributeValueInterface::class);
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraintViolation = $this->createMock(ConstraintViolationInterface::class);
@@ -65,13 +63,9 @@ class TextareaAttributeTypeTest extends TestCase
         $context = $this->createMock(ExecutionContextInterface::class);
         $validator = $this->createMock(ValidatorInterface::class);
 
-        $attributeValue->expects(self::once())
-            ->method('getValue')
-            ->willReturn(null);
+        $attributeValue->expects(self::once())->method('getValue')->willReturn(null);
 
-        $context->expects(self::once())
-            ->method('getValidator')
-            ->willReturn($validator);
+        $context->expects(self::once())->method('getValidator')->willReturn($validator);
 
         $validator->expects(self::once())
             ->method('validate')
@@ -86,16 +80,17 @@ class TextareaAttributeTypeTest extends TestCase
             }))
             ->willReturn($constraintViolationList);
 
-        $constraintViolationList->expects(self::once())
-            ->method('rewind');
+        $constraintViolationList->expects(self::once())->method('rewind');
+
         $constraintViolationList->expects(self::exactly(2))
             ->method('valid')
             ->willReturnOnConsecutiveCalls(true, false);
+
         $constraintViolationList->expects(self::once())
             ->method('current')
             ->willReturn($constraintViolation);
-        $constraintViolationList->expects(self::once())
-            ->method('next');
+
+        $constraintViolationList->expects(self::once())->method('next');
 
         $constraintViolation->expects(self::once())
             ->method('getMessage')
@@ -105,12 +100,13 @@ class TextareaAttributeTypeTest extends TestCase
             ->method('buildViolation')
             ->with('error message')
             ->willReturn($constraintViolationBuilder);
+
         $constraintViolationBuilder->expects(self::once())
             ->method('atPath')
             ->with('value')
             ->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->expects(self::once())
-            ->method('addViolation');
+
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->type->validate($attributeValue, $context, ['required' => true]);
     }

--- a/src/Sylius/Component/Attribute/tests/Factory/AttributeFactoryTest.php
+++ b/src/Sylius/Component/Attribute/tests/Factory/AttributeFactoryTest.php
@@ -30,25 +30,24 @@ class AttributeFactoryTest extends TestCase
     /** @var MockObject&ServiceRegistryInterface */
     private ServiceRegistryInterface $attributeTypesRegistry;
 
+    private AttributeFactory $attributeFactory;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->factory = $this->createMock(FactoryInterface::class);
         $this->attributeTypesRegistry = $this->createMock(ServiceRegistryInterface::class);
+        $this->attributeFactory = new AttributeFactory($this->factory, $this->attributeTypesRegistry);
     }
 
     public function testCanBeInstantiated(): void
     {
-        $attributeFactory = new AttributeFactory($this->factory, $this->attributeTypesRegistry);
-
-        self::assertInstanceOf(AttributeFactory::class, $attributeFactory);
+        self::assertInstanceOf(AttributeFactory::class, $this->attributeFactory);
     }
 
     public function testShouldImplementAttributeFactoryInterface(): void
     {
-        $attributeFactory = new AttributeFactory($this->factory, $this->attributeTypesRegistry);
-
-        self::assertInstanceOf(AttributeFactoryInterface::class, $attributeFactory);
+        self::assertInstanceOf(AttributeFactoryInterface::class, $this->attributeFactory);
     }
 
     public function testCanCreatesUntypedAttribute(): void
@@ -58,8 +57,7 @@ class AttributeFactoryTest extends TestCase
             ->method('createNew')
             ->willReturn($untypedAttribute);
 
-        $attributeFactory = new AttributeFactory($this->factory, $this->attributeTypesRegistry);
-        self::assertSame($untypedAttribute, $attributeFactory->createNew());
+        self::assertSame($untypedAttribute, $this->attributeFactory->createNew());
     }
 
     public function testCanCreatesTypedAttribute(): void
@@ -87,8 +85,6 @@ class AttributeFactoryTest extends TestCase
             ->method('setStorageType')
             ->with('datetime');
 
-        $attributeFactory = new AttributeFactory($this->factory, $this->attributeTypesRegistry);
-
-        self::assertSame($typedAttribute, $attributeFactory->createTyped('datetime'));
+        self::assertSame($typedAttribute, $this->attributeFactory->createTyped('datetime'));
     }
 }

--- a/src/Sylius/Component/Attribute/tests/Factory/AttributeFactoryTest.php
+++ b/src/Sylius/Component/Attribute/tests/Factory/AttributeFactoryTest.php
@@ -30,7 +30,7 @@ class AttributeFactoryTest extends TestCase
     /** @var MockObject&ServiceRegistryInterface */
     private ServiceRegistryInterface $attributeTypesRegistry;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->factory = $this->createMock(FactoryInterface::class);

--- a/src/Sylius/Component/Attribute/tests/Model/AttributeValueTest.php
+++ b/src/Sylius/Component/Attribute/tests/Model/AttributeValueTest.php
@@ -78,7 +78,7 @@ class AttributeValueTest extends TestCase
         self::assertSame('en', $this->attributeValue->getLocaleCode());
     }
 
-    public function testShouldHasNoValueByDefalut(): void
+    public function testShouldHasNoValueByDefault(): void
     {
         self::assertNull($this->attributeValue->getValue());
     }

--- a/src/Sylius/Component/Attribute/tests/Model/AttributeValueTest.php
+++ b/src/Sylius/Component/Attribute/tests/Model/AttributeValueTest.php
@@ -43,7 +43,7 @@ class AttributeValueTest extends TestCase
         self::assertNull($this->attributeValue->getId());
     }
 
-    public function testShouldDoesNotBelongToASubjectByDefault(): void
+    public function testDoesNotBelongToASubjectByDefault(): void
     {
         self::assertNull($this->attributeValue->getSubject());
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | OP-571
| License         | MIT

Fix to  [PHPSpec to PHPUnit] Attribute Component #17984 

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Reformatted test code for improved readability by consolidating multi-line mock method calls into single lines.
  - Removed unused mock variables in several test methods.
- **Tests**
  - Corrected typos in test method names to improve clarity.
  - Updated method visibility and introduced shared setup in one test class for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->