### PR TITLE
[Shop] Allow contextual product cards

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/product/common/card.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/common/card.html.twig
@@ -1,3 +1,3 @@
 <div {{ sylius_test_html_attribute('product', '%s'|format(product.code)) }} >
-    {% hook 'card' with {_prefixes: ['sylius_shop.shared.product']} %}
+    {% hook 'card' with {_prefixes: hookable_metadata.prefixes|default([])|merge(['sylius_shop.shared.product'])} %}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/common/list.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/common/list.html.twig
@@ -4,7 +4,7 @@
     <div {{ sylius_test_html_attribute(hookable_metadata.configuration.test_attribute|default('latest-products')) }}>
         <div class="products-grid">
             {% for product in latest_products %}
-                <div>{{ component('sylius_shop:product:card', { product: product, template: '@SyliusShop/product/common/card.html.twig' }) }}</div>
+                <div>{{ component('sylius_shop:product:card', { product: product, template: hookable_metadata.configuration.product_template|default('@SyliusShop/product/common/card.html.twig'), hookableMetadata: hookable_metadata }) }}</div>
             {% endfor %}
         </div>
     </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/index/content/body/main/products.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/index/content/body/main/products.html.twig
@@ -5,7 +5,7 @@
 {% if resources.data|length > 0 %}
     <div class="products-grid" {{ sylius_test_html_attribute('products') }}>
         {% for product in resources.data %}
-            {{ component('sylius_shop:product:card', { product: product, template: '@SyliusShop/product/common/card.html.twig' }) }}
+            {{ component('sylius_shop:product:card', { product: product, template: hookable_metadata.configuration.product_template|default('@SyliusShop/product/common/card.html.twig'), hookableMetadata: hookable_metadata }) }}
         {% endfor %}
     </div>
 {% else %}

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/product_listing/association.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/product_listing/association.html.twig
@@ -3,7 +3,7 @@
     <div {{ sylius_test_html_attribute('product-association', product_association.type.name) }}>
         <div class="products-grid">
             {% for product in associated_products %}
-                <div>{{ component('sylius_shop:product:card', { product: product, template: '@SyliusShop/product/common/card.html.twig' }) }}</div>
+                <div>{{ component('sylius_shop:product:card', { product: product, template: hookable_metadata.configuration.product_template|default('@SyliusShop/product/common/card.html.twig'), hookableMetadata: hookable_metadata }) }}</div>
             {% endfor %}
         </div>
     </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/product/horizontal_list.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/product/horizontal_list.html.twig
@@ -1,5 +1,5 @@
 <div class="products-grid">
     {% for product in products %}
-        <div>{{ component('sylius_shop:product:card', { product: product, template: '@SyliusShop/product/common/card.html.twig' }) }}</div>
+        <div>{{ component('sylius_shop:product:card', { product: product, template: hookable_metadata.configuration.product_template|default('@SyliusShop/product/common/card.html.twig'), hookableMetadata: hookable_metadata }) }}</div>
     {% endfor %}
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | kinda
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

- Add parent prefixes to the `card` hook with a fallback to `sylius_shop.shared.product`, so the card structure can be configured case by case and not only globally.
- Allow setting a custom product card template via hook configuration.