### PR TITLE
[Feature] Prioritize default locale in TranslationLocaleProvider output

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,7 @@
+# UPGRADE FROM `2.1` TO `2.2`
+
+### Translations
+
+1. The `TranslationLocaleProvider` now ensures that the default locale (configured as `locale` in `config/parameters.yaml`)
+   is always placed at the beginning of the returned locales array.  
+   Other locales remain in the same order as returned by the repository.

--- a/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
+++ b/src/Sylius/Component/Core/Provider/TranslationLocaleProvider.php
@@ -29,12 +29,23 @@ final class TranslationLocaleProvider implements TranslationLocaleProviderInterf
     {
         $locales = $this->localeRepository->getAll();
 
-        return array_map(
-            function (LocaleInterface $locale) {
+        $localeCodes = array_map(
+            static function (LocaleInterface $locale): string {
                 return (string) $locale->getCode();
             },
             $locales,
         );
+
+        $key = array_search($this->defaultLocaleCode, $localeCodes, true);
+
+        if ($key === false || $key === 0) {
+            return $localeCodes;
+        }
+
+        unset($localeCodes[$key]);
+        array_unshift($localeCodes, $this->defaultLocaleCode);
+
+        return $localeCodes;
     }
 
     public function getDefaultLocaleCode(): string

--- a/src/Sylius/Component/Core/tests/Provider/TranslationLocaleProviderTest.php
+++ b/src/Sylius/Component/Core/tests/Provider/TranslationLocaleProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Component\Core\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Provider\TranslationLocaleProvider;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Locale\Provider\LocaleCollectionProviderInterface;
+use Sylius\Resource\Translation\Provider\TranslationLocaleProviderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class TranslationLocaleProviderTest extends TestCase
+{
+    private LocaleCollectionProviderInterface&MockObject $localeCollectionProvider;
+    private LocaleInterface&MockObject $localePl;
+    private LocaleInterface&MockObject $localeEn;
+    private TranslationLocaleProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->localeCollectionProvider = $this->createMock(LocaleCollectionProviderInterface::class);
+        $this->localePl = $this->createMock(LocaleInterface::class);
+        $this->localeEn = $this->createMock(LocaleInterface::class);
+
+        $this->provider = new TranslationLocaleProvider($this->localeCollectionProvider, 'pl_PL');
+    }
+
+    public function testShouldImplementTranslationLocaleProviderInterface(): void
+    {
+        $this->assertInstanceOf(TranslationLocaleProviderInterface::class, $this->provider);
+    }
+
+    public function testShouldReturnDefinedLocalesCodesWithDefaultLocaleFirst(): void
+    {
+        $this->localePl->expects($this->once())->method('getCode')->willReturn('pl_PL');
+        $this->localeEn->expects($this->once())->method('getCode')->willReturn('en_US');
+
+        $this->localeCollectionProvider
+            ->expects($this->once())
+            ->method('getAll')
+            ->willReturn([$this->localeEn, $this->localePl]);
+
+        $codes = $this->provider->getDefinedLocalesCodes();
+
+        $this->assertSame(['pl_PL', 'en_US'], $codes);
+    }
+
+    public function testShouldReturnDefinedLocalesCodesWithoutDefaultLocaleIfNotPresent(): void
+    {
+        $this->localeEn->expects($this->once())->method('getCode')->willReturn('en_US');
+
+        $this->localeCollectionProvider
+            ->expects($this->once())
+            ->method('getAll')
+            ->willReturn([$this->localeEn]);
+
+        $codes = $this->provider->getDefinedLocalesCodes();
+
+        $this->assertSame(['en_US'], $codes);
+    }
+
+    public function testShouldReturnDefaultLocaleCode(): void
+    {
+        $this->assertSame('pl_PL', $this->provider->getDefaultLocaleCode());
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/Sylius/issues/17648
| License         | MIT

This PR ensures that the default locale code (defaultLocaleCode) is always placed at the beginning of the returned array.
Other locales remain in the same order as provided by the repository.

Default locale code is defined in: config/parameters.yaml

Added UnitTest for TranslationLocaleProvider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how available translation locales are assembled and ordered for more consistent results.
  * The configured default locale will now appear first when locales are listed, if present.
  * No changes to public APIs, settings, or user-facing configuration.

* **Documentation**
  * Added an upgrade note describing the new default-locale ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->