### PR TITLE
Make fixture factory constructor arguments protected

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
@@ -29,9 +29,9 @@ use Webmozart\Assert\Assert;
 
 class AddressExampleFactory extends AbstractExampleFactory
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<AddressInterface> $addressFactory
@@ -39,9 +39,9 @@ class AddressExampleFactory extends AbstractExampleFactory
      * @param RepositoryInterface<CustomerInterface> $customerRepository
      */
     public function __construct(
-        private FactoryInterface $addressFactory,
-        private RepositoryInterface $countryRepository,
-        private RepositoryInterface $customerRepository,
+        protected readonly FactoryInterface $addressFactory,
+        protected readonly RepositoryInterface $countryRepository,
+        protected readonly RepositoryInterface $customerRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -26,20 +26,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<AdminUserInterface> $userFactory
      * @param FactoryInterface<ImageInterface> $avatarImageFactory
      */
     public function __construct(
-        private FactoryInterface $userFactory,
-        private string $localeCode,
-        private FileLocatorInterface $fileLocator,
-        private ImageUploaderInterface $imageUploader,
-        private FactoryInterface $avatarImageFactory,
+        protected readonly FactoryInterface $userFactory,
+        protected readonly string $localeCode,
+        protected readonly FileLocatorInterface $fileLocator,
+        protected readonly ImageUploaderInterface $imageUploader,
+        protected readonly FactoryInterface $avatarImageFactory,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
@@ -22,10 +22,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class CatalogPromotionActionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CatalogPromotionActionInterface> $catalogPromotionActionFactory */
-    public function __construct(private FactoryInterface $catalogPromotionActionFactory)
+    public function __construct(protected readonly FactoryInterface $catalogPromotionActionFactory)
     {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
@@ -29,20 +29,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CatalogPromotionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<CatalogPromotionInterface> $catalogPromotionFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        private FactoryInterface $catalogPromotionFactory,
-        private RepositoryInterface $localeRepository,
-        private ChannelRepositoryInterface $channelRepository,
-        private ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
-        private ExampleFactoryInterface $catalogPromotionActionExampleFactory,
+        protected readonly FactoryInterface $catalogPromotionFactory,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly ChannelRepositoryInterface $channelRepository,
+        protected readonly ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
+        protected readonly ExampleFactoryInterface $catalogPromotionActionExampleFactory,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
@@ -20,10 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class CatalogPromotionScopeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CatalogPromotionScopeInterface> $catalogPromotionScopeFactory */
-    public function __construct(private FactoryInterface $catalogPromotionScopeFactory)
+    public function __construct(protected readonly FactoryInterface $catalogPromotionScopeFactory)
     {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -34,9 +34,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param RepositoryInterface<LocaleInterface> $localeRepository
@@ -45,12 +45,12 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param FactoryInterface<ShopBillingDataInterface> $shopBillingDataFactory
      */
     public function __construct(
-        private ChannelFactoryInterface $channelFactory,
-        private RepositoryInterface $localeRepository,
-        private RepositoryInterface $currencyRepository,
-        private RepositoryInterface $zoneRepository,
-        private TaxonRepositoryInterface $taxonRepository,
-        private FactoryInterface $shopBillingDataFactory,
+        protected readonly ChannelFactoryInterface $channelFactory,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly RepositoryInterface $currencyRepository,
+        protected readonly RepositoryInterface $zoneRepository,
+        protected readonly TaxonRepositoryInterface $taxonRepository,
+        protected readonly FactoryInterface $shopBillingDataFactory,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
@@ -23,12 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomerGroupExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CustomerGroupInterface> $customerGroupFactory */
-    public function __construct(private FactoryInterface $customerGroupFactory)
+    public function __construct(protected readonly FactoryInterface $customerGroupFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -30,15 +30,15 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory
 {
     public const DEFAULT_LOCALE = 'en_US';
 
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param RepositoryInterface<LocaleInterface> $localeRepository */
     public function __construct(
-        private PaymentMethodFactoryInterface $paymentMethodFactory,
-        private RepositoryInterface $localeRepository,
-        private ChannelRepositoryInterface $channelRepository,
+        protected readonly PaymentMethodFactoryInterface $paymentMethodFactory,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly ChannelRepositoryInterface $channelRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationExampleFactory.php
@@ -24,13 +24,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAssociationExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<ProductAssociationInterface> $productAssociationFactory */
     public function __construct(
-        private FactoryInterface $productAssociationFactory,
-        private ProductAssociationTypeRepositoryInterface $productAssociationTypeRepository,
-        private ProductRepositoryInterface $productRepository,
+        protected readonly FactoryInterface $productAssociationFactory,
+        protected readonly ProductAssociationTypeRepositoryInterface $productAssociationTypeRepository,
+        protected readonly ProductRepositoryInterface $productRepository,
     ) {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
@@ -25,17 +25,17 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAssociationTypeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductAssociationTypeInterface> $productAssociationTypeFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        private FactoryInterface $productAssociationTypeFactory,
-        private RepositoryInterface $localeRepository,
+        protected readonly FactoryInterface $productAssociationTypeFactory,
+        protected readonly RepositoryInterface $localeRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -25,18 +25,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAttributeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      * @param array<string, string> $attributeTypes
      */
     public function __construct(
-        private AttributeFactoryInterface $productAttributeFactory,
-        private RepositoryInterface $localeRepository,
-        private array $attributeTypes,
+        protected readonly AttributeFactoryInterface $productAttributeFactory,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly array $attributeTypes,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -47,9 +47,9 @@ use Webmozart\Assert\Assert;
 
 class ProductExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductInterface> $productFactory
@@ -66,22 +66,22 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param RepositoryInterface<TaxCategoryInterface> $taxCategoryRepository
      */
     public function __construct(
-        private FactoryInterface $productFactory,
-        private FactoryInterface $productVariantFactory,
-        private FactoryInterface $channelPricingFactory,
-        private ProductVariantGeneratorInterface $variantGenerator,
-        private FactoryInterface $productAttributeValueFactory,
-        private FactoryInterface $productImageFactory,
-        private FactoryInterface $productTaxonFactory,
-        private ImageUploaderInterface $imageUploader,
-        private SlugGeneratorInterface $slugGenerator,
-        private RepositoryInterface $taxonRepository,
-        private RepositoryInterface $productAttributeRepository,
-        private RepositoryInterface $productOptionRepository,
-        private RepositoryInterface $channelRepository,
-        private RepositoryInterface $localeRepository,
-        private RepositoryInterface $taxCategoryRepository,
-        private FileLocatorInterface $fileLocator,
+        protected readonly FactoryInterface $productFactory,
+        protected readonly FactoryInterface $productVariantFactory,
+        protected readonly FactoryInterface $channelPricingFactory,
+        protected readonly ProductVariantGeneratorInterface $variantGenerator,
+        protected readonly FactoryInterface $productAttributeValueFactory,
+        protected readonly FactoryInterface $productImageFactory,
+        protected readonly FactoryInterface $productTaxonFactory,
+        protected readonly ImageUploaderInterface $imageUploader,
+        protected readonly SlugGeneratorInterface $slugGenerator,
+        protected readonly RepositoryInterface $taxonRepository,
+        protected readonly RepositoryInterface $productAttributeRepository,
+        protected readonly RepositoryInterface $productOptionRepository,
+        protected readonly RepositoryInterface $channelRepository,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly RepositoryInterface $taxCategoryRepository,
+        protected readonly FileLocatorInterface $fileLocator,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -26,9 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductOptionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductOptionInterface> $productOptionFactory
@@ -36,9 +36,9 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        private FactoryInterface $productOptionFactory,
-        private FactoryInterface $productOptionValueFactory,
-        private RepositoryInterface $localeRepository,
+        protected readonly FactoryInterface $productOptionFactory,
+        protected readonly FactoryInterface $productOptionValueFactory,
+        protected readonly RepositoryInterface $localeRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
@@ -27,15 +27,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductReviewExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     public function __construct(
-        private ReviewFactoryInterface $productReviewFactory,
-        private ProductRepositoryInterface $productRepository,
-        private CustomerRepositoryInterface $customerRepository,
-        private StateMachineInterface $stateMachine,
+        protected readonly ReviewFactoryInterface $productReviewFactory,
+        protected readonly ProductRepositoryInterface $productRepository,
+        protected readonly CustomerRepositoryInterface $customerRepository,
+        protected readonly StateMachineInterface $stateMachine,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionActionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionActionExampleFactory.php
@@ -23,11 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionActionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
-    public function __construct(private PromotionActionFactoryInterface $promotionActionFactory)
+    /** @param PromotionActionFactoryInterface<PromotionActionInterface> $promotionActionFactory */
+    public function __construct(protected readonly PromotionActionFactoryInterface $promotionActionFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -31,9 +31,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<PromotionInterface> $promotionFactory
@@ -41,12 +41,12 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        private FactoryInterface $promotionFactory,
-        private ExampleFactoryInterface $promotionRuleExampleFactory,
-        private ExampleFactoryInterface $promotionActionExampleFactory,
-        private ChannelRepositoryInterface $channelRepository,
-        private FactoryInterface $couponFactory,
-        private RepositoryInterface $localeRepository,
+        protected readonly FactoryInterface $promotionFactory,
+        protected readonly ExampleFactoryInterface $promotionRuleExampleFactory,
+        protected readonly ExampleFactoryInterface $promotionActionExampleFactory,
+        protected readonly ChannelRepositoryInterface $channelRepository,
+        protected readonly FactoryInterface $couponFactory,
+        protected readonly RepositoryInterface $localeRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionRuleExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionRuleExampleFactory.php
@@ -23,12 +23,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionRuleExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
-    public function __construct(private PromotionRuleFactoryInterface $promotionRuleFactory)
-    {
+    /** @param PromotionRuleFactoryInterface<PromotionRuleInterface> $promotionRuleFactory */
+    public function __construct(
+        protected readonly PromotionRuleFactoryInterface $promotionRuleFactory,
+    ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
@@ -23,13 +23,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShippingCategoryExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<ShippingCategoryInterface> $shippingCategoryFactory */
-    public function __construct(private FactoryInterface $shippingCategoryFactory)
-    {
+    public function __construct(
+        protected readonly FactoryInterface $shippingCategoryFactory,
+    ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -32,9 +32,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShippingMethodExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ShippingMethodInterface> $shippingMethodFactory
@@ -44,12 +44,12 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
      * @param RepositoryInterface<TaxCategoryInterface> $taxCategoryRepository
      */
     public function __construct(
-        private FactoryInterface $shippingMethodFactory,
-        private RepositoryInterface $zoneRepository,
-        private RepositoryInterface $shippingCategoryRepository,
-        private RepositoryInterface $localeRepository,
-        private ChannelRepositoryInterface $channelRepository,
-        private RepositoryInterface $taxCategoryRepository,
+        protected readonly FactoryInterface $shippingMethodFactory,
+        protected readonly RepositoryInterface $zoneRepository,
+        protected readonly RepositoryInterface $shippingCategoryRepository,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly ChannelRepositoryInterface $channelRepository,
+        protected readonly RepositoryInterface $taxCategoryRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -27,9 +27,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ShopUserInterface> $shopUserFactory
@@ -37,9 +37,9 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
      * @param RepositoryInterface<CustomerGroupInterface> $customerGroupRepository
      */
     public function __construct(
-        private FactoryInterface $shopUserFactory,
-        private FactoryInterface $customerFactory,
-        private RepositoryInterface $customerGroupRepository,
+        protected readonly FactoryInterface $shopUserFactory,
+        protected readonly FactoryInterface $customerFactory,
+        protected readonly RepositoryInterface $customerGroupRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
@@ -23,12 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxCategoryExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<TaxCategoryInterface> $taxCategoryFactory */
-    public function __construct(private FactoryInterface $taxCategoryFactory)
+    public function __construct(protected readonly FactoryInterface $taxCategoryFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
@@ -27,9 +27,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<TaxRateInterface> $taxRateFactory
@@ -37,9 +37,9 @@ class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param RepositoryInterface<TaxCategoryInterface> $taxCategoryRepository
      */
     public function __construct(
-        private FactoryInterface $taxRateFactory,
-        private RepositoryInterface $zoneRepository,
-        private RepositoryInterface $taxCategoryRepository,
+        protected readonly FactoryInterface $taxRateFactory,
+        protected readonly RepositoryInterface $zoneRepository,
+        protected readonly RepositoryInterface $taxCategoryRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -27,19 +27,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    private Generator $faker;
+    protected Generator $faker;
 
-    private OptionsResolver $optionsResolver;
+    protected OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<TaxonInterface> $taxonFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        private FactoryInterface $taxonFactory,
-        private TaxonRepositoryInterface $taxonRepository,
-        private RepositoryInterface $localeRepository,
-        private TaxonSlugGeneratorInterface $taxonSlugGenerator,
+        protected readonly FactoryInterface $taxonFactory,
+        protected readonly TaxonRepositoryInterface $taxonRepository,
+        protected readonly RepositoryInterface $localeRepository,
+        protected readonly TaxonSlugGeneratorInterface $taxonSlugGenerator,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | no


<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Let's make fixture factories easier to extend by making their constructor arguments protected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased accessibility of various properties in multiple factory classes, changing them from private to protected. This allows for greater flexibility in extending these classes without affecting existing functionality or behavior. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->