### PR TITLE
[FIX] Fixing action clear cart after added address on shipping step

### DIFF
--- a/features/shop/cart/shopping_cart/clearing_cart.feature
+++ b/features/shop/cart/shopping_cart/clearing_cart.feature
@@ -16,7 +16,7 @@ Feature: Clearing cart
         And I clear my cart
         Then my cart should be cleared
 
-    @ui @javascript
+    @api @ui @javascript
     Scenario: Clearing cart after adding an address in checkout
         Given I added product "T-Shirt banana" to the cart
         And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/shop/cart/shopping_cart/clearing_cart.feature
+++ b/features/shop/cart/shopping_cart/clearing_cart.feature
@@ -15,3 +15,11 @@ Feature: Clearing cart
         When I check the details of my cart
         And I clear my cart
         Then my cart should be cleared
+
+    @ui @javascript
+    Scenario: Clearing cart after adding an address in checkout
+        Given I added product "T-Shirt banana" to the cart
+        And I have specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I check the details of my cart
+        And I clear my cart
+        Then my cart should be cleared

--- a/src/Sylius/Behat/Resources/config/suites/api/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/cart/shopping_cart.yml
@@ -18,6 +18,7 @@ default:
 
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.promotion

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -23,6 +23,7 @@ default:
 
                 - sylius.behat.context.setup.cart
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.checkout.address
                 - sylius.behat.context.setup.currency
                 - sylius.behat.context.setup.exchange_rate
                 - sylius.behat.context.setup.product

--- a/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/Component/Cart/FormComponent.php
@@ -96,6 +96,11 @@ class FormComponent
         $this->manager->remove($this->resource);
         $this->manager->flush();
 
+        $this->resource = $this->createResource();
+        $this->resetForm();
+        $this->isValidated = false;
+        $this->validatedFields = [];
+
         $this->shouldSaveCart = false;
         $this->submitForm();
         $this->emit(self::SYLIUS_SHOP_CART_CLEARED);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18421 
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing the cart now fully resets the cart and its form, removing lingering validation state and previously entered data; a fresh cart is created automatically after clearing for more reliable checkout behavior.

* **Tests**
  * Added a UI scenario for clearing the cart after entering a billing address and updated UI/API test suites to include checkout address setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->