### PR TITLE
[PHPSpec to PHPUnit] Locale Component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -222,7 +222,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.5",
         "psr/event-dispatcher": "^1.0",
-        "rector/custom-phpspec-to-phpunit": "*",
+        "rector/custom-phpspec-to-phpunit": "^0.6",
         "rector/rector": "^2.0",
         "robertfausk/behat-panther-extension": "^1.1",
         "sylius-labs/coding-standard": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -222,7 +222,7 @@
         "phpstan/phpstan-webmozart-assert": "^2.0",
         "phpunit/phpunit": "^10.5",
         "psr/event-dispatcher": "^1.0",
-        "rector/custom-phpspec-to-phpunit": "^0.6",
+        "rector/custom-phpspec-to-phpunit": "*",
         "rector/rector": "^2.0",
         "robertfausk/behat-panther-extension": "^1.1",
         "sylius-labs/coding-standard": "^4.4",

--- a/rector-spec-unit.php
+++ b/rector-spec-unit.php
@@ -12,7 +12,7 @@ use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
-        // __DIR__ . '/src/Sylius/Component/Addressing/spec',
+         __DIR__ . '/src/Sylius/Component/Locale/spec',
     ])
     ->withImportNames(removeUnusedImports: true)
     ->withSets([

--- a/rector-spec-unit.php
+++ b/rector-spec-unit.php
@@ -12,7 +12,7 @@ use Rector\Visibility\Rector\ClassMethod\ExplicitPublicClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
-         __DIR__ . '/src/Sylius/Component/Locale/spec',
+        // __DIR__ . '/src/Sylius/Addressing/Locale/spec',
     ])
     ->withImportNames(removeUnusedImports: true)
     ->withSets([

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -32,7 +32,8 @@
         "symfony/intl": "^6.4 || ^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "webmozart/assert": "^1.11"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -32,7 +32,7 @@
         "symfony/intl": "^6.4 || ^7.2"
     },
     "require-dev": {
-        "phpspec/phpspec": "^7.5"
+        "phpunit/phpunit": "^10.5"
     },
     "config": {
         "allow-plugins": {
@@ -54,7 +54,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Sylius\\Component\\Locale\\spec\\": "spec/"
+            "Tests\\Sylius\\Component\\Locale\\": "tests/"
         }
     },
     "repositories": [

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -29,11 +29,11 @@
         "php": "^8.2",
         "laminas/laminas-stdlib": "^3.19",
         "sylius/resource": "^1.12",
-        "symfony/intl": "^6.4 || ^7.2"
+        "symfony/intl": "^6.4 || ^7.2",
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5",
-        "webmozart/assert": "^1.11"
+        "phpunit/phpunit": "^10.5"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Component/Locale/phpspec.yml.dist
+++ b/src/Sylius/Component/Locale/phpspec.yml.dist
@@ -1,5 +1,0 @@
-suites:
-    main:
-        namespace: Sylius\Component\Locale
-        psr4_prefix: Sylius\Component\Locale
-        src_path: .

--- a/src/Sylius/Component/Locale/phpunit.xml.dist
+++ b/src/Sylius/Component/Locale/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="sylius_locale_component_test_suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Sylius/Component/Locale/spec/Context/ImmutableLocaleContextSpec.php
+++ b/src/Sylius/Component/Locale/spec/Context/ImmutableLocaleContextSpec.php
@@ -11,25 +11,27 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Context;
+namespace Tests\Sylius\Component\Locale\Context;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Locale\Context\ImmutableLocaleContext;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 
-final class ImmutableLocaleContextSpec extends ObjectBehavior
+final class ImmutableLocaleContextTest extends TestCase
 {
-    function let(): void
+    private ImmutableLocaleContext $immutableLocaleContext;
+    protected function setUp(): void
     {
-        $this->beConstructedWith('pl_PL');
+        $this->immutableLocaleContext = new ImmutableLocaleContext('pl_PL');
     }
 
-    function it_is_a_locale_context(): void
+    public function testALocaleContext(): void
     {
-        $this->shouldImplement(LocaleContextInterface::class);
+        $this->assertInstanceOf(LocaleContextInterface::class, $this->immutableLocaleContext);
     }
 
-    function it_gets_a_locale_code(): void
+    public function testGetsALocaleCode(): void
     {
-        $this->getLocaleCode()->shouldReturn('pl_PL');
+        $this->assertSame('pl_PL', $this->immutableLocaleContext->getLocaleCode());
     }
 }

--- a/src/Sylius/Component/Locale/spec/Context/ProviderBasedLocaleContextSpec.php
+++ b/src/Sylius/Component/Locale/spec/Context/ProviderBasedLocaleContextSpec.php
@@ -11,39 +11,45 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Context;
+namespace Tests\Sylius\Component\Locale\Context;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sylius\Component\Locale\Context\ProviderBasedLocaleContext;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
-final class ProviderBasedLocaleContextSpec extends ObjectBehavior
+final class ProviderBasedLocaleContextTest extends TestCase
 {
-    function let(LocaleProviderInterface $localeProvider): void
+    /**
+     * @var LocaleProviderInterface|MockObject
+     */
+    private MockObject $localeProviderMock;
+    private ProviderBasedLocaleContext $providerBasedLocaleContext;
+    protected function setUp(): void
     {
-        $this->beConstructedWith($localeProvider);
+        $this->localeProviderMock = $this->createMock(LocaleProviderInterface::class);
+        $this->providerBasedLocaleContext = new ProviderBasedLocaleContext($this->localeProviderMock);
     }
 
-    function it_is_a_locale_context(): void
+    public function testALocaleContext(): void
     {
-        $this->shouldImplement(LocaleContextInterface::class);
+        $this->assertInstanceOf(LocaleContextInterface::class, $this->providerBasedLocaleContext);
     }
 
-    function it_returns_the_channels_default_locale(LocaleProviderInterface $localeProvider): void
+    public function testReturnsTheChannelsDefaultLocale(): void
     {
-        $localeProvider->getAvailableLocalesCodes()->willReturn(['pl_PL', 'en_US']);
-        $localeProvider->getDefaultLocaleCode()->willReturn('pl_PL');
-
-        $this->getLocaleCode()->shouldReturn('pl_PL');
+        $this->localeProviderMock->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['pl_PL', 'en_US']);
+        $this->localeProviderMock->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
+        $this->assertSame('pl_PL', $this->providerBasedLocaleContext->getLocaleCode());
     }
 
-    function it_throws_a_locale_not_found_exception_if_default_locale_is_not_available(
-        LocaleProviderInterface $localeProvider,
-    ): void {
-        $localeProvider->getAvailableLocalesCodes()->willReturn(['es_ES', 'en_US']);
-        $localeProvider->getDefaultLocaleCode()->willReturn('pl_PL');
-
-        $this->shouldThrow(LocaleNotFoundException::class)->during('getLocaleCode');
+    public function testThrowsALocaleNotFoundExceptionIfDefaultLocaleIsNotAvailable(): void
+    {
+        $this->localeProviderMock->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['es_ES', 'en_US']);
+        $this->localeProviderMock->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
+        $this->expectException(LocaleNotFoundException::class);
+        $this->providerBasedLocaleContext->getLocaleCode();
     }
 }

--- a/src/Sylius/Component/Locale/spec/Converter/LocaleConverterSpec.php
+++ b/src/Sylius/Component/Locale/spec/Converter/LocaleConverterSpec.php
@@ -11,39 +11,48 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Converter;
+namespace Tests\Sylius\Component\Locale\Converter;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Locale\Converter\LocaleConverter;
+use InvalidArgumentException;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 
-final class LocaleConverterSpec extends ObjectBehavior
+final class LocaleConverterTest extends TestCase
 {
-    function it_is_a_locale_converter(): void
+    private LocaleConverter $localeConverter;
+    protected function setUp(): void
     {
-        $this->shouldImplement(LocaleConverterInterface::class);
+        $this->localeConverter = new LocaleConverter();
+    }
+    public function testALocaleConverter(): void
+    {
+        $this->assertInstanceOf(LocaleConverterInterface::class, $this->localeConverter);
     }
 
-    function it_converts_locale_name_to_locale_code(): void
+    public function testConvertsLocaleNameToLocaleCode(): void
     {
-        $this->convertNameToCode('German')->shouldReturn('de');
-        $this->convertNameToCode('Norwegian')->shouldReturn('no');
-        $this->convertNameToCode('Polish')->shouldReturn('pl');
+        $this->assertSame('de', $this->localeConverter->convertNameToCode('German'));
+        $this->assertSame('no', $this->localeConverter->convertNameToCode('Norwegian'));
+        $this->assertSame('pl', $this->localeConverter->convertNameToCode('Polish'));
     }
 
-    function it_converts_locale_code_to_locale_name(): void
+    public function testConvertsLocaleCodeToLocaleName(): void
     {
-        $this->convertCodeToName('de')->shouldReturn('German');
-        $this->convertCodeToName('no')->shouldReturn('Norwegian');
-        $this->convertCodeToName('pl')->shouldReturn('Polish');
+        $this->assertSame('German', $this->localeConverter->convertCodeToName('de'));
+        $this->assertSame('Norwegian', $this->localeConverter->convertCodeToName('no'));
+        $this->assertSame('Polish', $this->localeConverter->convertCodeToName('pl'));
     }
 
-    function it_throws_invalid_argument_exception_if_cannot_convert_name_to_code(): void
+    public function testThrowsInvalidArgumentExceptionIfCannotConvertNameToCode(): void
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('convertNameToCode', ['xyz']);
+        $this->expectException(InvalidArgumentException::class);
+        $this->localeConverter->convertNameToCode('xyz');
     }
 
-    function it_throws_invalid_argument_exception_if_cannot_convert_code_to_name(): void
+    public function testThrowsInvalidArgumentExceptionIfCannotConvertCodeToName(): void
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('convertCodeToName', ['xyz']);
+        $this->expectException(InvalidArgumentException::class);
+        $this->localeConverter->convertCodeToName('xyz');
     }
 }

--- a/src/Sylius/Component/Locale/spec/Model/LocaleSpec.php
+++ b/src/Sylius/Component/Locale/spec/Model/LocaleSpec.php
@@ -11,72 +11,70 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Model;
+namespace Tests\Sylius\Component\Locale\Model;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use Locale;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Model\TimestampableInterface;
 
-final class LocaleSpec extends ObjectBehavior
+final class LocaleTest extends TestCase
 {
-    function let(): void
+    private \Sylius\Component\Locale\Model\Locale $locale;
+    protected function setUp(): void
     {
-        \Locale::setDefault('en');
+        $this->locale = new \Sylius\Component\Locale\Model\Locale();
+        Locale::setDefault('en');
     }
 
-    function it_implements_a_locale_interface(): void
+    public function testImplementsALocaleInterface(): void
     {
-        $this->shouldImplement(LocaleInterface::class);
+        $this->assertInstanceOf(LocaleInterface::class, $this->locale);
     }
 
-    function it_is_timestampable(): void
+    public function testTimestampable(): void
     {
-        $this->shouldImplement(TimestampableInterface::class);
+        $this->assertInstanceOf(TimestampableInterface::class, $this->locale);
     }
 
-    function it_does_not_have_id_by_default(): void
+    public function testDoesNotHaveIdByDefault(): void
     {
-        $this->getId()->shouldReturn(null);
+        $this->assertNull($this->locale->getId());
     }
 
-    function it_has_no_code_by_default(): void
+    public function testHasNoCodeByDefault(): void
     {
-        $this->getCode()->shouldReturn(null);
+        $this->assertNull($this->locale->getCode());
     }
 
-    function its_code_is_mutable(): void
+    public function testItsCodeIsMutable(): void
     {
-        $this->setCode('de_DE');
-        $this->getCode()->shouldReturn('de_DE');
+        $this->locale->setCode('de_DE');
+        $this->assertSame('de_DE', $this->locale->getCode());
     }
 
-    function it_has_a_name(): void
+    public function testHasAName(): void
     {
-        $this->setCode('pl_PL');
-        $this->getName()->shouldReturn('Polish (Poland)');
-        $this->getName('es')->shouldReturn('polaco (Polonia)');
+        $this->locale->setCode('pl_PL');
+        $this->assertSame('Polish (Poland)', $this->locale->getName());
+        $this->assertSame('polaco (Polonia)', $this->locale->getName('es'));
 
-        $this->setCode('pl');
-        $this->getName()->shouldReturn('Polish');
-        $this->getName('es')->shouldReturn('polaco');
+        $this->locale->setCode('pl');
+        $this->assertSame('Polish', $this->locale->getName());
+        $this->assertSame('polaco', $this->locale->getName('es'));
     }
 
-    function it_returns_name_when_converted_to_string(): void
+    public function testReturnsNameWhenConvertedToString(): void
     {
-        $this->setCode('pl_PL');
-        $this->__toString()->shouldReturn('Polish (Poland)');
+        $this->locale->setCode('pl_PL');
+        $this->assertSame('Polish (Poland)', $this->locale->__toString());
 
-        $this->setCode('pl');
-        $this->__toString()->shouldReturn('Polish');
+        $this->locale->setCode('pl');
+        $this->assertSame('Polish', $this->locale->__toString());
     }
 
-    function it_initializes_creation_date_by_default(): void
+    public function testDoesNotHaveLastUpdateDateByDefault(): void
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
-    }
-
-    function it_does_not_have_last_update_date_by_default(): void
-    {
-        $this->getUpdatedAt()->shouldReturn(null);
+        $this->assertNull($this->locale->getUpdatedAt());
     }
 }

--- a/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/LocaleCollectionProviderSpec.php
@@ -11,35 +11,43 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Provider;
+namespace Tests\Sylius\Component\Locale\Provider;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sylius\Component\Locale\Provider\LocaleCollectionProvider;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 
-final class LocaleCollectionProviderSpec extends ObjectBehavior
+final class LocaleCollectionProviderTest extends TestCase
 {
+    /**
+     * @var RepositoryInterface|MockObject
+     */
+    private MockObject $localeRepositoryMock;
+    private LocaleCollectionProvider $localeCollectionProvider;
     /** @param RepositoryInterface<LocaleInterface> $localeRepository */
-    function let(RepositoryInterface $localeRepository): void
+    protected function setUp(): void
     {
-        $this->beConstructedWith($localeRepository);
+        $this->localeRepositoryMock = $this->createMock(RepositoryInterface::class);
+        $this->localeCollectionProvider = new LocaleCollectionProvider($this->localeRepositoryMock);
     }
 
-    function it_implements_locale_collection_provider_interface(): void
+    public function testImplementsLocaleCollectionProviderInterface(): void
     {
-        $this->shouldImplement(LocaleCollectionProviderInterface::class);
+        $this->assertInstanceOf(LocaleCollectionProviderInterface::class, $this->localeCollectionProvider);
     }
 
-    function it_returns_all_locales(
-        RepositoryInterface $localeRepository,
-        LocaleInterface $someLocale,
-        LocaleInterface $anotherLocale,
-    ): void {
-        $someLocale->getCode()->willReturn('en_US');
-        $anotherLocale->getCode()->willReturn('en_GB');
-        $localeRepository->findAll()->willReturn([$someLocale, $anotherLocale]);
-
-        $this->getAll()->shouldReturn(['en_US' => $someLocale, 'en_GB' => $anotherLocale]);
+    public function testReturnsAllLocales(): void
+    {
+        /** @var LocaleInterface|MockObject $someLocaleMock */
+        $someLocaleMock = $this->createMock(LocaleInterface::class);
+        /** @var LocaleInterface|MockObject $anotherLocaleMock */
+        $anotherLocaleMock = $this->createMock(LocaleInterface::class);
+        $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
+        $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');
+        $this->localeRepositoryMock->expects($this->once())->method('findAll')->willReturn([$someLocaleMock, $anotherLocaleMock]);
+        $this->assertSame(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock], $this->localeCollectionProvider->getAll());
     }
 }

--- a/src/Sylius/Component/Locale/spec/Provider/LocaleProviderSpec.php
+++ b/src/Sylius/Component/Locale/spec/Provider/LocaleProviderSpec.php
@@ -11,37 +11,44 @@
 
 declare(strict_types=1);
 
-namespace spec\Sylius\Component\Locale\Provider;
+namespace Tests\Sylius\Component\Locale\Provider;
 
-use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sylius\Component\Locale\Provider\LocaleProvider;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
-final class LocaleProviderSpec extends ObjectBehavior
+final class LocaleProviderTest extends TestCase
 {
-    function let(LocaleCollectionProviderInterface $localeCollectionProvider): void
+    /**
+     * @var LocaleCollectionProviderInterface|MockObject
+     */
+    private MockObject $localeCollectionProviderMock;
+    private LocaleProvider $localeProvider;
+    protected function setUp(): void
     {
-        $this->beConstructedWith($localeCollectionProvider, 'pl_PL');
+        $this->localeCollectionProviderMock = $this->createMock(LocaleCollectionProviderInterface::class);
+        $this->localeProvider = new LocaleProvider($this->localeCollectionProviderMock, 'pl_PL');
     }
 
-    function it_is_a_locale_provider_interface(): void
+    public function testALocaleProviderInterface(): void
     {
-        $this->shouldImplement(LocaleProviderInterface::class);
+        $this->assertInstanceOf(LocaleProviderInterface::class, $this->localeProvider);
     }
 
-    function it_returns_all_enabled_locales(
-        LocaleCollectionProviderInterface $localeCollectionProvider,
-        LocaleInterface $locale,
-    ): void {
-        $localeCollectionProvider->getAll()->willReturn([$locale]);
-        $locale->getCode()->willReturn('en_US');
-
-        $this->getAvailableLocalesCodes()->shouldReturn(['en_US']);
+    public function testReturnsAllEnabledLocales(): void
+    {
+        /** @var LocaleInterface|MockObject $localeMock */
+        $localeMock = $this->createMock(LocaleInterface::class);
+        $this->localeCollectionProviderMock->expects($this->once())->method('getAll')->willReturn([$localeMock]);
+        $localeMock->expects($this->once())->method('getCode')->willReturn('en_US');
+        $this->assertSame(['en_US'], $this->localeProvider->getAvailableLocalesCodes());
     }
 
-    function it_returns_the_default_locale(): void
+    public function testReturnsTheDefaultLocale(): void
     {
-        $this->getDefaultLocaleCode()->shouldReturn('pl_PL');
+        $this->assertSame('pl_PL', $this->localeProvider->getDefaultLocaleCode());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Context/CompositeLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/CompositeLocaleContextTest.php
@@ -41,9 +41,9 @@ final class CompositeLocaleContextTest extends TestCase
 
     public function testThrowsALocaleNotFoundExceptionIfNoneOfNestedLocaleContextsReturnedALocale(): void
     {
-        /** @var LocaleContextInterface|MockObject $localeContextMock */
+        /** @var LocaleContextInterface&MockObject $localeContextMock */
         $localeContextMock = $this->createMock(LocaleContextInterface::class);
-        $localeContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(LocaleNotFoundException::class);
+        $localeContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(new LocaleNotFoundException());
         $this->compositeLocaleContext->addContext($localeContextMock);
         $this->expectException(LocaleNotFoundException::class);
         $this->compositeLocaleContext->getLocaleCode();
@@ -51,13 +51,13 @@ final class CompositeLocaleContextTest extends TestCase
 
     public function testReturnsFirstResultReturnedByNestedRequestResolvers(): void
     {
-        /** @var LocaleContextInterface|MockObject $firstLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $firstLocaleContextMock */
         $firstLocaleContextMock = $this->createMock(LocaleContextInterface::class);
-        /** @var LocaleContextInterface|MockObject $secondLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $secondLocaleContextMock */
         $secondLocaleContextMock = $this->createMock(LocaleContextInterface::class);
-        /** @var LocaleContextInterface|MockObject $thirdLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $thirdLocaleContextMock */
         $thirdLocaleContextMock = $this->createMock(LocaleContextInterface::class);
-        $firstLocaleContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(LocaleNotFoundException::class);
+        $firstLocaleContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(new LocaleNotFoundException());
         $secondLocaleContextMock->expects($this->once())->method('getLocaleCode')->willReturn('en_US');
         $thirdLocaleContextMock->expects($this->never())->method('getLocaleCode');
         $this->compositeLocaleContext->addContext($firstLocaleContextMock);
@@ -68,15 +68,15 @@ final class CompositeLocaleContextTest extends TestCase
 
     public function testItsNestedRequestResolversCanHavePriority(): void
     {
-        /** @var LocaleContextInterface|MockObject $firstLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $firstLocaleContextMock */
         $firstLocaleContextMock = $this->createMock(LocaleContextInterface::class);
-        /** @var LocaleContextInterface|MockObject $secondLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $secondLocaleContextMock */
         $secondLocaleContextMock = $this->createMock(LocaleContextInterface::class);
-        /** @var LocaleContextInterface|MockObject $thirdLocaleContextMock */
+        /** @var LocaleContextInterface&MockObject $thirdLocaleContextMock */
         $thirdLocaleContextMock = $this->createMock(LocaleContextInterface::class);
         $firstLocaleContextMock->expects($this->never())->method('getLocaleCode');
         $secondLocaleContextMock->expects($this->once())->method('getLocaleCode')->willReturn('pl_PL');
-        $thirdLocaleContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(LocaleNotFoundException::class);
+        $thirdLocaleContextMock->expects($this->once())->method('getLocaleCode')->willThrowException(new LocaleNotFoundException());
         $this->compositeLocaleContext->addContext($firstLocaleContextMock, -5);
         $this->compositeLocaleContext->addContext($secondLocaleContextMock, 0);
         $this->compositeLocaleContext->addContext($thirdLocaleContextMock, 5);

--- a/src/Sylius/Component/Locale/tests/Context/CompositeLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/CompositeLocaleContextTest.php
@@ -13,19 +13,21 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Context;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Context\CompositeLocaleContext;
-use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
 
 final class CompositeLocaleContextTest extends TestCase
 {
     private CompositeLocaleContext $compositeLocaleContext;
+
     protected function setUp(): void
     {
         $this->compositeLocaleContext = new CompositeLocaleContext();
     }
+
     public function testImplementsLocaleContextInterface(): void
     {
         $this->assertInstanceOf(LocaleContextInterface::class, $this->compositeLocaleContext);

--- a/src/Sylius/Component/Locale/tests/Context/ImmutableLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/ImmutableLocaleContextTest.php
@@ -20,6 +20,7 @@ use Sylius\Component\Locale\Context\LocaleContextInterface;
 final class ImmutableLocaleContextTest extends TestCase
 {
     private ImmutableLocaleContext $immutableLocaleContext;
+
     protected function setUp(): void
     {
         $this->immutableLocaleContext = new ImmutableLocaleContext('pl_PL');

--- a/src/Sylius/Component/Locale/tests/Context/ImmutableLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/ImmutableLocaleContextTest.php
@@ -23,16 +23,17 @@ final class ImmutableLocaleContextTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->immutableLocaleContext = new ImmutableLocaleContext('pl_PL');
     }
 
     public function testALocaleContext(): void
     {
-        $this->assertInstanceOf(LocaleContextInterface::class, $this->immutableLocaleContext);
+        self::assertInstanceOf(LocaleContextInterface::class, $this->immutableLocaleContext);
     }
 
     public function testGetsALocaleCode(): void
     {
-        $this->assertSame('pl_PL', $this->immutableLocaleContext->getLocaleCode());
+        self::assertSame('pl_PL', $this->immutableLocaleContext->getLocaleCode());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
@@ -23,33 +23,33 @@ use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 final class ProviderBasedLocaleContextTest extends TestCase
 {
     /** @var LocaleProviderInterface&MockObject */
-    private MockObject $localeProviderMock;
+    private MockObject $localeProvider;
 
     private ProviderBasedLocaleContext $providerBasedLocaleContext;
 
     protected function setUp(): void
     {
-        $this->localeProviderMock = $this->createMock(LocaleProviderInterface::class);
-        $this->providerBasedLocaleContext = new ProviderBasedLocaleContext($this->localeProviderMock);
+        $this->localeProvider = $this->createMock(LocaleProviderInterface::class);
+        $this->providerBasedLocaleContext = new ProviderBasedLocaleContext($this->localeProvider);
     }
 
     public function testALocaleContext(): void
     {
-        $this->assertInstanceOf(LocaleContextInterface::class, $this->providerBasedLocaleContext);
+        self::assertInstanceOf(LocaleContextInterface::class, $this->providerBasedLocaleContext);
     }
 
     public function testReturnsTheChannelsDefaultLocale(): void
     {
-        $this->localeProviderMock->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['pl_PL', 'en_US']);
-        $this->localeProviderMock->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
-        $this->assertSame('pl_PL', $this->providerBasedLocaleContext->getLocaleCode());
+        $this->localeProvider->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['pl_PL', 'en_US']);
+        $this->localeProvider->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
+        self::assertSame('pl_PL', $this->providerBasedLocaleContext->getLocaleCode());
     }
 
     public function testThrowsALocaleNotFoundExceptionIfDefaultLocaleIsNotAvailable(): void
     {
-        $this->localeProviderMock->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['es_ES', 'en_US']);
-        $this->localeProviderMock->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
-        $this->expectException(LocaleNotFoundException::class);
+        $this->localeProvider->expects($this->once())->method('getAvailableLocalesCodes')->willReturn(['es_ES', 'en_US']);
+        $this->localeProvider->expects($this->once())->method('getDefaultLocaleCode')->willReturn('pl_PL');
+        self::expectException(LocaleNotFoundException::class);
         $this->providerBasedLocaleContext->getLocaleCode();
     }
 }

--- a/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
@@ -22,7 +22,7 @@ use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
 final class ProviderBasedLocaleContextTest extends TestCase
 {
-    /** @var LocaleProviderInterface|MockObject */
+    /** @var LocaleProviderInterface&MockObject */
     private MockObject $localeProviderMock;
 
     private ProviderBasedLocaleContext $providerBasedLocaleContext;

--- a/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
+++ b/src/Sylius/Component/Locale/tests/Context/ProviderBasedLocaleContextTest.php
@@ -13,20 +13,20 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Context;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Sylius\Component\Locale\Context\ProviderBasedLocaleContext;
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Sylius\Component\Locale\Context\LocaleNotFoundException;
+use Sylius\Component\Locale\Context\ProviderBasedLocaleContext;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
 final class ProviderBasedLocaleContextTest extends TestCase
 {
-    /**
-     * @var LocaleProviderInterface|MockObject
-     */
+    /** @var LocaleProviderInterface|MockObject */
     private MockObject $localeProviderMock;
+
     private ProviderBasedLocaleContext $providerBasedLocaleContext;
+
     protected function setUp(): void
     {
         $this->localeProviderMock = $this->createMock(LocaleProviderInterface::class);

--- a/src/Sylius/Component/Locale/tests/Converter/LocaleConverterTest.php
+++ b/src/Sylius/Component/Locale/tests/Converter/LocaleConverterTest.php
@@ -24,37 +24,38 @@ final class LocaleConverterTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->localeConverter = new LocaleConverter();
     }
 
     public function testALocaleConverter(): void
     {
-        $this->assertInstanceOf(LocaleConverterInterface::class, $this->localeConverter);
+        self::assertInstanceOf(LocaleConverterInterface::class, $this->localeConverter);
     }
 
     public function testConvertsLocaleNameToLocaleCode(): void
     {
-        $this->assertSame('de', $this->localeConverter->convertNameToCode('German'));
-        $this->assertSame('no', $this->localeConverter->convertNameToCode('Norwegian'));
-        $this->assertSame('pl', $this->localeConverter->convertNameToCode('Polish'));
+        self::assertSame('de', $this->localeConverter->convertNameToCode('German'));
+        self::assertSame('no', $this->localeConverter->convertNameToCode('Norwegian'));
+        self::assertSame('pl', $this->localeConverter->convertNameToCode('Polish'));
     }
 
     public function testConvertsLocaleCodeToLocaleName(): void
     {
-        $this->assertSame('German', $this->localeConverter->convertCodeToName('de'));
-        $this->assertSame('Norwegian', $this->localeConverter->convertCodeToName('no'));
-        $this->assertSame('Polish', $this->localeConverter->convertCodeToName('pl'));
+        self::assertSame('German', $this->localeConverter->convertCodeToName('de'));
+        self::assertSame('Norwegian', $this->localeConverter->convertCodeToName('no'));
+        self::assertSame('Polish', $this->localeConverter->convertCodeToName('pl'));
     }
 
     public function testThrowsInvalidArgumentExceptionIfCannotConvertNameToCode(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        self::expectException(InvalidArgumentException::class);
         $this->localeConverter->convertNameToCode('xyz');
     }
 
     public function testThrowsInvalidArgumentExceptionIfCannotConvertCodeToName(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        self::expectException(InvalidArgumentException::class);
         $this->localeConverter->convertCodeToName('xyz');
     }
 }

--- a/src/Sylius/Component/Locale/tests/Converter/LocaleConverterTest.php
+++ b/src/Sylius/Component/Locale/tests/Converter/LocaleConverterTest.php
@@ -13,18 +13,20 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Converter;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Converter\LocaleConverter;
-use InvalidArgumentException;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 
 final class LocaleConverterTest extends TestCase
 {
     private LocaleConverter $localeConverter;
+
     protected function setUp(): void
     {
         $this->localeConverter = new LocaleConverter();
     }
+
     public function testALocaleConverter(): void
     {
         $this->assertInstanceOf(LocaleConverterInterface::class, $this->localeConverter);

--- a/src/Sylius/Component/Locale/tests/Model/LocaleTest.php
+++ b/src/Sylius/Component/Locale/tests/Model/LocaleTest.php
@@ -13,69 +13,69 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Model;
 
-use Locale;
 use PHPUnit\Framework\TestCase;
+use Sylius\Component\Locale\Model\Locale;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Model\TimestampableInterface;
 
 final class LocaleTest extends TestCase
 {
-    private \Sylius\Component\Locale\Model\Locale $locale;
+    private Locale $locale;
 
     protected function setUp(): void
     {
-        $this->locale = new \Sylius\Component\Locale\Model\Locale();
-        Locale::setDefault('en');
+        parent::setUp();
+        $this->locale = new Locale();
     }
 
     public function testImplementsALocaleInterface(): void
     {
-        $this->assertInstanceOf(LocaleInterface::class, $this->locale);
+        self::assertInstanceOf(LocaleInterface::class, $this->locale);
     }
 
     public function testTimestampable(): void
     {
-        $this->assertInstanceOf(TimestampableInterface::class, $this->locale);
+        self::assertInstanceOf(TimestampableInterface::class, $this->locale);
     }
 
     public function testDoesNotHaveIdByDefault(): void
     {
-        $this->assertNull($this->locale->getId());
+        self::assertNull($this->locale->getId());
     }
 
     public function testHasNoCodeByDefault(): void
     {
-        $this->assertNull($this->locale->getCode());
+        self::assertNull($this->locale->getCode());
     }
 
     public function testItsCodeIsMutable(): void
     {
         $this->locale->setCode('de_DE');
-        $this->assertSame('de_DE', $this->locale->getCode());
+        self::assertSame('de_DE', $this->locale->getCode());
     }
 
     public function testHasAName(): void
     {
         $this->locale->setCode('pl_PL');
-        $this->assertSame('Polish (Poland)', $this->locale->getName());
-        $this->assertSame('polaco (Polonia)', $this->locale->getName('es'));
+        self::assertSame('Polish (Poland)', $this->locale->getName());
+        self::assertSame('polaco (Polonia)', $this->locale->getName('es'));
 
         $this->locale->setCode('pl');
-        $this->assertSame('Polish', $this->locale->getName());
-        $this->assertSame('polaco', $this->locale->getName('es'));
+        self::assertSame('Polish', $this->locale->getName());
+        self::assertSame('polaco', $this->locale->getName('es'));
     }
 
     public function testReturnsNameWhenConvertedToString(): void
     {
         $this->locale->setCode('pl_PL');
-        $this->assertSame('Polish (Poland)', $this->locale->__toString());
+        self::assertSame('Polish (Poland)', $this->locale->__toString());
 
         $this->locale->setCode('pl');
-        $this->assertSame('Polish', $this->locale->__toString());
+        self::assertSame('Polish', $this->locale->__toString());
     }
 
     public function testDoesNotHaveLastUpdateDateByDefault(): void
     {
-        $this->assertNull($this->locale->getUpdatedAt());
+        self::assertNull($this->locale->getUpdatedAt());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Model/LocaleTest.php
+++ b/src/Sylius/Component/Locale/tests/Model/LocaleTest.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Model;
 
-use PHPUnit\Framework\TestCase;
 use Locale;
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Model\TimestampableInterface;
 
 final class LocaleTest extends TestCase
 {
     private \Sylius\Component\Locale\Model\Locale $locale;
+
     protected function setUp(): void
     {
         $this->locale = new \Sylius\Component\Locale\Model\Locale();

--- a/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
@@ -23,39 +23,41 @@ use Symfony\Contracts\Cache\CacheInterface;
 final class CachedLocaleCollectionProviderTest extends TestCase
 {
     /** @var LocaleCollectionProviderInterface&MockObject */
-    private MockObject $decoratedMock;
+    private MockObject $decorated;
 
     /** @var CacheInterface&MockObject */
-    private MockObject $cacheMock;
+    private MockObject $cache;
 
     private CachedLocaleCollectionProvider $cachedLocaleCollectionProvider;
 
     protected function setUp(): void
     {
-        $this->decoratedMock = $this->createMock(LocaleCollectionProviderInterface::class);
-        $this->cacheMock = $this->createMock(CacheInterface::class);
-        $this->cachedLocaleCollectionProvider = new CachedLocaleCollectionProvider($this->decoratedMock, $this->cacheMock);
+        parent::setUp();
+        $this->decorated = $this->createMock(LocaleCollectionProviderInterface::class);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->cachedLocaleCollectionProvider = new CachedLocaleCollectionProvider($this->decorated, $this->cache);
     }
 
     public function testImplementsLocaleCollectionProviderInterface(): void
     {
-        $this->assertInstanceOf(LocaleCollectionProviderInterface::class, $this->cachedLocaleCollectionProvider);
+        self::assertInstanceOf(LocaleCollectionProviderInterface::class, $this->cachedLocaleCollectionProvider);
     }
 
     public function testReturnsAllLocalesViaCache(): void
     {
-        /** @var LocaleInterface&MockObject $someLocaleMock */
-        $someLocaleMock = $this->createMock(LocaleInterface::class);
-        /** @var LocaleInterface&MockObject $anotherLocaleMock */
-        $anotherLocaleMock = $this->createMock(LocaleInterface::class);
-        $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
-        $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');
-        $this->cacheMock->expects($this->once())->method('get')
+        /** @var LocaleInterface&MockObject $someLocale */
+        $someLocale = $this->createMock(LocaleInterface::class);
+        /** @var LocaleInterface&MockObject $anotherLocale */
+        $anotherLocale = $this->createMock(LocaleInterface::class);
+        $someLocale->method('getCode')->willReturn('en_US');
+        $anotherLocale->method('getCode')->willReturn('en_GB');
+        $this->cache->expects($this->once())->method('get')
             ->with('sylius_locales', $this->isType('callable'))
             ->willReturnCallback(function (string $key, callable $callback) {
                 return $callback();
             });
-        $this->decoratedMock->expects($this->once())->method('getAll')->willReturn(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock]);
-        $this->assertSame(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock], $this->cachedLocaleCollectionProvider->getAll());
+        $this->decorated->expects($this->once())->method('getAll')
+            ->willReturn(['en_US' => $someLocale, 'en_GB' => $anotherLocale]);
+        self::assertSame(['en_US' => $someLocale, 'en_GB' => $anotherLocale], $this->cachedLocaleCollectionProvider->getAll());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
@@ -22,10 +22,10 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedLocaleCollectionProviderTest extends TestCase
 {
-    /** @var LocaleCollectionProviderInterface|MockObject */
+    /** @var LocaleCollectionProviderInterface&MockObject */
     private MockObject $decoratedMock;
 
-    /** @var CacheInterface|MockObject */
+    /** @var CacheInterface&MockObject */
     private MockObject $cacheMock;
 
     private CachedLocaleCollectionProvider $cachedLocaleCollectionProvider;
@@ -44,13 +44,17 @@ final class CachedLocaleCollectionProviderTest extends TestCase
 
     public function testReturnsAllLocalesViaCache(): void
     {
-        /** @var LocaleInterface|MockObject $someLocaleMock */
+        /** @var LocaleInterface&MockObject $someLocaleMock */
         $someLocaleMock = $this->createMock(LocaleInterface::class);
-        /** @var LocaleInterface|MockObject $anotherLocaleMock */
+        /** @var LocaleInterface&MockObject $anotherLocaleMock */
         $anotherLocaleMock = $this->createMock(LocaleInterface::class);
         $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
         $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');
-        $this->cacheMock->expects($this->once())->method('get')->with('sylius_locales', $this->isType('callable'))->will(fn ($args) => $args[1]());
+        $this->cacheMock->expects($this->once())->method('get')
+            ->with('sylius_locales', $this->isType('callable'))
+            ->willReturnCallback(function (string $key, callable $callback) {
+                return $callback();
+            });
         $this->decoratedMock->expects($this->once())->method('getAll')->willReturn(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock]);
         $this->assertSame(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock], $this->cachedLocaleCollectionProvider->getAll());
     }

--- a/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/CachedLocaleCollectionProviderTest.php
@@ -13,24 +13,23 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Provider;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider;
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\CachedLocaleCollectionProvider;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 
 final class CachedLocaleCollectionProviderTest extends TestCase
 {
-    /**
-     * @var LocaleCollectionProviderInterface|MockObject
-     */
+    /** @var LocaleCollectionProviderInterface|MockObject */
     private MockObject $decoratedMock;
-    /**
-     * @var CacheInterface|MockObject
-     */
+
+    /** @var CacheInterface|MockObject */
     private MockObject $cacheMock;
+
     private CachedLocaleCollectionProvider $cachedLocaleCollectionProvider;
+
     protected function setUp(): void
     {
         $this->decoratedMock = $this->createMock(LocaleCollectionProviderInterface::class);
@@ -51,7 +50,7 @@ final class CachedLocaleCollectionProviderTest extends TestCase
         $anotherLocaleMock = $this->createMock(LocaleInterface::class);
         $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
         $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');
-        $this->cacheMock->expects($this->once())->method('get')->with('sylius_locales', $this->isType('callable'))->will(fn($args) => $args[1]());
+        $this->cacheMock->expects($this->once())->method('get')->with('sylius_locales', $this->isType('callable'))->will(fn ($args) => $args[1]());
         $this->decoratedMock->expects($this->once())->method('getAll')->willReturn(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock]);
         $this->assertSame(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock], $this->cachedLocaleCollectionProvider->getAll());
     }

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
@@ -23,30 +23,31 @@ use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 final class LocaleCollectionProviderTest extends TestCase
 {
     /** @var RepositoryInterface&MockObject */
-    private MockObject $localeRepositoryMock;
+    private MockObject $localeRepository;
 
     private LocaleCollectionProvider $localeCollectionProvider;
 
     protected function setUp(): void
     {
-        $this->localeRepositoryMock = $this->createMock(RepositoryInterface::class);
-        $this->localeCollectionProvider = new LocaleCollectionProvider($this->localeRepositoryMock);
+        parent::setUp();
+        $this->localeRepository = $this->createMock(RepositoryInterface::class);
+        $this->localeCollectionProvider = new LocaleCollectionProvider($this->localeRepository);
     }
 
     public function testImplementsLocaleCollectionProviderInterface(): void
     {
-        $this->assertInstanceOf(LocaleCollectionProviderInterface::class, $this->localeCollectionProvider);
+        self::assertInstanceOf(LocaleCollectionProviderInterface::class, $this->localeCollectionProvider);
     }
 
     public function testReturnsAllLocales(): void
     {
-        /** @var LocaleInterface&MockObject $someLocaleMock */
-        $someLocaleMock = $this->createMock(LocaleInterface::class);
-        /** @var LocaleInterface&MockObject $anotherLocaleMock */
-        $anotherLocaleMock = $this->createMock(LocaleInterface::class);
-        $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
-        $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');
-        $this->localeRepositoryMock->expects($this->once())->method('findAll')->willReturn([$someLocaleMock, $anotherLocaleMock]);
-        $this->assertSame(['en_US' => $someLocaleMock, 'en_GB' => $anotherLocaleMock], $this->localeCollectionProvider->getAll());
+        /** @var LocaleInterface&MockObject $someLocale */
+        $someLocale = $this->createMock(LocaleInterface::class);
+        /** @var LocaleInterface&MockObject $anotherLocale */
+        $anotherLocale = $this->createMock(LocaleInterface::class);
+        $someLocale->expects($this->once())->method('getCode')->willReturn('en_US');
+        $anotherLocale->expects($this->once())->method('getCode')->willReturn('en_GB');
+        $this->localeRepository->expects($this->once())->method('findAll')->willReturn([$someLocale, $anotherLocale]);
+        self::assertSame(['en_US' => $someLocale, 'en_GB' => $anotherLocale], $this->localeCollectionProvider->getAll());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
@@ -22,7 +22,7 @@ use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 
 final class LocaleCollectionProviderTest extends TestCase
 {
-    /** @var RepositoryInterface|MockObject */
+    /** @var RepositoryInterface&MockObject */
     private MockObject $localeRepositoryMock;
 
     private LocaleCollectionProvider $localeCollectionProvider;
@@ -40,9 +40,9 @@ final class LocaleCollectionProviderTest extends TestCase
 
     public function testReturnsAllLocales(): void
     {
-        /** @var LocaleInterface|MockObject $someLocaleMock */
+        /** @var LocaleInterface&MockObject $someLocaleMock */
         $someLocaleMock = $this->createMock(LocaleInterface::class);
-        /** @var LocaleInterface|MockObject $anotherLocaleMock */
+        /** @var LocaleInterface&MockObject $anotherLocaleMock */
         $anotherLocaleMock = $this->createMock(LocaleInterface::class);
         $someLocaleMock->expects($this->once())->method('getCode')->willReturn('en_US');
         $anotherLocaleMock->expects($this->once())->method('getCode')->willReturn('en_GB');

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleCollectionProviderTest.php
@@ -13,21 +13,20 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Provider;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Sylius\Component\Locale\Provider\LocaleCollectionProvider;
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProvider;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 
 final class LocaleCollectionProviderTest extends TestCase
 {
-    /**
-     * @var RepositoryInterface|MockObject
-     */
+    /** @var RepositoryInterface|MockObject */
     private MockObject $localeRepositoryMock;
+
     private LocaleCollectionProvider $localeCollectionProvider;
-    /** @param RepositoryInterface<LocaleInterface> $localeRepository */
+
     protected function setUp(): void
     {
         $this->localeRepositoryMock = $this->createMock(RepositoryInterface::class);

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
@@ -29,26 +29,27 @@ final class LocaleProviderTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->localeCollectionProviderMock = $this->createMock(LocaleCollectionProviderInterface::class);
         $this->localeProvider = new LocaleProvider($this->localeCollectionProviderMock, 'pl_PL');
     }
 
     public function testALocaleProviderInterface(): void
     {
-        $this->assertInstanceOf(LocaleProviderInterface::class, $this->localeProvider);
+        self::assertInstanceOf(LocaleProviderInterface::class, $this->localeProvider);
     }
 
     public function testReturnsAllEnabledLocales(): void
     {
-        /** @var LocaleInterface&MockObject $localeMock */
-        $localeMock = $this->createMock(LocaleInterface::class);
-        $this->localeCollectionProviderMock->expects($this->once())->method('getAll')->willReturn([$localeMock]);
-        $localeMock->expects($this->once())->method('getCode')->willReturn('en_US');
-        $this->assertSame(['en_US'], $this->localeProvider->getAvailableLocalesCodes());
+        /** @var LocaleInterface&MockObject $locale */
+        $locale = $this->createMock(LocaleInterface::class);
+        $this->localeCollectionProviderMock->expects($this->once())->method('getAll')->willReturn([$locale]);
+        $locale->expects($this->once())->method('getCode')->willReturn('en_US');
+        self::assertSame(['en_US'], $this->localeProvider->getAvailableLocalesCodes());
     }
 
     public function testReturnsTheDefaultLocale(): void
     {
-        $this->assertSame('pl_PL', $this->localeProvider->getDefaultLocaleCode());
+        self::assertSame('pl_PL', $this->localeProvider->getDefaultLocaleCode());
     }
 }

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
@@ -22,7 +22,7 @@ use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
 final class LocaleProviderTest extends TestCase
 {
-    /** @var LocaleCollectionProviderInterface|MockObject */
+    /** @var LocaleCollectionProviderInterface&MockObject */
     private MockObject $localeCollectionProviderMock;
 
     private LocaleProvider $localeProvider;
@@ -40,7 +40,7 @@ final class LocaleProviderTest extends TestCase
 
     public function testReturnsAllEnabledLocales(): void
     {
-        /** @var LocaleInterface|MockObject $localeMock */
+        /** @var LocaleInterface&MockObject $localeMock */
         $localeMock = $this->createMock(LocaleInterface::class);
         $this->localeCollectionProviderMock->expects($this->once())->method('getAll')->willReturn([$localeMock]);
         $localeMock->expects($this->once())->method('getCode')->willReturn('en_US');

--- a/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
+++ b/src/Sylius/Component/Locale/tests/Provider/LocaleProviderTest.php
@@ -13,20 +13,20 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Component\Locale\Provider;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Sylius\Component\Locale\Provider\LocaleProvider;
+use PHPUnit\Framework\TestCase;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
+use Sylius\Component\Locale\Provider\LocaleProvider;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 
 final class LocaleProviderTest extends TestCase
 {
-    /**
-     * @var LocaleCollectionProviderInterface|MockObject
-     */
+    /** @var LocaleCollectionProviderInterface|MockObject */
     private MockObject $localeCollectionProviderMock;
+
     private LocaleProvider $localeProvider;
+
     protected function setUp(): void
     {
         $this->localeCollectionProviderMock = $this->createMock(LocaleCollectionProviderInterface::class);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | OP-571
| License         | MIT

Rewrite PHPspec to PHPUnit Locale Component using rector/cusotm-phpspec-to-phpunit 

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependencies and autoloading configuration for the Locale component.
  - Removed PhpSpec configuration and legacy spec files.
  - Added PHPUnit configuration for improved test management.

- **Tests**
  - Migrated all Locale component tests from PhpSpec to PHPUnit.
  - Introduced comprehensive PHPUnit test classes for context, converter, model, and provider functionalities to ensure continued reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->