### PR TITLE
Exclude non-shippable units from shipments in OrderShipmentProcessor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -86,7 +87,10 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         Assert::isInstanceOf($order, OrderInterface::class);
 
         foreach ($order->getItemUnits() as $itemUnit) {
-            if (null === $itemUnit->getShipment() && $itemUnit->getShippable()->isShippingRequired()) {
+            /** @var ProductVariantInterface $shippable */
+            $shippable = $itemUnit->getShippable();
+
+            if (null === $itemUnit->getShipment() && $shippable->isShippingRequired()) {
                 $shipment->addUnit($itemUnit);
             }
         }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -86,7 +86,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         Assert::isInstanceOf($order, OrderInterface::class);
 
         foreach ($order->getItemUnits() as $itemUnit) {
-            if (null === $itemUnit->getShipment()) {
+            if (null === $itemUnit->getShipment() && $itemUnit->getShippable()->isShippingRequired()) {
                 $shipment->addUnit($itemUnit);
             }
         }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | replaces https://github.com/Sylius/Sylius/pull/17652/files
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shipment processing to ensure only items that require shipping are included in shipments.

- **Tests**
  - Enhanced test coverage to verify correct handling of shippable and non-shippable items in shipment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->