### PR TITLE
Require File instead of UploadedFile in AllowedImageMimeTypesValidator

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypesValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\File\File
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;
@@ -33,7 +33,7 @@ class AllowedImageMimeTypesValidator extends ConstraintValidator
             return;
         }
 
-        Assert::isInstanceOf($value, UploadedFile::class);
+        Assert::isInstanceOf($value, File::class);
         Assert::isInstanceOf($constraint, AllowedImageMimeTypes::class);
 
         if (!in_array($value->getMimeType(), $this->allowedMimeTypes, true)) {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/AllowedImageMimeTypesValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
-use Symfony\Component\HttpFoundation\File\File
+use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #18171 
| License         | MIT

Hi guys,
in the `validate` method of `Sylius\Bundle\CoreBundle\Validator\Constraints\AllowedImageMimeTypesValidator` a value of `Symfony\Component\HttpFoundation\File\UploadedFile` has been required only to check its mime type.

But in my opinion the validator should check for `Symfony\Component\HttpFoundation\File\File` instead of `UploadedFile`.

The `getMimeType()` is defined on the `Symfony\Component\HttpFoundation\File\File` class.

Moreover doing so will force to have Product images only set by form upload but there could be different flows setting File to Product objects (and not UploadedFile). For example in our SyliusAkeneoPlugin we have the [ImageValueHandler](https://github.com/webgriffe/SyliusAkeneoPlugin/blob/master/src/ValueHandler/ImageValueHandler.php#L193) which sets a File on the Product and not an UploadedFile because the image is not uploaded from the admin panel form but it's imported from Akeneo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image validation to support a broader range of file types, ensuring more consistent handling of uploaded images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->