### PR TITLE
[ProductBundle] Fix ProductAttributeValue mapping to use ProductAttributeInterface

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeValue.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeValue.orm.xml
@@ -21,7 +21,7 @@
             <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
 
-        <many-to-one field="attribute" target-entity="Sylius\Component\Attribute\Model\AttributeInterface">
+        <many-to-one field="attribute" target-entity="Sylius\Component\Product\Model\ProductAttributeInterface">
             <join-column name="attribute_id" referenced-column-name="id" nullable="false" />
         </many-to-one>
     </mapped-superclass>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.14
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

## Description

Fixes ProductAttributeValue Doctrine mapping to use the specific `ProductAttributeInterface` instead of generic `AttributeInterface`.

### Problem
The current mapping causes issues when implementing attribute systems for other resources, as Doctrine cannot correctly resolve relationships when multiple resources use attributes.

### Solution
Use `ProductAttributeInterface` for product-specific attribute values to ensure proper relationship mapping and prevent conflicts with other attribute implementations.
