### PR TITLE
Fix generating random fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -110,12 +110,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('hostname', fn (Options $options): string => $options['code'] . '.localhost')
             ->setDefault('color', fn (Options $options): string => $this->faker->hexColor)

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
@@ -52,12 +52,7 @@ class CustomerGroupExampleFactory extends AbstractExampleFactory implements Exam
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -85,12 +85,7 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory implements Exam
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('description', fn (Options $options): string => $this->faker->sentence())
             ->setDefault('instructions', null)

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
@@ -65,12 +65,7 @@ class ProductAssociationTypeExampleFactory extends AbstractExampleFactory implem
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -70,12 +70,7 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('translatable', true)
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('type', fn (Options $options): string => $this->faker->randomElement(array_keys($this->attributeTypes)))

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -115,12 +115,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
 
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -83,12 +83,7 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('values', null)
             ->setDefault('values', function (Options $options, ?array $values): array {

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
@@ -55,12 +55,7 @@ class ShippingCategoryExampleFactory extends AbstractExampleFactory implements E
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('description', fn (Options $options): string => $this->faker->paragraph)
         ;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -98,12 +98,7 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
     {
         $resolver
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('description', fn (Options $options): string => $this->faker->sentence())
             ->setDefault('enabled', fn (Options $options): bool => $this->faker->boolean(90))
             ->setAllowedTypes('enabled', 'bool')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
@@ -54,12 +54,7 @@ class TaxCategoryExampleFactory extends AbstractExampleFactory implements Exampl
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
             ->setDefault('description', fn (Options $options): string => $this->faker->paragraph)
         ;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
@@ -70,12 +70,7 @@ class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFac
     {
         $resolver
             ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
-            ->setDefault('name', function (): string {
-                /** @var string $words */
-                $words = $this->faker->words(3, true);
-
-                return $words;
-            })
+            ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
             ->setDefault('amount', fn (Options $options): float => $this->faker->randomFloat(2, 0, 0.4))
             ->setAllowedTypes('amount', 'float')
             ->setDefault('included_in_price', fn (Options $options): bool => $this->faker->boolean())


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

Fixes the issue during generating random fixtures:
```
Sylius\Component\Core\Formatter\StringInflector::nameToCode(): Argument #1 ($value) must be of type string, Closure given
```

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code readability and consistency by simplifying how default names are generated for various fixture factories. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->