### PR TITLE
Revert "[Fixtures] Make factory example constructor arguments protected"

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
@@ -29,9 +29,9 @@ use Webmozart\Assert\Assert;
 
 class AddressExampleFactory extends AbstractExampleFactory
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<AddressInterface> $addressFactory
@@ -39,9 +39,9 @@ class AddressExampleFactory extends AbstractExampleFactory
      * @param RepositoryInterface<CustomerInterface> $customerRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $addressFactory,
-        protected readonly RepositoryInterface $countryRepository,
-        protected readonly RepositoryInterface $customerRepository,
+        private FactoryInterface $addressFactory,
+        private RepositoryInterface $countryRepository,
+        private RepositoryInterface $customerRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -27,20 +27,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<AdminUserInterface> $userFactory
      * @param FactoryInterface<ImageInterface>|null $avatarImageFactory
      */
     public function __construct(
-        protected readonly FactoryInterface $userFactory,
-        protected readonly string $localeCode,
-        protected readonly ?FileLocatorInterface $fileLocator = null,
-        protected readonly ?ImageUploaderInterface $imageUploader = null,
-        protected readonly ?FactoryInterface $avatarImageFactory = null,
+        private FactoryInterface $userFactory,
+        private string $localeCode,
+        private ?FileLocatorInterface $fileLocator = null,
+        private ?ImageUploaderInterface $imageUploader = null,
+        private ?FactoryInterface $avatarImageFactory = null,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionActionExampleFactory.php
@@ -22,10 +22,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class CatalogPromotionActionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CatalogPromotionActionInterface> $catalogPromotionActionFactory */
-    public function __construct(protected readonly FactoryInterface $catalogPromotionActionFactory)
+    public function __construct(private FactoryInterface $catalogPromotionActionFactory)
     {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionExampleFactory.php
@@ -29,20 +29,20 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CatalogPromotionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<CatalogPromotionInterface> $catalogPromotionFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $catalogPromotionFactory,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly ChannelRepositoryInterface $channelRepository,
-        protected readonly ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
-        protected readonly ExampleFactoryInterface $catalogPromotionActionExampleFactory,
+        private FactoryInterface $catalogPromotionFactory,
+        private RepositoryInterface $localeRepository,
+        private ChannelRepositoryInterface $channelRepository,
+        private ExampleFactoryInterface $catalogPromotionScopeExampleFactory,
+        private ExampleFactoryInterface $catalogPromotionActionExampleFactory,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CatalogPromotionScopeExampleFactory.php
@@ -20,10 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class CatalogPromotionScopeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CatalogPromotionScopeInterface> $catalogPromotionScopeFactory */
-    public function __construct(protected readonly FactoryInterface $catalogPromotionScopeFactory)
+    public function __construct(private FactoryInterface $catalogPromotionScopeFactory)
     {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -35,14 +35,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
-    protected ?TaxonRepositoryInterface $taxonRepository;
+    private ?TaxonRepositoryInterface $taxonRepository;
 
     /** @var FactoryInterface<ShopBillingDataInterface>|null */
-    protected ?FactoryInterface $shopBillingDataFactory;
+    private ?FactoryInterface $shopBillingDataFactory;
 
     /**
      * @param RepositoryInterface<LocaleInterface> $localeRepository
@@ -51,10 +51,10 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param FactoryInterface<ShopBillingDataInterface>|null $shopBillingDataFactory
      */
     public function __construct(
-        protected readonly ChannelFactoryInterface $channelFactory,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly RepositoryInterface $currencyRepository,
-        protected readonly RepositoryInterface $zoneRepository,
+        private ChannelFactoryInterface $channelFactory,
+        private RepositoryInterface $localeRepository,
+        private RepositoryInterface $currencyRepository,
+        private RepositoryInterface $zoneRepository,
         ?TaxonRepositoryInterface $taxonRepository = null,
         ?FactoryInterface $shopBillingDataFactory = null,
     ) {

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/CustomerGroupExampleFactory.php
@@ -23,12 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomerGroupExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<CustomerGroupInterface> $customerGroupFactory */
-    public function __construct(protected readonly FactoryInterface $customerGroupFactory)
+    public function __construct(private FactoryInterface $customerGroupFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -29,15 +29,15 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory implements Exam
 {
     public const DEFAULT_LOCALE = 'en_US';
 
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param RepositoryInterface<LocaleInterface> $localeRepository */
     public function __construct(
-        protected readonly PaymentMethodFactoryInterface $paymentMethodFactory,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly ChannelRepositoryInterface $channelRepository,
+        private PaymentMethodFactoryInterface $paymentMethodFactory,
+        private RepositoryInterface $localeRepository,
+        private ChannelRepositoryInterface $channelRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationExampleFactory.php
@@ -24,13 +24,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAssociationExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<ProductAssociationInterface> $productAssociationFactory */
     public function __construct(
-        protected readonly FactoryInterface $productAssociationFactory,
-        protected readonly ProductAssociationTypeRepositoryInterface $productAssociationTypeRepository,
-        protected readonly ProductRepositoryInterface $productRepository,
+        private FactoryInterface $productAssociationFactory,
+        private ProductAssociationTypeRepositoryInterface $productAssociationTypeRepository,
+        private ProductRepositoryInterface $productRepository,
     ) {
         $this->optionsResolver = new OptionsResolver();
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAssociationTypeExampleFactory.php
@@ -25,17 +25,17 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAssociationTypeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductAssociationTypeInterface> $productAssociationTypeFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $productAssociationTypeFactory,
-        protected readonly RepositoryInterface $localeRepository,
+        private FactoryInterface $productAssociationTypeFactory,
+        private RepositoryInterface $localeRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -25,18 +25,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductAttributeExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      * @param array<string, string> $attributeTypes
      */
     public function __construct(
-        protected readonly AttributeFactoryInterface $productAttributeFactory,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly array $attributeTypes,
+        private AttributeFactoryInterface $productAttributeFactory,
+        private RepositoryInterface $localeRepository,
+        private array $attributeTypes,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -45,9 +45,9 @@ use Webmozart\Assert\Assert;
 
 class ProductExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductInterface> $productFactory
@@ -64,22 +64,22 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param RepositoryInterface<TaxCategoryInterface>|null $taxCategoryRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $productFactory,
-        protected readonly FactoryInterface $productVariantFactory,
-        protected readonly FactoryInterface $channelPricingFactory,
-        protected readonly ProductVariantGeneratorInterface $variantGenerator,
-        protected readonly FactoryInterface $productAttributeValueFactory,
-        protected readonly FactoryInterface $productImageFactory,
-        protected readonly FactoryInterface $productTaxonFactory,
-        protected readonly ImageUploaderInterface $imageUploader,
-        protected readonly SlugGeneratorInterface $slugGenerator,
-        protected readonly RepositoryInterface $taxonRepository,
-        protected readonly RepositoryInterface $productAttributeRepository,
-        protected readonly RepositoryInterface $productOptionRepository,
-        protected readonly RepositoryInterface $channelRepository,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly ?RepositoryInterface $taxCategoryRepository = null,
-        protected readonly ?FileLocatorInterface $fileLocator = null,
+        private FactoryInterface $productFactory,
+        private FactoryInterface $productVariantFactory,
+        private FactoryInterface $channelPricingFactory,
+        private ProductVariantGeneratorInterface $variantGenerator,
+        private FactoryInterface $productAttributeValueFactory,
+        private FactoryInterface $productImageFactory,
+        private FactoryInterface $productTaxonFactory,
+        private ImageUploaderInterface $imageUploader,
+        private SlugGeneratorInterface $slugGenerator,
+        private RepositoryInterface $taxonRepository,
+        private RepositoryInterface $productAttributeRepository,
+        private RepositoryInterface $productOptionRepository,
+        private RepositoryInterface $channelRepository,
+        private RepositoryInterface $localeRepository,
+        private ?RepositoryInterface $taxCategoryRepository = null,
+        private ?FileLocatorInterface $fileLocator = null,
     ) {
         if ($this->taxCategoryRepository === null) {
             trigger_deprecation(

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductOptionExampleFactory.php
@@ -26,9 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductOptionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ProductOptionInterface> $productOptionFactory
@@ -36,9 +36,9 @@ class ProductOptionExampleFactory extends AbstractExampleFactory implements Exam
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $productOptionFactory,
-        protected readonly FactoryInterface $productOptionValueFactory,
-        protected readonly RepositoryInterface $localeRepository,
+        private FactoryInterface $productOptionFactory,
+        private FactoryInterface $productOptionValueFactory,
+        private RepositoryInterface $localeRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductReviewExampleFactory.php
@@ -28,15 +28,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ProductReviewExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     public function __construct(
-        protected readonly ReviewFactoryInterface $productReviewFactory,
-        protected readonly ProductRepositoryInterface $productRepository,
-        protected readonly CustomerRepositoryInterface $customerRepository,
-        protected readonly FactoryInterface|StateMachineInterface $stateMachineFactory,
+        private ReviewFactoryInterface $productReviewFactory,
+        private ProductRepositoryInterface $productRepository,
+        private CustomerRepositoryInterface $customerRepository,
+        private FactoryInterface|StateMachineInterface $stateMachineFactory,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionActionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionActionExampleFactory.php
@@ -23,11 +23,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionActionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
-    public function __construct(protected readonly PromotionActionFactoryInterface $promotionActionFactory)
+    public function __construct(private PromotionActionFactoryInterface $promotionActionFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -31,9 +31,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<PromotionInterface> $promotionFactory
@@ -41,12 +41,12 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
      * @param RepositoryInterface<LocaleInterface>|null $localeRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $promotionFactory,
-        protected readonly ExampleFactoryInterface $promotionRuleExampleFactory,
-        protected readonly ExampleFactoryInterface $promotionActionExampleFactory,
-        protected readonly ChannelRepositoryInterface $channelRepository,
-        protected readonly ?FactoryInterface $couponFactory = null,
-        protected readonly ?RepositoryInterface $localeRepository = null,
+        private FactoryInterface $promotionFactory,
+        private ExampleFactoryInterface $promotionRuleExampleFactory,
+        private ExampleFactoryInterface $promotionActionExampleFactory,
+        private ChannelRepositoryInterface $channelRepository,
+        private ?FactoryInterface $couponFactory = null,
+        private ?RepositoryInterface $localeRepository = null,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionRuleExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionRuleExampleFactory.php
@@ -23,11 +23,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PromotionRuleExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
-    public function __construct(protected readonly PromotionRuleFactoryInterface $promotionRuleFactory)
+    public function __construct(private PromotionRuleFactoryInterface $promotionRuleFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingCategoryExampleFactory.php
@@ -23,12 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShippingCategoryExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<ShippingCategoryInterface> $shippingCategoryFactory */
-    public function __construct(protected readonly FactoryInterface $shippingCategoryFactory)
+    public function __construct(private FactoryInterface $shippingCategoryFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -32,9 +32,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShippingMethodExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ShippingMethodInterface> $shippingMethodFactory
@@ -44,12 +44,12 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
      * @param RepositoryInterface<TaxCategoryInterface>|null $taxCategoryRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $shippingMethodFactory,
-        protected readonly RepositoryInterface $zoneRepository,
-        protected readonly RepositoryInterface $shippingCategoryRepository,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly ChannelRepositoryInterface $channelRepository,
-        protected readonly ?RepositoryInterface $taxCategoryRepository = null,
+        private FactoryInterface $shippingMethodFactory,
+        private RepositoryInterface $zoneRepository,
+        private RepositoryInterface $shippingCategoryRepository,
+        private RepositoryInterface $localeRepository,
+        private ChannelRepositoryInterface $channelRepository,
+        private ?RepositoryInterface $taxCategoryRepository = null,
     ) {
         if ($this->taxCategoryRepository === null) {
             trigger_deprecation(

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -27,9 +27,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<ShopUserInterface> $shopUserFactory
@@ -37,9 +37,9 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
      * @param RepositoryInterface<CustomerGroupInterface> $customerGroupRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $shopUserFactory,
-        protected readonly FactoryInterface $customerFactory,
-        protected readonly RepositoryInterface $customerGroupRepository,
+        private FactoryInterface $shopUserFactory,
+        private FactoryInterface $customerFactory,
+        private RepositoryInterface $customerGroupRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxCategoryExampleFactory.php
@@ -23,12 +23,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxCategoryExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /** @param FactoryInterface<TaxCategoryInterface> $taxCategoryFactory */
-    public function __construct(protected readonly FactoryInterface $taxCategoryFactory)
+    public function __construct(private FactoryInterface $taxCategoryFactory)
     {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxRateExampleFactory.php
@@ -27,9 +27,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<TaxRateInterface> $taxRateFactory
@@ -37,9 +37,9 @@ class TaxRateExampleFactory extends AbstractExampleFactory implements ExampleFac
      * @param RepositoryInterface<TaxCategoryInterface> $taxCategoryRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $taxRateFactory,
-        protected readonly RepositoryInterface $zoneRepository,
-        protected readonly RepositoryInterface $taxCategoryRepository,
+        private FactoryInterface $taxRateFactory,
+        private RepositoryInterface $zoneRepository,
+        private RepositoryInterface $taxCategoryRepository,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -27,19 +27,19 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    protected Generator $faker;
+    private Generator $faker;
 
-    protected OptionsResolver $optionsResolver;
+    private OptionsResolver $optionsResolver;
 
     /**
      * @param FactoryInterface<TaxonInterface> $taxonFactory
      * @param RepositoryInterface<LocaleInterface> $localeRepository
      */
     public function __construct(
-        protected readonly FactoryInterface $taxonFactory,
-        protected readonly TaxonRepositoryInterface $taxonRepository,
-        protected readonly RepositoryInterface $localeRepository,
-        protected readonly TaxonSlugGeneratorInterface $taxonSlugGenerator,
+        private FactoryInterface $taxonFactory,
+        private TaxonRepositoryInterface $taxonRepository,
+        private RepositoryInterface $localeRepository,
+        private TaxonSlugGeneratorInterface $taxonSlugGenerator,
     ) {
         $this->faker = Factory::create();
         $this->optionsResolver = new OptionsResolver();


### PR DESCRIPTION
Reverts Sylius/Sylius#18266, because it can break customizations of fixture factories.

Ref.: https://github.com/Sylius/Sylius/pull/18266#issuecomment-3160651374