### PR TITLE
sort main and bulk actions by position

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/actions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/content/header/title_block/actions.html.twig
@@ -3,7 +3,7 @@
 <div class="col-12 col-md-auto ms-auto d-print-none">
     <div class="btn-list">
         {% if resources.definition.actionGroups.main is defined %}
-            {% for action in resources.definition.getEnabledActions('main') %}
+            {% for action in resources.definition.getEnabledActions('main')|sylius_sort_by('position') %}
                 {{ sylius_grid_render_action(resources, action, null) }}
             {% endfor %}
         {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/templates/shared/grid/data_table.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/grid/data_table.html.twig
@@ -11,7 +11,7 @@
             <div class="d-flex border-bottom pb-3">
                 {% if definition.actionGroups.bulk is defined and definition.getEnabledActions('bulk')|length > 0 %}
                     <div class="sylius-grid-nav__bulk">
-                        {% for action in definition.getEnabledActions('bulk') %}
+                        {% for action in definition.getEnabledActions('bulk')|sylius_sort_by('position') %}
                             {{ sylius_grid_render_bulk_action(grid, action, null) }}
                         {% endfor %}
                     </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/Sylius/Stack/issues/270
| License         | MIT

Fixes inconsistent ordering of main and bulk actions in the SyliusAdminBundle by sorting them by position, matching the fix introduced in https://github.com/Sylius/Stack/pull/276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Admin: Header action buttons are now displayed in a consistent, position-based order, improving predictability across views.
  - Shop: Bulk action options in grids are rendered in ascending position order for clearer selection and consistent presentation.
  - No actions were added or removed; only the display order changed to reflect defined positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->