### PR TITLE
[PHPSpec to PHPUnit] Order Bundle - Fix

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Tests/Context/SessionBasedCartContextTest.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Context/SessionBasedCartContextTest.php
@@ -24,9 +24,9 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class SessionBasedCartContextTest extends TestCase
 {
-    private MockObject&SessionInterface $session;
+    private SessionInterface&MockObject $session;
 
-    private MockObject&OrderRepositoryInterface $orderRepository;
+    private OrderRepositoryInterface&MockObject $orderRepository;
 
     private SessionBasedCartContext $sessionBasedCartContext;
 

--- a/src/Sylius/Bundle/OrderBundle/Tests/Context/SessionBasedCartContextTest.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Context/SessionBasedCartContextTest.php
@@ -24,11 +24,9 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 final class SessionBasedCartContextTest extends TestCase
 {
-    /** @var SessionInterface&MockObject */
-    private SessionInterface $session;
+    private MockObject&SessionInterface $session;
 
-    /** @var OrderRepositoryInterface&MockObject */
-    private OrderRepositoryInterface $orderRepository;
+    private MockObject&OrderRepositoryInterface $orderRepository;
 
     private SessionBasedCartContext $sessionBasedCartContext;
 

--- a/src/Sylius/Bundle/OrderBundle/Tests/Remover/ExpiredCartsRemoverTest.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Remover/ExpiredCartsRemoverTest.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\OrderBundle\Remover\ExpiredCartsRemover;
+use Sylius\Bundle\OrderBundle\SyliusExpiredCartsEvents;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Remover\ExpiredCartsRemoverInterface;
 use Sylius\Component\Order\Repository\OrderRepositoryInterface;
@@ -101,7 +102,10 @@ final class ExpiredCartsRemoverTest extends TestCase
             ->expects(self::exactly(4))
             ->method('dispatch')
             ->willReturnCallback(function ($event, $eventName) {
-                self::assertContains($eventName, ['sylius.carts.pre_remove', 'sylius.carts.post_remove']);
+                self::assertContains(
+                    $eventName,
+                    [SyliusExpiredCartsEvents::PRE_REMOVE, SyliusExpiredCartsEvents::POST_REMOVE],
+                );
 
                 return $event;
             });
@@ -111,13 +115,9 @@ final class ExpiredCartsRemoverTest extends TestCase
             ->method('remove')
             ->with($this->isInstanceOf(OrderInterface::class));
 
-        $this->objectManager
-            ->expects(self::exactly(2))
-            ->method('flush');
+        $this->objectManager->expects(self::exactly(2))->method('flush');
 
-        $this->objectManager
-            ->expects(self::exactly(2))
-            ->method('clear');
+        $this->objectManager->expects(self::exactly(2))->method('clear');
 
         $this->expiredCartsRemover->remove();
     }

--- a/src/Sylius/Bundle/OrderBundle/Tests/Resetter/CartChangesResetterTest.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/Resetter/CartChangesResetterTest.php
@@ -83,14 +83,11 @@ final class CartChangesResetterTest extends TestCase
             ->expects(self::exactly(2))
             ->method('getEntityState')
             ->willReturnCallback(function ($unit) use ($unitNew, $unitExisting) {
-                if ($unit === $unitNew) {
-                    return UnitOfWork::STATE_NEW;
-                }
-                if ($unit === $unitExisting) {
-                    return UnitOfWork::STATE_MANAGED;
-                }
-
-                return null;
+                return match ($unit) {
+                    $unitNew => UnitOfWork::STATE_NEW,
+                    $unitExisting => UnitOfWork::STATE_MANAGED,
+                    default => throw new \UnhandledMatchError(),
+                };
             });
 
         $item
@@ -103,8 +100,6 @@ final class CartChangesResetterTest extends TestCase
             ->method('refresh')
             ->willReturnCallback(function ($object) use ($item) {
                 self::assertTrue($object === $item || $object === $this->cart);
-
-                return null;
             });
 
         $this->cartChangesResetter->resetChanges($this->cart);

--- a/src/Sylius/Bundle/OrderBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/OrderBundle/phpunit.xml.dist
@@ -9,7 +9,7 @@
     </php>
 
     <testsuites>
-        <testsuite name="sylius_order_bundle_test_suite">
+        <testsuite name="sylius-order-bundle">
             <directory>./test/</directory>
             <directory>./Tests/</directory>
         </testsuite>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | OP-571
| License         | MIT

Fixes to already merged [PHPSpec to PHPUnit] Order Bundle
<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test property type declarations for improved clarity.
	- Replaced hardcoded event names in tests with predefined constants.
	- Simplified test logic and callbacks for better readability.
- **Chores**
	- Renamed the PHPUnit test suite for the Order Bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->