### PR TITLE
Remove product images duplication

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/app.js
@@ -10,6 +10,7 @@
 import '@sylius/shop-bundle/entrypoint';
 
 import { startStimulusApp } from '@symfony/stimulus-bridge';
+import ProductShowImagesController from './controllers/ProductShowImagesController';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
@@ -17,5 +18,7 @@ export const app = startStimulusApp(require.context(
     true,
     /\.[jt]sx?$/
 ));
+
+app.register('product-show-images', ProductShowImagesController);
 
 app.debug = process.env.NODE_ENV !== 'production';

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers/ProductShowImagesController.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers/ProductShowImagesController.js
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/* global Spotlight */
+
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    initialize() {
+        const mainImage = document.getElementById('main-image');
+        const thumbnails = mainImage.closest('.spotlight-group').querySelectorAll('.spotlight');
+        mainImage.addEventListener('click', (e) => {
+            e.preventDefault();
+            Spotlight.show(thumbnails, 0);
+        });
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers/ProductShowImagesController.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/assets/controllers/ProductShowImagesController.js
@@ -12,12 +12,30 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    initialize() {
-        const mainImage = document.getElementById('main-image');
-        const thumbnails = mainImage.closest('.spotlight-group').querySelectorAll('.spotlight');
-        mainImage.addEventListener('click', (e) => {
+    connect() {
+        const mainImage = this.element.querySelector('#main-image');
+        if (!mainImage) {
+            return;
+        }
+
+        this._onMainImageClick = (e) => {
+            const thumbnails = this.element.querySelectorAll('.spotlight');
+            if (!thumbnails || thumbnails.length === 0 || typeof Spotlight === 'undefined') {
+                return;
+            }
+
             e.preventDefault();
+
             Spotlight.show(thumbnails, 0);
-        });
+        };
+
+        mainImage.addEventListener('click', this._onMainImageClick);
+    }
+
+    disconnect() {
+        const mainImage = this.element.querySelector('#main-image');
+        if (mainImage && this._onMainImageClick) {
+            mainImage.removeEventListener('click', this._onMainImageClick);
+        }
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images.html.twig
@@ -9,7 +9,7 @@
     {% set path = original_path %}
 {% endif %}
 
-<div class="row spotlight-group mb-5">
+<div class="row spotlight-group mb-5" {{ stimulus_controller('product-show-images') }}>
     <div data-product-image="{{ path }}" data-product-link="{{ original_path }}"></div>
     {% hook 'images' with { original_path, path } %}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images/main_image.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/product/show/content/info/overview/images/main_image.html.twig
@@ -1,8 +1,8 @@
 {% set product = hookable_metadata.context.product %}
 
 <div class="col pe-lg-5 pe-xxl-5">
-    <a href="{{ hookable_metadata.context.original_path }}" class="d-block overflow-auto bg-light rounded-3 spotlight">
-        <img src="{{ hookable_metadata.context.path }}" alt="{{ product.name }}" class="img-fluid w-100 h-100 object-fit-cover"
+    <a href="{{ hookable_metadata.context.original_path }}" class="d-block overflow-auto bg-light rounded-3{% if product.images|length < 2 %} spotlight{% endif %}">
+        <img id="main-image" src="{{ hookable_metadata.context.path }}" alt="{{ product.name }}" class="img-fluid w-100 h-100 object-fit-cover"
             {% if product.images.first %}
                 {{ sylius_test_html_attribute('main-image', product.images.first.type) }}
             {% else %}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #16771
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clicking the main product image opens a Spotlight gallery to view and navigate full-size product images.
  * Main image interaction is more consistent across single- and multi-image products for smoother browsing.

* **Bug Fixes**
  * More predictable rendering when products lack a first image, avoiding unstable image attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->