### PR TITLE
[CI] Update matrix for 2.1 branch + fix test installer

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -123,7 +123,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}), Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }} - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony && matrix.symfony.replace('*', 'x') }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -104,6 +104,11 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: "20.x"
 
+            -   name: Fix permissions for var/log
+                run: |
+                    mkdir -p var/log
+                    chmod -R 777 var/log
+
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
 
@@ -123,7 +128,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony && matrix.symfony.replace('*', 'x') }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -104,10 +104,11 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: "20.x"
 
-            -   name: Fix permissions for var/log
+            -   name: Fix permissions for Symfony logs directory
                 run: |
-                    mkdir -p var/log
-                    chmod -R 777 var/log
+                    LOGS_DIR=$(bin/console debug:container --parameter=kernel.logs_dir | grep 'kernel.logs_dir' | awk '{print $2}')
+                    mkdir -p "$LOGS_DIR"
+                    chmod -R 777 "$LOGS_DIR"
 
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -8,11 +8,7 @@
         },
         {
           "php": "8.3",
-          "symfony": "7.2.*"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.3.*"
+          "symfony": "^7.2"
         }
       ]
     },
@@ -23,21 +19,14 @@
           "symfony": "^6.4",
           "mariadb": "10.11.13",
           "dbal": "^3.0",
-          "state_machine_adapter": "symfony_workflow"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.3.*",
-          "mariadb": "11.4.7",
-          "dbal": "^3.0",
-          "state_machine_adapter": "symfony_workflow"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.2.*",
-          "mariadb": "11.4.7",
-          "dbal": "^3.0",
           "state_machine_adapter": "winzou_state_machine"
+        },
+        {
+          "php": "8.3",
+          "symfony": "^7.2",
+          "mariadb": "11.4.7",
+          "dbal": "^3.0",
+          "state_machine_adapter": "symfony_workflow"
         }
       ]
     },
@@ -51,13 +40,7 @@
         },
         {
           "php": "8.3",
-          "symfony": "7.2.*",
-          "mysql": "8.4",
-          "twig": "^3.3"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.3.*",
+          "symfony": "^7.2",
           "mysql": "8.4",
           "twig": "^3.3"
         }
@@ -72,12 +55,7 @@
         },
         {
           "php": "8.3",
-          "symfony": "7.2.*",
-          "postgres": "16.9"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.3.*",
+          "symfony": "^7.2",
           "postgres": "17.5"
         }
       ]
@@ -97,11 +75,7 @@
         },
         {
           "php": "8.3",
-          "symfony": "7.2.*"
-        },
-        {
-          "php": "8.3",
-          "symfony": "7.3.*"
+          "symfony": "^7.2"
         }
       ]
     }
@@ -109,31 +83,31 @@
   "full": {
     "static-checks": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "7.2.*", "7.3.*"]
+      "symfony": ["^6.4", "~7.2.0", "~7.3.0"]
     },
     "e2e-mariadb": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "7.2.*", "7.3.*"],
+      "symfony": ["^6.4", "~7.2.0", "~7.3.0"],
       "mariadb": ["11.4.7"],
       "state_machine_adapter": ["symfony_workflow"],
       "include": [
         {
           "php": "8.3",
-          "symfony": "7.3.*",
-          "mariadb": "11.4.3",
+          "symfony": "~7.3.0",
+          "mariadb": "11.4.7",
           "state_machine_adapter": "winzou_state_machine"
         }
       ]
     },
     "e2e-mysql": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "7.2.*", "7.3.*"],
+      "symfony": ["^6.4", "~7.2.0", "~7.3.0"],
       "mysql": ["8.0", "8.4"],
       "twig": ["^3.3"]
     },
     "e2e-pgsql": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "7.2.*", "7.3.*"],
+      "symfony": ["^6.4", "~7.2.0", "~7.3.0"],
       "postgres": ["15.13", "16.9", "17.5"]
     },
     "frontend": {
@@ -145,7 +119,7 @@
     },
     "packages": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "7.2.*", "7.3.*"]
+      "symfony": ["^6.4", "~7.2.0", "~7.3.0"]
     }
   }
 }

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -8,7 +8,11 @@
         },
         {
           "php": "8.3",
-          "symfony": "^7.2"
+          "symfony": "7.2.*"
+        },
+        {
+          "php": "8.3",
+          "symfony": "7.3.*"
         }
       ]
     },
@@ -17,21 +21,21 @@
         {
           "php": "8.2",
           "symfony": "^6.4",
-          "mariadb": "10.11.9",
+          "mariadb": "10.11.13",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
         },
         {
           "php": "8.3",
-          "symfony": "^7.2",
-          "mariadb": "11.4.3",
+          "symfony": "7.3.*",
+          "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
         },
         {
           "php": "8.3",
-          "symfony": "^7.2",
-          "mariadb": "11.4.3",
+          "symfony": "7.2.*",
+          "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "winzou_state_machine"
         }
@@ -47,7 +51,13 @@
         },
         {
           "php": "8.3",
-          "symfony": "^7.2",
+          "symfony": "7.2.*",
+          "mysql": "8.4",
+          "twig": "^3.3"
+        },
+        {
+          "php": "8.3",
+          "symfony": "7.3.*",
           "mysql": "8.4",
           "twig": "^3.3"
         }
@@ -58,12 +68,17 @@
         {
           "php": "8.2",
           "symfony": "^6.4",
-          "postgres": "15.8"
+          "postgres": "15.13"
         },
         {
           "php": "8.3",
-          "symfony": "^7.2",
-          "postgres": "16.4"
+          "symfony": "7.2.*",
+          "postgres": "16.9"
+        },
+        {
+          "php": "8.3",
+          "symfony": "7.3.*",
+          "postgres": "17.5"
         }
       ]
     },
@@ -82,7 +97,11 @@
         },
         {
           "php": "8.3",
-          "symfony": "^7.2"
+          "symfony": "7.2.*"
+        },
+        {
+          "php": "8.3",
+          "symfony": "7.3.*"
         }
       ]
     }
@@ -90,17 +109,17 @@
   "full": {
     "static-checks": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.2"]
+      "symfony": ["^6.4", "7.2.*", "7.3.*"]
     },
     "e2e-mariadb": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.2"],
-      "mariadb": ["10.11.9", "11.4.3"],
+      "symfony": ["^6.4", "7.2.*", "7.3.*"],
+      "mariadb": ["11.4.7"],
       "state_machine_adapter": ["symfony_workflow"],
       "include": [
         {
           "php": "8.3",
-          "symfony": "^7.2",
+          "symfony": "7.3.*",
           "mariadb": "11.4.3",
           "state_machine_adapter": "winzou_state_machine"
         }
@@ -108,14 +127,14 @@
     },
     "e2e-mysql": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.2"],
+      "symfony": ["^6.4", "7.2.*", "7.3.*"],
       "mysql": ["8.0", "8.4"],
       "twig": ["^3.3"]
     },
     "e2e-pgsql": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.2"],
-      "postgres": ["14.13", "15.8", "16.4"]
+      "symfony": ["^6.4", "7.2.*", "7.3.*"],
+      "postgres": ["15.13", "16.9", "17.5"]
     },
     "frontend": {
       "include": [
@@ -126,7 +145,7 @@
     },
     "packages": {
       "php": ["8.2", "8.3"],
-      "symfony": ["^6.4", "^7.2"]
+      "symfony": ["^6.4", "7.2.*", "7.3.*"]
     }
   }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflow configurations to use newer versions of MariaDB and PostgreSQL for testing.
  - Expanded Symfony version constraints in test matrices.
  - Adjusted state machine adapter and simplified database version coverage in test scenarios.
  - Improved log artifact naming and fixed permissions on Symfony logs directory in CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->