### PR TITLE
[CI] Test both API Platform `~4.1.0` and `~4.2.0`

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -44,7 +44,7 @@ jobs:
     behat-no-js:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}"
+        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -96,13 +96,32 @@ jobs:
                     echo "{}" > public/build/shop/manifest.json
                     echo "{}" > public/build/app/admin/manifest.json
                     echo "{}" > public/build/app/shop/manifest.json
+                    
+            -   name: Require Api Platform packages
+                if: ${{ matrix.api_platform != '' && matrix.api_platform != null }}
+                run: |
+                    REQ="${{ matrix.api_platform }}"
+                    composer require --no-update \
+                        api-platform/doctrine-common:${REQ} \
+                        api-platform/doctrine-orm:${REQ} \
+                        api-platform/documentation:${REQ} \
+                        api-platform/http-cache:${REQ} \
+                        api-platform/hydra:${REQ} \
+                        api-platform/json-schema:${REQ} \
+                        api-platform/jsonld:${REQ} \
+                        api-platform/metadata:${REQ} \
+                        api-platform/openapi:${REQ} \
+                        api-platform/serializer:${REQ} \
+                        api-platform/state:${REQ} \
+                        api-platform/symfony:${REQ} \
+                        api-platform/validator:${REQ}
 
             -   name: Build application
                 uses: SyliusLabs/BuildTestAppAction@v2.4
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-apip-${{ matrix.api_platform || 'none' }}-"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-apip-${{ matrix.api_platform || 'none' }}-"
                     e2e: "yes"
                     database: "mariadb"
                     database_version: ${{ matrix.mariadb }}

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -31,6 +31,14 @@
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
+        },
+        {
+          "php": "8.4",
+          "symfony": "^7.3",
+          "mariadb": "11.4.7",
+          "dbal": "^3.0",
+          "state_machine_adapter": "symfony_workflow",
+          "api_platform": "~4.1.7"
         }
       ]
     },

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,3 +1,10 @@
+# UPGRADE FROM `2.1.5` TO `2.1.6`
+
+### API Platform
+
+1. API Platform 4.2: the title and description fields are no longer present (use hydra:title / hydra:description and violations instead).
+   PHPUnit and Behat tests have been updated to account for these changes.
+
 # UPGRADE FROM `2.1.2` TO `2.1.3`
 
 ### Deprecations

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -203,7 +203,7 @@ final class RegistrationContext implements Context
         $content = $this->getResponseContent();
 
         Assert::same(
-            $content['description'],
+            $content['hydra:description'],
             'Request does not have the following required fields specified: ' . implode(', ', $fields) . '.',
         );
         Assert::same($this->shopClient->getLastResponse()->getStatusCode(), 400);

--- a/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/FooApiCommandTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/FooApiCommandTest.php
@@ -40,7 +40,6 @@ final class FooApiCommandTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertJsonContains([
-            'description' => 'Request does not have the following required fields specified: bar.',
             'hydra:description' => 'Request does not have the following required fields specified: bar.',
             'hydra:title' => 'An error occurred',
         ]);

--- a/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
@@ -240,7 +240,7 @@ final class IriToIdentifierConverterTest extends TestCase
         yield [new \stdClass()];
     }
 
-    private static function unicodeUrlValues(): array
+    public static function unicodeUrlValues(): array
     {
         return [
             ['/resource/zażółć'],
@@ -255,7 +255,7 @@ final class IriToIdentifierConverterTest extends TestCase
         ];
     }
 
-    private static function invalidUrlValues(): array
+    public static function invalidUrlValues(): array
     {
         return [
             ['/resource/line\nbreak'],

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/Filter/TaxonFilterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/Filter/TaxonFilterTest.php
@@ -60,21 +60,24 @@ final class TaxonFilterTest extends TestCase
         $queryBuilder->method('addSelect')->willReturnSelf();
         $queryBuilder->method('innerJoin')->willReturnSelf();
         $queryBuilder->method('andWhere')->willReturnSelf();
-        $queryBuilder->method('addOrderBy')->willReturnSelf();
         $queryBuilder->method('setParameter')->willReturnSelf();
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('addOrderBy')
+            ->with(
+                $this->equalTo('productTaxon.position'),
+                $this->isNull(),
+            )
+            ->willReturnSelf();
 
         $taxon->method('getRoot')->willReturn($taxonRoot);
         $taxon->method('getLeft')->willReturn(3);
         $taxon->method('getRight')->willReturn(5);
 
-        $this->taxonFilter->filterProperty(
-            'taxon',
-            'api/taxon',
-            $queryBuilder,
-            $queryNameGenerator,
-            'resourceClass',
-        );
+        $this->taxonFilter->filterProperty('taxon', 'api/taxon', $queryBuilder, $queryNameGenerator, 'resourceClass');
     }
+
 
     public function test_it_does_not_add_order_by_if_different_order_parameter_specified(): void
     {

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Address/ShopUserBasedExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/Address/ShopUserBasedExtensionTest.php
@@ -108,9 +108,9 @@ final class ShopUserBasedExtensionTest extends TestCase
         $queryBuilder->method('expr')->willReturn($expr);
         $expr->method('eq')->with('o.customer', ':customer')->willReturn($comparison);
 
-        $queryBuilder->method('innerJoin')->with('o.customer', 'customer')->willReturn($queryBuilder);
-        $queryBuilder->method('andWhere')->with($comparison)->willReturn($queryBuilder);
-        $queryBuilder->method('setParameter')->with(':customer', $customer)->willReturn($queryBuilder);
+        $queryBuilder->expects($this->exactly(2))->method('innerJoin')->with('o.customer', 'customer')->willReturn($queryBuilder);
+        $queryBuilder->expects($this->exactly(2))->method('andWhere')->with($comparison)->willReturn($queryBuilder);
+        $queryBuilder->expects($this->exactly(2))->method('setParameter')->with($this->anything(), $customer)->willReturn($queryBuilder);
 
         $this->extension->applyToCollection($queryBuilder, $queryNameGenerator, AddressInterface::class);
         $this->extension->applyToItem($queryBuilder, $queryNameGenerator, AddressInterface::class, []);

--- a/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/ProductAssociation/EnabledProductsExtensionTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Doctrine/ORM/QueryExtension/Shop/ProductAssociation/EnabledProductsExtensionTest.php
@@ -64,7 +64,11 @@ final class EnabledProductsExtensionTest extends TestCase
     public function test_it_does_nothing_if_section_is_not_shop_api(): void
     {
         $section = $this->createMock(AdminApiSection::class);
-        $this->sectionProvider->method('getSection')->willReturn($section);
+        $this->sectionProvider->expects($this->once())->method('getSection')->willReturn($section);
+
+        $this->queryBuilder->expects($this->never())->method('innerJoin');
+        $this->queryBuilder->expects($this->never())->method('andWhere');
+        $this->queryBuilder->expects($this->never())->method('setParameter');
 
         $this->extension->applyToItem(
             $this->queryBuilder,

--- a/src/Sylius/Bundle/ApiBundle/tests/SectionResolver/AdminApiUriBasedSectionResolverTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/SectionResolver/AdminApiUriBasedSectionResolverTest.php
@@ -51,7 +51,7 @@ final class AdminApiUriBasedSectionResolverTest extends TestCase
         $this->resolver->getSection($path);
     }
 
-    public function nonMatchingPathsProvider(): array
+    public static function nonMatchingPathsProvider(): array
     {
         return [
             ['/shop'],

--- a/src/Sylius/Bundle/ApiBundle/tests/SectionResolver/ShopApiUriBasedSectionResolverTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/SectionResolver/ShopApiUriBasedSectionResolverTest.php
@@ -57,7 +57,7 @@ final class ShopApiUriBasedSectionResolverTest extends TestCase
         $this->resolver->getSection($path);
     }
 
-    public function nonMatchingPathsProvider(): array
+    public static function nonMatchingPathsProvider(): array
     {
         return [
             ['/shop'],

--- a/tests/Api/JsonApiTestCase.php
+++ b/tests/Api/JsonApiTestCase.php
@@ -274,11 +274,9 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
             '@context' => '/api/v2/contexts/Error',
             '@id' => '/api/v2/errors/' . $code,
             '@type' => 'hydra:Error',
-            'title' => 'An error occurred',
             'detail' => $message,
             'status' => $code,
             'type' => '/errors/' . $code,
-            'description' => $message,
             'hydra:description' => $message,
             'hydra:title' => 'An error occurred',
         ];

--- a/tests/Api/JsonApiTestCase.php
+++ b/tests/Api/JsonApiTestCase.php
@@ -281,7 +281,16 @@ abstract class JsonApiTestCase extends BaseJsonApiTestCase
             'hydra:title' => 'An error occurred',
         ];
 
-        Assert::assertSame($expectedContent, $content);
+        $actualFiltered = array_intersect_key($content, $expectedContent);
+        Assert::assertSame($expectedContent, $actualFiltered);
+
+        if (array_key_exists('title', $content)) {
+            Assert::assertSame($expectedContent['hydra:title'], $content['title']);
+        }
+        if (array_key_exists('description', $content)) {
+            Assert::assertSame($message, $content['description']);
+        }
+
         $this->assertResponseCode($this->client->getResponse(), $code);
     }
 

--- a/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_with_invalid_dates_response.json
+++ b/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_with_invalid_dates_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "endDate: End date cannot be set before start date.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('endDate: End date cannot be set before start date.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "endDate: End date cannot be set before start date.",
-    "description": "endDate: End date cannot be set before start date.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_with_taken_code_response.json
+++ b/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_with_taken_code_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: The catalog promotion with given code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: The catalog promotion with given code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "code: The catalog promotion with given code already exists.",
-    "description": "code: The catalog promotion with given code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_without_required_data_response.json
+++ b/tests/Api/Responses/admin/catalog_promotion/post_catalog_promotion_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Please enter catalog promotion code.\nname: Please enter catalog promotion name.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Please enter catalog promotion code.\nname: Please enter catalog promotion name.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "code: Please enter catalog promotion code.\nname: Please enter catalog promotion name.",
-    "description": "code: Please enter catalog promotion code.\nname: Please enter catalog promotion name.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/catalog_promotion/put_catalog_promotion_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/catalog_promotion/put_catalog_promotion_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/channel/delete_channel_that_cannot_be_deleted.json
+++ b/tests/Api/Responses/admin/channel/delete_channel_that_cannot_be_deleted.json
@@ -4,9 +4,9 @@
     "@type": "hydra:Error",
     "hydra:title": "An error occurred",
     "hydra:description": "The channel cannot be deleted. At least one enabled channel is required.",
-    "title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('The channel cannot be deleted. At least one enabled channel is required.').optional()",
     "detail": "The channel cannot be deleted. At least one enabled channel is required.",
     "status": 422,
-    "type": "\/errors\/422",
-    "description": "The channel cannot be deleted. At least one enabled channel is required."
+    "type": "\/errors\/422"
 }

--- a/tests/Api/Responses/admin/currency/post_currency_with_invalid_code_response.json
+++ b/tests/Api/Responses/admin/currency/post_currency_with_invalid_code_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: This value is not a valid currency code.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: This value is not a valid currency code.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "code: This value is not a valid currency code.",
-    "description": "code: This value is not a valid currency code.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/customer/post_customer_with_already_taken_email_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_with_already_taken_email_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "email: This email is already used.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('email: This email is already used.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "email: This email is already used.",
-    "description": "email: This email is already used.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/customer/post_customer_with_invalid_email_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_with_invalid_email_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "email: This email is invalid.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('email: This email is invalid.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "email: This email is invalid.",
-    "description": "email: This email is invalid.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "/validation_errors/@string@"
 }

--- a/tests/Api/Responses/admin/customer/post_customer_with_invalid_gender_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_with_invalid_gender_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "gender: The value you selected is not a valid choice.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('gender: The value you selected is not a valid choice.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "gender: The value you selected is not a valid choice.",
-    "description": "gender: The value you selected is not a valid choice.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/customer/post_customer_with_invalid_name_response.json
+++ b/tests/Api/Responses/admin/customer/post_customer_with_invalid_name_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "firstName: First name must be at least 2 characters long.\nlastName: Last name must be at least 2 characters long.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('firstName: First name must be at least 2 characters long.\nlastName: Last name must be at least 2 characters long.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "firstName: First name must be at least 2 characters long.\nlastName: Last name must be at least 2 characters long.",
-    "description": "firstName: First name must be at least 2 characters long.\nlastName: Last name must be at least 2 characters long.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/customer/update_customer_with_invalid_gender_response.json
+++ b/tests/Api/Responses/admin/customer/update_customer_with_invalid_gender_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "gender: The value you selected is not a valid choice.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('gender: The value you selected is not a valid choice.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "gender: The value you selected is not a valid choice.",
-    "description": "gender: The value you selected is not a valid choice.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/locale/post_locale_with_invalid_code_response.json
+++ b/tests/Api/Responses/admin/locale/post_locale_with_invalid_code_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: This value is not a valid locale code.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: This value is not a valid locale code.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "code: This value is not a valid locale code.",
-    "description": "code: This value is not a valid locale code.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/payment_method/put_payment_method_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/payment_method/put_payment_method_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product/delete_product_in_use_response.json
+++ b/tests/Api/Responses/admin/product/delete_product_in_use_response.json
@@ -4,9 +4,9 @@
     "@type": "hydra:Error",
     "hydra:title": "An error occurred",
     "hydra:description": "Cannot delete, the product is in use.",
-    "title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Cannot delete, the product is in use.').optional()",
     "detail": "Cannot delete, the product is in use.",
     "status": 422,
-    "type": "\/errors\/422",
-    "description": "Cannot delete, the product is in use."
+    "type": "\/errors\/422"
 }

--- a/tests/Api/Responses/admin/product/post_product_when_locale_differs_from_key.json
+++ b/tests/Api/Responses/admin/product/post_product_when_locale_differs_from_key.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "The locale of translation does not match the key. Key: \"en_US\", locale: \"locale\"",
     "status": 422,
     "type": "\/errors\/422",
-    "description": "The locale of translation does not match the key. Key: \"en_US\", locale: \"locale\"",
     "hydra:title": "An error occurred",
-    "hydra:description": "The locale of translation does not match the key. Key: \"en_US\", locale: \"locale\""
+    "hydra:description": "The locale of translation does not match the key. Key: \"en_US\", locale: \"locale\"",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('The locale of translation does not match the key. Key: \"en_US\", locale: \"locale\"').optional()"
 }

--- a/tests/Api/Responses/admin/product/post_product_with_invalid_translation_locale.json
+++ b/tests/Api/Responses/admin/product/post_product_with_invalid_translation_locale.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[a].locale: This value is not a valid locale.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[a].locale: This value is not a valid locale.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[a].locale: This value is not a valid locale.",
-    "description": "translations[a].locale: This value is not a valid locale.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product/post_product_without_required_data_response.json
+++ b/tests/Api/Responses/admin/product/post_product_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Please enter product code.\ntranslations[en_US].name: Please enter product name.\ntranslations[en_US].slug: Please enter product slug.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Please enter product code.\ntranslations[en_US].name: Please enter product name.\ntranslations[en_US].slug: Please enter product slug.').optional()",
     "status": 422,
     "violations": [
         {
@@ -23,7 +25,5 @@
         }
     ],
     "detail": "code: Please enter product code.\ntranslations[en_US].name: Please enter product name.\ntranslations[en_US].slug: Please enter product slug.",
-    "description": "code: Please enter product code.\ntranslations[en_US].name: Please enter product name.\ntranslations[en_US].slug: Please enter product slug.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product/put_product_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/product/put_product_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[pl_PL].locale: A translation for the \"pl_PL\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[pl_PL].locale: A translation for the \"pl_PL\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[pl_PL].locale: A translation for the \"pl_PL\" locale code already exists.",
-    "description": "translations[pl_PL].locale: A translation for the \"pl_PL\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_association/post_duplicated_association_product_response.json
+++ b/tests/Api/Responses/admin/product_association/post_duplicated_association_product_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "owner: An association with this owner and type already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('owner: An association with this owner and type already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "owner: An association with this owner and type already exists.",
-    "description": "owner: An association with this owner and type already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_association/post_product_association_without_required_data_response.json
+++ b/tests/Api/Responses/admin/product_association/post_product_association_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "type: Please enter association type.\nowner: Please enter association owner.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('type: Please enter association type.\nowner: Please enter association owner.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "type: Please enter association type.\nowner: Please enter association owner.",
-    "description": "type: Please enter association type.\nowner: Please enter association owner.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_association_type/post_product_association_type_without_required_data_response.json
+++ b/tests/Api/Responses/admin/product_association_type/post_product_association_type_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Please enter association type code.\ntranslations[en_US].name: Please enter association type name.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Please enter association type code.\ntranslations[en_US].name: Please enter association type name.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "code: Please enter association type code.\ntranslations[en_US].name: Please enter association type name.",
-    "description": "code: Please enter association type code.\ntranslations[en_US].name: Please enter association type name.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_association_type/put_product_association_type_with_duplicate_locale_translation_response.json
+++ b/tests/Api/Responses/admin/product_association_type/put_product_association_type_with_duplicate_locale_translation_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_product_attribute_with_unregistered_type_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_product_attribute_with_unregistered_type_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "type: The attribute type \"foobar\" is not registered. Available attribute types: text, textarea, checkbox, integer, float, percent, datetime, date, select.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('type: The attribute type \"foobar\" is not registered. Available attribute types: text, textarea, checkbox, integer, float, percent, datetime, date, select.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "type: The attribute type \"foobar\" is not registered. Available attribute types: text, textarea, checkbox, integer, float, percent, datetime, date, select.",
-    "description": "type: The attribute type \"foobar\" is not registered. Available attribute types: text, textarea, checkbox, integer, float, percent, datetime, date, select.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_product_attribute_without_required_data_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_product_attribute_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Please enter attribute code.\ntranslations[en_US].name: Please enter attribute name.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Please enter attribute code.\ntranslations[en_US].name: Please enter attribute name.').optional()",
     "status": 422,
     "violations":[
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "code: Please enter attribute code.\ntranslations[en_US].name: Please enter attribute name.",
-    "description": "code: Please enter attribute code.\ntranslations[en_US].name: Please enter attribute name.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_disabled_multiple_option_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_disabled_multiple_option_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "Configuration multiple must be true if min or max entries values are specified.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Configuration multiple must be true if min or max entries values are specified.').optional()",
     "status": 422,
     "violations":[
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "Configuration multiple must be true if min or max entries values are specified.",
-    "description": "Configuration multiple must be true if min or max entries values are specified.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_invalid_max_entries_configuration_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_invalid_max_entries_configuration_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "Configuration max entries value must be greater or equal to the min entries value.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Configuration max entries value must be greater or equal to the min entries value.').optional()",
     "status": 422,
     "violations":[
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "Configuration max entries value must be greater or equal to the min entries value.",
-    "description": "Configuration max entries value must be greater or equal to the min entries value.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_invalid_min_entries_configuration_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_select_product_attribute_with_invalid_min_entries_configuration_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "Configuration min entries value must be lower or equal to the number of added choices.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Configuration min entries value must be lower or equal to the number of added choices.').optional()",
     "status": 422,
     "violations":[
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "Configuration min entries value must be lower or equal to the number of added choices.",
-    "description": "Configuration min entries value must be lower or equal to the number of added choices.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/post_text_product_attribute_with_invalid_configuration_response.json
+++ b/tests/Api/Responses/admin/product_attribute/post_text_product_attribute_with_invalid_configuration_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "Configuration max length must be greater or equal to the min length.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Configuration max length must be greater or equal to the min length.').optional()",
     "status": 422,
     "violations":[
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "Configuration max length must be greater or equal to the min length.",
-    "description": "Configuration max length must be greater or equal to the min length.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_attribute/put_product_attribute_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/product_attribute/put_product_attribute_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_image/post_product_image_with_invalid_variant_response.json
+++ b/tests/Api/Responses/admin/product_image/post_product_image_with_invalid_variant_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
-    "description": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_image/put_product_image_with_invalid_variant_response.json
+++ b/tests/Api/Responses/admin/product_image/put_product_image_with_invalid_variant_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
-    "description": "The product variant with code \"CAP_YELLOW\" does not belong to the product with code \"MUG\", which is the owner of the image.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_option/put_product_option_value_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/product_option/put_product_option_value_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "values[0].translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('values[0].translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "values[0].translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "values[0].translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_option/put_product_option_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/product_option/put_product_option_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/product_variant/delete_product_variant_in_use_response.json
+++ b/tests/Api/Responses/admin/product_variant/delete_product_variant_in_use_response.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Cannot delete, the product variant is in use.",
     "status": 422,
     "type": "\/errors\/422",
-    "description": "Cannot delete, the product variant is in use.",
     "hydra:title": "An error occurred",
-    "hydra:description": "Cannot delete, the product variant is in use."
+    "hydra:description": "Cannot delete, the product variant is in use.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Cannot delete, the product variant is in use.\"').optional()"
 }

--- a/tests/Api/Responses/admin/product_variant/post_product_variant_when_channel_code_differs_from_key.json
+++ b/tests/Api/Responses/admin/product_variant/post_product_variant_when_channel_code_differs_from_key.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "The channelCode of channelPricing does not match the key. Key: \"WEB\", channelCode: \"MOBILE\"",
     "status": 422,
     "type": "\/errors\/422",
-    "description": "The channelCode of channelPricing does not match the key. Key: \"WEB\", channelCode: \"MOBILE\"",
     "hydra:title": "An error occurred",
-    "hydra:description": "The channelCode of channelPricing does not match the key. Key: \"WEB\", channelCode: \"MOBILE\""
+    "hydra:description": "The channelCode of channelPricing does not match the key. Key: \"WEB\", channelCode: \"MOBILE\"",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('The channelCode of channelPricing does not match the key. Key: \"WEB\", channelCode: \"MOBILE\"').optional()"
 }

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_actions_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "@string@",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.optional()",
     "status": 422,
     "violations": [
         {
@@ -43,7 +45,5 @@
         }
     ],
     "detail": "@string@",
-    "description": "@string@",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_dates_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_dates_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "endsAt: End date cannot be set prior start date.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('endsAt: End date cannot be set prior start date.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "endsAt: End date cannot be set prior start date.",
-    "description": "endsAt: End date cannot be set prior start date.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_invalid_rules_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "@string@",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.optional()",
     "status": 422,
     "violations": [
         {
@@ -58,7 +60,5 @@
         }
     ],
     "detail": "@string@",
-    "description": "@string@",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion/post_promotion_with_taken_code_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_with_taken_code_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: The promotion with given code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: The promotion with given code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "code: The promotion with given code already exists.",
-    "description": "code: The promotion with given code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion/post_promotion_without_required_data_response.json
+++ b/tests/Api/Responses/admin/promotion/post_promotion_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Please enter promotion code.\nname: Please enter promotion name.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Please enter promotion code.\nname: Please enter promotion name.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "code: Please enter promotion code.\nname: Please enter promotion name.",
-    "description": "code: Please enter promotion code.\nname: Please enter promotion name.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion/put_promotion_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/promotion/put_promotion_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/promotion_coupon/generate_promotion_coupons_with_invalid_promotion_code_response.json
+++ b/tests/Api/Responses/admin/promotion_coupon/generate_promotion_coupons_with_invalid_promotion_code_response.json
@@ -4,9 +4,9 @@
     "@type": "hydra:Error",
     "hydra:title": "An error occurred",
     "hydra:description": "Promotion with the \"non_existing_promotion_code\" code not found.",
-    "title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Promotion with the \"non_existing_promotion_code\" code not found.').optional()",
     "detail": "Promotion with the \"non_existing_promotion_code\" code not found.",
     "status": 404,
-    "type": "\/errors\/404",
-    "description": "Promotion with the \"non_existing_promotion_code\" code not found."
+    "type": "\/errors\/404"
 }

--- a/tests/Api/Responses/admin/tax_rate/put_tax_rate_with_malformed_amount_response.json
+++ b/tests/Api/Responses/admin/tax_rate/put_tax_rate_with_malformed_amount_response.json
@@ -4,9 +4,9 @@
     "@type": "hydra:Error",
     "hydra:title": "An error occurred",
     "hydra:description": "Amount must be a numeric value.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Amount must be a numeric value.').optional()",
     "status": 400,
     "type": "\/errors\/400",
-    "title": "An error occurred",
-    "detail": "Amount must be a numeric value.",
-    "description": "Amount must be a numeric value."
+    "detail": "Amount must be a numeric value."
 }

--- a/tests/Api/Responses/admin/taxon/post_taxon_with_taken_code_response.json
+++ b/tests/Api/Responses/admin/taxon/post_taxon_with_taken_code_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "code: Taxon with given code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('code: Taxon with given code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "code: Taxon with given code already exists.",
-    "description": "code: Taxon with given code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/taxon/post_taxon_without_required_data_response.json
+++ b/tests/Api/Responses/admin/taxon/post_taxon_without_required_data_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description":"translations[en_US].name: Please enter taxon name.\ntranslations[en_US].slug: Please enter taxon slug.\ncode: Please enter taxon code.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].name: Please enter taxon name.\ntranslations[en_US].slug: Please enter taxon slug.\ncode: Please enter taxon code.').optional()",
     "status": 422,
     "violations":[
         {
@@ -23,7 +25,5 @@
         }
     ],
     "detail":"translations[en_US].name: Please enter taxon name.\ntranslations[en_US].slug: Please enter taxon slug.\ncode: Please enter taxon code.",
-    "description":"translations[en_US].name: Please enter taxon name.\ntranslations[en_US].slug: Please enter taxon slug.\ncode: Please enter taxon code.",
-    "type":"\/validation_errors\/@string@",
-    "title":"An error occurred"
+    "type":"\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/admin/taxon/put_taxon_with_duplicate_locale_translation.json
+++ b/tests/Api/Responses/admin/taxon/put_taxon_with_duplicate_locale_translation.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('translations[en_US].locale: A translation for the \"en_US\" locale code already exists.').optional()",
     "status": 422,
     "violations": [
         {
@@ -13,7 +15,5 @@
         }
     ],
     "detail": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "description": "translations[en_US].locale: A translation for the \"en_US\" locale code already exists.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/common/image/invalid_filter.json
+++ b/tests/Api/Responses/common/image/invalid_filter.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Filter \"invalid\" is not configured.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Filter \"invalid\" is not configured.",
     "hydra:title": "An error occurred",
-    "hydra:description": "Filter \"invalid\" is not configured."
+    "hydra:description": "Filter \"invalid\" is not configured.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Filter \"invalid\" is not configured.').optional()"
 }

--- a/tests/Api/Responses/shop/checkout/cart/add_item_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/cart/add_item_with_missing_fields.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: productVariant, quantity.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: productVariant, quantity.",
     "hydra:description": "Request does not have the following required fields specified: productVariant, quantity.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: productVariant, quantity.').optional()"
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_item_quantity_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_item_quantity_with_missing_fields.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: quantity.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: quantity.",
     "hydra:description": "Request does not have the following required fields specified: quantity.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: quantity.').optional()"
 }

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_with_missing_fields.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: paymentMethod.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: paymentMethod.",
     "hydra:description": "Request does not have the following required fields specified: paymentMethod.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: paymentMethod.').optional()"
 }

--- a/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method_with_missing_fields.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: shippingMethod.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: shippingMethod.",
     "hydra:description": "Request does not have the following required fields specified: shippingMethod.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: shippingMethod.').optional()"
 }

--- a/tests/Api/Responses/shop/customer/reset_password_validation_response.json
+++ b/tests/Api/Responses/shop/customer/reset_password_validation_response.json
@@ -4,6 +4,8 @@
     "@type": "@string@.startsWith('ConstraintViolation')",
     "hydra:title": "An error occurred",
     "hydra:description": "email: This email is invalid.\nlocaleCode: This value is not a valid locale code.",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('email: This email is invalid.\nlocaleCode: This value is not a valid locale code.').optional()",
     "status": 422,
     "violations": [
         {
@@ -18,7 +20,5 @@
         }
     ],
     "detail": "email: This email is invalid.\nlocaleCode: This value is not a valid locale code.",
-    "description": "email: This email is invalid.\nlocaleCode: This value is not a valid locale code.",
-    "type": "\/validation_errors\/@string@",
-    "title": "An error occurred"
+    "type": "\/validation_errors\/@string@"
 }

--- a/tests/Api/Responses/shop/payment_request/post_payment_request_without_required_data.json
+++ b/tests/Api/Responses/shop/payment_request/post_payment_request_without_required_data.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: paymentMethodCode.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: paymentMethodCode.",
     "hydra:description": "Request does not have the following required fields specified: paymentMethodCode.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: paymentMethodCode.').optional()"
 }

--- a/tests/Api/Responses/shop/product_review/create_product_review_with_missing_fields.json
+++ b/tests/Api/Responses/shop/product_review/create_product_review_with_missing_fields.json
@@ -2,11 +2,11 @@
     "@context": "\/api\/v2\/contexts\/Error",
     "@id": "\/api\/v2\/errors\/400",
     "@type": "hydra:Error",
-    "title": "An error occurred",
     "detail": "Request does not have the following required fields specified: title, rating, comment, product.",
     "status": 400,
     "type": "\/errors\/400",
-    "description": "Request does not have the following required fields specified: title, rating, comment, product.",
     "hydra:description": "Request does not have the following required fields specified: title, rating, comment, product.",
-    "hydra:title": "An error occurred"
+    "hydra:title": "An error occurred",
+    "title": "@string@.contains('An error occurred').optional()",
+    "description": "@string@.contains('Request does not have the following required fields specified: title, rating, comment, product.').optional()"
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Fundamental change in responses:

In 4.2 the proper response is:
\"invalid\" is not configured.",
  "hydra:description": "Filter \"invalid\" is not configured.",
  "hydra:title": "An error occurred"

In comparison to 4.1:
  "hydra:description": "Filter \"invalid\" is not configured.",
  "hydra:title": "An error occurred",
  "title": "An error occurred",
  "description": "Filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Standardized API error responses: removed duplicated root title/description/type entries and introduced optional title/description matchers; hydra fields and error details preserved.

- Documentation
  - Added upgrade notes for 2.1.5 → 2.1.6 describing API Platform 4.x error-field behavior and updated test expectations.

- Chores
  - CI: added PHP 8.4 / Symfony 7.3 MariaDB matrix entry and conditional Api Platform runs with segregated cache keys.

- Tests
  - Updated many API response fixtures; tightened mock expectations and exposed some test data providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->