### PR TITLE
Fixes error when cancelled order with PARTIALLY_REFUNDED payment state

### DIFF
--- a/features/admin/inventory/managing_inventory/verify_reserved_inventory_is_back_in_stock_on_order_cancelling.feature
+++ b/features/admin/inventory/managing_inventory/verify_reserved_inventory_is_back_in_stock_on_order_cancelling.feature
@@ -102,3 +102,15 @@ Feature: Inventory releasing on order cancellation
         When I view all variants of the product "T-Shirt banana"
         Then the variant "Green" should have 5 items on hand
         And the "Green" variant should have 0 items on hold
+
+    @api @ui
+    Scenario: Verify the reserved inventory and quantity of product's items is back in stock after cancellation of a partially refunded order
+        Given there is a customer "john.doe@gmail.com" that placed an order "#00000022"
+        And the customer bought 3 units of "Green" variant of product "T-Shirt banana"
+        And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
+        And the order "#00000022" is already paid
+        But this order has been partially refunded
+        And the order "#00000022" was cancelled
+        When I view all variants of the product "T-Shirt banana"
+        Then the variant "Green" should have 5 items on hand
+        And the "Green" variant should have 0 items on hold

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -708,6 +708,17 @@ final readonly class OrderContext implements Context
     }
 
     /**
+     * @Given /^(this order) has been partially refunded$/
+     * @Given the customer has partially refunded the order with number :order
+     */
+    public function thisOrderHasBeenPartiallyRefunded(OrderInterface $order): void
+    {
+        $this->stateMachine->apply($order, OrderPaymentTransitions::GRAPH, OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^the customer cancelled (this order)$/
      * @Given /^(this order) was cancelled$/
      * @Given the order :order was cancelled

--- a/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php
+++ b/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php
@@ -25,7 +25,7 @@ final class OrderInventoryOperator implements OrderInventoryOperatorInterface
     {
         if (in_array(
             $order->getPaymentState(),
-            [OrderPaymentStates::STATE_PAID, OrderPaymentStates::STATE_REFUNDED],
+            [OrderPaymentStates::STATE_PAID, OrderPaymentStates::STATE_REFUNDED, OrderPaymentStates::STATE_PARTIALLY_REFUNDED],
             true,
         )) {
             $this->giveBack($order);

--- a/src/Sylius/Component/Core/tests/Inventory/Operator/OrderInventoryOperatorTest.php
+++ b/src/Sylius/Component/Core/tests/Inventory/Operator/OrderInventoryOperatorTest.php
@@ -112,6 +112,19 @@ final class OrderInventoryOperatorTest extends TestCase
         $this->operator->cancel($this->order);
     }
 
+    public function testShouldIncreasesOnHandDuringCancellingOfPartiallyRefundedOrder(): void
+    {
+        $this->order->expects($this->once())->method('getPaymentState')->willReturn(OrderPaymentStates::STATE_PARTIALLY_REFUNDED);
+        $this->order->expects($this->once())->method('getItems')->willReturn(new ArrayCollection([$this->orderItem]));
+        $this->orderItem->expects($this->once())->method('getVariant')->willReturn($this->productVariant);
+        $this->productVariant->expects($this->once())->method('isTracked')->willReturn(true);
+        $this->orderItem->expects($this->once())->method('getQuantity')->willReturn(10);
+        $this->productVariant->expects($this->once())->method('getOnHand')->willReturn(0);
+        $this->productVariant->expects($this->once())->method('setOnHand')->with(10);
+
+        $this->operator->cancel($this->order);
+    }
+
     public function testShouldThrowNotEnoughUnitsOnHoldExceptionIfDifferenceBetweenOnHoldAndItemQuantityIsSmallerThanZeroDuringCancelling(): void
     {
         $this->expectException(NotEnoughUnitsOnHoldException::class);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/RefundPlugin/issues/418
| License         | MIT

When partially refund an order (using RefundPlugin) and then attempt to cancel it, and items are tracked, an exception occurs (https://github.com/Sylius/RefundPlugin/issues/418). This fix causes use of giveBack() function instead of release() in above case.
<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inventory handling when canceling orders with partially refunded payments. Items from such orders are now restocked consistently, matching behavior for paid and fully refunded orders.
  * Improves stock accuracy and consistency during order cancellations; no changes to behavior for other payment states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->