### PR TITLE
FEAT: [AdminBundle] Open shop preview and nessecary  user dropdown links in new tab

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Shared/Navbar/UserDropdownComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Shared/Navbar/UserDropdownComponent.php
@@ -65,16 +65,19 @@ class UserDropdownComponent
                 'title' => 'sylius.ui.documentation',
                 'url' => 'https://docs.sylius.com',
                 'class' => 'small text-muted',
+                'attributes' => [ 'target' => '_blank', 'rel' => 'noopener' ],
             ],
             [
                 'title' => 'sylius.ui.join_slack',
                 'url' => 'https://sylius.com/slack',
                 'class' => 'small text-muted',
+                'attributes' => [ 'target' => '_blank', 'rel' => 'noopener' ],
             ],
             [
                 'title' => 'sylius.ui.report_an_issue',
                 'url' => 'https://github.com/Sylius/Sylius/issues',
                 'class' => 'small text-muted',
+                'attributes' => [ 'target' => '_blank', 'rel' => 'noopener' ],
             ],
         ];
     }

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/navbar/menu/shop_preview.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/navbar/menu/shop_preview.html.twig
@@ -2,7 +2,7 @@
 
 {% if channels|length == 1 %}
     {% set channel = channels|first %}
-    <a class="" href="{{ sylius_channel_url(homepage_path, channel) }}">
+    <a class="" href="{{ sylius_channel_url(homepage_path, channel) }}" target="_blank" rel="noopener">
         <span data-bs-toggle="tooltip" data-bs-title="{{ 'sylius.ui.view_your_store'|trans }}" data-bs-placement="right">
             {{ ux_icon('tabler:arrow-up-right') }}
         </span>
@@ -16,7 +16,7 @@
         </div>
         <ul class="dropdown-menu dropdown-menu-sm-end">
             {% for channel in channels %}
-                <li><a class="dropdown-item" href="{{ sylius_channel_url(homepage_path, channel) }}">{{ channel.name }}</a></li>
+                <li><a class="dropdown-item" href="{{ sylius_channel_url(homepage_path, channel) }}" target="_blank" rel="noopener">{{ channel.name }}</a></li>
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #18341 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This change improves the handling with opening the shop preview link, and the link to the Sylius Docs, Sylius Slack, and GitHub in the user dropdown component in a new tab.

For more details about this change i tryed to document everything as good as possible in the linked github ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin external links (Documentation, Slack, Report Issue) now open in a new tab.
  * Shop Preview links (single-channel and dropdown items) now open in a new tab.

* **Bug Fixes**
  * External links include rel="noopener" to improve security and prevent tabnabbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->