### PR TITLE
feat(hooks): trigger hooks on product index and product show

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/index.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/index.html.twig
@@ -1,5 +1,7 @@
 {% extends '@SyliusShop/shared/layout/base.html.twig' %}
 
+{% set prefixes = ['sylius_shop.product.index'] %}
+
 {% block content %}
     {% hook 'sylius_shop.product.index' with { products, resources } %}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show.html.twig
@@ -1,5 +1,7 @@
 {% extends '@SyliusShop/shared/layout/base.html.twig' %}
 
+{% set prefixes = ['sylius_shop.product.show'] %}
+
 {% block title %}{{ product.name }} | {{ parent() }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

To trigger some hooks like `sylius_shop.product.index#metatags` and `sylius_shop.product.show#metatags`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced new template variables for internal use without affecting existing page behavior or appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->