### PR TITLE
[Admin][Taxon] Pass the tree data to stimulus controller without HTML escaping

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/taxon/sections/tree.html.twig
@@ -1,6 +1,6 @@
 {# Rendered with \Sylius\Bundle\AdminBundle\Twig\Component\Taxon\TreeComponent #}
 
-<div {{ attributes.defaults(stimulus_controller('taxon-tree', {treeData: this.tree, autoOpen: true})) }}>
+<div {{ attributes.defaults(stimulus_controller('taxon-tree', {autoOpen: true})) }} data-taxon-tree-tree-data-value="{{ this.tree|json_encode }}">
     <div class="card mb-5">
         <div data-loading>
             <div class="sylius-loader">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT