### PR TITLE
[BUGFIX] Correct pricing currency resolution in product variant view

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantContentPricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_variantContentPricing.html.twig
@@ -21,9 +21,9 @@
                     <td class="five wide gray text">
                         <strong>{{ channelPricing.channelCode|sylius_channel_name }}</strong>
                     </td>
-                    <td>{{ money.format(channelPricing.price, product.channels.first.baseCurrency) }}</td>
-                    <td>{{ channelPricing.originalPrice ? money.format(channelPricing.originalPrice, product.channels.first.baseCurrency) : '-' }}</td>
-                    <td>{{ channelPricing.lowestPriceBeforeDiscount ? money.format(channelPricing.lowestPriceBeforeDiscount, product.channels.first.baseCurrency) : '-' }}</td>
+                    <td>{{ money.format(channelPricing.price, currencies[channelPricing.channelCode]) }}</td>
+                    <td>{{ channelPricing.originalPrice ? money.format(channelPricing.originalPrice, currencies[channelPricing.channelCode]) : '-' }}</td>
+                    <td>{{ channelPricing.lowestPriceBeforeDiscount ? money.format(channelPricing.lowestPriceBeforeDiscount, currencies[channelPricing.channelCode]) : '-' }}</td>
                     {% include '@SyliusAdmin/Product/Show/_appliedPromotions.html.twig' %}
                     <td>
                         <a class="ui blue labeled icon button" href="{{ path('sylius_admin_channel_pricing_log_entry_index', {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/Sylius/issues/17512
| License         | MIT

Currently, in the admin product variant pricing template (_variantContentPricing.html.twig), the currency is resolved via product.channels.first.baseCurrency.
This causes issues when:

the product is not assigned to any active channel,

or when multiple channels with different base currencies exist.

As a result, Twig may throw an error (Impossible to access an attribute ("baseCurrency") on a bool variable) or display incorrect values.

This PR replaces the usage of product.channels.first.baseCurrency with a lookup from sylius_channels_currencies()[channelPricing.channelCode], ensuring that the currency displayed in the pricing table always matches the channel of the given ChannelPricing.