### PR TITLE
Select product attribute render error fix

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/non_translatable/body/value.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/non_translatable/body/value.html.twig
@@ -2,7 +2,7 @@
 
 <div class="col-12 col-md-8">
     {% for attribute_value in attributes|filter(attribute_value => attribute_value.localeCode == null) %}
-        <p {{ sylius_test_html_attribute('non-translatable-attribute-value', "%s"|format(attribute_value.value)) }}>
+        <p {{ sylius_test_html_attribute('non-translatable-attribute-value', "%s"|format(attribute_value.value is iterable ? attribute_value.value|join(', ') : attribute_value.value)) }}>
             {% include [
                 '@SyliusAdmin/product/show/content/page_body/attributes/types/'~attribute_value.type~'.html.twig',
                 '@SyliusAttribute/Types/'~attribute_value.type~'.html.twig',

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/non_translatable/body/value.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/non_translatable/body/value.html.twig
@@ -9,6 +9,8 @@
                 '@SyliusAdmin/product/show/content/page_body/attributes/types/default.html.twig'
             ] with {
                 'attribute': attribute_value,
+                'locale': hookable_metadata.context.sylius_base_locale,
+                'fallbackLocale': hookable_metadata.context.sylius_base_locale,
             } %}
         </p>
     {% endfor %}

--- a/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/translatable/body/value.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/show/content/page_body/attributes/translatable/body/value.html.twig
@@ -10,6 +10,7 @@
             ] with {
                 'attribute': attribute_value,
                 'locale': hookable_metadata.context.locale_code,
+                'fallbackLocale': hookable_metadata.context.sylius_base_locale,
             } %}
         </p>
     {% endfor %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17683
| License         | MIT

This PR fixes rendering issues on the product detail page caused by select-type product attributes. It resolves improper array handling in `sylius_test_html_attribute()` and adds the missing `locale`, `fallbackLocale` variables in the template for non-translatable select attributes.
<img width="1127" height="676" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/ef2d71b9-7507-4b9f-8694-3e13ac440acc" />
<img width="1135" height="626" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/db613601-1f39-4ba3-85f3-4fcc5ac89722" />

