### PR TITLE
Revert "[AdminBundle] Hide Impersonate button when user shop account is locked"

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Details/_email.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Details/_email.html.twig
@@ -11,8 +11,8 @@
             <i class="{{ user.verified ? 'green checkmark' : 'red remove' }} icon"></i>
             {{ 'sylius.ui.email_verified'|trans }}
         </div>
-        {% if is_shop_enabled() and user.isAccountNonLocked and user.enabled %}
         <br />
+        {% if is_shop_enabled() %}
             {{ buttons.default(path('sylius_admin_impersonate_user', {'username': user.emailCanonical}), 'sylius.ui.impersonate', 'impersonate', 'unhide', 'blue') }}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
I’m reverting this as it introduced a soft BC break.  
Ref: https://github.com/Sylius/Sylius/pull/18378#issuecomment-3371108297