### PR TITLE
[Admin] Fix defining fallback url for back button

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/actions/cancel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/actions/cancel.html.twig
@@ -2,7 +2,7 @@
 
 {% set configuration = hookable_metadata.context.configuration %}
 
-{% set index_url = sylius_generate_redirect_path(app.request.headers.get('referer')|default(path(
+{% set fallback_url = app.request.headers.get('referer')|default(sylius_generate_redirect_path(path(
     configuration.vars.index.route.name|default(configuration.getRouteName('index')),
     configuration.vars.index.route.parameters|default(configuration.vars.route.parameters|default({}))
 ))) %}
@@ -10,5 +10,5 @@
 {{ button.cancel(sylius_test_form_attribute('cancel-changes-button')|merge({
     text: 'sylius.ui.back'|trans,
     class: 'btn',
-    fallback_url: index_url
+    fallback_url: fallback_url
 })) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved variable naming and streamlined the logic for determining the cancel button's fallback URL. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->