### PR TITLE
Fixing phpstan native error types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2065,6 +2065,18 @@ parameters:
 			path: src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
 
 		-
+			message: '#^PHPDoc tag @var with type Sylius\\Resource\\Factory\\FactoryInterface\<Sylius\\Component\\Order\\Model\\AdjustmentInterface\> is not subtype of native type Sylius\\Resource\\Factory\\Factory\.$#'
+			identifier: varTag.nativeType
+			count: 2
+			path: src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemUnitsTaxesApplicatorTest.php
+
+		-
+			message: '#^PHPDoc tag @var with type Sylius\\Resource\\Factory\\FactoryInterface\<Sylius\\Component\\Order\\Model\\AdjustmentInterface\> is not subtype of native type Sylius\\Resource\\Factory\\Factory\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: src/Sylius/Component/Core/Test/Tests/Taxation/Applicator/OrderItemsTaxesApplicatorTest.php
+
+		-
 			message: '#^Method Sylius\\Component\\Currency\\Model\\ExchangeRateInterface\:\:setRatio\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,7 +37,6 @@ parameters:
 
     ignoreErrors:
         - identifier: missingType.generics # This need to be fixed, too many classes are using generics without PHPDoc type
-        - identifier: varTag.nativeType
         - '/(Interface|Class) [a-zA-Z\\]+ specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior, we are basing on Psalm for generics checks        - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'
         - '/Method Sylius\\Bundle\\(Admin|Shop)Bundle\\Twig\\Component\\[a-zA-Z\\]+\:\:getDataModelValue\(\) is unused./'
         - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'

--- a/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/CatalogPromotion/Processor/CatalogPromotionRemovalProcessor.php
@@ -30,7 +30,6 @@ final class CatalogPromotionRemovalProcessor implements CatalogPromotionRemovalP
 
     public function removeCatalogPromotion(string $catalogPromotionCode): void
     {
-        /** @var CatalogPromotionInterface|null $catalogPromotion */
         $catalogPromotion = $this->getCatalogPromotion($catalogPromotionCode);
 
         if ($catalogPromotion->getState() === CatalogPromotionStates::STATE_PROCESSING) {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;
@@ -32,7 +31,6 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
         /** @var OrderProductEligibility $constraint */
         Assert::isInstanceOf($constraint, OrderProductEligibility::class);
 
-        /** @var OrderItemInterface[] $orderItems */
         $orderItems = $value->getItems();
 
         foreach ($orderItems as $orderItem) {

--- a/src/Sylius/Component/Payment/tests/Model/PaymentMethodTest.php
+++ b/src/Sylius/Component/Payment/tests/Model/PaymentMethodTest.php
@@ -120,7 +120,7 @@ final class PaymentMethodTest extends TestCase
 
     public function testItsGatewayConfigIsMutable(): void
     {
-        /** @var GatewayConfigInterface|MockObject $gatewayConfigMock */
+        /** @var GatewayConfigInterface&MockObject $gatewayConfigMock */
         $gatewayConfigMock = $this->createMock(GatewayConfigInterface::class);
         $this->paymentMethod->setGatewayConfig($gatewayConfigMock);
         $this->assertSame($gatewayConfigMock, $this->paymentMethod->getGatewayConfig());


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | refs #17963 
| License         | MIT

Replacing the error message ignore from identifier with the two places that actually matter. Those places are probably being reported because the Factory class that inherits from the interface in the resource bundle which is not generic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Removed redundant and unused inline comments and import statements to improve code clarity.
  - Updated PHPDoc type annotations for improved accuracy in test files.

- **Chores**
  - Updated static analysis configuration to refine error reporting and suppress specific baseline warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->