### PR TITLE
refs #18326 Add CSS Class in side barre search

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
@@ -68,3 +68,8 @@ input[type="file"].form-control {
 .form-control:focus {
     box-shadow: none;
 }
+
+.form-control-dark:focus {
+    color: #ffffff;
+}
+

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_form.scss
@@ -68,8 +68,3 @@ input[type="file"].form-control {
 .form-control:focus {
     box-shadow: none;
 }
-
-.form-control-dark:focus {
-    color: #ffffff;
-}
-

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
@@ -1,5 +1,5 @@
-<div class="input-group ps-2 pt-2 pb-3 menu-search">
+<div class="input-group ps-2 pt-2 pb-3 menu-search" data-bs-theme="dark"> 
     <button class="btn btn-sm" type="button" disabled data-menu-search-icon>{{ ux_icon('tabler:search', {'class': 'icon mx-1'}) }}</button>
     <button class="btn btn-sm btn-dark" type="button" data-menu-search-clear>{{ ux_icon('tabler:x', {'class': 'icon mx-1'}) }}</button>
-    <input class="form-control form-control-sm form-control-dark" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
+    <input class="form-control form-control-sm bg-dark text-white" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
@@ -1,5 +1,5 @@
 <div class="input-group ps-2 pt-2 pb-3 menu-search">
     <button class="btn btn-sm" type="button" disabled data-menu-search-icon>{{ ux_icon('tabler:search', {'class': 'icon mx-1'}) }}</button>
-    <button class="btn btn-sm" type="button" data-menu-search-clear>{{ ux_icon('tabler:x', {'class': 'icon mx-1'}) }}</button>
-    <input class="form-control form-control-sm" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
+    <button class="btn btn-sm btn-dark" type="button" data-menu-search-clear>{{ ux_icon('tabler:x', {'class': 'icon mx-1'}) }}</button>
+    <input class="form-control form-control-sm form-control-dark" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/search.html.twig
@@ -1,5 +1,5 @@
-<div class="input-group ps-2 pt-2 pb-3 menu-search" data-bs-theme="dark"> 
+<div class="input-group ps-2 pt-2 pb-3 menu-search">
     <button class="btn btn-sm" type="button" disabled data-menu-search-icon>{{ ux_icon('tabler:search', {'class': 'icon mx-1'}) }}</button>
     <button class="btn btn-sm btn-dark" type="button" data-menu-search-clear>{{ ux_icon('tabler:x', {'class': 'icon mx-1'}) }}</button>
-    <input class="form-control form-control-sm bg-dark text-white" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
+    <input class="form-control form-control-sm text-white" placeholder="{{ 'sylius.ui.search_menu'|trans }}..." type="text" data-menu-search>
 </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18326 
| License         | MIT

Add the dark CSS to the search bare in admin sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dark theme styling for the admin sidebar search to improve visibility in dark mode.

* **Style**
  * Updated search input and clear button appearance for better contrast and visual consistency.

* **Bug Fixes**
  * No changes to placeholder text or translation keys; behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->