### PR TITLE
[Admin] Fix error message during creating admin user by CLI command

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Console/Command/CreateAdminUserCommand.php
+++ b/src/Sylius/Bundle/AdminBundle/Console/Command/CreateAdminUserCommand.php
@@ -74,11 +74,10 @@ final class CreateAdminUserCommand extends Command
         try {
             $this->handle(new CreateAdminUser(...array_values($adminUserData)));
         } catch (HandlerFailedException $exception) {
-            $this->io->error(
-                $exception
-                ->getWrappedExceptions(CreateAdminUserFailedException::class)[0]
-                ->getMessage(),
-            );
+            $exceptions = $exception->getWrappedExceptions(CreateAdminUserFailedException::class);
+            if ($wrappedException = reset($exceptions)) {
+                $this->io->error($wrappedException->getMessage());
+            }
 
             return Command::FAILURE;
         }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18024
| License         | MIT

Creating the Admin User by CLI command with the same email and username:

_Before:_
![image](https://github.com/user-attachments/assets/78d055ed-9d5c-4957-963c-e6b595c19f8a)

_After:_
![image](https://github.com/user-attachments/assets/e3d32443-0dac-4bd0-b95b-0f804f8d5005)

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
