### PR TITLE
Remove orm-3 branch from hydratator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "psr/log": "^3.0",
         "ramsey/uuid": "^4.7",
         "stof/doctrine-extensions-bundle": "^1.12",
-        "sylius-labs/association-hydrator": "^1.2 || dev-orm-3",
+        "sylius-labs/association-hydrator": "^1.2",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.2",
         "sylius/fixtures-bundle": "^1.9",
         "sylius/grid": "^1.13",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -34,7 +34,7 @@
         "knplabs/knp-gaufrette-bundle": "^0.9",
         "league/flysystem-bundle": "^3.3",
         "liip/imagine-bundle": "^2.13",
-        "sylius-labs/association-hydrator": "^1.2 || dev-orm-3",
+        "sylius-labs/association-hydrator": "^1.2",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.2",
         "sylius/addressing-bundle": "^2.0",
         "sylius/attribute-bundle": "^2.0",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | orm-3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #17972 
| License         | MIT

Now association hydrator 1.3 has been released, we can remove "dev" usage.

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
