### PR TITLE
Update storage based locale switcher to redirect to homepage if the d…

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,3 +1,13 @@
+# UPGRADE FROM `2.1.2` TO `2.1.3`
+
+### Deprecations
+
+1. Not passing the `Symfony\Component\Routing\Matcher\UrlMatcherInterface` instance as the last argument to the `Sylius\Bundle\ShopBundle\Locale\StorageBasedLocaleSwitcher` constructor is deprecated and will be required in Sylius 3.0.
+
+### Service configuration changes
+
+1. The priority of the `sylius_shop.context.locale.storage_based` service's tag `sylius.context.locale` has been changed from `-64` to `64` to ensure proper execution order in the locale context chain.
+
 # UPGRADE FROM `2.0` TO `2.1`
 
 ### General

--- a/src/Sylius/Bundle/ShopBundle/Locale/StorageBasedLocaleSwitcher.php
+++ b/src/Sylius/Bundle/ShopBundle/Locale/StorageBasedLocaleSwitcher.php
@@ -17,17 +17,40 @@ use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Locale\LocaleStorageInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 final class StorageBasedLocaleSwitcher implements LocaleSwitcherInterface
 {
-    public function __construct(private LocaleStorageInterface $localeStorage, private ChannelContextInterface $channelContext)
-    {
+    public function __construct(
+        private LocaleStorageInterface $localeStorage,
+        private ChannelContextInterface $channelContext,
+        private ?UrlMatcherInterface $urlMatcher = null
+    ) {
+        if (null === $this->urlMatcher) {
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '2.1',
+                'Not passing a "%s" to "%s" is deprecated and will be required in Sylius 3.0.',
+                UrlMatcherInterface::class,
+                self::class
+            );
+        }
     }
 
     public function handle(Request $request, string $localeCode): RedirectResponse
     {
         $this->localeStorage->set($this->channelContext->getChannel(), $localeCode);
+        $url = $request->headers->get('referer', $request->getSchemeAndHttpHost());
 
-        return new RedirectResponse($request->headers->get('referer', $request->getSchemeAndHttpHost()));
+        if ($this->urlMatcher) {
+            try {
+                $this->urlMatcher->match($url);
+            } catch (ResourceNotFoundException) {
+                return new RedirectResponse($request->getSchemeAndHttpHost());
+            }
+        }
+
+        return new RedirectResponse($url);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/integrations/locale/storage.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/integrations/locale/storage.xml
@@ -20,6 +20,7 @@
         <service id="sylius_shop.locale_switcher" class="Sylius\Bundle\ShopBundle\Locale\StorageBasedLocaleSwitcher">
             <argument type="service" id="sylius_shop.storage.locale" />
             <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="router" />
         </service>
 
         <service id="sylius_shop.storage.locale" class="Sylius\Component\Core\Locale\LocaleStorage">
@@ -31,7 +32,7 @@
             <argument type="service" id="sylius.context.channel" />
             <argument type="service" id="sylius_shop.storage.locale" />
             <argument type="service" id="sylius.provider.locale" />
-            <tag name="sylius.context.locale" priority="-64" />
+            <tag name="sylius.context.locale" priority="64" />
         </service>
 
         <service id="sylius_shop.router.locale_stripping" class="Sylius\Bundle\ShopBundle\Router\LocaleStrippingRouter"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1  <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The wrong priority was causing the storage based locale switcher to not work 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved locale switching behavior to provide more accurate redirects after changing the locale.
* **Documentation**
  * Added upgrade instructions for migrating from Sylius 2.1.2 to 2.1.3, including notes on upcoming deprecations and service configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->