### PR TITLE
[API][Shop] Add more images endpoints

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -23,6 +23,7 @@
     "ApiPlatform\\Metadata\\Patch",
     "ApiPlatform\\Metadata\\Post",
     "ApiPlatform\\Metadata\\Put",
+    "ApiPlatform\\Metadata\\QueryParameter",
     "ApiPlatform\\Metadata\\Resource\\Factory\\ResourceMetadataCollectionFactoryInterface",
     "ApiPlatform\\Metadata\\Resource\\ResourceMetadataCollection",
     "ApiPlatform\\Metadata\\UriVariablesConverterInterface",

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -5,6 +5,8 @@
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object", "mixed", "never",
     "random_bytes", "random_int",
     "ApiPlatform\\Doctrine\\Common\\Filter\\OrderFilterInterface",
+    "ApiPlatform\\Hydra\\Serializer\\CollectionFiltersNormalizer",
+    "ApiPlatform\\JsonLd\\Serializer\\HydraPrefixTrait",
     "ApiPlatform\\Metadata\\CollectionOperationInterface",
     "ApiPlatform\\Metadata\\Delete",
     "ApiPlatform\\Metadata\\DeleteOperationInterface",

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Hydra/Serializer/EmptyCollectionFiltersNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Hydra/Serializer/EmptyCollectionFiltersNormalizer.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\ApiPlatform\Hydra\Serializer;
+
+use ApiPlatform\Hydra\Serializer\CollectionFiltersNormalizer;
+use ApiPlatform\JsonLd\Serializer\HydraPrefixTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @internal
+ * @see CollectionFiltersNormalizer
+ *
+ * Decorates the default behavior of the CollectionFiltersNormalizer
+ * to remove empty search node when no particular data is present.
+ */
+final class EmptyCollectionFiltersNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use HydraPrefixTrait;
+
+    private const SEARCH_SUFFIX = 'search';
+
+    private const MAPPING_SUFFIX = 'mapping';
+
+    private const TEMPLATE_SUFFIX = 'template';
+
+    private const EMPTY_FILTERS_QUERY = '{?}';
+
+    public function __construct(
+        private readonly NormalizerInterface $decorated,
+    ) {
+    }
+
+    public function normalize(
+        mixed $data,
+        ?string $format = null,
+        array $context = [],
+    ): array|string|int|float|bool|\ArrayObject|null {
+        $data = $this->decorated->normalize($data, $format, $context);
+        if (!is_array($data)) {
+            return $data;
+        }
+
+        $hydraPrefix = $this->getHydraPrefix($context);
+
+        $searchKey = $hydraPrefix . self::SEARCH_SUFFIX;
+        $search = $data[$searchKey] ?? null;
+        if (false === is_array($search) || [] === $search) {
+            return $data;
+        }
+
+        $iri = $data['@id'] ?? '';
+        if ('' === $iri) {
+            return $data;
+        }
+
+        if (false === $this->hasFiltersDefined($hydraPrefix, $iri, $search)) {
+            unset($data[$searchKey]);
+        }
+
+        return $data;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $this->decorated->supportsNormalization($data, $format, $context);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return $this->decorated->getSupportedTypes($format);
+    }
+
+    public function setNormalizer(NormalizerInterface $normalizer): void
+    {
+        if ($this->decorated instanceof NormalizerAwareInterface) {
+            $this->decorated->setNormalizer($normalizer);
+        }
+    }
+
+    private function hasFiltersDefined(string $hydraPrefix, string $iri, array $search): bool
+    {
+        $mapping = $search[$hydraPrefix . self::MAPPING_SUFFIX] ?? [];
+        $searchTemplate = $search[$hydraPrefix . self::TEMPLATE_SUFFIX] ?? '';
+        if ([] === $mapping && '' === $searchTemplate) {
+            return false;
+        }
+
+        return false === $this->isSearchTemplateEmpty($iri, $searchTemplate);
+    }
+
+    private function isSearchTemplateEmpty(string $iri, string $searchTemplate): bool
+    {
+        return strtolower($iri . self::EMPTY_FILTERS_QUERY) === strtolower($searchTemplate);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/Resource/Factory/ImageFilterAwareResourceMetadataCollectionFactory.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Metadata/Resource/Factory/ImageFilterAwareResourceMetadataCollectionFactory.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Sylius\Bundle\ApiBundle\OpenApi\Documentation\ImageDocumentationModifier;
+use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ImageNormalizer;
+
+/**
+ * @internal
+ *
+ * @see ImageNormalizer
+ * @see ImageDocumentationModifier
+ */
+final readonly class ImageFilterAwareResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    private QueryParameter $filterParameter;
+
+    /** @param array<class-string> $imageAwareResources */
+    public function __construct(
+        private ResourceMetadataCollectionFactoryInterface $decorated,
+        private array $imageAwareResources,
+    ) {
+        $this->filterParameter = new QueryParameter(
+            key: ImageNormalizer::FILTER_QUERY_PARAMETER,
+            description: 'Image filter to be applied on image resources.',
+        );
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+        if (!$this->isResourceImageRelated($resourceClass)) {
+            return $resourceMetadataCollection;
+        }
+
+        foreach ($resourceMetadataCollection as $resourceMetadata) {
+            $operations = $resourceMetadata->getOperations();
+            if (null === $operations) {
+                continue;
+            }
+
+            /** @var Operation $operation */
+            foreach ($operations as $name => $operation) {
+                if (!$operation instanceof Get && !$operation instanceof GetCollection) {
+                    continue;
+                }
+
+                $operation = $this->resolveImageFilterParameter($operation);
+
+                $operations->remove($name);
+                $operations->add($name, $operation);
+            }
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    private function resolveImageFilterParameter(Operation $operation): Operation {
+        $filterParameterKey = $this->filterParameter->getKey();
+        $parameters = $operation->getParameters() ?? [];
+        if ([] !== $parameters) {
+            if ($parameters->has($filterParameterKey)) {
+                return $operation;
+            }
+
+            $parameters->add($filterParameterKey, $this->filterParameter);
+        } else {
+            $parameters = [$filterParameterKey => $this->filterParameter];
+        }
+
+        return $operation->withParameters($parameters);
+    }
+
+    private function isResourceImageRelated(string $resourceClass): bool
+    {
+        foreach ($this->imageAwareResources as $imageAwareResource) {
+            if (is_a($resourceClass, $imageAwareResource, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
@@ -19,6 +19,28 @@
     <resource class="%sylius.model.product_image.class%">
         <operations>
             <operation
+                name="sylius_api_shop_product_product_image_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/products/{code}/images"
+            >
+                <parameters>
+                    <parameter key="imageFilter" description="Image filter to apply." />
+                </parameters>
+                <uriVariables>
+                    <uriVariable parameterName="code" fromClass="%sylius.model.product.class%" fromProperty="images"/>
+                </uriVariables>
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:shop:product_image:index</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+            </operation>
+
+            <operation
                 name="sylius_api_shop_product_product_image_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/products/{code}/images/{id}"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
@@ -35,6 +35,9 @@
                         </value>
                     </values>
                 </normalizationContext>
+                <filters>
+                    <filter>sylius_api.search_filter.shop.image</filter>
+                </filters>
             </operation>
 
             <operation

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/ProductImage.xml
@@ -23,9 +23,6 @@
                 class="ApiPlatform\Metadata\GetCollection"
                 uriTemplate="/shop/products/{code}/images"
             >
-                <parameters>
-                    <parameter key="imageFilter" description="Image filter to apply." />
-                </parameters>
                 <uriVariables>
                     <uriVariable parameterName="code" fromClass="%sylius.model.product.class%" fromProperty="images"/>
                 </uriVariables>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
@@ -19,6 +19,25 @@
     <resource class="%sylius.model.taxon_image.class%">
         <operations>
             <operation
+                name="sylius_api_shop_taxon_taxon_image_get_collection"
+                class="ApiPlatform\Metadata\GetCollection"
+                uriTemplate="/shop/taxons/{code}/images"
+            >
+                <uriVariables>
+                    <uriVariable parameterName="code" fromClass="%sylius.model.taxon.class%" fromProperty="images"/>
+                </uriVariables>
+                <normalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>sylius:shop:taxon_image:index</value>
+                            </values>
+                        </value>
+                    </values>
+                </normalizationContext>
+            </operation>
+
+            <operation
                 name="sylius_api_shop_taxon_taxon_image_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/taxons/{code}/images/{id}"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/TaxonImage.xml
@@ -35,6 +35,9 @@
                         </value>
                     </values>
                 </normalizationContext>
+                <filters>
+                    <filter>sylius_api.search_filter.shop.image</filter>
+                </filters>
             </operation>
 
             <operation

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
@@ -11,9 +11,10 @@
 
 -->
 
-<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+<serializer
+    xmlns="http://symfony.com/schema/dic/serializer-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Component\Core\Model\ProductImage">
         <attribute name="id">
@@ -21,6 +22,7 @@
             <group>sylius:admin:product_image:show</group>
             <group>sylius:admin:product:index</group>
             <group>sylius:admin:product:show</group>
+            <group>sylius:shop:product_image:index</group>
             <group>sylius:shop:product_image:show</group>
             <group>sylius:shop:product:index</group>
             <group>sylius:shop:product:show</group>
@@ -31,6 +33,7 @@
             <group>sylius:admin:product_image:show</group>
             <group>sylius:admin:product:index</group>
             <group>sylius:admin:product:show</group>
+            <group>sylius:shop:product_image:index</group>
             <group>sylius:shop:product_image:show</group>
             <group>sylius:shop:product:index</group>
             <group>sylius:shop:product:show</group>
@@ -47,6 +50,7 @@
             <group>sylius:admin:product_image:update</group>
             <group>sylius:admin:product:index</group>
             <group>sylius:admin:product:show</group>
+            <group>sylius:shop:product_image:index</group>
             <group>sylius:shop:product_image:show</group>
             <group>sylius:shop:product:index</group>
             <group>sylius:shop:product:show</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonImage.xml
@@ -11,18 +11,19 @@
 
 -->
 
-<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+<serializer
+    xmlns="http://symfony.com/schema/dic/serializer-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Component\Core\Model\TaxonImage">
         <attribute name="id">
             <group>sylius:admin:taxon_image:index</group>
             <group>sylius:admin:taxon_image:show</group>
-            <group>sylius:shop:taxon_image:index</group>
-            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:admin:taxon:index</group>
             <group>sylius:admin:taxon:show</group>
+            <group>sylius:shop:taxon_image:index</group>
+            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:shop:taxon:index</group>
             <group>sylius:shop:taxon:show</group>
         </attribute>
@@ -30,10 +31,10 @@
         <attribute name="path">
             <group>sylius:admin:taxon_image:index</group>
             <group>sylius:admin:taxon_image:show</group>
-            <group>sylius:shop:taxon_image:index</group>
-            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:admin:taxon:index</group>
             <group>sylius:admin:taxon:show</group>
+            <group>sylius:shop:taxon_image:index</group>
+            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:shop:taxon:index</group>
             <group>sylius:shop:taxon:show</group>
         </attribute>
@@ -47,10 +48,10 @@
             <group>sylius:admin:taxon_image:index</group>
             <group>sylius:admin:taxon_image:show</group>
             <group>sylius:admin:taxon_image:update</group>
-            <group>sylius:shop:taxon_image:index</group>
-            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:admin:taxon:index</group>
             <group>sylius:admin:taxon:show</group>
+            <group>sylius:shop:taxon_image:index</group>
+            <group>sylius:shop:taxon_image:show</group>
             <group>sylius:shop:taxon:index</group>
             <group>sylius:shop:taxon:show</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -22,6 +22,11 @@
 
     <parameters>
         <parameter key="sylius.model.address.interface">Sylius\Component\Addressing\Model\AddressInterface</parameter>
+        <parameter key="sylius_api.normalization.image_filter.supported_interfaces" type="collection">
+            <parameter>Sylius\Component\Core\Model\ImageInterface</parameter>
+            <parameter>Sylius\Component\Core\Model\ImageAwareInterface</parameter>
+            <parameter>Sylius\Component\Core\Model\ImagesAwareInterface</parameter>
+        </parameter>
     </parameters>
 
     <services>
@@ -108,13 +113,24 @@
             by ExtractorResourceMetadataCollectionFactory (decoration priority 800).
             This decorator should run immediately after to merge only non-null metadata.
         -->
-        <service id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.duplicate_operation_replacer"
-                 class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\DuplicateOperationReplacerResourceMetadataCollectionFactory"
-                 decorates="api_platform.metadata.resource.metadata_collection_factory"
-                 decoration-priority="799"
-                 public="false"
+        <service
+            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.duplicate_operation_replacer"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\DuplicateOperationReplacerResourceMetadataCollectionFactory"
+            decorates="api_platform.metadata.resource.metadata_collection_factory"
+            decoration-priority="799"
+            public="false"
         >
             <argument type="service" id=".inner" />
+        </service>
+
+        <service
+            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.image_filter_aware"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\ImageFilterAwareResourceMetadataCollectionFactory"
+            decorates="api_platform.metadata.resource.metadata_collection_factory"
+            public="false"
+        >
+            <argument type="service" id=".inner" />
+            <argument>%sylius_api.normalization.image_filter.supported_interfaces%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -22,11 +22,6 @@
 
     <parameters>
         <parameter key="sylius.model.address.interface">Sylius\Component\Addressing\Model\AddressInterface</parameter>
-        <parameter key="sylius_api.normalization.image_filter.supported_interfaces" type="collection">
-            <parameter>Sylius\Component\Core\Model\ImageInterface</parameter>
-            <parameter>Sylius\Component\Core\Model\ImageAwareInterface</parameter>
-            <parameter>Sylius\Component\Core\Model\ImagesAwareInterface</parameter>
-        </parameter>
     </parameters>
 
     <services>
@@ -84,53 +79,6 @@
         <service id="sylius_api.listener.admin_authentication_success" class="Sylius\Bundle\ApiBundle\EventListener\AdminAuthenticationSuccessListener">
             <argument type="service" id="api_platform.symfony.iri_converter" />
             <tag name="kernel.event_listener" event="lexik_jwt_authentication.on_authentication_success" method="onAuthenticationSuccessResponse" />
-        </service>
-
-        <service
-            id="sylius_api.api_platform.routing.iri_converter"
-            class="Sylius\Bundle\ApiBundle\ApiPlatform\Routing\IriConverter"
-            decorates="api_platform.symfony.iri_converter"
-            decoration-priority="64"
-        >
-            <argument type="service" id=".inner" />
-            <argument type="service" id="sylius_api.provider.path_prefix" />
-            <argument type="service" id="sylius_api.operation_resolver.path_prefix_based" />
-            <argument type="service" id="api_platform.router" />
-        </service>
-
-        <service
-            id="sylius_api.api_platform.routing.api_loader"
-            class="Sylius\Bundle\ApiBundle\ApiPlatform\Routing\ApiLoader"
-            decorates="api_platform.route_loader"
-        >
-            <argument type="service" id=".inner" />
-            <argument>%sylius_api.operations_to_remove%</argument>
-        </service>
-
-        <!--
-            https://api-platform.com/docs/core/bootstrap/
-            The metadata for an API resource is loaded from XML, YAML, and PHP files
-            by ExtractorResourceMetadataCollectionFactory (decoration priority 800).
-            This decorator should run immediately after to merge only non-null metadata.
-        -->
-        <service
-            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.duplicate_operation_replacer"
-            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\DuplicateOperationReplacerResourceMetadataCollectionFactory"
-            decorates="api_platform.metadata.resource.metadata_collection_factory"
-            decoration-priority="799"
-            public="false"
-        >
-            <argument type="service" id=".inner" />
-        </service>
-
-        <service
-            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.image_filter_aware"
-            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\ImageFilterAwareResourceMetadataCollectionFactory"
-            decorates="api_platform.metadata.resource.metadata_collection_factory"
-            public="false"
-        >
-            <argument type="service" id=".inner" />
-            <argument>%sylius_api.normalization.image_filter.supported_interfaces%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_platform.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_platform.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <parameters>
+        <parameter key="sylius_api.normalization.image_filter.supported_interfaces" type="collection">
+            <parameter>Sylius\Component\Core\Model\ImageInterface</parameter>
+            <parameter>Sylius\Component\Core\Model\ImageAwareInterface</parameter>
+            <parameter>Sylius\Component\Core\Model\ImagesAwareInterface</parameter>
+        </parameter>
+    </parameters>
+
+    <services>
+        <service
+            id="sylius_api.api_platform.routing.iri_converter"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Routing\IriConverter"
+            decorates="api_platform.symfony.iri_converter"
+            decoration-priority="64"
+        >
+            <argument type="service" id=".inner" />
+            <argument type="service" id="sylius_api.provider.path_prefix" />
+            <argument type="service" id="sylius_api.operation_resolver.path_prefix_based" />
+            <argument type="service" id="api_platform.router" />
+        </service>
+
+        <service
+            id="sylius_api.api_platform.routing.api_loader"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Routing\ApiLoader"
+            decorates="api_platform.route_loader"
+        >
+            <argument type="service" id=".inner" />
+            <argument>%sylius_api.operations_to_remove%</argument>
+        </service>
+
+        <!--
+            https://api-platform.com/docs/core/bootstrap/
+            The metadata for an API resource is loaded from XML, YAML, and PHP files
+            by ExtractorResourceMetadataCollectionFactory (decoration priority 800).
+            This decorator should run immediately after to merge only non-null metadata.
+        -->
+        <service
+            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.duplicate_operation_replacer"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\DuplicateOperationReplacerResourceMetadataCollectionFactory"
+            decorates="api_platform.metadata.resource.metadata_collection_factory"
+            decoration-priority="799"
+            public="false"
+        >
+            <argument type="service" id=".inner" />
+        </service>
+
+        <service
+            id="sylius_api.api_platform.metadata.resource.metadata_collection_factory.image_filter_aware"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\ImageFilterAwareResourceMetadataCollectionFactory"
+            decorates="api_platform.metadata.resource.metadata_collection_factory"
+            public="false"
+        >
+            <argument type="service" id=".inner" />
+            <argument>%sylius_api.normalization.image_filter.supported_interfaces%</argument>
+        </service>
+
+        <service
+            id="sylius_api.api_platform.hydra.normalizer.empty_collection_filters"
+            class="Sylius\Bundle\ApiBundle\ApiPlatform\Hydra\Serializer\EmptyCollectionFiltersNormalizer"
+            decorates="api_platform.hydra.normalizer.collection"
+            public="false"
+        >
+            <argument type="service" id=".inner" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/shop/filters.xml
@@ -41,6 +41,13 @@
             <tag name="api_platform.filter" />
         </service>
 
+        <service id="sylius_api.search_filter.shop.image" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="type">exact</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
         <service id="sylius_api.search_filter.shop.product_association_type.owner_based" class="Sylius\Bundle\ApiBundle\Doctrine\ORM\Filter\OwnerBasedProductAssociationTypesFilter">
             <argument type="service" id="sylius.section_resolver.uri_based" />
             <argument>%sylius.model.product_association.class%</argument>

--- a/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Hydra/Serializer/EmptyCollectionFiltersNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Hydra/Serializer/EmptyCollectionFiltersNormalizerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Tests\ApiPlatform\Hydra\Serializer;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\ApiPlatform\Hydra\Serializer\EmptyCollectionFiltersNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class EmptyCollectionFiltersNormalizerTest extends TestCase
+{
+    private MockObject&NormalizerInterface $decorated;
+
+    private EmptyCollectionFiltersNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->decorated = $this->createMock(NormalizerInterface::class);
+        $this->normalizer = new EmptyCollectionFiltersNormalizer($this->decorated);
+    }
+
+    #[DataProvider('getNormalizationCases')]
+    public function test_normalize_behaviors(array $normalizedData, array $expectedResult): void
+    {
+        $this->decorated->method('normalize')->willReturn($normalizedData);
+
+        $result = $this->normalizer->normalize(['any']);
+
+        self::assertSame($expectedResult, $result);
+    }
+
+    public static function getNormalizationCases(): iterable
+    {
+        yield 'search is null' => [
+            ['hydra:search' => null],
+            ['hydra:search' => null],
+        ];
+
+        yield 'search is empty array' => [
+            ['hydra:search' => []],
+            ['hydra:search' => []],
+        ];
+
+        yield 'iri is empty' => [
+            ['@id' => '', 'hydra:search' => ['some_key' => 'some_val']],
+            ['@id' => '', 'hydra:search' => ['some_key' => 'some_val']],
+        ];
+
+        yield 'mapping and template both empty' => [
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => [],
+                    'hydra:template' => '',
+                ],
+            ],
+            ['@id' => '/products'],
+        ];
+
+        yield 'mapping is not empty, template empty' => [
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => ['some' => 'thing'],
+                    'hydra:template' => '',
+                ],
+            ],
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => ['some' => 'thing'],
+                    'hydra:template' => '',
+                ],
+            ],
+        ];
+
+        yield 'template matches iri + {?}' => [
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => [],
+                    'hydra:template' => '/products{?}',
+                ],
+            ],
+            ['@id' => '/products'],
+        ];
+
+        yield 'template does not match iri + {?}' => [
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => [],
+                    'hydra:template' => '/products{?field}',
+                ],
+            ],
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => [],
+                    'hydra:template' => '/products{?field}',
+                ],
+            ],
+        ];
+
+        yield 'mapping is not empty and template does not match iri' => [
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => ['field' => 'value'],
+                    'hydra:template' => '/products{?field}',
+                ],
+            ],
+            [
+                '@id' => '/products',
+                'hydra:search' => [
+                    'hydra:mapping' => ['field' => 'value'],
+                    'hydra:template' => '/products{?field}',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Metadata/Resource/Factory/ImageFilterAwareResourceMetadataCollectionFactoryTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Metadata/Resource/Factory/ImageFilterAwareResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Resource\Factory\ImageFilterAwareResourceMetadataCollectionFactory;
+use Sylius\Bundle\ApiBundle\Serializer\Normalizer\ImageNormalizer;
+use Sylius\Component\Core\Model\Image;
+use Sylius\Component\Core\Model\ImageInterface;
+
+final class ImageFilterAwareResourceMetadataCollectionFactoryTest extends TestCase
+{
+    private ResourceMetadataCollectionFactoryInterface&MockObject $decorated;
+
+    private ImageFilterAwareResourceMetadataCollectionFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+
+        $this->factory = new ImageFilterAwareResourceMetadataCollectionFactory(
+            $this->decorated,
+            [ImageInterface::class],
+        );
+    }
+
+    #[Test]
+    public function it_returns_unchanged_metadata_when_resource_is_not_image_related(): void
+    {
+        $resourceClass = \stdClass::class;
+        $resourceMetadataCollection = $this->createMetadataCollection($resourceClass, [
+            'get' => [
+                'operationName' => 'get',
+                'operationType' => Get::class,
+            ],
+            'get_collection' => [
+                'operationName' => 'get_collection',
+                'operationType' => GetCollection::class,
+                'parameters' => [ImageNormalizer::FILTER_QUERY_PARAMETER],
+            ],
+        ]);
+
+        $this->decorated->expects($this->once())
+            ->method('create')
+            ->with($resourceClass)
+            ->willReturn($resourceMetadataCollection)
+        ;
+
+        $this->assertSame($resourceMetadataCollection, $this->factory->create($resourceClass));
+    }
+
+    #[Test]
+    public function it_returns_unchanged_metadata_when_resource_has_no_operations(): void
+    {
+        $resourceClass = Image::class;
+        $resourceMetadataCollection = $this->createMetadataCollection($resourceClass, []);
+
+        $this->decorated->expects($this->once())
+            ->method('create')
+            ->with($resourceClass)
+            ->willReturn($resourceMetadataCollection)
+        ;
+
+        $this->assertSame($resourceMetadataCollection, $this->factory->create($resourceClass));
+    }
+
+    #[DataProvider('getUnhandledOperations')]
+    #[Test]
+    public function it_returns_unchanged_metadata_when_resource_has_only_unhandled_operations(
+        string $operationClass,
+    ): void {
+        $resourceClass = Image::class;
+        $resourceMetadataCollection = $this->createMetadataCollection($resourceClass, [
+            $operationClass => [
+                'operationName' => $operationClass,
+                'operationType' => $operationClass,
+            ],
+        ]);
+
+        $this->decorated->expects($this->once())
+            ->method('create')
+            ->with($resourceClass)
+            ->willReturn($resourceMetadataCollection)
+        ;
+
+        $this->assertSame($resourceMetadataCollection, $this->factory->create($resourceClass));
+    }
+
+    #[DataProvider('getHandledOperations')]
+    #[Test]
+    public function it_returns_unchanged_metadata_when_resource_already_has_image_filter_parameter(
+        string $operationClass,
+    ): void {
+        $resourceClass = Image::class;
+        $resourceMetadataCollection = $this->createMetadataCollection($resourceClass, [
+            $operationClass => [
+                'operationName' => $operationClass,
+                'operationType' => $operationClass,
+                'parameters' => [ImageNormalizer::FILTER_QUERY_PARAMETER],
+            ],
+        ]);
+
+        $this->decorated->expects($this->once())
+            ->method('create')
+            ->with($resourceClass)
+            ->willReturn($resourceMetadataCollection)
+        ;
+
+        $this->assertSame($resourceMetadataCollection, $this->factory->create($resourceClass));
+    }
+
+    #[DataProvider('getHandledOperationsWithParameters')]
+    #[Test]
+    public function it_adds_filter_parameter_to_handled_operations_when_missing(
+        string $operationClass,
+        array $operationParameters,
+    ): void {
+        $resourceClass = Image::class;
+        $originalResourceMetadataCollection = $this->createMetadataCollection($resourceClass, [
+            $operationClass => [
+                'operationName' => $operationClass,
+                'operationType' => $operationClass,
+                'parameters' => $operationParameters,
+            ],
+        ]);
+
+        $this->decorated->expects($this->once())
+            ->method('create')
+            ->with($resourceClass)
+            ->willReturn($originalResourceMetadataCollection)
+        ;
+
+        $result = $this->factory->create($resourceClass);
+        $resultOperation = $result->getOperation($operationClass);
+
+        $joinedParameters = array_merge($operationParameters, [ImageNormalizer::FILTER_QUERY_PARAMETER]);
+
+        $this->assertNotEmpty(iterator_to_array($resultOperation->getParameters()));
+
+        foreach ($joinedParameters as $joinedParameter) {
+            $this->assertTrue(
+                $resultOperation->getParameters()->has($joinedParameter),
+                sprintf(
+                    'Parameter "%s" should be present in the operation "%s".',
+                    $joinedParameter,
+                    $operationClass,
+                ),
+            );
+        }
+    }
+
+    public static function getUnhandledOperations(): iterable
+    {
+        yield 'GraphQL operation' => [GraphQlOperation::class];
+        yield 'Custom operation' => [HttpOperation::class];
+        yield 'Delete operation' => [Delete::class];
+        yield 'Patch operation' => [Patch::class];
+        yield 'Post operation' => [Post::class];
+        yield 'Put operation' => [Put::class];
+    }
+
+    public static function getHandledOperations(): iterable
+    {
+        yield 'Get operation' => [Get::class];
+        yield 'Get collection operation' => [GetCollection::class];
+    }
+
+    public static function getHandledOperationsWithParameters(): iterable
+    {
+        yield 'Get operation without parameters' => [Get::class, []];
+        yield 'Get operation with parameters' => [Get::class, ['another_parameter']];
+        yield 'Get collection operation without parameters' => [GetCollection::class, []];
+        yield 'Get collection operation with parameters' => [GetCollection::class, ['another_parameter']];
+    }
+
+    /**
+     * @param array<string, array{
+     *     operationName: string,
+     *     operationType: class-string,
+     *     parameters?: string[],
+     * }> $operations
+     */
+    private function createMetadataCollection(string $resourceClass, array $operations): ResourceMetadataCollection
+    {
+        $operationsArray = [];
+        foreach ($operations as $operationData) {
+            /** @var HttpOperation $operation */
+            $operation = new $operationData['operationType']();
+
+            $operationParameters = $operationData['parameters'] ?? [];
+            if ([] !== $operationParameters) {
+                $parameters = [];
+                foreach ($operationParameters as $parameter) {
+                    $parameters[$parameter] = new QueryParameter(
+                        key: $parameter,
+                    );
+                }
+
+                $operation = $operation->withParameters($parameters);
+            }
+
+            $operationsArray[$operationData['operationName']] = $operation;
+        }
+
+        $apiResource = new ApiResource(
+            operations: $operationsArray,
+            class: $resourceClass,
+        );
+
+        return new ResourceMetadataCollection($resourceClass, [$apiResource]);
+    }
+}

--- a/tests/Api/DataFixtures/ORM/product/product_image.yaml
+++ b/tests/Api/DataFixtures/ORM/product/product_image.yaml
@@ -26,7 +26,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: '@product_cap'
         fallbackLocale: 'en_US'
         currentLocale: 'en'
-        
+
 Sylius\Component\Core\Model\ProductImage:
     product_mug_thumbnail:
         type: 'thumbnail'

--- a/tests/Api/Responses/admin/order/get_adjustments_for_a_given_order.json
+++ b/tests/Api/Responses/admin/order/get_adjustments_for_a_given_order.json
@@ -60,11 +60,5 @@
             "neutral": false,
             "locked": false
         }
-    ],
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/admin\/orders\/token\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    ]
 }

--- a/tests/Api/Responses/admin/order/get_adjustments_for_a_given_order_with_type_filter.json
+++ b/tests/Api/Responses/admin/order/get_adjustments_for_a_given_order_with_type_filter.json
@@ -50,11 +50,5 @@
     "hydra:view": {
         "@id": "\/api\/v2\/admin\/orders\/token\/adjustments?type=order_promotion",
         "@type": "hydra:PartialCollectionView"
-    },
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/admin\/orders\/token\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
     }
 }

--- a/tests/Api/Responses/admin/order_item/get_order_item_adjustments.json
+++ b/tests/Api/Responses/admin/order_item/get_order_item_adjustments.json
@@ -20,11 +20,5 @@
             "locked": false
         }
     ],
-    "hydra:totalItems": 2,
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/admin\/order-items\/@integer@\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    "hydra:totalItems": 2
 }

--- a/tests/Api/Responses/admin/order_item/get_order_item_adjustments_with_type_filter.json
+++ b/tests/Api/Responses/admin/order_item/get_order_item_adjustments_with_type_filter.json
@@ -16,11 +16,5 @@
     "hydra:view": {
         "@id": "\/api\/v2\/admin\/order-items\/@integer@\/adjustments?type=order_promotion",
         "@type": "hydra:PartialCollectionView"
-    },
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/admin\/order-items\/@integer@\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
     }
 }

--- a/tests/Api/Responses/shop/order/get_order_adjustments.json
+++ b/tests/Api/Responses/shop/order/get_order_adjustments.json
@@ -40,11 +40,5 @@
             "amount": -1000,
             "neutral": false
         }
-    ],
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/orders\/TOKEN\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    ]
 }

--- a/tests/Api/Responses/shop/order/get_order_adjustments_with_type_filter.json
+++ b/tests/Api/Responses/shop/order/get_order_adjustments_with_type_filter.json
@@ -17,11 +17,5 @@
     "hydra:view": {
         "@id": "\/api\/v2\/shop\/orders\/TOKEN\/adjustments?type=shipping",
         "@type": "hydra:PartialCollectionView"
-    },
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/orders\/TOKEN\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
     }
 }

--- a/tests/Api/Responses/shop/order_item/get_empty_order_item_adjustments.json
+++ b/tests/Api/Responses/shop/order_item/get_empty_order_item_adjustments.json
@@ -3,11 +3,5 @@
     "@id": "\/api\/v2\/shop\/orders\/WRONG_TOKEN\/items\/@integer@\/adjustments",
     "@type": "hydra:Collection",
     "hydra:totalItems": 0,
-    "hydra:member": [],
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/orders\/WRONG_TOKEN\/items\/@integer@\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    "hydra:member": []
 }

--- a/tests/Api/Responses/shop/order_item/get_order_item_adjustments.json
+++ b/tests/Api/Responses/shop/order_item/get_order_item_adjustments.json
@@ -31,11 +31,5 @@
             "amount": -1000,
             "neutral": false
         }
-    ],
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/orders\/token\/items\/@integer@\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    ]
 }

--- a/tests/Api/Responses/shop/order_item/get_order_item_adjustments_with_type_filter.json
+++ b/tests/Api/Responses/shop/order_item/get_order_item_adjustments_with_type_filter.json
@@ -7,11 +7,5 @@
     "hydra:view": {
         "@id": "\/api\/v2\/shop\/orders\/token\/items\/@integer@\/adjustments?type=promotion",
         "@type": "hydra:PartialCollectionView"
-    },
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/orders\/token\/items\/@integer@\/adjustments{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
     }
 }

--- a/tests/Api/Responses/shop/product_image/get_product_images.json
+++ b/tests/Api/Responses/shop/product_image/get_product_images.json
@@ -1,0 +1,22 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductImage",
+    "@id": "\/api\/v2\/shop\/products\/MUG\/images",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/products\/MUG\/images\/@integer@",
+            "@type": "ProductImage",
+            "id": "@integer@",
+            "type": "thumbnail",
+            "path": "https:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/thumbnail.jpg"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/products\/MUG\/images\/@integer@",
+            "@type": "ProductImage",
+            "id": "@integer@",
+            "type": "main",
+            "path": "https:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/main.jpg"
+        }
+    ]
+}

--- a/tests/Api/Responses/shop/product_image/get_product_images.json
+++ b/tests/Api/Responses/shop/product_image/get_product_images.json
@@ -18,5 +18,24 @@
             "type": "main",
             "path": "https:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/main.jpg"
         }
-    ]
+    ],
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/products\/MUG\/images{?type,type[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type",
+                "property": "type",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type[]",
+                "property": "type",
+                "required": false
+            }
+        ]
+    }
 }

--- a/tests/Api/Responses/shop/product_image/get_product_images_with_image_filter.json
+++ b/tests/Api/Responses/shop/product_image/get_product_images_with_image_filter.json
@@ -22,5 +22,24 @@
     "hydra:view": {
         "@id": "\/api\/v2\/shop\/products\/MUG\/images?imageFilter=sylius_small",
         "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/products\/MUG\/images{?type,type[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type",
+                "property": "type",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type[]",
+                "property": "type",
+                "required": false
+            }
+        ]
     }
 }

--- a/tests/Api/Responses/shop/product_image/get_product_images_with_image_filter.json
+++ b/tests/Api/Responses/shop/product_image/get_product_images_with_image_filter.json
@@ -1,0 +1,26 @@
+{
+    "@context": "\/api\/v2\/contexts\/ProductImage",
+    "@id": "\/api\/v2\/shop\/products\/MUG\/images",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/products\/MUG\/images\/@integer@",
+            "@type": "ProductImage",
+            "id": "@integer@",
+            "type": "thumbnail",
+            "path": "https:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/thumbnail.jpg"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/products\/MUG\/images\/@integer@",
+            "@type": "ProductImage",
+            "id": "@integer@",
+            "type": "main",
+            "path": "https:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/main.jpg"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/products\/MUG\/images?imageFilter=sylius_small",
+        "@type": "hydra:PartialCollectionView"
+    }
+}

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
@@ -1,0 +1,28 @@
+{
+    "@context": "\/api\/v2\/contexts\/TaxonImage",
+    "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images\/@integer@",
+            "@type": "TaxonImage",
+            "id": "@integer@",
+            "type": "thumbnail",
+            "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/thumbnail.jpg"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images\/@integer@",
+            "@type": "TaxonImage",
+            "id": "@integer@",
+            "type": "banner",
+            "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/banner.jpg"
+        }
+    ],
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": []
+    }
+}

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
@@ -18,11 +18,5 @@
             "type": "banner",
             "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/banner.jpg"
         }
-    ],
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
-    }
+    ]
 }

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images.json
@@ -18,5 +18,24 @@
             "type": "banner",
             "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_original\/uo\/banner.jpg"
         }
-    ]
+    ],
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?type,type[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type",
+                "property": "type",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type[]",
+                "property": "type",
+                "required": false
+            }
+        ]
+    }
 }

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
@@ -22,5 +22,24 @@
     "hydra:view": {
         "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images?imageFilter=sylius_small",
         "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?type,type[]}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type",
+                "property": "type",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "type[]",
+                "property": "type",
+                "required": false
+            }
+        ]
     }
 }

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
@@ -1,0 +1,32 @@
+{
+    "@context": "\/api\/v2\/contexts\/TaxonImage",
+    "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images",
+    "@type": "hydra:Collection",
+    "hydra:totalItems": 2,
+    "hydra:member": [
+        {
+            "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images\/@integer@",
+            "@type": "TaxonImage",
+            "id": "@integer@",
+            "type": "thumbnail",
+            "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/thumbnail.jpg"
+        },
+        {
+            "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images\/@integer@",
+            "@type": "TaxonImage",
+            "id": "@integer@",
+            "type": "banner",
+            "path": "http:\/\/localhost\/media\/cache\/resolve\/sylius_small\/uo\/banner.jpg"
+        }
+    ],
+    "hydra:view": {
+        "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images?imageFilter=sylius_small",
+        "@type": "hydra:PartialCollectionView"
+    },
+    "hydra:search": {
+        "@type": "hydra:IriTemplate",
+        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?}",
+        "hydra:variableRepresentation": "BasicRepresentation",
+        "hydra:mapping": []
+    }
+}

--- a/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
+++ b/tests/Api/Responses/shop/taxon_image/get_taxon_images_with_image_filter.json
@@ -22,11 +22,5 @@
     "hydra:view": {
         "@id": "\/api\/v2\/shop\/taxons\/CATEGORY\/images?imageFilter=sylius_small",
         "@type": "hydra:PartialCollectionView"
-    },
-    "hydra:search": {
-        "@type": "hydra:IriTemplate",
-        "hydra:template": "\/api\/v2\/shop\/taxons\/CATEGORY\/images{?}",
-        "hydra:variableRepresentation": "BasicRepresentation",
-        "hydra:mapping": []
     }
 }

--- a/tests/Api/Shop/ProductImagesTest.php
+++ b/tests/Api/Shop/ProductImagesTest.php
@@ -30,6 +30,60 @@ final class ProductImagesTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_gets_product_images(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['product/product_image.yaml']);
+
+        /** @var ProductInterface $product */
+        $product = $fixtures['product_mug'];
+
+        $this->requestGet(
+            uri: sprintf('/api/v2/shop/products/%s/images', $product->getCode()),
+            headers: ['HTTPS' => true],
+        );
+
+        $this->assertResponse($this->client->getResponse(), 'shop/product_image/get_product_images');
+    }
+
+    #[Test]
+    public function it_gets_product_images_with_image_filter(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['product/product_image.yaml']);
+
+        /** @var ProductInterface $product */
+        $product = $fixtures['product_mug'];
+
+        $this->requestGet(
+            sprintf('/api/v2/shop/products/%s/images', $product->getCode()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'sylius_small'],
+            ['HTTPS' => true],
+        );
+
+        $this->assertResponse($this->client->getResponse(), 'shop/product_image/get_product_images_with_image_filter');
+    }
+
+    #[Test]
+    public function it_prevents_getting_product_images_with_an_invalid_image_filter(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['product/product_image.yaml']);
+
+        /** @var ProductInterface $product */
+        $product = $fixtures['product_mug'];
+
+        $this->requestGet(
+            sprintf('/api/v2/shop/products/%s/images', $product->getCode()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid'],
+            ['HTTPS' => true],
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'common/image/invalid_filter',
+            Response::HTTP_BAD_REQUEST,
+        );
+    }
+
+    #[Test]
     public function it_gets_a_product_image(): void
     {
         $fixtures = $this->loadFixturesFromFiles(['product/product_image.yaml']);

--- a/tests/Api/Shop/TaxonImagesTest.php
+++ b/tests/Api/Shop/TaxonImagesTest.php
@@ -22,6 +22,70 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class TaxonImagesTest extends JsonApiTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpDefaultGetHeaders();
+    }
+
+    #[Test]
+    public function it_gets_taxon_images(): void
+    {
+        $fixtures = $this->loadFixturesFromFile('taxon_image.yaml');
+
+        /** @var TaxonInterface $taxon */
+        $taxon = $fixtures['taxon'];
+
+        $this->requestGet(sprintf('/api/v2/shop/taxons/%s/images', $taxon->getCode()));
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/taxon_image/get_taxon_images',
+            Response::HTTP_OK,
+        );
+    }
+
+    #[Test]
+    public function it_gets_taxon_images_with_an_image_filter(): void
+    {
+        $fixtures = $this->loadFixturesFromFile('taxon_image.yaml');
+
+        /** @var TaxonInterface $taxon */
+        $taxon = $fixtures['taxon'];
+
+        $this->requestGet(
+            sprintf('/api/v2/shop/taxons/%s/images', $taxon->getCode()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'sylius_small'],
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'shop/taxon_image/get_taxon_images_with_image_filter',
+            Response::HTTP_OK,
+        );
+    }
+
+    #[Test]
+    public function it_prevents_getting_taxon_images_with_an_invalid_image_filter(): void
+    {
+        $fixtures = $this->loadFixturesFromFile('taxon_image.yaml');
+
+        /** @var TaxonInterface $taxon */
+        $taxon = $fixtures['taxon'];
+
+        $this->requestGet(
+            sprintf('/api/v2/shop/taxons/%s/images', $taxon->getCode()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid'],
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'common/image/invalid_filter',
+            Response::HTTP_BAD_REQUEST,
+        );
+    }
+
     #[Test]
     public function it_gets_a_taxon_image(): void
     {
@@ -33,11 +97,7 @@ final class TaxonImagesTest extends JsonApiTestCase
         /** @var TaxonInterface $taxon */
         $taxon = $taxonImage->getOwner();
 
-        $this->client->request(
-            method: 'GET',
-            uri: sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()),
-            server: self::CONTENT_TYPE_HEADER,
-        );
+        $this->requestGet(sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()));
 
         $this->assertResponse(
             $this->client->getResponse(),
@@ -57,11 +117,9 @@ final class TaxonImagesTest extends JsonApiTestCase
         /** @var TaxonInterface $taxon */
         $taxon = $taxonImage->getOwner();
 
-        $this->client->request(
-            method: 'GET',
-            uri: sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()),
-            parameters: [ImageNormalizer::FILTER_QUERY_PARAMETER => 'sylius_small'],
-            server: self::CONTENT_TYPE_HEADER,
+        $this->requestGet(
+            sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'sylius_small'],
         );
 
         $this->assertResponse(
@@ -82,11 +140,9 @@ final class TaxonImagesTest extends JsonApiTestCase
         /** @var TaxonInterface $taxon */
         $taxon = $taxonImage->getOwner();
 
-        $this->client->request(
-            method: 'GET',
-            uri: sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()),
-            parameters: [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid'],
-            server: self::CONTENT_TYPE_HEADER,
+        $this->requestGet(
+            sprintf('/api/v2/shop/taxons/%s/images/%s', $taxon->getCode(), $taxonImage->getId()),
+            [ImageNormalizer::FILTER_QUERY_PARAMETER => 'invalid'],
         );
 
         $this->assertResponse(


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | kinda
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added collection endpoints for product and taxon images with support for image filter query parameters.
  - Introduced automatic addition of image filter query parameters to relevant API operations for image-related resources.
  - Enhanced API responses by updating serialization groups and supporting filtered image URLs.
  - Added normalization that removes empty filter metadata from Hydra API collection responses.
- **Bug Fixes**
  - Improved error handling for invalid image filter parameters, returning proper error responses.
- **Tests**
  - Added tests covering image filter behavior, collection retrieval, and error handling for product and taxon images.
  - Introduced tests for normalization behavior removing empty filter metadata.
- **Chores**
  - Updated service configurations to decorate and extend API Platform services for image filter support and response normalization.
  - Removed obsolete service decorators related to API routing and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->