### PR TITLE
Enable cache busting & subresource integrity in Webpack config

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -25,6 +25,7 @@ class SyliusAdmin {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
             })
+            .enableIntegrityHashes(Encore.isProduction())
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const adminConfig = Encore.getWebpackConfig();

--- a/src/Sylius/Bundle/AdminBundle/index.js
+++ b/src/Sylius/Bundle/AdminBundle/index.js
@@ -26,6 +26,10 @@ class SyliusAdmin {
                 options.additionalData = `$rootDir: '${rootDir}';`;
             })
             .enableIntegrityHashes(Encore.isProduction())
+            .configureFilenames({
+                js: 'js/[name].[contenthash:8].js',
+                css: 'css/[name].[contenthash:8].css',
+            })
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const adminConfig = Encore.getWebpackConfig();

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -24,6 +24,7 @@ class SyliusShop {
                 // eslint-disable-next-line no-param-reassign
                 options.additionalData = `$rootDir: '${rootDir}';`;
             })
+            .enableIntegrityHashes(Encore.isProduction())
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const shopConfig = Encore.getWebpackConfig();

--- a/src/Sylius/Bundle/ShopBundle/index.js
+++ b/src/Sylius/Bundle/ShopBundle/index.js
@@ -25,6 +25,10 @@ class SyliusShop {
                 options.additionalData = `$rootDir: '${rootDir}';`;
             })
             .enableIntegrityHashes(Encore.isProduction())
+            .configureFilenames({
+                js: 'js/[name].[contenthash:8].js',
+                css: 'css/[name].[contenthash:8].css',
+            })
             .enableStimulusBridge(path.resolve(__dirname, 'Resources/assets/controllers.json'));
 
         const shopConfig = Encore.getWebpackConfig();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 <!-- see the comment below -->
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

This update enables cache busting for all CSS and JS assets by appending a unique hash to their filenames. As a result, browsers are forced to load the latest versions of these files after each application rebuild, preventing stale content from being served from cache.

Additionally, Subresource Integrity (SRI) is enabled to ensure that loaded files match their expected content, improving security when serving assets from different sources.
