### PR TITLE
[DEPRECATIONS] Mark `CartActions` interface and `OrderItemController` as deprecated

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1,3 +1,14 @@
+# UPGRADE FROM `v1.14.10` TO `v1.14.11`
+
+## Classes and Interfaces Deprecations
+
+1. These classes have been deprecated and will be removed in 2.0.
+
+| Deprecated class/interface                                 | Will be replaced with                                                    |
+|------------------------------------------------------------|--------------------------------------------------------------------------|
+| `Sylius\Bundle\OrderBundle\Controller\OrderItemController` | `Sylius\Bundle\ShopBundle\Twig\Component\Product\AddToCartFormComponent` |
+| `Sylius\Component\Order\CartActions`                       | `Sylius\Component\Order\SyliusCartEvents`                                |
+
 # UPGRADE FROM `v1.14.1` TO `v1.14.2`
 
 1. Extracted a new `sylius.order_processing.adjustment_clearing_types` parameter responsible for the collection of adjustment types to be cleared during order processing.

--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
@@ -32,6 +32,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
+trigger_deprecation(
+    'sylius/order-bundle',
+    '1.14',
+    'The "%s" class is deprecated. Will be removed in Sylius 2.0.',
+    OrderItemController::class,
+);
 /** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 class OrderItemController extends ResourceController
 {

--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 class OrderItemController extends ResourceController
 {
     public function addAction(Request $request): Response

--- a/src/Sylius/Component/Order/CartActions.php
+++ b/src/Sylius/Component/Order/CartActions.php
@@ -13,6 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Order;
 
+trigger_deprecation(
+    'sylius/order',
+    '1.14',
+    'The "%s" class is deprecated. Will be removed in Sylius 2.0.',
+    CartActions::class,
+);
 /** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 interface CartActions
 {

--- a/src/Sylius/Component/Order/CartActions.php
+++ b/src/Sylius/Component/Order/CartActions.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Order;
 
+/** @deprecated since Sylius 1.14 and will be removed in Sylius 2.0. */
 interface CartActions
 {
     public const ADD = 'add';


### PR DESCRIPTION
…in preparation for Sylius 2.0.

| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/issues/17588
| License         | MIT

Adding deprecations:
- Sylius\Bundle\OrderBundle\Controller\OrderItemController
- Sylius\Component\Order\CartActions
