### PR TITLE
[ShopBundle] Fix missing void return

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/SyliusShopBundle.php
+++ b/src/Sylius/Bundle/ShopBundle/SyliusShopBundle.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SyliusShopBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new LogoutListenerPass());
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This pull request includes a small change to the `SyliusShopBundle` class. The `build` method's signature was updated to include a return type of `void`, improving type safety.

Fix deprecation notice:

```
Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Sylius\Bundle\ShopBundle\SyliusShopBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```