### PR TITLE
[Shop] Variant listening visual improvement

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table.html.twig
@@ -1,3 +1,3 @@
-<table {{ sylius_test_html_attribute('product-variants') }}>
+<table class="table align-middle mb-0" {{ sylius_test_html_attribute('product-variants') }}>
     {% hook 'table' %}
 </table>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body.html.twig
@@ -1,7 +1,7 @@
-{% set selectedVariant = hookable_metadata.context.variant %}
+{% set selected_variant = hookable_metadata.context.variant %}
 <tbody>
 {% for key, variant in hookable_metadata.context.product.enabledVariants %}
-    <tr class="{% if variant.code == selectedVariant.code %}table-success{% endif %}" {{ sylius_test_html_attribute('product-variants-row') }}>
+    <tr class="{% if variant.code == selected_variant.code %}table-success{% endif %}" {{ sylius_test_html_attribute('product-variants-row') }}>
         {% hook 'body' with { variant, key } %}
     </tr>
 {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body.html.twig
@@ -1,7 +1,8 @@
+{% set selectedVariant = hookable_metadata.context.variant %}
 <tbody>
-    {% for key, variant in hookable_metadata.context.product.enabledVariants %}
-        <tr {{ sylius_test_html_attribute('product-variants-row') }}>
-            {% hook 'body' with { variant, key } %}
-        </tr>
-    {% endfor %}
+{% for key, variant in hookable_metadata.context.product.enabledVariants %}
+    <tr class="{% if variant.code == selectedVariant.code %}table-success{% endif %}" {{ sylius_test_html_attribute('product-variants-row') }}>
+        {% hook 'body' with { variant, key } %}
+    </tr>
+{% endfor %}
 </tbody>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/name.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/name.html.twig
@@ -2,13 +2,13 @@
 {% set product = hookable_metadata.context.product %}
 
 <td>
-    {{ variant.name|default(variant.descriptor) }}
+    <div class="fw-semibold">{{ variant.name|default(variant.descriptor) }}</div>
     {% if product.hasOptions() %}
         <div>
             {% for option_value in variant.optionValues %}
-                <div>
+                <span class="badge text-bg-light text-muted">
                     {{ option_value.value }}
-                </div>
+                </span>
             {% endfor %}
         </div>
     {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/price.html.twig
@@ -1,11 +1,11 @@
 {% import "@SyliusShop/shared/macro/money.html.twig" as money %}
 
-{% set variant             = hookable_metadata.context.variant %}
-{% set channel_pricing     = variant.getChannelPricingForChannel(sylius.channel) %}
-{% set applied_promotions  = channel_pricing.appliedPromotions|map(p => {'label': p.label, 'description': p.description}) %}
-{% set days                = sylius.channel.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod %}
-{% set has_discount        = variant|sylius_has_discount({'channel': sylius.channel}) %}
-{% set has_lowest_price    = variant|sylius_has_lowest_price({'channel': sylius.channel}) %}
+{% set variant = hookable_metadata.context.variant %}
+{% set channel_pricing = variant.getChannelPricingForChannel(sylius.channel) %}
+{% set applied_promotions = channel_pricing.appliedPromotions|map(p => {'label': p.label, 'description': p.description}) %}
+{% set days = sylius.channel.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod %}
+{% set has_discount = variant|sylius_has_discount({'channel': sylius.channel}) %}
+{% set has_lowest_price = variant|sylius_has_lowest_price({'channel': sylius.channel}) %}
 
 {% if has_discount %}
     {% set original_int = channel_pricing.originalPrice %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/body/price.html.twig
@@ -1,25 +1,47 @@
 {% import "@SyliusShop/shared/macro/money.html.twig" as money %}
 
-{% set variant = hookable_metadata.context.variant %}
-{% set channel_pricing = variant.getChannelPricingForChannel(sylius.channel) %}
-{% set applied_promotions = channel_pricing.appliedPromotions|map(promotion => ({'label': promotion.label, 'description': promotion.description})) %}
-{% set days = sylius.channel.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod %}
-{% set has_lowest_price = variant|sylius_has_lowest_price({'channel': sylius.channel})%}
-{% set has_discount = variant|sylius_has_discount({'channel': sylius.channel}) %}
+{% set variant             = hookable_metadata.context.variant %}
+{% set channel_pricing     = variant.getChannelPricingForChannel(sylius.channel) %}
+{% set applied_promotions  = channel_pricing.appliedPromotions|map(p => {'label': p.label, 'description': p.description}) %}
+{% set days                = sylius.channel.channelPriceHistoryConfig.lowestPriceForDiscountedProductsCheckingPeriod %}
+{% set has_discount        = variant|sylius_has_discount({'channel': sylius.channel}) %}
+{% set has_lowest_price    = variant|sylius_has_lowest_price({'channel': sylius.channel}) %}
 
-<td
+{% if has_discount %}
+    {% set original_int = channel_pricing.originalPrice %}
+    {% set current_int  = channel_pricing.price %}
+    {% set discount_pct = ((original_int - current_int) / original_int * 100)|round(0) %}
+{% endif %}
+
+<td class="text-end"
     data-applied-promotions="{{ applied_promotions|json_encode }}"
     {% if has_discount %}
-        data-original-price="{{ money.calculateOriginalPrice(variant) }}"
-        {% if has_lowest_price %}
-            {% set lowest_price_before_discount = money.calculateLowestPrice(variant) %}
-            data-lowest-price-before-discount="{{
-            'sylius.ui.lowest_price_days_before_discount_was'|trans({
-                '%days%': days,
-                '%price%': lowest_price_before_discount
-            })
-            }}"
-        {% endif %}
+    data-original-price="{{ money.calculateOriginalPrice(variant) }}"
+    {% if has_lowest_price %}
+        data-lowest-price-before-discount="{{
+        'sylius.ui.lowest_price_days_before_discount_was'|trans({
+            '%days%': days,
+            '%price%': money.calculateLowestPrice(variant)
+        })
+        }}"
+    {% endif %}
     {% endif %}>
-    {{ money.calculatePrice(variant) }}
+
+    {% if has_discount %}
+        <div class="d-inline-flex align-items-center gap-2">
+            <span class="fw-semibold text-success">
+                {{ money.calculatePrice(variant) }}
+            </span>
+
+            <span class="text-muted text-decoration-line-through small">
+                {{ money.calculateOriginalPrice(variant) }}
+            </span>
+
+            <span class="badge bg-danger-subtle text-danger">
+                -{{ discount_pct }}%
+            </span>
+        </div>
+    {% else %}
+        <span class="fw-semibold">{{ money.calculatePrice(variant) }}</span>
+    {% endif %}
 </td>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/head/price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/head/price.html.twig
@@ -1,1 +1,1 @@
-<th>{{ 'sylius.ui.price'|trans }}</th>
+<th class="text-end">{{ 'sylius.ui.price'|trans }}</th>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/head/selection.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/summary/add_to_cart/variants/table/head/selection.html.twig
@@ -1,1 +1,1 @@
-<th></th>
+<th class="text-end"></th>


### PR DESCRIPTION
Fixes #18141 

I’ve improved the appearance of the variant listing by adjusting the table layout. The underlying structure remains unchanged, and no elements in the YAML were modified or added.

![image](https://github.com/user-attachments/assets/0c7abf88-bcea-4b1d-a8e9-1aa478c2da12)
![image](https://github.com/user-attachments/assets/69410082-b42e-4719-b702-bb35a804d03a)
![image](https://github.com/user-attachments/assets/de2c7f6d-532f-49cc-8f57-84bf8ba37370)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Style**
  * Enhanced table and row styling for product variants, including improved alignment and spacing.
  * Visually highlights the selected product variant in the table.
  * Updated the appearance of variant names and option values with bold text and badge-style elements.
  * Improved price display for discounted variants, showing original price, discount percentage, and clearer formatting.
  * Right-aligned price and selection headers for better table readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->