### PR TITLE
[Shop] Image/File Uploud Buttons Size Fix

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
@@ -59,8 +59,10 @@ textarea.form-control {
     min-height: 44px;
 }
 
-.form-control[type="file"] {
-    min-height: unset;
+input[type="file"].form-control {
+    &::file-selector-button {
+        min-height: 44px;
+    }
 }
 
 .form-control:focus {

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
@@ -59,6 +59,10 @@ textarea.form-control {
     min-height: 44px;
 }
 
+.form-control[type="file"] {
+    min-height: unset;
+}
+
 .form-control:focus {
     box-shadow: none;
 }


### PR DESCRIPTION
Before:
<img width="389" height="118" alt="image" src="https://github.com/user-attachments/assets/dba44ae3-addf-4a43-839e-3cb861e7d39e" />

After:
<img width="395" height="304" alt="image" src="https://github.com/user-attachments/assets/f0cdcd9e-b1d8-433e-861c-fbfdd9d2d70c" />>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced file input buttons to have a consistent minimum height with other form controls for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->