### PR TITLE
[API][Shop] Add index endpoints for ProductOption/Value

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductBasedProductOptionFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductBasedProductOptionFilter.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Product\Model\ProductOptionInterface;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+final class ProductBasedProductOptionFilter extends AbstractFilter
+{
+    public function __construct(
+        private string $productClass,
+        ManagerRegistry $managerRegistry,
+        ?LoggerInterface $logger = null,
+        ?array $properties = null,
+        ?NameConverterInterface $nameConverter = null,
+    ) {
+        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
+    }
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = []
+    ): void {
+        if (!is_a($resourceClass, ProductOptionInterface::class, true)) {
+            return;
+        }
+        if ('productCode' !== $property || $value === null || $value === '') {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
+        $productJoinAlias = $queryNameGenerator->generateJoinAlias('product');
+
+        $productCodeParameter = $queryNameGenerator->generateParameterName('productCode');
+
+        $queryBuilder
+            ->innerJoin(
+                Product::class,
+                $productJoinAlias,
+                Join::WITH,
+                sprintf('%s.code = :%s', $productJoinAlias, $productCodeParameter)
+            )
+            ->andWhere(sprintf('%s MEMBER OF %s.options', $rootAlias, $productJoinAlias))
+            ->setParameter($productCodeParameter, $value)
+        ;
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'productCode' => [
+                'property' => 'productCode',
+                'type' => 'string',
+                'required' => false,
+                'swagger' => [
+                    'description' => 'Filter by product code',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductVariantCatalogPromotionFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductVariantCatalogPromotionFilter.php
@@ -34,7 +34,16 @@ final class ProductVariantCatalogPromotionFilter extends AbstractFilter
         ?array $properties = null,
         ?NameConverterInterface $nameConverter = null,
     ) {
-        parent::__construct($managerRegistry, $requestStack, $logger, $properties, $nameConverter);
+        if (null !== $requestStack) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.1',
+                'Passing a "%s" as the third constructor argument is deprecated and will be prohibited in 3.0.',
+                RequestStack::class,
+            );
+        }
+
+        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
     }
 
     protected function filterProperty(

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductVariantOptionValueFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/ORM/Filter/ProductVariantOptionValueFilter.php
@@ -33,7 +33,16 @@ final class ProductVariantOptionValueFilter extends AbstractFilter
         ?array $properties = null,
         ?NameConverterInterface $nameConverter = null,
     ) {
-        parent::__construct($managerRegistry, $requestStack, $logger, $properties, $nameConverter);
+        if (null !== $requestStack) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.1',
+                'Passing a "%s" as the third constructor argument is deprecated and will be prohibited in 3.0.',
+                RequestStack::class,
+            );
+        }
+
+        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
     }
 
     protected function filterProperty(

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOption.xml
@@ -19,6 +19,25 @@
     <resource class="%sylius.model.product_option.class%">
         <operations>
             <operation
+                name="sylius_api_shop_product_option_collection_get"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/product-options"
+            >
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:shop:product_option:index</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+                <filters>
+                    <filter>sylius_api.product_code_search_filter.shop.product_option</filter>
+                </filters>
+            </operation>
+
+            <operation
                 name="sylius_api_shop_product_option_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/product-options/{code}"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductOptionValue.xml
@@ -19,6 +19,25 @@
     <resource class="%sylius.model.product_option_value.class%">
         <operations>
             <operation
+                name="sylius_api_shop_product_option_value_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/product-option-values"
+            >
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:shop:product_option_value:index</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+                <filters>
+                    <filter>sylius_api.product_code_search_filter.shop.product_option_value</filter>
+                </filters>
+            </operation>
+
+            <operation
                 name="sylius_api_shop_product_option_product_option_value_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/product-options/{optionCode}/values/{code}"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOption.xml
@@ -21,11 +21,13 @@
             <group>sylius:admin:product_option:show</group>
             <group>sylius:admin:product_option:create</group>
             <group>sylius:shop:product_option:show</group>
+            <group>sylius:shop:product_option:index</group>
         </attribute>
         <attribute name="name">
             <group>sylius:admin:product_option:index</group>
             <group>sylius:admin:product_option:show</group>
             <group>sylius:shop:product_option:show</group>
+            <group>sylius:shop:product_option:index</group>
         </attribute>
         <attribute name="createdAt">
             <group>sylius:admin:product_option:index</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
@@ -18,10 +18,12 @@
     <class name="Sylius\Component\Product\Model\ProductOptionValue">
         <attribute name="value">
             <group>sylius:admin:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:index</group>
             <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="option">
             <group>sylius:admin:product_option_value:show</group>
+            <group>sylius:shop:product_option_value:index</group>
             <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="code">
@@ -29,6 +31,7 @@
             <group>sylius:admin:product_option_value:show</group>
             <group>sylius:admin:product_option:create</group>
             <group>sylius:admin:product_option:update</group>
+            <group>sylius:shop:product_option_value:index</group>
             <group>sylius:shop:product_option_value:show</group>
         </attribute>
         <attribute name="translations">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
@@ -73,6 +73,12 @@
             <tag name="api_platform.filter" />
         </service>
 
+        <service id="sylius_api.product_code_search_filter.shop.product_option" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter\ProductBasedProductOptionFilter">
+            <argument>%sylius.model.product.class%</argument>
+            <argument type="service" id="doctrine" />
+            <tag name="api_platform.filter" />
+        </service>
+
         <service id="sylius_api.price_order_filter.shop.product" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter\ProductPriceOrderFilter">
             <argument type="service" id="doctrine" />
             <tag name="api_platform.filter" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
@@ -79,6 +79,12 @@
             <tag name="api_platform.filter" />
         </service>
 
+        <service id="sylius_api.product_code_search_filter.shop.product_option_value" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter\ProductBasedProductOptionValueFilter">
+            <argument>%sylius.model.product.class%</argument>
+            <argument type="service" id="doctrine" />
+            <tag name="api_platform.filter" />
+        </service>
+
         <service id="sylius_api.price_order_filter.shop.product" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter\ProductPriceOrderFilter">
             <argument type="service" id="doctrine" />
             <tag name="api_platform.filter" />

--- a/tests/Api/DataFixtures/ORM/product/products_with_options.yaml
+++ b/tests/Api/DataFixtures/ORM/product/products_with_options.yaml
@@ -1,0 +1,138 @@
+Sylius\Component\Core\Model\Product:
+    product_mug:
+        code: 'MUG'
+        enabled: true
+        options:
+            - '@product_option_color'
+            - '@product_option_size'
+        mainTaxon: '@taxon_mugs'
+        channels: ['@channel_web']
+        currentLocale: 'en_US'
+    product_cap:
+        code: 'CAP'
+        channels: ['@channel_web']
+        currentLocale: 'en_US'
+        options: ['@product_option_color']
+    product_socks:
+        code: 'SOCKS'
+        channels: ['@channel_web']
+        currentLocale: 'en_US'
+        options:
+            - '@product_option_color'
+            - '@product_option_size'
+
+Sylius\Component\Core\Model\ProductTranslation:
+    product_translation_mug_en_US:
+        locale: 'en_US'
+        translatable: '@product_mug'
+        slug: 'mug'
+        name: 'Mug'
+        description: 'This is a mug'
+        shortDescription: 'Short mug description'
+        metaKeywords: 'mug'
+        metaDescription: 'Mug description'
+    product_translation_cap_en_US:
+        locale: 'en_US'
+        translatable: '@product_cap'
+        slug: 'cap'
+        name: 'Cap'
+    product_translation_socks_en_US:
+        locale: 'en_US'
+        translatable: '@product_socks'
+        slug: 'socks'
+        name: 'Socks'
+
+Sylius\Component\Core\Model\ProductVariant:
+    product_variant_mug_blue:
+        code: 'MUG_BLUE'
+        product: '@product_mug'
+        currentLocale: 'en_US'
+        optionValues: ['@product_option_value_color_blue']
+    product_variant_mug_red:
+        code: 'MUG_RED'
+        product: '@product_mug'
+        currentLocale: 'en_US'
+        optionValues: ['@product_option_value_color_red']
+    product_variant_cap_red:
+        code: 'CAP_RED'
+        product: '@product_cap'
+        currentLocale: 'en_US'
+        optionValues: ['@product_option_value_color_red']
+
+Sylius\Component\Product\Model\ProductVariantTranslation:
+    product_variant_translation_mug_blue:
+        locale: 'en_US'
+        name: 'Blue Mug'
+        translatable: '@product_variant_mug_blue'
+    product_variant_translation_mug_red:
+        locale: 'en_US'
+        name: 'Red Mug'
+        translatable: '@product_variant_mug_red'
+
+Sylius\Component\Product\Model\ProductOption:
+    product_option_color:
+        code: 'COLOR'
+    product_option_size:
+        code: 'SIZE'
+
+Sylius\Component\Product\Model\ProductOptionTranslation:
+    product_option_translation_color:
+        locale: 'en_US'
+        name: 'Color'
+        translatable: '@product_option_color'
+    product_option_translation_size:
+        locale: 'en_US'
+        name: 'Size'
+        translatable: '@product_option_size'
+
+Sylius\Component\Product\Model\ProductOptionValue:
+    product_option_value_color_blue:
+        code: 'COLOR_BLUE'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_color'
+    product_option_value_color_red:
+        code: 'COLOR_RED'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_color'
+    product_option_value_size_small:
+        code: 'SIZE_SMALL'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_size'
+    product_option_value_size_large:
+        code: 'SIZE_LARGE'
+        currentLocale: 'en_US'
+        fallbackLocale: 'en_US'
+        option: '@product_option_size'
+
+Sylius\Component\Product\Model\ProductOptionValueTranslation:
+    product_option_value_translation_blue:
+        locale: 'en_US'
+        value: 'Blue'
+        translatable: '@product_option_value_color_blue'
+    product_option_value_translation_red:
+        locale: 'en_US'
+        value: 'Red'
+        translatable: '@product_option_value_color_red'
+    product_option_value_translation_small:
+        locale: 'en_US'
+        value: 'Small'
+        translatable: '@product_option_value_size_small'
+    product_option_value_translation_large:
+        locale: 'en_US'
+        value: 'Large'
+        translatable: '@product_option_value_size_large'
+
+Sylius\Component\Core\Model\Taxon:
+    taxon_mugs:
+        code: 'MUGS'
+    taxon_caps:
+        code: 'CAPS'
+
+Sylius\Component\Core\Model\ProductTaxon:
+    product_taxon:
+        product: '@product_mug'
+        taxon: '@taxon_mugs'
+        position: 0

--- a/tests/Api/Responses/shop/product_option/get_product_options.json
+++ b/tests/Api/Responses/shop/product_option/get_product_options.json
@@ -1,0 +1,33 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOption",
+    "@id": "\/api\/v2\/shop\/product-options",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR",
+            "@type": "ProductOption",
+            "code": "COLOR",
+            "name": "Color"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE",
+            "@type": "ProductOption",
+            "code": "SIZE",
+            "name": "Size"
+        }
+    ],
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-options{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/shop/product_option/get_product_options_of_product_cap.json
+++ b/tests/Api/Responses/shop/product_option/get_product_options_of_product_cap.json
@@ -1,0 +1,31 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOption",
+    "@id": "\/api\/v2\/shop\/product-options",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 1,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR",
+            "@type": "ProductOption",
+            "code": "COLOR",
+            "name": "Color"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/product-options?productCode=CAP",
+        "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-options{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/shop/product_option/get_product_options_of_product_mug.json
+++ b/tests/Api/Responses/shop/product_option/get_product_options_of_product_mug.json
@@ -1,0 +1,37 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOption",
+    "@id": "\/api\/v2\/shop\/product-options",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR",
+            "@type": "ProductOption",
+            "code": "COLOR",
+            "name": "Color"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE",
+            "@type": "ProductOption",
+            "code": "SIZE",
+            "name": "Size"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/product-options?productCode=MUG",
+        "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-options{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/shop/product_option_value/get_product_option_values.json
+++ b/tests/Api/Responses/shop/product_option_value/get_product_option_values.json
@@ -1,0 +1,49 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOptionValue",
+    "@id": "\/api\/v2\/shop\/product-option-values",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 4,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_BLUE",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_BLUE",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Blue"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_RED",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_RED",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Red"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE\/values\/SIZE_SMALL",
+            "@type": "ProductOptionValue",
+            "code": "SIZE_SMALL",
+            "option": "\/api\/v2\/shop\/product-options\/SIZE",
+            "value": "Small"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE\/values\/SIZE_LARGE",
+            "@type": "ProductOptionValue",
+            "code": "SIZE_LARGE",
+            "option": "\/api\/v2\/shop\/product-options\/SIZE",
+            "value": "Large"
+        }
+    ],
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-option-values{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/shop/product_option_value/get_product_option_values_of_product_cap.json
+++ b/tests/Api/Responses/shop/product_option_value/get_product_option_values_of_product_cap.json
@@ -1,0 +1,39 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOptionValue",
+    "@id": "\/api\/v2\/shop\/product-option-values",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_BLUE",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_BLUE",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Blue"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_RED",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_RED",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Red"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/product-option-values?productCode=CAP",
+        "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-option-values{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Responses/shop/product_option_value/get_product_option_values_of_product_mug.json
+++ b/tests/Api/Responses/shop/product_option_value/get_product_option_values_of_product_mug.json
@@ -1,0 +1,53 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductOptionValue",
+    "@id": "\/api\/v2\/shop\/product-option-values",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 4,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_BLUE",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_BLUE",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Blue"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/COLOR\/values\/COLOR_RED",
+            "@type": "ProductOptionValue",
+            "code": "COLOR_RED",
+            "option": "\/api\/v2\/shop\/product-options\/COLOR",
+            "value": "Red"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE\/values\/SIZE_SMALL",
+            "@type": "ProductOptionValue",
+            "code": "SIZE_SMALL",
+            "option": "\/api\/v2\/shop\/product-options\/SIZE",
+            "value": "Small"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/product-options\/SIZE\/values\/SIZE_LARGE",
+            "@type": "ProductOptionValue",
+            "code": "SIZE_LARGE",
+            "option": "\/api\/v2\/shop\/product-options\/SIZE",
+            "value": "Large"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/product-option-values?productCode=MUG",
+        "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/product-option-values{?productCode}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "productCode",
+                "property": "productCode",
+                "required": false
+            }
+        ]
+    }
+}

--- a/tests/Api/Shop/ProductOptionValuesTest.php
+++ b/tests/Api/Shop/ProductOptionValuesTest.php
@@ -11,22 +11,66 @@
 
 declare(strict_types=1);
 
-namespace Api\Shop;
+namespace Sylius\Tests\Api\Shop;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Sylius\Tests\Api\JsonApiTestCase;
 
 final class ProductOptionValuesTest extends JsonApiTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpDefaultGetHeaders();
+    }
+
+    #[Test]
+    public function it_returns_product_option_values(): void
+    {
+        $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'product/products_with_options.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/shop/product-option-values');
+
+        $this->assertResponseSuccessful('shop/product_option_value/get_product_option_values');
+    }
+
+    #[DataProvider('productCodesProvider')]
+    #[Test]
+    public function it_returns_product_option_values_within_product_with_code(string $productCode): void
+    {
+        $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'product/products_with_options.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/shop/product-option-values', [
+            'productCode' => $productCode,
+        ]);
+
+        $this->assertResponseSuccessful(sprintf(
+            'shop/product_option_value/get_product_option_values_of_product_%s',
+            strtolower($productCode),
+        ));
+    }
+
     #[Test]
     public function it_returns_product_option_value(): void
     {
-        $this->setUpDefaultGetHeaders();
-
         $this->loadFixturesFromFile('product/product_with_many_locales.yaml');
 
         $this->requestGet('/api/v2/shop/product-options/COLOR/values/COLOR_RED');
 
         $this->assertResponseSuccessful('shop/product_option_value/get_product_option_value');
+    }
+
+    public static function productCodesProvider(): iterable
+    {
+        yield ['MUG'];
+        yield ['CAP'];
     }
 }

--- a/tests/Api/Shop/ProductOptionsTest.php
+++ b/tests/Api/Shop/ProductOptionsTest.php
@@ -13,11 +13,48 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Shop;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Sylius\Tests\Api\JsonApiTestCase;
 
 final class ProductOptionsTest extends JsonApiTestCase
 {
+    #[Test]
+    public function it_returns_product_options(): void
+    {
+        $this->setUpDefaultGetHeaders();
+
+        $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'product/products_with_options.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/shop/product-options');
+
+        $this->assertResponseSuccessful('shop/product_option/get_product_options');
+    }
+
+    #[DataProvider('productCodesProvider')]
+    #[Test]
+    public function it_returns_product_options_within_product_with_code(string $productCode): void
+    {
+        $this->setUpDefaultGetHeaders();
+
+        $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'product/products_with_options.yaml',
+        ]);
+
+        $this->requestGet('/api/v2/shop/product-options', [
+            'productCode' => $productCode,
+        ]);
+
+        $this->assertResponseSuccessful(sprintf(
+            'shop/product_option/get_product_options_of_product_%s',
+            strtolower($productCode),
+        ));
+    }
+
     #[Test]
     public function it_returns_product_option(): void
     {
@@ -28,5 +65,11 @@ final class ProductOptionsTest extends JsonApiTestCase
         $this->requestGet('/api/v2/shop/product-options/COLOR');
 
         $this->assertResponseSuccessful('shop/product_option/get_product_option');
+    }
+
+    public static function productCodesProvider(): iterable
+    {
+        yield ['MUG'];
+        yield ['CAP'];
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | -
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new API endpoints to retrieve product options and product option values in the shop, with support for filtering by product code.
  - Introduced filtering capabilities for product options and option values based on related product codes in the shop API.
- **Bug Fixes**
  - Updated serialization settings to ensure correct fields are included in shop product option and option value listings.
- **Tests**
  - Added new test cases and fixtures to verify retrieval and filtering of product options and option values by product code in the shop API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->