### PR TITLE
Replace hardcoded text with respective translation key in Breadcrumb bar

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/header/breadcrumbs.html.twig
@@ -10,6 +10,6 @@
 {% endif %}
 
 {{ breadcrumbs([
-    { 'name': 'Dashboard', 'url': path('sylius_admin_dashboard'), 'active': false },
-    { 'name': title, 'active': true },
+    { name: 'sylius.ui.dashboard', 'url': path('sylius_admin_dashboard'), 'active': false },
+    { name: title, 'active': true },
 ]) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

I realized a little inconsistency in the breadcrumb templates. The crud/index breadcrumb file contains `Dashboard` as a harcoded string while the other templates use the `sylius.ui.dashboard` translation key. This PR makes the crud/index breadcrumb also use the translation key.