### PR TITLE
[Core] Change where to andWhere method in ProductRepository

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -186,7 +186,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     public function findOneByChannelAndCode(ChannelInterface $channel, string $code): ?ProductInterface
     {
         $product = $this->createQueryBuilder('o')
-            ->where('o.code = :code')
+            ->andWhere('o.code = :code')
             ->andWhere(':channel MEMBER OF o.channels')
             ->andWhere('o.enabled = :enabled')
             ->setParameter('channel', $channel)
@@ -212,7 +212,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     public function findOneByCode(string $code): ?ProductInterface
     {
         return $this->createQueryBuilder('o')
-            ->where('o.code = :code')
+            ->andWhere('o.code = :code')
             ->setParameter('code', $code)
             ->getQuery()
             ->getOneOrNullResult()
@@ -222,7 +222,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     public function findOneByIdHydrated(mixed $id): ?ProductInterface
     {
         $product = $this->createQueryBuilder('o')
-            ->where('o.id = :id')
+            ->andWhere('o.id = :id')
             ->setParameter('id', $id)
             ->getQuery()
             ->getOneOrNullResult()
@@ -264,7 +264,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
             ->addSelect('association')
             ->leftJoin('o.associations', 'association')
             ->innerJoin('association.associatedProducts', 'associatedProduct', 'WITH', 'associatedProduct.enabled = :enabled')
-            ->where('o.code = :code')
+            ->andWhere('o.code = :code')
             ->andWhere(':channel MEMBER OF o.channels')
             ->andWhere('o.enabled = :enabled')
             ->setParameter('channel', $channel)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This PR updates the ProductRepository queries by replacing the usage of `where` with `andWhere` method.

The reason for this change is to allow extending the query builder in plugins or end applications without unintentionally overriding existing conditions. Using `where` resets any previous conditions, which can lead to unexpected behavior when additional constraints are added later. Switching to `andWhere` ensures that all conditions are preserved and combined properly.

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
