### PR TITLE
[AdminBundle] Hide Impersonate button when user shop account is locked

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Details/_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Details/_email.html.twig
@@ -11,8 +11,8 @@
             <i class="{{ user.verified ? 'green checkmark' : 'red remove' }} icon"></i>
             {{ 'sylius.ui.email_verified'|trans }}
         </div>
+        {% if is_shop_enabled() and user.isAccountNonLocked and user.enabled %}
         <br />
-        {% if is_shop_enabled() %}
             {{ buttons.default(path('sylius_admin_impersonate_user', {'username': user.emailCanonical}), 'sylius.ui.impersonate', 'impersonate', 'unhide', 'blue') }}
         {% endif %}
     {% endif %}


### PR DESCRIPTION


| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #13476, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The “Impersonate” button in Customer > Email details now appears only when the shop is enabled and the customer’s account is active and not locked, preventing impersonation of disabled/locked users.
  - Minor UI polish: when the button is hidden, extra spacing is removed to keep the layout clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->