### PR TITLE
TASK: [2.1] [Maintenance] adjust translation guide in github issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,6 @@ contact_links:
     - name: 🙋🏼 Support Question
       url: https://sylius.com/support/
       about: GitHub issues are just for reporting Sylius bugs and suggesting new features. If you have questions about using Sylius or third-party bundles, feel free to check out our support options in `https://sylius.com/support`
-    - name: 🇺🇸 Translations
-      url: https://translate.sylius.com/
-      about: See `https://translate.sylius.com/` to add or fix Sylius translations.
+    - name: 🌍 UI Translations
+      url: https://docs.sylius.com/the-book/contributing/contributing-translations
+      about: Have a look at `https://docs.sylius.com/the-book/contributing/contributing-translations` to read more about how you can contribute translations to Sylius.


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

<img width="800" height="593" alt="image" src="https://github.com/user-attachments/assets/8060f6d7-e3b1-49a1-8eec-2cc71f39aaec" />

I noticed that the URL `translate.sylius.com` wasnt working anymore. So i adjusted the title, url, and description with the latest informations on how to contribute translations to sylius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the issue template to replace the Translations contact with a UI Translations contact, including a refreshed link and clearer guidance for requesting or discussing UI translation updates.
  - Improves discoverability and accuracy for contributors seeking translation support.
  - No impact on application behavior or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->