### PR TITLE
[API][Shop][Product] Allow serializing the default variant

### DIFF
--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -115,6 +115,7 @@
             <argument type="service" id="sylius.behat.request_factory" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument>%sylius.security.api_route%</argument>
+            <argument type="service" id="sylius.resolver.product_variant.default" />
         </service>
 
         <service id="sylius.behat.context.api.shop.product_attribute" class="Sylius\Behat\Context\Api\Shop\ProductAttributeContext">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
@@ -145,5 +145,9 @@
             <group>sylius:shop:product:index</group>
             <group>sylius:shop:product:show</group>
         </attribute>
+        <attribute name="defaultVariantData">
+            <group>sylius:shop:product:index</group>
+            <group>sylius:shop:product:show</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -53,6 +53,8 @@
         <attribute name="name">
             <group>sylius:shop:product_variant:index</group>
             <group>sylius:shop:product_variant:show</group>
+            <group>sylius:shop:product:index</group>
+            <group>sylius:shop:product:show</group>
         </attribute>
         <attribute name="enabled">
             <group>sylius:admin:product_variant:index</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -53,8 +53,8 @@
         <attribute name="name">
             <group>sylius:shop:product_variant:index</group>
             <group>sylius:shop:product_variant:show</group>
-            <group>sylius:shop:product:index</group>
-            <group>sylius:shop:product:show</group>
+            <group>sylius:shop:product:index:default_variant</group>
+            <group>sylius:shop:product:show:default_variant</group>
         </attribute>
         <attribute name="enabled">
             <group>sylius:admin:product_variant:index</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -45,6 +45,10 @@
                 <argument>sylius:shop:product:show</argument>
             </argument>
             <argument type="service" id="serializer.normalizer.object" />
+            <argument type="collection">
+                <argument>sylius:shop:product:index:default_variant</argument>
+                <argument>sylius:shop:product:show:default_variant</argument>
+            </argument>
             <tag name="serializer.normalizer" priority="64" />
         </service>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -44,6 +44,7 @@
                 <argument>sylius:shop:product:index</argument>
                 <argument>sylius:shop:product:show</argument>
             </argument>
+            <argument type="service" id="serializer.normalizer.object" />
             <tag name="serializer.normalizer" priority="64" />
         </service>
 
@@ -87,6 +88,8 @@
             <argument type="collection">
                 <argument>sylius:shop:product_variant:index</argument>
                 <argument>sylius:shop:product_variant:show</argument>
+                <argument>sylius:shop:product:index</argument>
+                <argument>sylius:shop:product:show</argument>
             </argument>
             <tag name="serializer.normalizer" priority="64" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ApiBundle\Serializer\SerializationGroupsSupportTrait;
 use Sylius\Bundle\CoreBundle\SectionResolver\SectionProviderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -36,7 +37,16 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
         private readonly IriConverterInterface $iriConverter,
         private readonly SectionProviderInterface $sectionProvider,
         private readonly array $serializationGroups,
+        private readonly ?AbstractObjectNormalizer $objectNormalizer = null,
     ) {
+        if (null === $this->objectNormalizer) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.1',
+                'Not passing $objectNormalizer through constructor is deprecated and will be prohibited in Sylius 3.0.',
+                self::class,
+            );
+        }
     }
 
     public function normalize(mixed $object, ?string $format = null, array $context = []): array
@@ -50,9 +60,7 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
 
         $data = $this->normalizer->normalize($object, $format, $context);
 
-        $defaultVariant = $this->defaultProductVariantResolver->getVariant($object);
-
-        $data['defaultVariant'] = $defaultVariant === null ? null : $this->iriConverter->getIriFromResource($defaultVariant);
+        $this->populateDefaultVariantData($data, $object, $format, $context);
 
         return $data;
     }
@@ -70,5 +78,26 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
     public function getSupportedTypes(?string $format): array
     {
         return [ProductInterface::class => false];
+    }
+
+    private function populateDefaultVariantData(array &$data, ProductInterface $product, ?string $format, array $context): void
+    {
+        $data['defaultVariant'] = null;
+        $data['defaultVariantData'] = null;
+
+        $defaultVariant = $this->defaultProductVariantResolver->getVariant($product);
+        if (null === $defaultVariant) {
+            return;
+        }
+
+        $data['defaultVariant'] = $this->iriConverter->getIriFromResource($defaultVariant);
+
+        if (null === $this->objectNormalizer) {
+            return;
+        }
+
+        if ([] !== $this->objectNormalizer->normalize($defaultVariant, $format, $context)) {
+            $data['defaultVariantData'] = $this->normalizer->normalize($defaultVariant, $format, $context);
+        }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
@@ -38,6 +38,7 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
         private readonly SectionProviderInterface $sectionProvider,
         private readonly array $serializationGroups,
         private readonly ?AbstractObjectNormalizer $objectNormalizer = null,
+        private readonly array $defaultVariantSerializationGroups = [],
     ) {
         if (null === $this->objectNormalizer) {
             trigger_deprecation(
@@ -96,11 +97,12 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
             return;
         }
 
-        $defaultVariantData = $this->objectNormalizer->normalize($defaultVariant, $format, $context);
-        if ([] === $defaultVariantData) {
+        $context['groups'] = array_merge($context['groups'] ?? [], $this->defaultVariantSerializationGroups);
+
+        if ([] === $this->objectNormalizer->normalize($defaultVariant, $format, $context)) {
             return;
         }
 
-        $data['defaultVariantData'] = $defaultVariantData;
+        $data['defaultVariantData'] = $this->normalizer->normalize($defaultVariant, $format, $context);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/ProductNormalizer.php
@@ -96,8 +96,11 @@ final class ProductNormalizer implements NormalizerInterface, NormalizerAwareInt
             return;
         }
 
-        if ([] !== $this->objectNormalizer->normalize($defaultVariant, $format, $context)) {
-            $data['defaultVariantData'] = $this->normalizer->normalize($defaultVariant, $format, $context);
+        $defaultVariantData = $this->objectNormalizer->normalize($defaultVariant, $format, $context);
+        if ([] === $defaultVariantData) {
+            return;
         }
+
+        $data['defaultVariantData'] = $defaultVariantData;
     }
 }

--- a/tests/Api/DataFixtures/ORM/product/product_with_many_locales.yaml
+++ b/tests/Api/DataFixtures/ORM/product/product_with_many_locales.yaml
@@ -19,7 +19,7 @@ Sylius\Component\Locale\Model\Locale:
     locale_en:
         code: 'en_US'
     locale_pl:
-        code: 'pl_PL' 
+        code: 'pl_PL'
     locale_de:
         code: 'de_DE'
 
@@ -41,21 +41,21 @@ Sylius\Component\Core\Model\ProductTranslation:
         name: 'Mug'
         description: 'This is a mug'
         shortDescription: 'Short mug description'
-        translatable: '@product_mug'    
+        translatable: '@product_mug'
     product_translation_mug_pl_PL:
         slug: 'kubek'
         locale: 'pl_PL'
         name: 'Kubek'
         description: 'To jest kubek'
         shortDescription: 'Krótki opis kubka'
-        translatable: '@product_mug'    
+        translatable: '@product_mug'
     product_translation_mug_de_DE:
         slug: 'Becher'
         locale: 'de_DE'
         name: 'Becher'
         description: 'das ist becher'
         shortDescription: 'Kurzbeschreibung der Becher'
-        translatable: '@product_mug'   
+        translatable: '@product_mug'
     product_translation_cup_en_US:
         slug: 'Cup'
         locale: 'en_US'
@@ -90,6 +90,10 @@ Sylius\Component\Product\Model\ProductVariantTranslation:
         locale: 'pl_PL'
         name: 'Kubek niebieski'
         translatable: '@product_variant_mug_blue'
+    product_variant_mug_blue_translation_de_DE:
+        locale: 'de_DE'
+        name: 'Blauer Brecher'
+        translatable: '@product_variant_mug_blue'
     product_variant_mug_red_translation_en_EN:
         locale: 'en_US'
         name: 'Red Mug'
@@ -97,6 +101,10 @@ Sylius\Component\Product\Model\ProductVariantTranslation:
     product_variant_mug_red_translation_pl_PL:
         locale: 'pl_PL'
         name: 'Kubek czerwony'
+        translatable: '@product_variant_mug_red'
+    product_variant_mug_red_translation_de_DE:
+        locale: 'de_DE'
+        name: 'Roter Brecher'
         translatable: '@product_variant_mug_red'
 
 Sylius\Component\Core\Model\ChannelPricing:
@@ -112,7 +120,7 @@ Sylius\Component\Product\Model\ProductOption:
     product_option_color:
         code: 'COLOR'
         currentLocale: 'en_US'
-        
+
 Sylius\Component\Product\Model\ProductOptionTranslation:
     product_option_translation_en_EN:
         locale: 'en_US'

--- a/tests/Api/Responses/shop/product/get_associated_products_by_owner_collection.json
+++ b/tests/Api/Responses/shop/product/get_associated_products_by_owner_collection.json
@@ -22,7 +22,8 @@
             "name": "Cup",
             "description": "@string@",
             "slug": "Cup",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         },
         {
             "@id": "\/api\/v2\/shop\/products\/HAT2",
@@ -43,7 +44,8 @@
             "name": "Hat 2",
             "description": "@string@",
             "slug": "Hat-2",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         }
     ],
     "hydra:totalItems": 2,

--- a/tests/Api/Responses/shop/product/get_associated_products_by_type_collection.json
+++ b/tests/Api/Responses/shop/product/get_associated_products_by_type_collection.json
@@ -22,7 +22,8 @@
             "name": "Hat 2",
             "description": "@string@",
             "slug": "Hat-2",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         }
     ],
     "hydra:totalItems": 1,

--- a/tests/Api/Responses/shop/product/get_product_with_associations.json
+++ b/tests/Api/Responses/shop/product/get_product_with_associations.json
@@ -26,5 +26,15 @@
     "\/api\/v2\/shop\/product-associations\/@integer@",
     "\/api\/v2\/shop\/product-associations\/@integer@"
   ],
-  "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+  "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+  "defaultVariantData": {
+    "@context": "\/api\/v2\/contexts\/ProductVariant",
+    "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+    "@type": "ProductVariant",
+    "name": "Blue Mug",
+    "inStock": true,
+    "price": 2000,
+    "originalPrice": 3000,
+    "lowestPriceBeforeDiscount": null
+  }
 }

--- a/tests/Api/Responses/shop/product/get_product_with_de_DE_locale_translation.json
+++ b/tests/Api/Responses/shop/product/get_product_with_de_DE_locale_translation.json
@@ -25,5 +25,15 @@
     "associations": [
       "\/api\/v2\/shop\/product-associations\/@integer@"
     ],
-    "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+    "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+    "defaultVariantData": {
+        "@context": "\/api\/v2\/contexts\/ProductVariant",
+        "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+        "@type": "ProductVariant",
+        "name": "Blauer Brecher",
+        "inStock": true,
+        "price": 2000,
+        "originalPrice": 3000,
+        "lowestPriceBeforeDiscount": null
+    }
 }

--- a/tests/Api/Responses/shop/product/get_product_with_default_locale_translation.json
+++ b/tests/Api/Responses/shop/product/get_product_with_default_locale_translation.json
@@ -25,5 +25,15 @@
   "associations": [
     "\/api\/v2\/shop\/product-associations\/@integer@"
   ],
-  "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+  "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+  "defaultVariantData": {
+      "@context": "\/api\/v2\/contexts\/ProductVariant",
+      "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+      "@type": "ProductVariant",
+      "name": "Blue Mug",
+      "inStock": true,
+      "price": 2000,
+      "originalPrice": 3000,
+      "lowestPriceBeforeDiscount": null
+  }
 }

--- a/tests/Api/Responses/shop/product/get_products_collection_response.json
+++ b/tests/Api/Responses/shop/product/get_products_collection_response.json
@@ -27,7 +27,16 @@
             "description": "@string@",
             "slug": "mug",
             "associations": [],
-            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+            "defaultVariantData": {
+                "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+                "@type": "ProductVariant",
+                "name": "Blue Mug",
+                "inStock": true,
+                "price": 2000,
+                "originalPrice": 3000,
+                "lowestPriceBeforeDiscount": null
+            }
         }
     ],
     "hydra:totalItems": 1,

--- a/tests/Api/Responses/shop/product/get_products_collection_with_associations_response.json
+++ b/tests/Api/Responses/shop/product/get_products_collection_with_associations_response.json
@@ -22,7 +22,8 @@
             "name": "Cup",
             "description": "@string@",
             "slug": "Cup",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         },
         {
             "@id": "\/api\/v2\/shop\/products\/HAT2",
@@ -72,7 +73,16 @@
                 "\/api\/v2\/shop\/product-associations\/@integer@",
                 "\/api\/v2\/shop\/product-associations\/@integer@"
             ],
-            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+            "defaultVariantData": {
+                "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+                "@type": "ProductVariant",
+                "name": "Blue Mug",
+                "inStock": true,
+                "price": 2000,
+                "originalPrice": 3000,
+                "lowestPriceBeforeDiscount": null
+            }
         },
         {
             "@id": "\/api\/v2\/shop\/products\/TANKARD",
@@ -93,7 +103,8 @@
             "name": "Tankard",
             "description": "Tankard description",
             "slug": "Tankard",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         }
     ],
     "hydra:totalItems": 4,

--- a/tests/Api/Responses/shop/product/get_products_collection_with_associations_response.json
+++ b/tests/Api/Responses/shop/product/get_products_collection_with_associations_response.json
@@ -44,7 +44,8 @@
             "name": "Hat 2",
             "description": "@string@",
             "slug": "Hat-2",
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         },
         {
             "@id": "\/api\/v2\/shop\/products\/MUG",

--- a/tests/Api/Responses/shop/product/get_products_with_reviews.json
+++ b/tests/Api/Responses/shop/product/get_products_with_reviews.json
@@ -26,7 +26,16 @@
             "name": "Cap",
             "description": null,
             "slug": "cap",
-            "defaultVariant": "\/api\/v2\/shop\/product-variants\/CAP_RED"
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/CAP_RED",
+            "defaultVariantData": {
+                "@id": "\/api\/v2\/shop\/product-variants\/CAP_RED",
+                "@type": "ProductVariant",
+                "name": null,
+                "inStock": true,
+                "price": 2000,
+                "originalPrice": 2000,
+                "lowestPriceBeforeDiscount": null
+            }
         },
         {
             "@id": "\/api\/v2\/shop\/products\/MUG",
@@ -69,7 +78,16 @@
             "name": "Mug",
             "description": "@string@",
             "slug": "mug",
-            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE"
+            "defaultVariant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+            "defaultVariantData": {
+                "@id": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+                "@type": "ProductVariant",
+                "name": "Blue Mug",
+                "inStock": true,
+                "price": 2000,
+                "originalPrice": 3000,
+                "lowestPriceBeforeDiscount": null
+            }
         },
         {
             "@id": "\/api\/v2\/shop\/products\/SOCKS",
@@ -92,7 +110,8 @@
             "description": null,
             "slug": "socks",
             "associations": [],
-            "defaultVariant": null
+            "defaultVariant": null,
+            "defaultVariantData": null
         }
     ],
     "hydra:totalItems": 3,


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | -
| License         | MIT

<s>Allowed the serialization of `defaultVariant` field on shop's product endpoints (before it was a hardcoded cast to iri), and expanded its data to contain name, prices and appliedPromotions.</s>

#### Update:
Left the `defaultVariant` field as is due to BC;
Added a `defaultVariantData` field on shop's product endpoints and configured it to contain the name, prices and appliedPromotions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Product details in the API now include a new field with comprehensive information about the default product variant, in addition to its URI.
  - The product variant name is now visible in more product listing and detail views.

- **Bug Fixes**
  - Improved accuracy and consistency of product variant information in API responses.
  - Reduced redundant API calls by embedding default variant data directly in product responses.

- **Tests**
  - Enhanced test data with new translations for product variants.
  - Updated API response examples to reflect the enriched product variant data structure.
  - Extended product normalization tests to cover inclusion of detailed default variant data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->