### PR TITLE
[Composer] Remove beta version from sylius/resource-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "sylius/mailer-bundle": "^2.1",
         "sylius/registry": "^1.6",
         "sylius/resource": "^1.12",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/theme-bundle": "^2.4",
         "sylius/twig-extra": "^0.8",
         "sylius/twig-hooks": "^0.8",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -29,7 +29,7 @@
         "php": "^8.2",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/addressing": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/intl": "^6.4 || ^7.2"
     },

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -30,7 +30,7 @@
         "ramsey/uuid": "^4.7",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/attribute": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^8.2",
         "sylius/channel": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -52,7 +52,7 @@
         "sylius/payment-bundle": "^2.0",
         "sylius/product-bundle": "^2.0",
         "sylius/promotion-bundle": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/review-bundle": "^2.0",
         "sylius/shipping-bundle": "^2.0",
         "sylius/state-machine-abstraction": "^2.0",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^8.2",
         "sylius/currency": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/intl": "^6.4 || ^7.2"
     },

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -39,7 +39,7 @@
         "doctrine/orm": "^2.18 || ^3.3",
         "egulias/email-validator": "^4.0",
         "sylius/customer": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "webmozart/assert": "^1.11"
     },

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.2",
         "sylius/inventory": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/validator": "^6.4 || ^7.2"
     },

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.2",
         "sylius/locale": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/cache-contracts": "^3.5",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/intl": "^6.4 || ^7.2",
         "webmozart/assert": "^1.11"

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -31,7 +31,7 @@
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/money-bundle": "^2.0",
         "sylius/order": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/service-contracts": "^3.5"
     },

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.2",
         "sylius/payment": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/state-machine-abstraction": "^2.0",
         "symfony/doctrine-bridge": "^6.4 || ^7.2",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -35,7 +35,7 @@
         "sylius/currency": "^2.0",
         "sylius/order-bundle": "^2.0",
         "sylius/payment-bundle": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "php-http/httplug": "^2.4",
         "php-http/message-factory": "^1.1"
     },

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -31,7 +31,7 @@
         "sylius/attribute-bundle": "^2.0",
         "sylius/locale-bundle": "^2.0",
         "sylius/product": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },
     "require-dev": {

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -32,7 +32,7 @@
         "sylius/money-bundle": "^2.0",
         "sylius/promotion": "^2.0",
         "sylius/registry": "^1.6",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "symfony/clock": "^6.4 || ^7.2",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -41,7 +41,7 @@
         "php": "^8.2",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/mailer-bundle": "^2.1",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/review": "^2.0",
         "sylius/user-bundle": "^2.0",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -31,7 +31,7 @@
         "php": "^8.2",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/money-bundle": "^2.0",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/shipping": "^2.0",
         "symfony/clock": "^6.4 || ^7.2",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -30,7 +30,7 @@
         "php": "^8.2",
         "stof/doctrine-extensions-bundle": "^1.12",
         "sylius/registry": "^1.6",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/taxation": "^2.0",
         "symfony/clock": "^6.4 || ^7.2",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^8.2",
         "stof/doctrine-extensions-bundle": "^1.12",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/taxonomy": "^2.0",
         "symfony/framework-bundle": "^6.4.1 || ^7.2"
     },

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -41,7 +41,7 @@
         "doctrine/orm": "^2.18 || ^3.3",
         "egulias/email-validator": "^4.0",
         "sylius/mailer-bundle": "^2.1",
-        "sylius/resource-bundle": "^1.12 || ^1.13@beta",
+        "sylius/resource-bundle": "^1.12",
         "sylius/user": "^2.0",
         "symfony/framework-bundle": "^6.4.1 || ^7.2",
         "symfony/password-hasher": "^6.4 || ^7.2",


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency requirements to restrict the "sylius/resource-bundle" package to stable version ^1.12 only, removing support for beta versions. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->