### PR TITLE
[Refactor] Remove unused Connection mock from test

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/tests/EventListener/SelectProductAttributeChoiceRemoveListenerTest.php
+++ b/src/Sylius/Bundle/ProductBundle/tests/EventListener/SelectProductAttributeChoiceRemoveListenerTest.php
@@ -53,11 +53,9 @@ final class SelectProductAttributeChoiceRemoveListenerTest extends TestCase
         $productAttributeValue = $this->createMock(ProductAttributeValueInterface::class);
         /** @var QueryBuilder&MockObject $queryBuilder */
         $queryBuilder = $this->createMock(QueryBuilder::class);
-        /** @var Connection&MockObject $connection */
-        $connection = $this->createMock(Connection::class);
         /** @var Query&MockObject $query */
         $query = $this->createMock(Query::class);
-        /** @var UnitOfWork&MockInterface $unitOfWork */
+        /** @var UnitOfWork&MockObject $unitOfWork */
         $unitOfWork = $this->createMock(UnitOfWork::class);
 
         $productAttributeValueRepository = new ProductAttributeValueRepository($this->entityManager, new ClassMetadata(ProductAttributeValue::class));
@@ -83,7 +81,6 @@ final class SelectProductAttributeChoiceRemoveListenerTest extends TestCase
         ;
 
         $this->entityManager->expects($this->once())->method('getUnitOfWork')->willReturn($unitOfWork);
-        $this->entityManager->expects($this->once())->method('getConnection')->willReturn($connection);
         $this->entityManager
             ->expects($this->once())
             ->method('getRepository')


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | kinda
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This PR fixes the package build by resolving the following error:
<img width="1662" height="954" alt="image" src="https://github.com/user-attachments/assets/714760fe-9d71-4c15-a992-aa106d46faef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up product attribute listener tests by removing unnecessary database connection mocks and related expectations.
  * Updated mock type annotations for improved accuracy.
  * Simplified test setup, reducing noise and improving clarity and reliability.
  * No changes to application behavior or public API; purely test maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->