### PR TITLE
Use form-select css class for address_book dropdownlist

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/addresses/address/address_book.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/checkout/address/content/form/addresses/address/address_book.html.twig
@@ -3,7 +3,7 @@
 {% if addresses is not empty %}
     <div {{ attributes }} class="my-3">
         <div>
-            <select class="form-control" data-model="addressId" {{ sylius_test_html_attribute('address-book') }}>
+            <select class="form-select" data-model="addressId" {{ sylius_test_html_attribute('address-book') }}>
                 <option value="" selected hidden>{{ 'sylius.ui.select_address_from_book'|trans }}</option>
                 {% for address in addresses %}
                     <option value="{{ address.id }}">


### PR DESCRIPTION
Hello there! First PR here. I noticed the dropdown select in `address_book` template is using the `form-control` Bootstrap class (normally for text inputs). It's thus rendering without the dropdown arrow we expect from a dropdown list. I replaced it with the proper `form-select` Bootstrap class.

Here's a screenshot taken from the demo website today showing how the select renders: 

<img width="1280" height="640" alt="Screenshot of the checkout address page showing the Select address from my book dropdown without an arrow on the right." src="https://github.com/user-attachments/assets/676ca3e5-fc3f-41c1-b2cd-52f239d734e4" />

And here's a screenshot with the fix: 

<img width="1280" height="640" alt="Screenshot of the checkout address page showing the Select address from my book dropdown with an arrow on the right." src="https://github.com/user-attachments/assets/d2710da5-4f37-40d0-b1c1-89b8a54bc8d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the address book chooser dropdown in checkout to the latest form styling, providing clearer visuals, better spacing, and a consistent appearance with other inputs across the site.
  * Improves usability on mobile and desktop without altering how you select or save addresses. No action is required from users; the control behaves the same while looking more polished and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->