### PR TITLE
Fix argument of ZoneEligibilityChecker to use the new service id

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/shipping.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/shipping.xml
@@ -51,7 +51,7 @@
 
         <service id="sylius.checker.shipping_method.zone_eligibility"
                  class="Sylius\Component\Core\Shipping\Checker\Eligibility\ZoneEligibilityChecker">
-            <argument type="service" id="sylius.zone_matcher"/>
+            <argument type="service" id="sylius.matcher.zone"/>
             <tag name="sylius.shipping_method_eligibility_checker"/>
         </service>
     </services>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after https://github.com/Sylius/Sylius/pull/18339
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
