### PR TITLE
[API] Set URL generation strategy for Taxon resource after the API Platform changes with usage of genId

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/properties/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/properties/Channel.xml
@@ -80,5 +80,5 @@
     <property resource="%sylius.model.channel.class%" name="shippingAddressInCheckoutRequired" writable="true" readable="true" />
     <property resource="%sylius.model.channel.class%" name="shopBillingData" writable="true" genId="false"/>
     <property resource="%sylius.model.channel.class%" name="menuTaxon" writable="true" readable="true" />
-    <property resource="%sylius.model.channel.class%" name="channelPriceHistoryConfig" writable="true" genId="false"/>
+    <property resource="%sylius.model.channel.class%" name="channelPriceHistoryConfig" writable="true" genId="false" />
 </properties>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/Taxon.xml
@@ -16,7 +16,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0 https://api-platform.com/schema/metadata/resources-3.0.xsd"
 >
-    <resource class="%sylius.model.taxon.class%">
+    <resource class="%sylius.model.taxon.class%" urlGenerationStrategy="1">
         <operations>
             <operation name="sylius_api_admin_taxon_get_collection" class="ApiPlatform\Metadata\GetCollection" uriTemplate="/admin/taxons">
                 <normalizationContext>


### PR DESCRIPTION

| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This PR fixes issue with APIP 4.1.17: https://github.com/Sylius/Sylius/actions/runs/15963124014/job/45018806151#step:11:16, after https://github.com/api-platform/core/pull/7219.

Reference: https://github.com/api-platform/core/issues/7261
<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Taxon API resource configuration to explicitly set the URL generation strategy, which affects how URLs are generated for Taxon-related API operations.

* **Style**
  * Minor formatting adjustment in the XML property tag for channel price history configuration (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->