### PR TITLE
[Core] Fix options in Type constraint for ChannelPriceHistoryConfig + fix supports check of PaymentRequestAfterPayResponseProvider

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestAfterPayResponseProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderPay/Provider/PaymentRequestAfterPayResponseProvider.php
@@ -68,7 +68,9 @@ final class PaymentRequestAfterPayResponseProvider implements AfterPayResponsePr
 
     public function supports(RequestConfiguration $requestConfiguration): bool
     {
-        return null !== $this->getPaymentRequestHash($requestConfiguration);
+        $hash = $this->getPaymentRequestHash($requestConfiguration);
+
+        return null !== $hash && '' !== $hash;
     }
 
     private function getPaymentRequestHash(RequestConfiguration $requestConfiguration): mixed

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ChannelPriceHistoryConfig.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ChannelPriceHistoryConfig.xml
@@ -23,7 +23,7 @@
                 </option>
             </constraint>
             <constraint name="Type">
-                <option name="value">int</option>
+                <option name="type">int</option>
                 <option name="groups">
                     <value>sylius</value>
                 </option>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
