### PR TITLE
[Composer] Bump APIP to 4.1 and remove conflict to api-platform/json-ld

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -1,9 +1,0 @@
-# CONFLICTS
-
-This document explains why certain conflicts were added to `composer.json` and
-references related issues.
-
-- `api-platform/jsonld: ^4.1.1`
-
-  API Platform introduced changes in version 4.1.1 that modify API responses, potentially breaking compatibility with our current implementation.  
-  To ensure stable behavior, we have added this conflict until we can verify and adapt to the changes.

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "ext-sodium": "*",
-        "api-platform/doctrine-orm": "^4.0.3",
-        "api-platform/symfony": "^4.0.3",
+        "api-platform/doctrine-orm": "^4.1.7",
+        "api-platform/symfony": "^4.1.7",
         "babdev/pagerfanta-bundle": "^4.4",
         "behat/transliterator": "^1.5",
         "doctrine/collections": "^2.2",
@@ -242,9 +242,6 @@
         "hwi/oauth-bundle": "If you want to use Facebook login (see https://docs.sylius.com/en/latest/cookbook/shop/facebook-login.html)",
         "winzou/state-machine": "If you want to use Winzou State Machine (^0.4)",
         "winzou/state-machine-bundle": "If you want to use Winzou State Machine (^0.6)"
-    },
-    "conflict": {
-        "api-platform/jsonld": "^4.1.1"
     },
     "config": {
         "preferred-install": {

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": "^8.2",
         "doctrine/dbal": "^3.9",
-        "api-platform/doctrine-orm": "^4.0.3",
-        "api-platform/symfony": "^4.0.3",
+        "api-platform/doctrine-orm": "^4.1.7",
+        "api-platform/symfony": "^4.1.7",
         "lexik/jwt-authentication-bundle": "^3.1",
         "sylius/core-bundle": "^2.0",
         "sylius/payum-bundle": "^2.0",
@@ -46,9 +46,6 @@
         "symfony/dotenv": "^6.4 || ^7.2",
         "symfony/webpack-encore-bundle": "^2.2",
         "theofidry/alice-data-fixtures": "^1.7"
-    },
-    "conflict": {
-        "api-platform/jsonld": "^4.1.1"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/17763
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to require newer versions of key packages for improved compatibility.
  - Removed restrictions related to a previously conflicting package version.
  - Deleted outdated documentation regarding dependency conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->