### PR TITLE
[Promotion] Corrects order of amounts to apply correct promotion amount

### DIFF
--- a/features/promotion/receiving_discount/receiving_fixed_discount_distributed_on_item_units.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_distributed_on_item_units.feature
@@ -1,0 +1,23 @@
+@receiving_discount
+Feature: Receiving fixed discount distributed correctly on item units
+    In order to pay proper amount while buying promoted goods
+    As a Visitor
+    I want to have fixed discounts applied correctly across item units
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$10.56"
+        And the store has a product "Symfony Mug" priced at "$60.00"
+        And there is a promotion "Small Order Discount" with priority 0
+        And it gives "$20.00" discount to every order
+        And there is a promotion "Large Order Discount" with priority 1
+        And it gives "$80.00" discount to every order
+        And the store has "DHL" shipping method with "$1.26" fee
+
+    @ui @api
+    Scenario: Applying stacked fixed discounts on multiple item units
+        When I add 3 products "PHP T-Shirt" to the cart
+        And I add 1 products "Symfony Mug" to the cart
+        Then my cart total should be "$1.26"
+        And my discount should be "-$91.68"
+        And my cart shipping total should be "$1.26"

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -55,12 +55,8 @@ final class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustm
         ChannelInterface $channel,
     ): void {
         $splitPromotionAmount = $this->distributor->distribute($itemPromotionAmount, $item->getQuantity());
-        // Sort the splitPromotionAmount to ensure that the first unit will be the one with the greatest total
-        sort($splitPromotionAmount, SORT_NUMERIC);
+        sort($splitPromotionAmount, \SORT_NUMERIC);
 
-        // Sort units by total adjustment amount to ensure that the first unit will be the one with the greatest total
-        // This is important because we want to apply the promotion to the unit in same order as the splitPromotionAmount
-        // Without this, the order unit total could be less than the promotion amount.
         $orderUnits = $item->getUnits()->toArray();
         usort($orderUnits, function (OrderItemUnitInterface $a, OrderItemUnitInterface $b): int {
             return $b->getAdjustmentsTotal() <=> $a->getAdjustmentsTotal();

--- a/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
@@ -71,8 +71,11 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $magnumItemChannelPricing->getMinimumPrice()->willReturn(0);
 
         $firstColtUnit->getTotal()->willReturn(1000);
+        $firstColtUnit->getAdjustmentsTotal()->willReturn(0);
         $secondColtUnit->getTotal()->willReturn(1000);
+        $secondColtUnit->getAdjustmentsTotal()->willReturn(10);
         $magnumUnit->getTotal()->willReturn(2000);
+        $magnumUnit->getAdjustmentsTotal()->willReturn(5);
 
         $order
             ->getItems()
@@ -99,7 +102,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 500)
-            ->willReturn($firstAdjustment, $secondAdjustment)
+            ->willReturn($secondAdjustment, $firstAdjustment)
         ;
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 999)
@@ -285,8 +288,11 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $coltItemChannelPricing->getMinimumPrice()->willReturn(0);
 
         $firstColtUnit->getTotal()->willReturn(1000);
+        $firstColtUnit->getAdjustmentsTotal()->willReturn(0);
         $secondColtUnit->getTotal()->willReturn(1000);
+        $secondColtUnit->getAdjustmentsTotal()->willReturn(10);
         $thirdColtUnit->getTotal()->willReturn(1000);
+        $thirdColtUnit->getAdjustmentsTotal()->willReturn(5);
 
         $order
             ->getItems()
@@ -311,7 +317,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
-            ->willReturn($firstAdjustment, $secondAdjustment)
+            ->willReturn($secondAdjustment, $firstAdjustment)
         ;
 
         $firstAdjustment->setOriginCode('WINTER_GUNS_PROMOTION')->shouldBeCalled();
@@ -344,7 +350,9 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $coltItemChannelPricing->getMinimumPrice()->willReturn(0);
 
         $firstColtUnit->getTotal()->willReturn(1000);
+        $firstColtUnit->getAdjustmentsTotal()->willReturn(0);
         $secondColtUnit->getTotal()->willReturn(1000);
+        $secondColtUnit->getAdjustmentsTotal()->willReturn(10);
 
         $order
             ->getItems()
@@ -405,8 +413,11 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $magnumItemChannelPricing->getMinimumPrice()->willReturn(1900);
 
         $firstColtUnit->getTotal()->willReturn(1000);
+        $firstColtUnit->getAdjustmentsTotal()->willReturn(0);
         $secondColtUnit->getTotal()->willReturn(1000);
+        $secondColtUnit->getAdjustmentsTotal()->willReturn(10);
         $magnumUnit->getTotal()->willReturn(2000);
+        $magnumUnit->getAdjustmentsTotal()->willReturn(5);
 
         $order
             ->getItems()
@@ -433,7 +444,7 @@ final class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
 
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', -500)
-            ->willReturn($firstAdjustment, $secondAdjustment)
+            ->willReturn($secondAdjustment, $firstAdjustment)
         ;
         $adjustmentFactory
             ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', -100)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17862 
| License         | MIT

This PR is based on the work of @delyriand from PR #17864 and completes the implementation.

Prerequisites:

- Create one cart promotion with 20$ order fixed discount without rule
- Create one cart promotion with 80$ order fixed discount without rule
- Add to cart 3 items of 10.56$
- Add to cart 1 item of 60$

Before the fix:
<img width="720" height="355" alt="image" src="https://github.com/user-attachments/assets/669ed562-1a17-4db1-b5b2-9c431a336013" />

After:
<img width="720" height="283" alt="image" src="https://github.com/user-attachments/assets/50239e2a-8918-4d00-803b-03d9475668b9" />