### PR TITLE
feat(shipping method): avoid to break native live collection in admin form

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form.html.twig
@@ -1,6 +1,4 @@
-{# Rendered with \Sylius\Bundle\AdminBundle\Twig\Component\ShippingMethod\FormComponent #}
-
-{% form_theme form '@SyliusAdmin/shipping_method/form_theme.html.twig' %}
+{# Rendered with \Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponent #}
 
 <div class="container-xl" {{ attributes }}>
     {{ form_start(form, {'attr': {'novalidate': 'novalidate', 'id': form.vars.id}}) }}

--- a/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form/rules.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form/rules.html.twig
@@ -1,3 +1,8 @@
+{% set form = hookable_metadata.context.form %}
+
+{# Set custom form theme for live collection #}
+{% form_theme form '@SyliusAdmin/shipping_method/form_theme.html.twig' %}
+
 <div class="card mb-3" {{ sylius_test_html_attribute('rules') }}>
     <div class="card-header">
         <div class="card-title">
@@ -18,3 +23,6 @@
         {{ form_row(hookable_metadata.context.form.rules.vars.button_add) }}
     </div>
 </div>
+
+{# Reset with the default form theme #}
+{% form_theme form '@SyliusAdmin/shared/form_theme.html.twig' %}

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/validators.fr.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/validators.fr.yml
@@ -4,34 +4,34 @@
 sylius:
     shipping_category:
         name:
-            max_length: "Le nom de la catégorie ne peut dépasser les {{ limit }} caractères.' :contentReference[oaicite:21]{index=21}"
-            min_length: "Le nom de la catégorie doit contenir au moins {{ limit }} caractères.' :contentReference[oaicite:22]{index=22}"
-            not_blank: "Veuillez entrer le nom de la catégorie de livraison.' :contentReference[oaicite:23]{index=23}"
+            max_length: "Le nom de la catégorie ne peut dépasser les {{ limit }} caractères."
+            min_length: "Le nom de la catégorie doit contenir au moins {{ limit }} caractères."
+            not_blank: "Veuillez entrer le nom de la catégorie de livraison"
         code:
-            max_length: "Le code de la catégorie de livraison ne doit pas dépasser {{ limit }} caractères.' :contentReference[oaicite:24]{index=24}"
-            not_blank: "Veuillez entrer le code de la catégorie de livraison.' :contentReference[oaicite:25]{index=25}"
-            regex: "Le code de la méthode de livraison peut uniquement être constitué de lettres, chiffres, tirets et traits de soulignement.' :contentReference[oaicite:26]{index=26}"
-            unique: "Ce code de catégorie de livraison existe déjà.' :contentReference[oaicite:27]{index=27}"
+            max_length: "Le code de la catégorie de livraison ne doit pas dépasser {{ limit }} caractères"
+            not_blank: "Veuillez entrer le code de la catégorie de livraison"
+            regex: "Le code de la méthode de livraison peut uniquement être constitué de lettres, chiffres, tirets et traits de soulignement"
+            unique: "Ce code de catégorie de livraison existe déjà"
 
     shipping_method:
         calculator:
-            min: "Les frais de port ne peuvent pas être inférieurs à 0.' :contentReference[oaicite:28]{index=28}"
-            not_blank: "Veuillez sélectionner une méthode de calcul pour la livraison.' :contentReference[oaicite:29]{index=29}"
-            invalid: "Calculateur invalide. Les calculateurs disponibles sont {{ available_calculators }}.' :contentReference[oaicite:30]{index=30}"
+            min: "Les frais de port ne peuvent pas être inférieurs à 0"
+            not_blank: "Veuillez sélectionner une méthode de calcul pour la livraison"
+            invalid: "Calculateur invalide. Les calculateurs disponibles sont {{ available_calculators }}"
         name:
-            max_length: "Le nom de la méthode de livraison ne peut dépasser les {{ limit }} caractères.' :contentReference[oaicite:31]{index=31}"
-            min_length: "Le nom de la méthode de livraison doit contenir au moins {{ limit }} caractères.' :contentReference[oaicite:32]{index=32}"
-            not_blank: "Veuillez entrer le nom de la méthode de livraison.' :contentReference[oaicite:33]{index=33}"
+            max_length: "Le nom de la méthode de livraison ne peut dépasser les {{ limit }} caractères"
+            min_length: "Le nom de la méthode de livraison doit contenir au moins {{ limit }} caractères"
+            not_blank: "Veuillez entrer le nom de la méthode de livraison"
         code:
-            max_length: "Le code du mode de livraison ne doit pas dépasser {{ limit }} caractères.' :contentReference[oaicite:34]{index=34}"
-            not_blank: "Veuillez entrer le code du mode de livraison.' :contentReference[oaicite:35]{index=35}"
-            regex: "Le code de la méthode de livraison peut uniquement être constitué de lettres, chiffres et tirets.' :contentReference[oaicite:36]{index=36}"
-            unique: "Ce code de mode de livraison existe déjà.' :contentReference[oaicite:37]{index=37}"
+            max_length: "Le code du mode de livraison ne doit pas dépasser {{ limit }} caractères"
+            not_blank: "Veuillez entrer le code du mode de livraison"
+            regex: "Le code de la méthode de livraison peut uniquement être constitué de lettres, chiffres et tirets"
+            unique: "Ce code de mode de livraison existe déjà"
         zone:
-            not_blank: "S''il vous plaît sélectionnez zone de méthode de livraison.' :contentReference[oaicite:38]{index=38}"
+            not_blank: "S'il vous plaît sélectionnez zone de méthode de livraison"
         rule:
-            invalid_type: "Le type de règle n''est pas valide. Les types de règles disponibles sont {{ available_rule_types }}.' :contentReference[oaicite:39]{index=39}"
+            invalid_type: "Le type de règle n'est pas valide. Les types de règles disponibles sont {{ available_rule_types }}"
 
     shipment:
         shipping_method:
-            not_blank: "Veuillez sélectionner un mode de livraison.' :contentReference[oaicite:40]{index=40}"
+            not_blank: "Veuillez sélectionner un mode de livraison"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

## Avoid to break live collection inside the shipping method form

### Before

The button add is never displayed because the form theme require to have custom template and call specific form_row like the rules

```
    <div class="card-footer">
        {{ form_row(hookable_metadata.context.form.rules.vars.button_add) }}
    </div>
```

https://github.com/user-attachments/assets/2632e520-b148-4f16-bbed-ca2602606f9f

## After
    
The collection button works correctly, and the button to add rule is working too

https://github.com/user-attachments/assets/72d7791d-ca00-4fcc-b443-9ce4a262165b


    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied consistent theming to the Shipping Method rules section for a more polished, coherent appearance; default theme is restored after rendering.

* **Refactor**
  * Unified the admin form header rendering with a shared form component, simplifying template setup without changing behavior.

* **Translations**
  * Improved French validation messages for shipping categories, methods, and shipments (corrected apostrophes, punctuation, and standardized phrasing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->