### PR TITLE
[SHOP][FEATURE] Add event dispatching for address updates in checkout

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,22 @@
+# UPGRADE FROM `2.1` TO `2.2`
+
+### Deprecations
+
+1. Not passing an instance of `Symfony\Contracts\EventDispatcher\EventDispatcherInterface` as the last argument to the constructor of `Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address\FormComponent` is deprecated since Sylius 2.2 and will be required in Sylius 3.0.
+
+   This change enables extending the checkout address form with custom fields via the `sylius.checkout.address_updated` event.
+
+```php
+use Symfony\Component\Routing\RouterInterface;
+
+    public function __construct(
+        OrderRepositoryInterface $repository,
+        FormFactoryInterface $formFactory,
+        string $resourceClass,
+        string $formClass,
+        protected readonly CustomerContextInterface $customerContext,
+        protected readonly UserRepositoryInterface $shopUserRepository,
+        protected readonly AddressRepositoryInterface $addressRepository,
++       protected readonly ?EventDispatcherInterface $eventDispatcher = null,
+    )
+```

--- a/src/Sylius/Bundle/ShopBundle/Event/CheckoutAddressUpdatedEvent.php
+++ b/src/Sylius/Bundle/ShopBundle/Event/CheckoutAddressUpdatedEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Event;
+
+use ArrayObject;
+use Sylius\Component\Addressing\Model\AddressInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CheckoutAddressUpdatedEvent extends Event
+{
+    public function __construct(
+        private ArrayObject $formData,
+        private AddressInterface $address,
+    ) {
+    }
+
+    public function getFormData(): ArrayObject
+    {
+        return $this->formData;
+    }
+
+    public function getAddress(): AddressInterface
+    {
+        return $this->address;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="sylius.context.customer" />
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.repository.address" />
+            <argument type="service" id="event_dispatcher" />
 
             <tag name="sylius.live_component.shop" key="sylius_shop:checkout:address:form" />
         </service>

--- a/src/Sylius/Bundle/ShopBundle/ShopEvents.php
+++ b/src/Sylius/Bundle/ShopBundle/ShopEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle;
+
+interface ShopEvents
+{
+    public const CHECKOUT_ADDRESS_UPDATED = 'sylius.checkout.address_updated';
+}

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -62,7 +62,7 @@ class FormComponent
 
         if (null === $this->eventDispatcher) {
             trigger_deprecation(
-                'sylius/sylius',
+                'sylius/shop-bundle',
                 '2.2',
                 'Not passing an $eventDispatcher to the constructor of %s is deprecated and will be required in Sylius 3.0.',
                 self::class,

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address;
 
+use ArrayObject;
+use Sylius\Bundle\ShopBundle\Event\CheckoutAddressUpdatedEvent;
+use Sylius\Bundle\ShopBundle\ShopEvents;
 use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -21,6 +24,7 @@ use Sylius\Component\Core\Repository\AddressRepositoryInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Customer\Context\CustomerContextInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -52,8 +56,18 @@ class FormComponent
         protected readonly CustomerContextInterface $customerContext,
         protected readonly UserRepositoryInterface $shopUserRepository,
         protected readonly AddressRepositoryInterface $addressRepository,
+        protected readonly ?EventDispatcherInterface $eventDispatcher = null,
     ) {
         $this->initialize($repository, $formFactory, $resourceClass, $formClass);
+
+        if (null === $this->eventDispatcher) {
+            trigger_deprecation(
+                'sylius/sylius',
+                '2.2',
+                'Not passing an $eventDispatcher to the constructor of %s is deprecated and will be required in Sylius 3.0.',
+                self::class,
+            );
+        }
     }
 
     #[PreReRender(priority: -100)]
@@ -86,7 +100,14 @@ class FormComponent
         $newAddress['city'] = $address->getCity();
         $newAddress['postcode'] = $address->getPostcode();
 
-        $this->formValues[$field] = $newAddress;
+        $formData = new ArrayObject($newAddress);
+
+        $this->eventDispatcher?->dispatch(
+            new CheckoutAddressUpdatedEvent($formData, $address),
+            ShopEvents::CHECKOUT_ADDRESS_UPDATED,
+        );
+
+        $this->formValues[$field] = (array) $formData;
     }
 
     protected function instantiateForm(): FormInterface


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/issues/17906
| License         | MIT

This PR introduces a new event sylius.checkout.address_updated, dispatched from the FormComponent of the checkout address step in the ShopBundle.

The purpose of this event is to allow plugins and applications to dynamically extend the address form data (e.g. adding custom fields) when selecting an address from the address book. This eliminates the need to override the live component entirely.

To support this, we inject EventDispatcherInterface into the FormComponent. The argument is currently optional, but its absence is deprecated since Sylius 2.2 and will be required in Sylius 3.0. A deprecation warning is triggered accordingly.

This change is fully backward-compatible.