### PR TITLE
[New routing] Admin countries crud

### DIFF
--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -18,8 +18,10 @@ sylius_core:
                     enabled: false
                 admin_catalog_promotion:
                     enabled: false                
-                admin_channel:
-                    enabled: false                
+                admin_channel:            
+                    enabled: false        
+                admin_country:
+                    enabled: false
                 admin_product:
                     enabled: false
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/country.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/country.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Sylius\Bundle\AdminBundle\Form\Type\CountryType;
+use Sylius\Resource\Metadata\Create;
+use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Operations;
+use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\Metadata\Update;
+
+return (new ResourceMetadata())
+    ->withRoutePrefix('/%sylius_admin.path_name%')
+    ->withClass('%sylius.model.country.class%')
+    ->withSection('admin')
+    ->withTemplatesDir('@SyliusAdmin/shared/crud')
+    ->withFormType(CountryType::class)
+    ->withRouteCondition("not context.isSyliusRoutingBcLayerEnabled('admin_country')")
+    ->withOperations(new Operations(operations: [
+        new Create(
+            routeName: '_sylius_admin_country_create',
+            redirectToRoute: 'sylius_admin_country_update',
+        ),
+        new Update(
+            routeName: '_sylius_admin_country_update',
+            redirectToRoute: 'sylius_admin_country_update',
+        ),
+        new Index(
+            routeName: '_sylius_admin_country_index',
+            grid: 'sylius_admin_country',
+        ),
+    ]))
+;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
@@ -9,4 +9,5 @@ sylius_admin_country:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\CountryType
         permission: true
+        condition: "context.isSyliusRoutingBcLayerEnabled('admin_country')"
     type: sylius.resource


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | new-routing
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fine-grained control over admin route compatibility layers, allowing global and per-route enablement or disablement.
  * Added new resource configurations for catalog promotions, countries, and products in the admin interface, supporting advanced CRUD and bulk operations.
  * Implemented a custom request context to manage compatibility layer routing.

* **Bug Fixes**
  * Improved route matching logic in admin page resolution.

* **Chores**
  * Updated dependencies to require newer development versions of resource packages.

* **Tests**
  * Added and updated tests to cover new routing configuration options and request context behaviors.
  * Adjusted test cases for redirect path formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->