### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/getting-started-with-sylius/customizing-business-logic.md
+++ b/docs/getting-started-with-sylius/customizing-business-logic.md
@@ -89,7 +89,7 @@ Now that your calculator is registered, you can create a new **Shipping Method**
 
  
 
-<figure><img src="../.gitbook/assets/shipping-cost-1.png" alt=""><figcaption><p>Shipping cost for 1 pacel</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/shipping-cost-1.png" alt=""><figcaption><p>Shipping cost for 1 parcel</p></figcaption></figure>
 
  
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | n
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Fix typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in an image caption, changing "pacel" to "parcel" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->