### PR TITLE
[API][Shop] Fix hardcoded variants squashing on product

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtension.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
+use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+final readonly class EnabledVariantsExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    public function __construct(private SectionProviderInterface $sectionProvider)
+    {
+    }
+
+    /**
+     * @param array<array-key, mixed> $context
+     */
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->modifyQueryBuilder($queryBuilder, $queryNameGenerator, $resourceClass);
+    }
+
+    /**
+     * @param array<array-key, mixed> $identifiers
+     * @param array<array-key, mixed> $context
+     */
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $this->modifyQueryBuilder($queryBuilder, $queryNameGenerator, $resourceClass);
+    }
+
+    private function modifyQueryBuilder(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+    ): void {
+        if (!is_a($resourceClass, ProductInterface::class, true)) {
+            return;
+        }
+
+        if (!$this->sectionProvider->getSection() instanceof ShopApiSection) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $variantAliasName = $queryNameGenerator->generateJoinAlias('variant');
+        $enabledParameterName = $queryNameGenerator->generateParameterName('enabled');
+
+        $queryBuilder
+            ->addSelect($variantAliasName)
+            ->leftJoin(sprintf('%s.variants', $rootAlias), $variantAliasName)
+            ->andWhere(sprintf('%s.enabled = :%s OR %1$s.id IS NULL', $variantAliasName, $enabledParameterName))
+            ->setParameter($enabledParameterName, true)
+        ;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtension.php
@@ -17,6 +17,7 @@ use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
@@ -75,8 +76,7 @@ final readonly class EnabledVariantsExtension implements QueryCollectionExtensio
 
         $queryBuilder
             ->addSelect($variantAliasName)
-            ->leftJoin(sprintf('%s.variants', $rootAlias), $variantAliasName)
-            ->andWhere(sprintf('%s.enabled = :%s OR %1$s.id IS NULL', $variantAliasName, $enabledParameterName))
+            ->leftJoin(sprintf('%s.variants', $rootAlias), $variantAliasName, Join::WITH, sprintf('%s.enabled = :%s', $variantAliasName, $enabledParameterName))
             ->setParameter($enabledParameterName, true)
         ;
     }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -59,6 +59,15 @@
         </service>
 
         <service
+            id="sylius_api.doctrine.orm.query_extension.shop.product.enabled_variants"
+            class="Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\EnabledVariantsExtension"
+        >
+            <argument type="service" id="sylius.section_resolver.uri_based" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+            <tag name="api_platform.doctrine.orm.query_extension.item" />
+        </service>
+
+        <service
             id="sylius_api.doctrine.orm.query_extension.shop.product.taxon_based"
             class="Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\TaxonBasedExtension"
         >

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
@@ -18,7 +18,6 @@ use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
 use Sylius\Bundle\ApiBundle\Serializer\SerializationGroupsSupportTrait;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Product\Model\ProductVariantInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -50,12 +49,6 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
         $context[self::ALREADY_CALLED] = true;
 
         $data = $this->normalizer->normalize($object, $format, $context);
-
-        $data['variants'] = $object
-            ->getEnabledVariants()
-            ->map(fn (ProductVariantInterface $variant): string => $this->iriConverter->getIriFromResource($variant))
-            ->getValues()
-        ;
 
         $defaultVariant = $this->defaultProductVariantResolver->getVariant($object);
 

--- a/src/Sylius/Bundle/ApiBundle/Tests/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Doctrine/ORM/QueryExtension/Shop/Product/EnabledVariantsExtensionTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Tests\Doctrine\ORM\QueryExtension\Shop\Product;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\Doctrine\ORM\QueryExtension\Shop\Product\EnabledVariantsExtension;
+use Sylius\Bundle\ApiBundle\SectionResolver\AdminApiSection;
+use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
+use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final class EnabledVariantsExtensionTest extends TestCase
+{
+    private EnabledVariantsExtension $extension;
+
+    /** @var SectionProviderInterface|MockObject */
+    private $sectionProvider;
+
+    protected function setUp(): void
+    {
+        $this->sectionProvider = $this->createMock(SectionProviderInterface::class);
+        $this->extension = new EnabledVariantsExtension($this->sectionProvider);
+    }
+
+    public function test_it_is_a_query_extension(): void
+    {
+        $this->assertInstanceOf(QueryCollectionExtensionInterface::class, $this->extension);
+        $this->assertInstanceOf(QueryItemExtensionInterface::class, $this->extension);
+    }
+
+    public function test_it_does_nothing_if_current_resource_is_not_a_product(): void
+    {
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $this->sectionProvider->expects($this->never())->method('getSection');
+
+        $queryBuilder->expects($this->never())->method('getRootAliases');
+
+        $this->extension->applyToCollection(
+            $queryBuilder,
+            $this->createMock(QueryNameGeneratorInterface::class),
+            TaxonInterface::class,
+            new Get(name: Request::METHOD_GET)
+        );
+    }
+
+    public function test_it_does_nothing_if_in_admin_section(): void
+    {
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $this->sectionProvider
+            ->expects($this->once())
+            ->method('getSection')
+            ->willReturn($this->createMock(AdminApiSection::class))
+        ;
+
+        $queryBuilder->expects($this->never())->method('getRootAliases');
+
+        $this->extension->applyToCollection(
+            $queryBuilder,
+            $this->createMock(QueryNameGeneratorInterface::class),
+            ProductInterface::class,
+            new Get(name: Request::METHOD_GET)
+        );
+    }
+
+    public function test_it_filters_out_disabled_variants_on_collection(): void
+    {
+        $shopApiSection = $this->createMock(ShopApiSection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryNameGenerator = $this->createMock(QueryNameGeneratorInterface::class);
+
+        $this->sectionProvider->expects($this->once())->method('getSection')->willReturn($shopApiSection);
+
+        $queryNameGenerator
+            ->expects($this->once())
+            ->method('generateJoinAlias')
+            ->with('variant')
+            ->willReturn('variant')
+        ;
+
+        $queryNameGenerator
+            ->expects($this->once())
+            ->method('generateParameterName')
+            ->with('enabled')
+            ->willReturn('enabledParameter')
+        ;
+
+        $queryBuilder->expects($this->once())->method('getRootAliases')->willReturn(['o']);
+        $queryBuilder->expects($this->once())->method('addSelect')->with('variant')->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('leftJoin')->with('o.variants', 'variant')->willReturnSelf();
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('andWhere')
+            ->with('variant.enabled = :enabledParameter OR variant.id IS NULL')
+            ->willReturnSelf()
+        ;
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('enabledParameter', true)
+            ->willReturnSelf()
+        ;
+
+        $this->extension->applyToCollection(
+            $queryBuilder,
+            $queryNameGenerator,
+            ProductInterface::class,
+            new GetCollection(),
+        );
+    }
+    public function test_it_filters_out_disabled_variants_on_item(): void
+    {
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryNameGenerator = $this->createMock(QueryNameGeneratorInterface::class);
+
+        $this->sectionProvider
+            ->expects($this->once())
+            ->method('getSection')
+            ->willReturn($this->createMock(ShopApiSection::class))
+        ;
+
+        $queryNameGenerator
+            ->expects($this->once())
+            ->method('generateJoinAlias')
+            ->with('variant')
+            ->willReturn('variant')
+        ;
+
+        $queryNameGenerator
+            ->expects($this->once())
+            ->method('generateParameterName')
+            ->with('enabled')
+            ->willReturn('enabledParameter')
+        ;
+
+        $queryBuilder->expects($this->once())->method('getRootAliases')->willReturn(['o']);
+        $queryBuilder->expects($this->once())->method('addSelect')->with('variant')->willReturnSelf();
+        $queryBuilder->expects($this->once())->method('leftJoin')->with('o.variants', 'variant')->willReturnSelf();
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('andWhere')
+            ->with('variant.enabled = :enabledParameter OR variant.id IS NULL')
+            ->willReturnSelf()
+        ;
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('enabledParameter', true)
+            ->willReturnSelf();
+
+        $this->extension->applyToItem(
+            $queryBuilder,
+            $queryNameGenerator,
+            ProductInterface::class,
+            [],
+            new Get(),
+        );
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/Normalizer/ProductNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/Normalizer/ProductNormalizerSpec.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ApiBundle\Serializer\Normalizer;
 
 use ApiPlatform\Metadata\IriConverterInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\SectionResolver\AdminApiSection;
 use Sylius\Bundle\ApiBundle\SectionResolver\ShopApiSection;
@@ -80,12 +79,10 @@ final class ProductNormalizerSpec extends ObjectBehavior
             'sylius_product_normalizer_already_called' => true,
             'groups' => ['sylius:product:index'],
         ])->willReturn([]);
-        $product->getEnabledVariants()->willReturn(new ArrayCollection([$variant->getWrappedObject()]));
         $defaultProductVariantResolver->getVariant($product)->willReturn($variant);
         $iriConverter->getIriFromResource($variant)->willReturn('/api/v2/shop/product-variants/CODE');
 
         $this->normalize($product, null, ['groups' => ['sylius:product:index']])->shouldReturn([
-            'variants' => ['/api/v2/shop/product-variants/CODE'],
             'defaultVariant' => '/api/v2/shop/product-variants/CODE',
         ]);
     }
@@ -105,12 +102,10 @@ final class ProductNormalizerSpec extends ObjectBehavior
             'groups' => ['sylius:product:index'],
         ])->willReturn([]);
         $iriConverter->getIriFromResource($variant)->willReturn('/api/v2/shop/product-variants/CODE');
-        $product->getEnabledVariants()->willReturn(new ArrayCollection([$variant->getWrappedObject()]));
 
         $defaultProductVariantResolver->getVariant($product)->willReturn(null);
 
         $this->normalize($product, null, ['groups' => ['sylius:product:index']])->shouldReturn([
-            'variants' => ['/api/v2/shop/product-variants/CODE'],
             'defaultVariant' => null,
         ]);
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Due to how the variants were handled on shop product endpoints there was no way to change their serialization groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Product queries in the shop API now include only enabled product variants, ensuring more accurate and relevant product listings.

- **Bug Fixes**
  - The "variants" and "defaultVariant" fields in product responses now correctly reflect enabled variants, providing more consistent and reliable API data.

- **Tests**
  - Added and updated test cases and fixtures to verify the correct filtering and display of enabled product variants in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->