### PR TITLE
Send Password Request Mail only on enabled Users

### DIFF
--- a/features/account/resetting_password.feature
+++ b/features/account/resetting_password.feature
@@ -58,3 +58,12 @@ Feature: Resetting a password
         And I confirm my new password as "newp@ssw0rd"
         And I reset it
         Then I should not be able to change my password with this token
+
+    @ui @email
+    Scenario: Preventing password reset email for not enabled user
+        Given there is a disabled user "ghost@example.com" identified by "ghost"
+        When I want to reset password
+        And I specify customer email as "ghost@example.com"
+        And I reset it
+        Then I should be notified that email with reset instruction has been sent
+        But "ghost@example.com" should receive no emails

--- a/src/Sylius/Behat/Context/Setup/UserContext.php
+++ b/src/Sylius/Behat/Context/Setup/UserContext.php
@@ -50,6 +50,20 @@ final class UserContext implements Context
     }
 
     /**
+     * @Given there is a disabled user :email identified by :password
+     * @Given there was disabled account of :email with password :password
+     * @Given there is a disabled user :email
+     */
+    public function thereIsDisabledUserIdentifiedBy($email, $password = 'sylius')
+    {
+        $user = $this->userFactory->create(['email' => $email, 'password' => $password, 'enabled' => false]);
+
+        $this->sharedStorage->set('user', $user);
+
+        $this->userRepository->add($user);
+    }
+
+    /**
      * @Given I registered with previously used :email email and :password password
      * @Given I have already registered :email account
      */

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -221,7 +221,7 @@ class UserController extends ResourceController
             Assert::isInstanceOf($userRepository, UserRepositoryInterface::class);
 
             $user = $userRepository->findOneByEmail($passwordReset->getEmail());
-            if (null !== $user) {
+            if (null !== $user && $user->isEnabled()) {
                 $this->handleResetPasswordRequest($generator, $user, $senderEvent);
             }
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Prevent sending of password mail if user is not enabled. In our case it is used to spam people which never created a account in our shop.

This PR builds upon changes introduced in #18037 by @revoltek-daniel 
