### PR TITLE
[Composer] Conflict with symfony/serializer:^6.4.23 because of a fatal error in APIP 2.7

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -1,7 +1,6 @@
 # CONFLICTS
 
-This document explains why certain conflicts were added to `composer.json` and
-references related issues.
+This document explains why certain conflicts were added to `composer.json` and references related issues.
 
 - `lexik/jwt-authentication-bundle: ^2.18`
 

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -37,3 +37,8 @@ references related issues.
 
   This version moved files to flatten paths into a PSR-4 structure, which lead to a fatal error:
   `PHP Fatal error:  Uncaught Error: Failed opening required '/home/runner/work/Sylius/Sylius/vendor/behat/gherkin/src/../../../i18n.php' (include_path='.:/usr/share/php') in /home/runner/work/Sylius/Sylius/vendor/behat/gherkin/src/Keywords/CachedArrayKeywords.php:34`
+
+- `symfony/serializer:^6.4.23`:
+
+  This version introduces a change in method signature that is not compatible with API Platform 2.7 and leads to a fatal error:
+  `PHP Fatal error:  Declaration of ApiPlatform\Serializer\AbstractItemNormalizer::getAllowedAttributes($classOrObject, array $context, $attributesAsString = false) must be compatible with Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::getAllowedAttributes(object|string $classOrObject, array $context, bool $attributesAsString = false): array|bool in /home/runner/work/Sylius/Sylius/vendor/api-platform/core/src/Serializer/AbstractItemNormalizer.php on line 493`

--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,7 @@
         "behat/gherkin": "^4.13.0",
         "lexik/jwt-authentication-bundle": "^2.18",
         "stof/doctrine-extensions-bundle": "1.8.0",
+        "symfony/serializer": "^6.4.23",
         "symfony/validator": "5.4.25",
         "twig/twig": "3.9.0"
     },

--- a/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
+++ b/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
@@ -1,0 +1,8 @@
+# CONFLICTS
+
+This document explains why certain conflicts were added to `composer.json` and references related issues.
+
+- `symfony/serializer:^6.4.23`:
+
+  This version introduces a change in method signature that is not compatible with API Platform 2.7 and leads to a fatal error:
+  `PHP Fatal error:  Declaration of ApiPlatform\Serializer\AbstractItemNormalizer::getAllowedAttributes($classOrObject, array $context, $attributesAsString = false) must be compatible with Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::getAllowedAttributes(object|string $classOrObject, array $context, bool $attributesAsString = false): array|bool in /home/runner/work/Sylius/Sylius/vendor/api-platform/core/src/Serializer/AbstractItemNormalizer.php on line 493`

--- a/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
+++ b/src/Sylius/Bundle/ApiBundle/CONFLICTS.md
@@ -2,6 +2,16 @@
 
 This document explains why certain conflicts were added to `composer.json` and references related issues.
 
+- `api-platform/core:2.7.17`:
+
+  This version introduced class aliases, which lead to a fatal error:
+  `The autoloader expected class "ApiPlatform\Core\Bridge\Symfony\Bundle\DependencyInjection\ApiPlatformExtension" to be defined in file ".../vendor/api-platform/core/src/Core/Bridge/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php". The file was found but the class was not in it, the class name or namespace probably has a typo.`
+
+- `lexik/jwt-authentication-bundle: ^2.18`
+
+  After bumping to this version ApiBundle starts failing due to requesting a non-existing `api_platform.openapi.factory.legacy` service.
+  As we are not using this service across the ApiBundle we added this conflict to unlock the builds, until we investigate the problem.
+
 - `symfony/serializer:^6.4.23`:
 
   This version introduces a change in method signature that is not compatible with API Platform 2.7 and leads to a fatal error:

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -48,7 +48,8 @@
     "conflict": {
         "api-platform/core": "2.7.17",
         "doctrine/doctrine-bundle": "2.3.0",
-        "lexik/jwt-authentication-bundle": "^2.18"
+        "lexik/jwt-authentication-bundle": "^2.18",
+        "symfony/serializer": "^6.4.23"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/actions/runs/15961757109/job/45015313493#step:13:11
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
