### PR TITLE
[Fix][Admin] Fix order summary to show product name and options from time of purchase

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/items/body/item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/show/content/sections/items/body/item.html.twig
@@ -1,5 +1,6 @@
 {% from '@SyliusAdmin/shared/helper/product_image.html.twig' import image %}
 
+{% set item = hookable_metadata.context.item %}
 {% set product = hookable_metadata.context.product %}
 {% set variant = hookable_metadata.context.variant %}
 
@@ -11,11 +12,11 @@
         <div class="thumbnail-box-content">
             <div class="mb-1">
                 <a href="{{ path('sylius_admin_product_show', { id: product.id }) }}">
-                    <strong>{{ product.name }}</strong>
+                    <strong>{{ item.productName }}</strong>
                 </a>
             </div>
             <div class="text-muted small" {{ sylius_test_html_attribute('code') }}>{{ variant.code }}</div>
-            <div class="text-muted small">{{ variant.name }}</div>
+            <div class="text-muted small">{{ item.variantName }}</div>
         </div>
     </div>
 </td>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0 or 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18305
| License         | MIT

Admin order summaries now preserve original product/variant names from the moment of purchase, even if the product is renamed later.