### PR TITLE
[New routing] Admin orders crud

### DIFF
--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -21,6 +21,7 @@ sylius_core:
                 admin_currency: false
                 admin_customer: false
                 admin_locale: false
+                admin_order: false
                 admin_product: false
 
 sylius_api:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/order.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/order.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Sylius\Bundle\AdminBundle\Form\Type\OrderType;
+use Sylius\Bundle\CoreBundle\StateMachine\State\ApplyStateMachineTransitionProcessor;
+use Sylius\Resource\Metadata\ApplyStateMachineTransition;
+use Sylius\Resource\Metadata\Index;
+use Sylius\Resource\Metadata\Operations;
+use Sylius\Resource\Metadata\ResourceMetadata;
+use Sylius\Resource\Metadata\Show;
+use Sylius\Resource\Metadata\Update;
+
+return (new ResourceMetadata())
+    ->withRoutePrefix('/%sylius_admin.path_name%')
+    ->withClass('%sylius.model.order.class%')
+    ->withSection('admin')
+    ->withTemplatesDir('@SyliusAdmin/shared/crud')
+    ->withFormType(OrderType::class)
+    ->withRouteCondition("not context.isSyliusRoutingBcLayerEnabled('admin_order')")
+    ->withOperations(new Operations(operations: [
+        new Index(
+            routeName: '_sylius_admin_order_index',
+            grid: 'sylius_admin_order',
+        ),
+        new Show(
+            routeName: '_sylius_admin_order_show',
+            repositoryMethod: 'findOrderById',
+        ),
+        new Show(
+            routeName: '_sylius_admin_order_history',
+            template: '@SyliusAdmin/order/history.html.twig',
+            shortName: 'history',
+            repositoryMethod: 'findOrderById',
+        ),
+        new Update(
+            routeName: '_sylius_admin_order_update',
+            repositoryMethod: 'findOrderById',
+            formOptions: ['validation_groups' => ['sylius_shipping_address_update']],
+            redirectToRoute: 'sylius_admin_order_show',
+        ),
+        new ApplyStateMachineTransition(
+            routeName: '_sylius_admin_order_cancel',
+            processor: ApplyStateMachineTransitionProcessor::class,
+            repositoryMethod: 'findOrderById',
+            notificationMessage: 'sylius.resource.update',
+            redirectToRoute: 'sylius_admin_order_show',
+            stateMachineTransition: 'cancel',
+            stateMachineGraph: 'sylius_order',
+        ),
+    ]))
+;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -8,11 +8,13 @@ sylius_admin_order:
         form:
             type: Sylius\Bundle\AdminBundle\Form\Type\OrderType
         permission: true
+        condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     type: sylius.resource
 
 sylius_admin_order_show:
     path: /orders/{id}
     methods: [GET]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     defaults:
         _controller: sylius.controller.order::showAction
         _sylius:
@@ -27,6 +29,7 @@ sylius_admin_order_show:
 sylius_admin_order_history:
     path: /orders/{id}/history
     methods: [GET]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     defaults:
         _controller: sylius.controller.order::showAction
         _sylius:
@@ -41,6 +44,7 @@ sylius_admin_order_history:
 sylius_admin_order_update:
     path: /orders/{id}/edit
     methods: [GET, PUT]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     defaults:
         _controller: sylius.controller.order::updateAction
         _sylius:
@@ -60,6 +64,7 @@ sylius_admin_order_update:
 sylius_admin_order_cancel:
     path: /orders/{id}/cancel
     methods: [PUT]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     defaults:
         _controller: sylius.controller.order::applyStateMachineTransitionAction
         _sylius:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -300,6 +300,12 @@
             <argument>%sylius_core.routing.bc_layer%</argument>
         </service>
 
+        <service id="Sylius\Bundle\CoreBundle\StateMachine\State\ApplyStateMachineTransitionProcessor">
+            <argument type="service" id="sylius_abstraction.state_machine" />
+            <argument type="service" id="Sylius\Resource\Doctrine\Common\State\PersistProcessor" />
+            <tag name="sylius.state_processor" />
+        </service>
+
         <service id="sylius.security.voter.impersonation" class="Sylius\Bundle\CoreBundle\Security\ImpersonationVoter">
             <argument type="service" id="request_stack" />
             <argument type="service" id="security.firewall.map" />

--- a/src/Sylius/Bundle/CoreBundle/StateMachine/State/ApplyStateMachineTransitionProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/StateMachine/State/ApplyStateMachineTransitionProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\StateMachine\State;
+
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Resource\Context\Context;
+use Sylius\Resource\Metadata\Operation;
+use Sylius\Resource\Metadata\StateMachineAwareOperationInterface;
+use Sylius\Resource\State\ProcessorInterface;
+use Webmozart\Assert\Assert;
+
+final class ApplyStateMachineTransitionProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private StateMachineInterface $stateMachine,
+        private ProcessorInterface $writeProcessor,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, Context $context): mixed
+    {
+        Assert::isInstanceOf($operation, StateMachineAwareOperationInterface::class);
+
+        $transition = $operation->getStateMachineTransition() ?? null;
+        $graph = $operation->getStateMachineGraph() ?? null;
+
+        Assert::notNull($transition, sprintf('No State machine transition was found on operation "%s".', $operation->getName() ?? ''));
+        Assert::notNull($graph, sprintf('No State machine graph was found on operation "%s".', $operation->getName() ?? ''));
+
+        if (\is_object($data) && $this->stateMachine->can($data, $graph, $transition)) {
+            $this->stateMachine->apply($data, $graph, $transition);
+        }
+
+        return $this->writeProcessor->process($data, $operation, $context);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | new-routing
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

On this [ResourceMetadataCollectionFactory](https://github.com/Sylius/SyliusResourceBundle/blob/1.14/src/Component/src/Metadata/Resource/Factory/StateMachineResourceMetadataCollectionFactory.php), a state machine processor is used to apply the transition. This one works, but it uses a fixed state machine component. On state machine abstraction package, it's specified on a specific graph.

So I've created a new `ApplyStateMachineTransitionProcessor` in the core that will be used for state machine transitions and will use your StateMachineInterface. It's closed to the existing one on Resource side (https://github.com/Sylius/SyliusResourceBundle/blob/1.14/src/Component/src/Symfony/Workflow/OperationStateMachine.php)