### PR TITLE
[Maintenance] GA fixes

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -84,6 +84,7 @@ jobs:
                     composer require winzou/state-machine-bundle:^0.6 --no-update   
 
             -   name: Prepare manifest.json files
+                if: "${{ inputs.branch != '1.14' }}"
                 run: |
                     mkdir -p public/build/admin
                     mkdir -p public/build/shop

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -110,7 +110,9 @@ jobs:
                     chrome_version: stable
 
             -   name: Run PHPUnit
-                run: vendor/bin/phpunit --testsuite all --colors=always
+                run: |
+                    vendor/bin/phpunit --testsuite all --colors=always
+                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -61,10 +61,10 @@ jobs:
                 env:
                     BRANCH: ${{ inputs.branch }}
                 run: |
-                    if [ "$BRANCH" == "1.12" ]; then
-                        echo "USE_LEGACY_POSTGRES_SETUP=yes" >> $GITHUB_ENV
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
                     else
-                        echo "USE_LEGACY_POSTGRES_SETUP=no" >> $GITHUB_ENV
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
 
             -   name: "Checkout (With Branch)"
@@ -103,10 +103,9 @@ jobs:
                     e2e: "yes"
                     database: "mariadb"
                     database_version: ${{ matrix.mariadb }}
-                    legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
             -   name: Run PHPUnit

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -60,10 +60,10 @@ jobs:
                 env:
                     BRANCH: ${{ inputs.branch }}
                 run: |
-                    if [ "$BRANCH" == "1.12" ]; then
-                        echo "USE_LEGACY_POSTGRES_SETUP=yes" >> $GITHUB_ENV
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
                     else
-                        echo "USE_LEGACY_POSTGRES_SETUP=no" >> $GITHUB_ENV
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
 
             -   name: "Checkout (With Branch)"
@@ -99,10 +99,9 @@ jobs:
                     cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
                     database_version: ${{ matrix.mysql }}
-                    legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
 
             -   name: Fix permissions for Symfony logs directory
                 run: |
@@ -155,10 +154,10 @@ jobs:
                 env:
                     BRANCH: ${{ inputs.branch }}
                 run: |
-                    if [ "$BRANCH" == "1.12" ]; then
-                        echo "USE_LEGACY_POSTGRES_SETUP=yes" >> $GITHUB_ENV
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
                     else
-                        echo "USE_LEGACY_POSTGRES_SETUP=no" >> $GITHUB_ENV
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
 
             -   name: "Checkout (With Branch)"
@@ -195,10 +194,9 @@ jobs:
                     e2e: "yes"
                     e2e_js: "yes"
                     database_version: ${{ matrix.mysql }}
-                    legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
 
             -   name: Run Behat (Chromedriver)
                 run: |
@@ -212,7 +210,7 @@ jobs:
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
                 continue-on-error: true
-            
+
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
@@ -243,10 +241,10 @@ jobs:
                 env:
                     BRANCH: ${{ inputs.branch }}
                 run: |
-                    if [ "$BRANCH" == "1.12" ]; then
-                        echo "USE_LEGACY_POSTGRES_SETUP=yes" >> $GITHUB_ENV
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
                     else
-                        echo "USE_LEGACY_POSTGRES_SETUP=no" >> $GITHUB_ENV
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
 
             -   name: "Checkout (With Branch)"
@@ -283,10 +281,9 @@ jobs:
                     e2e: "yes"
                     e2e_js: "yes"
                     database_version: ${{ matrix.mysql }}
-                    legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
             -   name: Run Behat (Panther)

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -114,7 +114,9 @@ jobs:
                 run: bin/console sylius:install --no-interaction -vvv
 
             -   name: Run PHPUnit
-                run: vendor/bin/phpunit --testsuite all --colors=always
+                run: |
+                    vendor/bin/phpunit --testsuite all --colors=always
+                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -81,6 +81,7 @@ jobs:
                 run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
             -   name: Prepare manifest.json files
+                if: "${{ inputs.branch != '1.14' }}"
                 run: |
                     mkdir -p public/build/admin
                     mkdir -p public/build/shop

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -275,7 +275,23 @@ jobs:
                 if: matrix.twig == '^2.12'
                 run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
+            -   name: Build application for Full 1.14 build
+                if: "${{ inputs.branch == '1.14' }}"
+                uses: SyliusLabs/BuildTestAppAction@v2.3
+                with:
+                    build_type: "sylius"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    e2e: "yes"
+                    e2e_js: "yes"
+                    database_version: ${{ matrix.mysql }}
+                    php_version: ${{ matrix.php }}
+                    symfony_version: ${{ matrix.symfony }}
+                    node_version: ${{ env.NODE_VERSION }}
+                    chrome_version: stable
+
             -   name: Build application
+                if: "${{ inputs.branch != '1.14' }}"
                 uses: SyliusLabs/BuildTestAppAction@v2.4
                 with:
                     build_type: "sylius"

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -60,10 +60,10 @@ jobs:
                 env:
                     BRANCH: ${{ inputs.branch }}
                 run: |
-                    if [ "$BRANCH" == "1.12" ]; then
-                        echo "USE_LEGACY_POSTGRES_SETUP=yes" >> $GITHUB_ENV
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
                     else
-                        echo "USE_LEGACY_POSTGRES_SETUP=no" >> $GITHUB_ENV
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
 
             -   name: "Checkout (With Branch)"
@@ -96,10 +96,9 @@ jobs:
                     e2e: "yes"
                     database: "postgresql"
                     database_version: ${{ matrix.postgres }}
-                    legacy_postgresql_setup: ${{ env.USE_LEGACY_POSTGRES_SETUP }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
             -   name: Run PHPUnit

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -103,7 +103,9 @@ jobs:
                     chrome_version: stable
 
             -   name: Run PHPUnit
-                run: vendor/bin/phpunit --testsuite all --colors=always
+                run: |
+                    vendor/bin/phpunit --testsuite all --colors=always
+                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -77,6 +77,7 @@ jobs:
                 uses: actions/checkout@v4
 
             -   name: Prepare manifest.json files
+                if: "${{ inputs.branch != '1.14' }}"
                 run: |
                     mkdir -p public/build/admin
                     mkdir -p public/build/shop

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -52,6 +52,7 @@ jobs:
                     composer config prefer-stable true
 
             -   name: Prepare manifest.json files
+                if: "${{ inputs.branch != '1.14' }}"
                 run: |
                     mkdir -p public/build/admin
                     mkdir -p public/build/shop

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -33,6 +33,16 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: Set variables
+                shell: bash
+                env:
+                    BRANCH: ${{ inputs.branch }}
+                run: |
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    else
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
+                    fi
             -
                 uses: actions/checkout@v4
 
@@ -40,7 +50,7 @@ jobs:
                 run: |
                     composer config minimum-stability dev
                     composer config prefer-stable true
-                    
+
             -   name: Prepare manifest.json files
                 run: |
                     mkdir -p public/build/admin
@@ -51,7 +61,7 @@ jobs:
                     echo "{}" > public/build/shop/manifest.json
                     echo "{}" > public/build/app/admin/manifest.json
                     echo "{}" > public/build/app/shop/manifest.json
-            
+
             -   name: Build application
                 uses: SyliusLabs/BuildTestAppAction@v2.4
                 with:
@@ -62,7 +72,7 @@ jobs:
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
 
             -   name: Run PHPUnit
                 continue-on-error: ${{ inputs.ignore-failure }}
@@ -106,6 +116,17 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: Set variables
+                shell: bash
+                env:
+                    BRANCH: ${{ inputs.branch }}
+                run: |
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    else
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
+                    fi
+
             -   name: "Checkout (With Branch)"
                 if: "${{ inputs.branch != '' }}"
                 uses: actions/checkout@v4
@@ -141,10 +162,9 @@ jobs:
                     e2e: "yes"
                     e2e_js: "yes"
                     database_version: ${{ matrix.mysql }}
-                    legacy_postgresql_setup: "no"
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
 
             -   name: Run Behat (Chromedriver)
                 run: |
@@ -188,6 +208,17 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: Set variables
+                shell: bash
+                env:
+                    BRANCH: ${{ inputs.branch }}
+                run: |
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    else
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
+                    fi
+
             -   name: "Checkout (With Branch)"
                 if: "${{ inputs.branch != '' }}"
                 uses: actions/checkout@v4
@@ -226,7 +257,7 @@ jobs:
                     legacy_postgresql_setup: "no"
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: "24.x"
+                    node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
             -   name: Run Behat (Panther)

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -77,7 +77,9 @@ jobs:
 
             -   name: Run PHPUnit
                 continue-on-error: ${{ inputs.ignore-failure }}
-                run: vendor/bin/phpunit --testsuite all --colors=always
+                run: |
+                    vendor/bin/phpunit --testsuite all --colors=always
+                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -33,16 +33,6 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
-            -   name: Set variables
-                shell: bash
-                env:
-                    BRANCH: ${{ inputs.branch }}
-                run: |
-                    if [ "$BRANCH" == "1.14" ]; then
-                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    else
-                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
-                    fi
             -
                 uses: actions/checkout@v4
 
@@ -52,7 +42,6 @@ jobs:
                     composer config prefer-stable true
 
             -   name: Prepare manifest.json files
-                if: "${{ inputs.branch != '1.14' }}"
                 run: |
                     mkdir -p public/build/admin
                     mkdir -p public/build/shop
@@ -73,13 +62,11 @@ jobs:
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: ${{ env.NODE_VERSION }}
+                    node_version: "24.x"
 
             -   name: Run PHPUnit
                 continue-on-error: ${{ inputs.ignore-failure }}
-                run: |
-                    vendor/bin/phpunit --testsuite all --colors=always
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
+                run: vendor/bin/phpunit --testsuite all --colors=always
 
             -   name: Run CLI Behat
                 run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
@@ -119,17 +106,6 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
-            -   name: Set variables
-                shell: bash
-                env:
-                    BRANCH: ${{ inputs.branch }}
-                run: |
-                    if [ "$BRANCH" == "1.14" ]; then
-                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    else
-                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
-                    fi
-
             -   name: "Checkout (With Branch)"
                 if: "${{ inputs.branch != '' }}"
                 uses: actions/checkout@v4
@@ -167,7 +143,7 @@ jobs:
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: ${{ env.NODE_VERSION }}
+                    node_version: "24.x"
 
             -   name: Run Behat (Chromedriver)
                 run: |
@@ -211,17 +187,6 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
-            -   name: Set variables
-                shell: bash
-                env:
-                    BRANCH: ${{ inputs.branch }}
-                run: |
-                    if [ "$BRANCH" == "1.14" ]; then
-                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    else
-                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
-                    fi
-
             -   name: "Checkout (With Branch)"
                 if: "${{ inputs.branch != '' }}"
                 uses: actions/checkout@v4
@@ -260,7 +225,7 @@ jobs:
                     legacy_postgresql_setup: "no"
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
-                    node_version: ${{ env.NODE_VERSION }}
+                    node_version: "24.x"
                     chrome_version: stable
 
             -   name: Run Behat (Panther)

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -121,6 +121,10 @@ jobs:
             -   name: Run PHPStan
                 run: vendor/bin/phpstan analyse
 
+            -   name: Run PHPSpec
+                if: "${{ inputs.branch == '1.14' }}"
+                run: vendor/bin/phpspec run --ansi --no-interaction -f dot
+
             -   name: Run ComposerRequireChecker
                 run: |
                     (cat composer.json | jq '.["autoload-dev"]["psr-4"] |= . + {"Sylius\\Behat\\": "src/Sylius/Behat/"}' | jq 'del(.autoload["psr-4"]["Sylius\\Behat\\"])') > _composer.json


### PR DESCRIPTION
Tweaked the workflows a bit to be compatible with 2.x and 1.14 in full builds since these always use the workflows from the default branch:
- Brought back running phpspec tests for 1.14;
- Added the previous phpunit suite and used both (tests of a missing suite simply don't get run);
- Parametrized node version based on the branch;
- Downgraded the testApp action for Symfony 5.4 (No clue why it doesn't work w/ the latest one :shrug:)

The full tests on 1.14 ran from this branch are [green](https://github.com/NoResponseMate/Sylius/actions/runs/15585204820/job/43889793639). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a step to run PHPSpec tests automatically for branch "1.14" during static checks.
- **Improvements**
  - Node.js version used in workflows now adjusts automatically based on the branch, ensuring compatibility for branch "1.14".
  - Expanded PHPUnit testing to run both "all" and "Sylius Test Suite" for more comprehensive coverage.
  - Dynamic selection of test app version and build action based on branch for improved workflow flexibility.
- **Other**
  - Minor workflow optimizations and conditional step execution based on branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->