### PR TITLE
[CI] Load Node version conditionally + bring back phpspecs for 2.0 full builds

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -63,6 +63,8 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    elif [ "$BRANCH" == "2.0" ]; then
+                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -62,6 +62,8 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    elif [ "$BRANCH" == "2.0" ]; then
+                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
@@ -159,6 +161,8 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    elif [ "$BRANCH" == "2.0" ]; then
+                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
@@ -246,6 +250,8 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    elif [ "$BRANCH" == "2.0" ]; then
+                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -62,6 +62,8 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    elif [ "$BRANCH" == "2.0" ]; then
+                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -122,7 +122,7 @@ jobs:
                 run: vendor/bin/phpstan analyse
 
             -   name: Run PHPSpec
-                if: "${{ inputs.branch == '1.14' }}"
+                if: ${{ inputs.branch == '1.14' || inputs.branch == '2.0' }}
                 run: vendor/bin/phpspec run --ansi --no-interaction -f dot
 
             -   name: Run ComposerRequireChecker


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The full builds for 2.0 are now green: https://github.com/GSadee/Sylius/actions/runs/15990161535 🟢 

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to support Node.js 22.x for the "2.0" branch in end-to-end tests for MariaDB, MySQL, and PostgreSQL.
  * Adjusted static checks to run PHPSpec on both "1.14" and "2.0" branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->