### PR TITLE
[PaymentRequest] Keep the already set payload when available

### DIFF
--- a/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProvider.php
+++ b/src/Sylius/Bundle/PaymentBundle/Provider/DefaultPayloadProvider.php
@@ -20,6 +20,6 @@ final class DefaultPayloadProvider implements DefaultPayloadProviderInterface
 {
     public function getPayload(PaymentRequestInterface $paymentRequest): mixed
     {
-        return null;
+        return $paymentRequest->getPayload() ?: null;
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When working with Stripe Subscription Payment method edition I see that the `DefaultPayloadProvider` was not acting like the `DefaultActionProvider`. This PR is here to fix this in order to let the already set payload to be used.
