### PR TITLE
Fix invalid property types for 'translations'

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotion.xml
@@ -192,6 +192,9 @@ Example configuration for `percentage_discount` action type:
                         <attribute name="description">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
         <property name="scopes" writable="true" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
@@ -142,6 +142,9 @@
                         <attribute name="instructions">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -253,6 +253,9 @@
                         <attribute name="metaDescription">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
         <property name="productTaxons" readable="true" writable="true" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
@@ -109,6 +109,9 @@
                         <attribute name="name">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAttribute.xml
@@ -237,6 +237,9 @@ Example configuration for a `select` type attribute:
                         <attribute name="name">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -120,6 +120,9 @@
                         <attribute name="name">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -59,11 +59,14 @@
         <property name="code" identifier="true" required="true" />
         <property name="translations" readable="true" writable="true" >
             <attribute name="openapi_context">
-                <attribute name="type">array</attribute>
+                <attribute name="type">object</attribute>
                 <attribute name="example">
                     <attribute name="en_US">
                         <attribute name="value">string</attribute>
                     </attribute>
+                </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
                 </attribute>
             </attribute>
         </property>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -120,11 +120,14 @@
         <property name="product" />
         <property name="translations">
             <attribute name="openapi_context">
-                <attribute name="type">array</attribute>
+                <attribute name="type">object</attribute>
                 <attribute name="example">
                     <attribute name="en_US">
                         <attribute name="name">string</attribute>
                     </attribute>
+                </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
                 </attribute>
             </attribute>
         </property>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -223,6 +223,9 @@ Example configuration for `order_fixed_discount` action type:
                         <attribute name="label">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -247,6 +247,9 @@ Example configuration for `flat_rate` shipping charges calculator:
                         <attribute name="description">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
         <property name="description" readable="true" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
@@ -182,6 +182,9 @@
                         <attribute name="slug">string</attribute>
                     </attribute>
                 </attribute>
+                <attribute name="additionalProperties">
+                    <attribute name="type">object</attribute>
+                </attribute>
             </attribute>
         </property>
         <property name="images" writable="false" required="false">


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no 
| Related tickets | https://github.com/Sylius/Sylius/issues/14879
| License         | MIT

Issue was present in 1.14. Updated files from old array-based translations schema to the proper object-based schema with additional properties support.
<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
