### PR TITLE
[Composer][1.14] More specific confflict with serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,7 +190,7 @@
         "behat/gherkin": "^4.13.0",
         "lexik/jwt-authentication-bundle": "^2.18",
         "stof/doctrine-extensions-bundle": "1.8.0",
-        "symfony/serializer": "^6.4.23",
+        "symfony/serializer": "6.4.23",
         "symfony/validator": "5.4.25",
         "twig/twig": "3.9.0"
     },


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #18195 
| License         | MIT

The bug raised in #18195 as been revert in symfony/serializer in 6.4.24 (cf https://github.com/symfony/symfony/pull/60958) 

I guess we can target the conflict only on 6.4.23 now.
