### PR TITLE
Add nameToProductCode method to StringInflector

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -117,7 +117,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
         $resolver
             ->setDefault('name', fn (Options $options): string => $this->faker->words(3, true))
 
-            ->setDefault('code', fn (Options $options): string => StringInflector::nameToCode($options['name']))
+            ->setDefault('code', fn (Options $options): string => StringInflector::nameToProductCode($options['name']))
 
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')

--- a/src/Sylius/Component/Core/Formatter/StringInflector.php
+++ b/src/Sylius/Component/Core/Formatter/StringInflector.php
@@ -28,6 +28,13 @@ final class StringInflector
         return str_replace([' ', '-', '\''], '_', $value);
     }
 
+    public static function nameToProductCode(string $value): string
+    {
+        $value = str_replace([' ', '-', '\''], '_', $value);
+
+        return preg_replace('/[^\w-]/', '', $value) ?? '';
+    }
+
     public static function nameToSlug(string $value): string
     {
         return str_replace(['_'], '-', self::nameToLowercaseCode(Transliterator::transliterate($value)));


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18310 
| License         | MIT

Fixes invalid product code generation in fixtures by introducing a safer `nameToProductCode()` helper method that ensures compatibility with Sylius's regex validation. Prevents E2E test failures caused by special characters in product names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved default product code generation for new products and fixtures, using a name-based conversion for more consistent, readable codes.
  * Spaces, hyphens, and apostrophes are normalized to underscores; unsupported characters are removed for cleaner outputs.
  * Behavior affects newly generated codes only and does not modify existing product codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->