### PR TITLE
[SHOP][FEATURE] Introduce address form modifiers in checkout component

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,20 @@
+# UPGRADE FROM `2.1` TO `2.2`
+
+### Deprecations
+
+1. Not injecting a `tagged_iterator with the tag `sylius_shop.modifier.address_form_values` into the constructor of `Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address\FormComponent` is deprecated since Sylius 2.2 and will be required in Sylius 3.0.
+
+   This change enables extending the checkout address form with custom fields or logic by registering services tagged with `sylius_shop.modifier.address_form_values`, which implement the `AddressFormValuesModifierInterface`.
+
+```php
+    public function __construct(
+        OrderRepositoryInterface $repository,
+        FormFactoryInterface $formFactory,
+        string $resourceClass,
+        string $formClass,
+        protected readonly CustomerContextInterface $customerContext,
+        protected readonly UserRepositoryInterface $shopUserRepository,
+        protected readonly AddressRepositoryInterface $addressRepository,
++       private readonly ?iterable $addressFormValuesModifiers = null,
+    )
+```

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -15,7 +15,7 @@
         protected readonly CustomerContextInterface $customerContext,
         protected readonly UserRepositoryInterface $shopUserRepository,
         protected readonly AddressRepositoryInterface $addressRepository,
-+       private readonly ?iterable $addressFormValuesModifiers = null,
++       protected readonly ?iterable $addressFormValuesModifiers = null,
     )
 ```
 ### Translations

--- a/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
@@ -9,11 +9,17 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Sylius\Bundle\ShopBundle\Modifier;
 
-use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Addressing\Model\AddressInterface;
 
 interface AddressFormValuesModifierInterface
 {
+    /**
+     * @param array<string, mixed> $newAddress
+     * @return array<string, mixed>
+     */
     public function modify(array $newAddress, AddressInterface $address): array;
 }

--- a/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
@@ -18,8 +18,9 @@ use Sylius\Component\Addressing\Model\AddressInterface;
 interface AddressFormValuesModifierInterface
 {
     /**
-     * @param array<string, mixed> $newAddress
+     * @param array<string, mixed> $addressData
+     *
      * @return array<string, mixed>
      */
-    public function modify(array $newAddress, AddressInterface $address): array;
+    public function modify(array $addressData, AddressInterface $address): array;
 }

--- a/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Modifier/AddressFormValuesModifierInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShopBundle\Modifier;
+
+use Sylius\Component\Core\Model\AddressInterface;
+
+interface AddressFormValuesModifierInterface
+{
+    public function modify(array $newAddress, AddressInterface $address): array;
+}

--- a/src/Sylius/Bundle/ShopBundle/Modifier/DefaultAddressFormValuesModifier.php
+++ b/src/Sylius/Bundle/ShopBundle/Modifier/DefaultAddressFormValuesModifier.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Modifier;
+
+use Sylius\Component\Addressing\Model\AddressInterface;
+
+final readonly class DefaultAddressFormValuesModifier implements AddressFormValuesModifierInterface
+{
+    /**
+     * @param array<string, mixed> $addressData
+     *
+     * @return array<string, mixed>
+     */
+    public function modify(array $addressData, AddressInterface $address): array
+    {
+        $addressData['firstName'] = $address->getFirstName();
+        $addressData['lastName'] = $address->getLastName();
+        $addressData['phoneNumber'] = $address->getPhoneNumber();
+        $addressData['company'] = $address->getCompany();
+        $addressData['countryCode'] = $address->getCountryCode();
+        if ($address->getProvinceCode() !== null) {
+            $addressData['provinceCode'] = $address->getProvinceCode();
+        }
+        if ($address->getProvinceName() !== null) {
+            $addressData['provinceName'] = $address->getProvinceName();
+        }
+        $addressData['street'] = $address->getStreet();
+        $addressData['city'] = $address->getCity();
+        $addressData['postcode'] = $address->getPostcode();
+
+        return $addressData;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/modifier.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/modifier.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Sylius Sp. z o.o.
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container
+    xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <service id="sylius_shop.modifier.default_address_form_values" class="Sylius\Bundle\ShopBundle\Modifier\DefaultAddressFormValuesModifier">
+            <tag name="sylius_shop.modifier.address_form_values" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig/component/checkout.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="sylius.context.customer" />
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.repository.address" />
+            <argument type="tagged_iterator" tag="sylius_shop.modifier.address_form_values" />
 
             <tag name="sylius.live_component.shop" key="sylius_shop:checkout:address:form" />
         </service>

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -52,6 +52,7 @@ class FormComponent
         protected readonly CustomerContextInterface $customerContext,
         protected readonly UserRepositoryInterface $shopUserRepository,
         protected readonly AddressRepositoryInterface $addressRepository,
+        private readonly iterable $addressFormValuesModifiers,
     ) {
         $this->initialize($repository, $formFactory, $resourceClass, $formClass);
     }
@@ -85,6 +86,10 @@ class FormComponent
         $newAddress['street'] = $address->getStreet();
         $newAddress['city'] = $address->getCity();
         $newAddress['postcode'] = $address->getPostcode();
+
+        foreach ($this->addressFormValuesModifiers as $modifier) {
+            $newAddress = $modifier->modify($newAddress, $address);
+        }
 
         $this->formValues[$field] = $newAddress;
     }

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address;
 use Sylius\Bundle\ShopBundle\Modifier\AddressFormValuesModifierInterface;
 use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
+use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Core\Repository\AddressRepositoryInterface;
@@ -54,7 +55,7 @@ class FormComponent
         protected readonly UserRepositoryInterface $shopUserRepository,
         protected readonly AddressRepositoryInterface $addressRepository,
         /** @var iterable<AddressFormValuesModifierInterface> */
-        private readonly ?iterable $addressFormValuesModifiers = null,
+        protected readonly ?iterable $addressFormValuesModifiers = null,
     ) {
         $this->initialize($repository, $formFactory, $resourceClass, $formClass);
         if (null === $this->addressFormValuesModifiers) {
@@ -62,6 +63,8 @@ class FormComponent
                 'sylius/shop-bundle',
                 '2.2',
                 'Not passing a "%s" to "%s" is deprecated and will be required in Sylius 3.0.',
+                AddressFormValuesModifierInterface::class,
+                self::class,
             );
         }
     }
@@ -79,25 +82,17 @@ class FormComponent
     public function addressFieldUpdated(#[LiveArg] mixed $addressId, #[LiveArg] string $field): void
     {
         $address = $this->addressRepository->find($addressId);
+        if (null === $address) {
+            return;
+        }
 
         $newAddress = [];
-        $newAddress['firstName'] = $address->getFirstName();
-        $newAddress['lastName'] = $address->getLastName();
-        $newAddress['phoneNumber'] = $address->getPhoneNumber();
-        $newAddress['company'] = $address->getCompany();
-        $newAddress['countryCode'] = $address->getCountryCode();
-        if ($address->getProvinceCode() !== null) {
-            $newAddress['provinceCode'] = $address->getProvinceCode();
-        }
-        if ($address->getProvinceName() !== null) {
-            $newAddress['provinceName'] = $address->getProvinceName();
-        }
-        $newAddress['street'] = $address->getStreet();
-        $newAddress['city'] = $address->getCity();
-        $newAddress['postcode'] = $address->getPostcode();
-
-        foreach ($this->addressFormValuesModifiers as $modifier) {
-            $newAddress = $modifier->modify($newAddress, $address);
+        if (null === $this->addressFormValuesModifiers) {
+            $newAddress = $this->createAddressArrayFromEntity($address);
+        } else {
+            foreach ($this->addressFormValuesModifiers as $modifier) {
+                $newAddress = $modifier->modify($newAddress, $address);
+            }
         }
 
         $this->formValues[$field] = $newAddress;
@@ -110,5 +105,32 @@ class FormComponent
             $this->resource,
             ['customer' => $this->customerContext->getCustomer()],
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function createAddressArrayFromEntity(AddressInterface $address): array
+    {
+        $newAddress = [
+            'firstName' => $address->getFirstName(),
+            'lastName' => $address->getLastName(),
+            'phoneNumber' => $address->getPhoneNumber(),
+            'company' => $address->getCompany(),
+            'countryCode' => $address->getCountryCode(),
+            'street' => $address->getStreet(),
+            'city' => $address->getCity(),
+            'postcode' => $address->getPostcode(),
+        ];
+
+        if (null !== $address->getProvinceCode()) {
+            $newAddress['provinceCode'] = $address->getProvinceCode();
+        }
+
+        if (null !== $address->getProvinceName()) {
+            $newAddress['provinceName'] = $address->getProvinceName();
+        }
+
+        return $newAddress;
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Checkout/Address/FormComponent.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig\Component\Checkout\Address;
 
+use Sylius\Bundle\ShopBundle\Modifier\AddressFormValuesModifierInterface;
 use Sylius\Bundle\UiBundle\Twig\Component\ResourceFormComponentTrait;
 use Sylius\Bundle\UiBundle\Twig\Component\TemplatePropTrait;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -52,9 +53,17 @@ class FormComponent
         protected readonly CustomerContextInterface $customerContext,
         protected readonly UserRepositoryInterface $shopUserRepository,
         protected readonly AddressRepositoryInterface $addressRepository,
-        private readonly iterable $addressFormValuesModifiers,
+        /** @var iterable<AddressFormValuesModifierInterface> */
+        private readonly ?iterable $addressFormValuesModifiers = null,
     ) {
         $this->initialize($repository, $formFactory, $resourceClass, $formClass);
+        if (null === $this->addressFormValuesModifiers) {
+            trigger_deprecation(
+                'sylius/shop-bundle',
+                '2.2',
+                'Not passing a "%s" to "%s" is deprecated and will be required in Sylius 3.0.',
+            );
+        }
     }
 
     #[PreReRender(priority: -100)]

--- a/tests/Modifier/DefaultAddressFormValuesModifierTest.php
+++ b/tests/Modifier/DefaultAddressFormValuesModifierTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Modifier;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ShopBundle\Modifier\DefaultAddressFormValuesModifier;
+use Sylius\Component\Addressing\Model\AddressInterface;
+
+final class DefaultAddressFormValuesModifierTest extends TestCase
+{
+    public function test_it_modifies_address_data(): void
+    {
+        $address = $this->createMock(AddressInterface::class);
+        $address->method('getFirstName')->willReturn('Helmut');
+        $address->method('getLastName')->willReturn('Grokenberger');
+        $address->method('getPhoneNumber')->willReturn('+123 123 555 0000');
+        $address->method('getCompany')->willReturn('Berlin Taxi Cooperative');
+        $address->method('getCountryCode')->willReturn('DE');
+        $address->method('getProvinceCode')->willReturn('BE');
+        $address->method('getProvinceName')->willReturn('Berlin');
+        $address->method('getStreet')->willReturn('Fiktive Straße 7');
+        $address->method('getCity')->willReturn('Berlin');
+        $address->method('getPostcode')->willReturn('DE-00000');
+
+        $modifier = new DefaultAddressFormValuesModifier();
+
+        $result = $modifier->modify([], $address);
+
+        $this->assertSame([
+            'firstName' => 'Helmut',
+            'lastName' => 'Grokenberger',
+            'phoneNumber' => '+123 123 555 0000',
+            'company' => 'Berlin Taxi Cooperative',
+            'countryCode' => 'DE',
+            'provinceCode' => 'BE',
+            'provinceName' => 'Berlin',
+            'street' => 'Fiktive Straße 7',
+            'city' => 'Berlin',
+            'postcode' => 'DE-00000',
+        ], $result);
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/issues/17906
| License         | MIT

This PR introduces a new mechanism for extending the checkout address `FormComponent` via tagged services implementing `AddressFormValuesModifierInterface`.

This approach uses dependency injection and a tagged_iterator with the tag `sylius_shop.modifier.address_form_values`. These modifiers allow plugins and applications to dynamically transform or enrich the address data.