### PR TITLE
Send Password Request Mail only on enabled Users

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -221,7 +221,7 @@ class UserController extends ResourceController
             Assert::isInstanceOf($userRepository, UserRepositoryInterface::class);
 
             $user = $userRepository->findOneByEmail($passwordReset->getEmail());
-            if (null !== $user) {
+            if (null !== $user && $user->isEnabled()) {
                 $this->handleResetPasswordRequest($generator, $user, $senderEvent);
             }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Prevent sending of password mail if user is not enabled. In our case it is used to spam people which never created a account in our shop.