### PR TITLE
Fix product creation by admin api

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/ProductAttributeValueDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Denormalizer/ProductAttributeValueDenormalizer.php
@@ -51,6 +51,7 @@ final class ProductAttributeValueDenormalizer implements DenormalizerInterface, 
 
         $this->validateValue($data);
         $data = $this->denormalizeValue($data);
+        $data = $this->ensureAttributeFirst($data);
 
         return $this->denormalizer->denormalize($data, $type, $format, $context);
     }
@@ -67,6 +68,10 @@ final class ProductAttributeValueDenormalizer implements DenormalizerInterface, 
      */
     private function denormalizeValue(array $data): array
     {
+        if (!isset($data['attribute']) || !isset($data['value'])) {
+            return $data;
+        }
+
         /** @var ProductAttributeInterface $attribute */
         $attribute = $this->iriConverter->getResourceFromIri($data['attribute']);
 
@@ -77,9 +82,40 @@ final class ProductAttributeValueDenormalizer implements DenormalizerInterface, 
         return $data;
     }
 
+    /**
+     * Ensures 'attribute' key comes before 'value' in the array to prevent
+     * setValue() being called before setAttribute() during denormalization.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function ensureAttributeFirst(array $data): array
+    {
+        if (!isset($data['attribute'])) {
+            return $data;
+        }
+
+        $result = [];
+
+        $result['attribute'] = $data['attribute'];
+
+        foreach ($data as $key => $value) {
+            if ($key !== 'attribute') {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
     /** @param array<array-key, mixed> $data */
     private function validateValue(array $data): void
     {
+        if (!isset($data['value']) || !isset($data['attribute'])) {
+            return;
+        }
+
         $value = $data['value'];
         if ($value === null) {
             return;

--- a/tests/Api/Admin/ProductsTest.php
+++ b/tests/Api/Admin/ProductsTest.php
@@ -148,6 +148,64 @@ final class ProductsTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_creates_a_product_with_value_before_attribute(): void
+    {
+        $this->loadFixturesFromFiles([
+            'authentication/api_administrator.yaml',
+            'taxonomy.yaml',
+            'product/product_option.yaml',
+            'product/product_attribute.yaml',
+        ]);
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        $this->client->request(
+            method: 'POST',
+            uri: '/api/v2/admin/products',
+            server: $header,
+            content: json_encode([
+                'code' => 'CUP',
+                'variantSelectionMethod' => ProductInterface::VARIANT_SELECTION_MATCH,
+                'enabled' => true,
+                'options' => [
+                    '/api/v2/admin/product-options/COLOR',
+                ],
+                'mainTaxon' => '/api/v2/admin/taxons/MUG',
+                'channels' => [
+                    '/api/v2/admin/channels/WEB_GB',
+                ],
+                'attributes' => [[
+                    'value' => true,
+                    'attribute' => '/api/v2/admin/product-attributes/dishwasher_safe',
+                ]],
+                'translations' => [
+                    'en_US' => [
+                        'slug' => 'cup',
+                        'name' => 'Cup',
+                        'description' => 'This is a cup',
+                        'shortDescription' => 'Short cup description',
+                        'metaKeywords' => 'cup',
+                        'metaDescription' => 'Cup description',
+                    ],
+                    'pl_PL' => [
+                        'slug' => 'filiżanka',
+                        'name' => 'Filiżanka',
+                        'description' => 'To jest filiżanka',
+                        'shortDescription' => 'Krótki opis filiżanki',
+                        'metaKeywords' => 'filiżanka',
+                        'metaDescription' => 'Opis filiżanki',
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/product/post_product_with_value_before_attribute_response',
+            Response::HTTP_CREATED,
+        );
+    }
+
+    #[Test]
     public function it_does_not_create_a_product_without_required_data(): void
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yaml');

--- a/tests/Api/Responses/admin/product/post_product_with_value_before_attribute_response.json
+++ b/tests/Api/Responses/admin/product/post_product_with_value_before_attribute_response.json
@@ -1,0 +1,58 @@
+{
+    "@context": "\/api\/v2\/contexts\/Product",
+    "@id": "\/api\/v2\/admin\/products\/CUP",
+    "@type": "Product",
+    "id": "@integer@",
+    "code": "CUP",
+    "variantSelectionMethod": "match",
+    "enabled": true,
+    "options": [
+        "\/api\/v2\/admin\/product-options\/COLOR"
+    ],
+    "variants": [],
+    "mainTaxon": "\/api\/v2\/admin\/taxons\/MUG",
+    "productTaxons": [],
+    "channels": [
+        "\/api\/v2\/admin\/channels\/WEB_GB"
+    ],
+    "reviews": [],
+    "associations": [],
+    "attributes": [
+        {
+            "@id": "\/api\/v2\/admin\/product-attribute-values\/@integer@",
+            "@type": "ProductAttributeValue",
+            "id": "@integer@",
+            "attribute": "\/api\/v2\/admin\/product-attributes\/dishwasher_safe",
+            "value": true,
+            "localeCode": null
+        }
+    ],
+    "averageRating": 0,
+    "images": [],
+    "translations": {
+        "en_US": {
+            "@id": "\/api\/v2\/admin\/products\/CUP\/translations\/en_US",
+            "@type": "ProductTranslation",
+            "id": "@integer@",
+            "name": "Cup",
+            "slug": "cup",
+            "description": "This is a cup",
+            "shortDescription": "Short cup description",
+            "metaKeywords": "cup",
+            "metaDescription": "Cup description"
+        },
+        "pl_PL": {
+            "@id": "\/api\/v2\/admin\/products\/CUP\/translations\/pl_PL",
+            "@type": "ProductTranslation",
+            "id": "@integer@",
+            "name": "Filiżanka",
+            "slug": "filiżanka",
+            "description": "To jest filiżanka",
+            "shortDescription": "Krótki opis filiżanki",
+            "metaKeywords": "filiżanka",
+            "metaDescription": "Opis filiżanki"
+        }
+    },
+    "createdAt": "@date@",
+    "updatedAt": "@date@"
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - API product creation now accepts product attributes regardless of whether the attribute reference or its value appears first.
  - Added guards to skip processing when required attribute or value fields are missing, preventing spurious validation errors.
- Tests
  - Added test and fixture verifying product creation succeeds when attribute fields are provided in varying orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->