### PR TITLE
Add form help rendering to forms

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/Form/_generalHost.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/Form/_generalHost.html.twig
@@ -6,6 +6,7 @@
             {{ form_widget(form.hostname) }}
         </div>
         {{ form_errors(form.hostname) }}
+        {{ form_help(form.hostname) }}
     </div>
     {{ form_row(form.contactEmail) }}
     {{ form_row(form.contactPhoneNumber) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Common/Form/_province.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Common/Form/_province.html.twig
@@ -4,3 +4,4 @@
 {% else %}
     {{ form_widget(form) }}
 {% endif %}
+{{ form_help(form) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -64,6 +64,7 @@
             </div>
             <div class="attribute-error">
                 {{ form_errors(form.value) }}
+                {{ form_help(form.value) }}
             </div>
         </div>
         <input type="hidden" name="{{ form.attribute.vars.full_name }}" id="{{ form.attribute.vars.id }}" value="{{ form.vars.data.attribute.code }}"/>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
@@ -20,6 +20,7 @@
                     </div>
                 </div>
                 {{ form_errors(associationForm) }}
+                {{ form_help(associationForm) }}
             </div>
         {% endfor %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -13,6 +13,7 @@
             <div class="ui inverted dimmer">
                 <div class="ui loader"></div>
             </div>
+            {{ form_help(form.productTaxons) }}
         </div>
 
         {{ sylius_template_event(['sylius.admin.product.' ~ action ~ '.tab_taxonomy', 'sylius.admin.product.tab_taxonomy'], {'form': form}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
@@ -11,4 +11,5 @@
     </div>
     {% endif %}
     {{ form_errors(slugField) }}
+    {{ form_help(slugField) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_channelPricings.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_channelPricings.html.twig
@@ -9,6 +9,7 @@
     </div>
     <div id="sylius_product_variant_channelPricings">
         {{ form_errors(form.channelPricings) }}
+        {{ form_help(form.channelPricings) }}
         {% for channelCode, channelPricing in form.channelPricings %}
             <div class="ui segment">
                 <div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
@@ -17,6 +17,7 @@
             {% for categoryRequirementChoiceForm in form.categoryRequirement %}
                 {{ form_row(categoryRequirementChoiceForm) }}
             {% endfor %}
+            {{ form_help(form.categoryRequirement) }}
             <h4 class="ui dividing header">{{ 'sylius.ui.taxes'|trans }}</h4>
             {{ form_row(form.taxCategory) }}
             <h4 class="ui dividing header">{{ 'sylius.ui.shipping_charges'|trans }}</h4>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_slugField.html.twig
@@ -11,4 +11,5 @@
     </div>
     {% endif %}
     {{ form_errors(slugField) }}
+    {{ form_help(slugField) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_coupon.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_coupon.html.twig
@@ -5,4 +5,5 @@
     </div>
     <br>
     {{ form_errors(form.promotionCoupon) }}
+    {{ form_help(form.promotionCoupon) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
@@ -19,6 +19,7 @@
         <span class="sylius-quantity ui form">
             {{ form_widget(form.quantity, sylius_test_form_attribute('cart-item-quantity-input', item.productName)|sylius_merge_recursive({'attr': {'form': main_form}})) }}
             {{ form_errors(form.quantity) }}
+            {{ form_help(form.quantity) }}
         </span>
     </td>
     <td class="center aligned">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
@@ -8,5 +8,6 @@
         {% else %}
             {% include '@SyliusShop/Checkout/SelectPayment/_unavailable.html.twig' %}
         {% endfor %}
+        {{ form_help(form.method) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
@@ -10,5 +10,6 @@
         {% else %}
             {% include '@SyliusShop/Checkout/SelectShipping/_unavailable.html.twig' %}
         {% endfor %}
+        {{ form_help(form.method) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_province.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_province.html.twig
@@ -5,3 +5,4 @@
 {% else %}
     {{ form_widget(form, sylius_test_form_attribute('province-name')) }}
 {% endif %}
+{{ form_help(form) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_form.html.twig
@@ -2,19 +2,23 @@
     <div class="ui huge star rating" data-rating="0" data-max-rating="5"></div>
     <br/>
     {{ form_errors(form.rating) }}
+    {{ form_help(form.rating) }}
     {{ form_widget(form.rating, sylius_test_form_attribute('rating')|sylius_merge_recursive( {'attr': {'style': 'display: none'}})) }}
 </div>
 <div class="field">
     {{ form_widget(form.title, sylius_test_form_attribute('title')|sylius_merge_recursive( {'attr': {'placeholder': 'sylius.ui.title'|trans}})) }}
     {{ form_errors(form.title) }}
+    {{ form_help(form.title) }}
 </div>
 <div class="field">
     {{ form_widget(form.comment, sylius_test_form_attribute('comment')|sylius_merge_recursive( {'attr': {'placeholder': 'sylius.ui.write_your_own_review'|trans}})) }}
     {{ form_errors(form.comment) }}
+    {{ form_help(form.comment) }}
 </div>
 {% if not is_granted("IS_AUTHENTICATED_REMEMBERED") %}
     <div class="field">
         {{ form_widget(form.author.email, sylius_test_form_attribute('author-email')|sylius_merge_recursive( {'attr': {'placeholder': 'sylius.ui.email'|trans}})) }}
         {{ form_errors(form.author.email) }}
+        {{ form_help(form.author.email) }}
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
@@ -69,6 +69,7 @@
         </div>
         <div class="ui element">
             {{- form_errors(form.file) -}}
+            {{- form_help(form.file) -}}
         </div>
         {% if product.id is not null and 0 != product.variants|length and not product.simple %}
             {{ form_row(form.productVariants) }}
@@ -92,6 +93,7 @@
         </div>
         <div class="ui element">
             {{- form_errors(form.file) -}}
+            {{- form_help(form.file) -}}
         </div>
     {% endapply %}
 {% endblock %}
@@ -109,6 +111,7 @@
         </div>
         <div class="ui element">
             {{- form_errors(form.file) -}}
+            {{- form_help(form.file) -}}
         </div>
     {% endapply %}
 {% endblock %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -26,14 +26,26 @@
     {%- endif -%}
 {%- endblock form_errors -%}
 
+{%- block form_help -%}
+    {%- if help is not empty -%}
+        <p id="{{ id }}_help" class="text-muted" style="margin-top: 0.5em; font-size: 0.9em; color: #6c757d;"{% with { attr: help_attr } %}{{ block('attributes') }}{% endwith %}>
+            {%- if translation_domain is same as(false) -%}
+                {{- help -}}
+            {%- else -%}
+                {{- help|trans(help_translation_parameters, translation_domain) -}}
+            {%- endif -%}
+        </p>
+    {%- endif -%}
+{%- endblock form_help -%}
+
 {% block checkbox_row -%}
     <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
         <div class="ui toggle checkbox">
             {{- form_widget(form) -}}
             {{- form_label(form) -}}
-            {{- form_help(form) -}}
             {{- form_errors(form) -}}
         </div>
+        {{- form_help(form) -}}
     </div>
 {%- endblock checkbox_row %}
 
@@ -44,6 +56,7 @@
             {{- form_widget(form) -}}
             {{- form_errors(form) -}}
         </div>
+        {{- form_help(form) -}}
     </div>
 {%- endblock radio_row %}
 
@@ -59,6 +72,7 @@
         {{- form_label(form) -}}
         {% set attr = attr|merge({'class': attr.class|default ~ ' ui dropdown'}) %}
         {{- form_widget(form, {'attr': attr}) -}}
+        {{- form_help(form) -}}
         {{- form_errors(form) -}}
     </div>
 {%- endblock choice_row %}
@@ -224,6 +238,7 @@
             <div class="default text">{% if placeholder is defined %} {{ placeholder|trans }} {% endif %}</div>
             <div class="menu"></div>
         </div>
+        {{- form_help(form) -}}
         {{- form_errors(form) -}}
     </div>
 {% endblock %}
@@ -257,6 +272,7 @@
             {{ form_widget(form.file) }}
         </div>
         <div class="ui element">
+            {{- form_help(form.file) -}}
             {{- form_errors(form.file) -}}
         </div>
     {% endapply %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -31,6 +31,7 @@
         <div class="ui toggle checkbox">
             {{- form_widget(form) -}}
             {{- form_label(form) -}}
+            {{- form_help(form) -}}
             {{- form_errors(form) -}}
         </div>
     </div>
@@ -74,6 +75,7 @@
                 </div>
             {% endfor -%}
         </div>
+        {{- form_help(form) -}}
     </div>
 {%- endblock choice_widget_expanded -%}
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Allows to add help to forms:
<img width="1083" height="1755" alt="image" src="https://github.com/user-attachments/assets/3eaf475e-f812-4ecc-b720-e0ab630d3fcf" />
