### PR TITLE
docs: fix broken link in resource-layer.md

### DIFF
--- a/docs/the-book/architecture/resource-layer.md
+++ b/docs/the-book/architecture/resource-layer.md
@@ -173,4 +173,4 @@ app_product_create:
                 parameters: [$store]
 ```
 
-All other methods have the same level of flexibility and are documented in the [Resource Bundle documentation](https://stack.sylius.com/resource/index).
+All other methods have the same level of flexibility and are documented in the [Resource Bundle documentation](https://docs.sylius.com/sylius-stack/resource/index).

--- a/docs/the-book/architecture/resource-layer.md
+++ b/docs/the-book/architecture/resource-layer.md
@@ -173,4 +173,4 @@ app_product_create:
                 parameters: [$store]
 ```
 
-All other methods have the same level of flexibility and are documented in the [SyliusResourceBundle](https://github.com/Sylius/SyliusResourceBundle/blob/master/docs/index.md).
+All other methods have the same level of flexibility and are documented in the [Resource Bundle documentation](https://stack.sylius.com/resource/index).


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Fixes a broken link in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the link to the Resource Bundle documentation in the resource layer guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->