### PR TITLE
TASK: [2.1] [AttributeBundle] add missing translations for float attributes type

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
@@ -17,6 +17,7 @@ sylius:
             configuration: Konfiguration
             date: Datum
             datetime: Datum/Zeit
+            float: 'Gleitkommazahl'
             integer: Ganzzahl
             percent: Prozent
             select: Auswahl

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_AT.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_AT.yml
@@ -17,7 +17,7 @@ sylius:
             configuration: 'Konfiguration'
             date: 'Datum'
             datetime: 'Datum/Uhrzeit'
-            float: 'Gleitkomma'
+            float: 'Gleitkommazahl'
             integer: 'Ganzzahl'
             percent: 'Prozent'
             select: 'Auswählen'

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_CH.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de_CH.yml
@@ -17,7 +17,7 @@ sylius:
             configuration: 'Konfiguration'
             date: 'Datum'
             datetime: 'Datum und Uhrzeit'
-            float: 'Fließkommazahl'
+            float: 'Gleitkommazahl'
             integer: 'Ganzzahl'
             percent: 'Prozent'
             select: 'Auswählen'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
@@ -365,6 +365,7 @@ sylius:
         fulfill: 'Zu erfüllen'
         fulfilled: 'Erfüllt'
         fulfilled_orders: 'Erfüllte Bestellungen'
+        float: 'Gleitkommazahl'
         gateway: 'Schnittstelle'
         gateway_configuration: 'Gateway-Konfiguration'
         general: 'Allgemein'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_AT.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_AT.yml
@@ -372,7 +372,7 @@ sylius:
         filters: 'Filter'
         first_name: 'Vorname'
         fixed_discount: 'Fixer Rabatt'
-        float: 'Fließkommazahl'
+        float: 'Gleitkommazahl'
         for_products: 'Für Produkte'
         for_taxons: 'Für Taxons'
         for_variants: 'Für Varianten'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
@@ -372,7 +372,7 @@ sylius:
         filters: 'Filter'
         first_name: 'Vorname'
         fixed_discount: 'Fester Rabatt'
-        float: 'Fließkommazahl'
+        float: 'Gleitkommazahl'
         for_products: 'Für Produkte'
         for_taxons: 'Für Taxons'
         for_variants: 'Für Varianten'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This pull request adds, and adjusts two translations for the float attributes type in the AttributesBundle for German, and Austria German.


<img width="235" height="435" alt="2025-09-30 19_23_15-NVIDIA" src="https://github.com/user-attachments/assets/4b925aea-c9b5-44be-9c34-0d1c9b6fbd1d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added German label "Gleitkommazahl" for the “float” field in attribute configuration and UI.

- Chores
  - Harmonized German translations across DE, AT and CH locales by replacing prior variants (e.g., "Fließkomma"/"Fließkommazahl") with "Gleitkommazahl" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->