### PR TITLE
[CI] Test Symfony 7.3 beta on unstable builds

### DIFF
--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -25,7 +25,7 @@ jobs:
                 include:
                     -
                         php: "8.3"
-                        symfony: "7.3.x-dev"
+                        symfony: "^7.3@beta"
                         mysql: "8.4"
 
         env:

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -18,29 +18,18 @@ permissions:
     contents: read
 
 jobs:
-    get-matrix:
-        runs-on: ubuntu-latest
-        name: "Get matrix"
-        outputs:
-            matrix: ${{ steps.matrix.outputs.prop }}
-        steps:
-            -   uses: actions/checkout@v4
-            -   name: "Get matrix"
-                id: matrix
-                uses: notiz-dev/github-action-json-property@release
-                with:
-                    path: '.github/workflows/matrix.json'
-                    prop_path: '${{ inputs.type }}.packages'
-
     test_unstable:
-        needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (Unstable Dependencies)"
         timeout-minutes: 25
 
         strategy:
             fail-fast: false
-            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+            matrix:
+                include:
+                    -
+                        php: "8.3"
+                        symfony: "^7.3@beta"
 
         env:
             COMPOSER_ROOT_VERSION: "dev-main"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Deprecations?   | 
| Related tickets | bases on #18048 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow to use a broader Symfony version constraint for unstable end-to-end tests.
	- Simplified package testing workflow by removing dynamic matrix generation and switching to a static test configuration for PHP 8.3 and Symfony ^7.3@beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->