### PR TITLE
Remove phpspec/prophecy-phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -214,7 +214,6 @@
         "mockery/mockery": "^1.6",
         "nyholm/psr7": "^1.8",
         "phparkitect/phparkitect": "^0.6",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -41,7 +41,6 @@
         "doctrine/doctrine-bundle": "^2.13",
         "doctrine/orm": "^2.18 || ^3.3",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "^6.4 || ^7.2",
         "symfony/dependency-injection": "^6.4.1 || ^7.2",

--- a/src/Sylius/Bundle/AddressingBundle/tests/Form/Type/CountryChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/tests/Form/Type/CountryChoiceTypeTest.php
@@ -15,9 +15,7 @@ namespace Tests\Sylius\Bundle\AddressingBundle\Form\Type;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophecy\ProphecyInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\AddressingBundle\Form\Type\CountryChoiceType;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -27,48 +25,37 @@ use Symfony\Component\Form\Test\TypeTestCase;
 
 final class CountryChoiceTypeTest extends TypeTestCase
 {
-    use ProphecyTrait;
+    private RepositoryInterface&MockObject $countryRepository;
 
-    private ObjectProphecy $countryRepository;
+    private CountryInterface&MockObject $france;
 
-    /** @var ProphecyInterface|CountryInterface */
-    private $france;
+    private CountryInterface&MockObject $poland;
 
-    /** @var ProphecyInterface|CountryInterface */
-    private $poland;
-
-    /** @var ProphecyInterface|CountryInterface */
-    private $austria;
+    private CountryInterface&MockObject $austria;
 
     protected function setUp(): void
     {
-        $this->countryRepository = $this->prophesize(RepositoryInterface::class);
+        $this->countryRepository = $this->createMock(RepositoryInterface::class);
 
-        /** @var ProphecyInterface|CountryInterface $france */
-        $france = $this->prophesize(CountryInterface::class);
-        $france->getCode()->willReturn('FR');
-        $france->getName()->willReturn('France');
-        $this->france = $france;
+        $this->france = $this->createMock(CountryInterface::class);
+        $this->france->method('getCode')->willReturn('FR');
+        $this->france->method('getName')->willReturn('France');
 
-        /** @var ProphecyInterface|CountryInterface $poland */
-        $poland = $this->prophesize(CountryInterface::class);
-        $poland->getCode()->willReturn('PL');
-        $poland->getName()->willReturn('Poland');
-        $this->poland = $poland;
+        $this->poland = $this->createMock(CountryInterface::class);
+        $this->poland->method('getCode')->willReturn('PL');
+        $this->poland->method('getName')->willReturn('Poland');
 
-        /** @var ProphecyInterface|CountryInterface $austria */
-        $austria = $this->prophesize(CountryInterface::class);
-        $austria->getCode()->willReturn('AT');
-        $austria->getName()->willReturn('Austria');
-        $austria->isEnabled()->willReturn(false);
-        $this->austria = $austria;
+        $this->austria = $this->createMock(CountryInterface::class);
+        $this->austria->method('getCode')->willReturn('AT');
+        $this->austria->method('getName')->willReturn('Austria');
+        $this->austria->method('isEnabled')->willReturn(false);
 
         parent::setUp();
     }
 
     protected function getExtensions(): array
     {
-        $type = new CountryChoiceType($this->countryRepository->reveal());
+        $type = new CountryChoiceType($this->countryRepository);
 
         return [
             new PreloadedExtension([$type], []),
@@ -78,10 +65,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_only_enabled_countries_by_default(): void
     {
-        $this->countryRepository->findBy(['enabled' => true])->willReturn([
-            $this->france->reveal(),
-            $this->poland->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findBy')
+            ->with(['enabled' => true])
+            ->willReturn([
+                $this->france,
+                $this->poland,
+            ]);
 
         $this->assertChoicesLabels(['France', 'Poland']);
     }
@@ -89,11 +80,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_all_countries_when_option_enabled_is_false(): void
     {
-        $this->countryRepository->findAll()->willReturn([
-            $this->france->reveal(),
-            $this->poland->reveal(),
-            $this->austria->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findAll')
+            ->willReturn([
+                $this->france,
+                $this->poland,
+                $this->austria,
+            ]);
 
         $this->assertChoicesLabels(['Austria', 'France', 'Poland'], ['enabled' => false]);
     }
@@ -101,10 +95,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_enabled_countries_in_an_alphabetical_order(): void
     {
-        $this->countryRepository->findBy(['enabled' => true])->willReturn([
-            $this->poland->reveal(),
-            $this->france->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findBy')
+            ->with(['enabled' => true])
+            ->willReturn([
+                $this->poland,
+                $this->france,
+            ]);
 
         $this->assertChoicesLabels(['France', 'Poland']);
     }
@@ -112,11 +110,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_all_countries_in_an_alphabetical_order(): void
     {
-        $this->countryRepository->findAll()->willReturn([
-            $this->poland->reveal(),
-            $this->france->reveal(),
-            $this->austria->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findAll')
+            ->willReturn([
+                $this->poland,
+                $this->france,
+                $this->austria,
+            ]);
 
         $this->assertChoicesLabels(['Austria', 'France', 'Poland'], ['enabled' => false]);
     }
@@ -124,11 +125,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_all_filtered_out_countries(): void
     {
-        $this->countryRepository->findAll()->willReturn([
-            $this->france->reveal(),
-            $this->poland->reveal(),
-            $this->austria->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findAll')
+            ->willReturn([
+                $this->france,
+                $this->poland,
+                $this->austria,
+            ]);
 
         $this->assertChoicesLabels(['Poland'], ['choice_filter' => static fn (?CountryInterface $country): bool => $country !== null && $country->getName() === 'Poland', 'enabled' => false]);
     }
@@ -136,10 +140,14 @@ final class CountryChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_enabled_filtered_out_countries(): void
     {
-        $this->countryRepository->findBy(['enabled' => true])->willReturn([
-            $this->france->reveal(),
-            $this->poland->reveal(),
-        ]);
+        $this->countryRepository
+            ->expects($this->once())
+            ->method('findBy')
+            ->with(['enabled' => true])
+            ->willReturn([
+                $this->france,
+                $this->poland,
+            ]);
 
         $this->assertChoicesLabels(['Poland'], ['choice_filter' => static fn (?CountryInterface $country): bool => $country !== null && $country->getName() === 'Poland']);
     }

--- a/src/Sylius/Bundle/AddressingBundle/tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/tests/Form/Type/ZoneChoiceTypeTest.php
@@ -15,9 +15,7 @@ namespace Tests\Sylius\Bundle\AddressingBundle\Form\Type;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophecy\ProphecyInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
 use Sylius\Component\Addressing\Model\Scope as AddressingScope;
 use Sylius\Component\Addressing\Model\ZoneInterface;
@@ -28,39 +26,31 @@ use Symfony\Component\Form\Test\TypeTestCase;
 
 final class ZoneChoiceTypeTest extends TypeTestCase
 {
-    use ProphecyTrait;
+    private RepositoryInterface&MockObject $zoneRepository;
 
-    private ObjectProphecy $zoneRepository;
+    private ZoneInterface&MockObject $zoneAllScopes;
 
-    /** @var ProphecyInterface|ZoneInterface */
-    private $zoneAllScopes;
+    private ZoneInterface&MockObject $zoneTaxScope;
 
-    /** @var ProphecyInterface|ZoneInterface */
-    private $zoneTaxScope;
-
-    /** @var ProphecyInterface|ZoneInterface */
-    private $zoneShippingScope;
+    private ZoneInterface&MockObject $zoneShippingScope;
 
     protected function setUp(): void
     {
-        $this->zoneRepository = $this->prophesize(RepositoryInterface::class);
+        $this->zoneRepository = $this->createMock(RepositoryInterface::class);
 
-        /** @var ProphecyInterface|ZoneInterface $zoneAllScopes */
-        $zoneAllScopes = $this->prophesize(ZoneInterface::class);
-        $zoneAllScopes->getCode()->willReturn('all');
-        $zoneAllScopes->getName()->willReturn('All');
+        $zoneAllScopes = $this->createMock(ZoneInterface::class);
+        $zoneAllScopes->method('getCode')->willReturn('all');
+        $zoneAllScopes->method('getName')->willReturn('All');
         $this->zoneAllScopes = $zoneAllScopes;
 
-        /** @var ProphecyInterface|ZoneInterface $zoneTaxScope */
-        $zoneTaxScope = $this->prophesize(ZoneInterface::class);
-        $zoneTaxScope->getCode()->willReturn('tax');
-        $zoneTaxScope->getName()->willReturn('Tax');
+        $zoneTaxScope = $this->createMock(ZoneInterface::class);
+        $zoneTaxScope->method('getCode')->willReturn('tax');
+        $zoneTaxScope->method('getName')->willReturn('Tax');
         $this->zoneTaxScope = $zoneTaxScope;
 
-        /** @var ProphecyInterface|ZoneInterface $zoneShippingScope */
-        $zoneShippingScope = $this->prophesize(ZoneInterface::class);
-        $zoneShippingScope->getCode()->willReturn('shipping');
-        $zoneShippingScope->getName()->willReturn('Shipping');
+        $zoneShippingScope = $this->createMock(ZoneInterface::class);
+        $zoneShippingScope->method('getCode')->willReturn('shipping');
+        $zoneShippingScope->method('getName')->willReturn('Shipping');
         $this->zoneShippingScope = $zoneShippingScope;
 
         parent::setUp();
@@ -74,7 +64,7 @@ final class ZoneChoiceTypeTest extends TypeTestCase
             'shipping' => 'Shipping',
         ];
 
-        $type = new ZoneChoiceType($this->zoneRepository->reveal(), $scopeTypes);
+        $type = new ZoneChoiceType($this->zoneRepository, $scopeTypes);
 
         return [
             new PreloadedExtension([$type], []),
@@ -84,10 +74,10 @@ final class ZoneChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_all_scopes_by_default(): void
     {
-        $this->zoneRepository->findBy([])->willReturn([
-            $this->zoneAllScopes->reveal(),
-            $this->zoneTaxScope->reveal(),
-            $this->zoneShippingScope->reveal(),
+        $this->zoneRepository->method('findBy')->with([])->willReturn([
+            $this->zoneAllScopes,
+            $this->zoneTaxScope,
+            $this->zoneShippingScope,
         ]);
 
         $this->assertChoicesLabels(['All', 'Tax', 'Shipping']);
@@ -96,10 +86,10 @@ final class ZoneChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_all_scopes_when_zone_scope_set_to_all(): void
     {
-        $this->zoneRepository->findBy([])->willReturn([
-            $this->zoneAllScopes->reveal(),
-            $this->zoneTaxScope->reveal(),
-            $this->zoneShippingScope->reveal(),
+        $this->zoneRepository->method('findBy')->with([])->willReturn([
+            $this->zoneAllScopes,
+            $this->zoneTaxScope,
+            $this->zoneShippingScope,
         ]);
 
         $this->assertChoicesLabels(['All', 'Tax', 'Shipping'], ['zone_scope' => AddressingScope::ALL]);
@@ -108,9 +98,9 @@ final class ZoneChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_tax_scopes_when_zone_scope_set_to_tax(): void
     {
-        $this->zoneRepository->findBy(['scope' => ['tax', AddressingScope::ALL]])->willReturn([
-            $this->zoneAllScopes->reveal(),
-            $this->zoneTaxScope->reveal(),
+        $this->zoneRepository->method('findBy')->with(['scope' => ['tax', AddressingScope::ALL]])->willReturn([
+            $this->zoneAllScopes,
+            $this->zoneTaxScope,
         ]);
 
         $this->assertChoicesLabels(['All', 'Tax'], ['zone_scope' => 'tax']);
@@ -119,9 +109,9 @@ final class ZoneChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_returns_shipping_scopes_when_zone_scope_set_to_shipping(): void
     {
-        $this->zoneRepository->findBy(['scope' => ['shipping', AddressingScope::ALL]])->willReturn([
-            $this->zoneAllScopes->reveal(),
-            $this->zoneShippingScope->reveal(),
+        $this->zoneRepository->method('findBy')->with(['scope' => ['shipping', AddressingScope::ALL]])->willReturn([
+            $this->zoneAllScopes,
+            $this->zoneShippingScope,
         ]);
 
         $this->assertChoicesLabels(['All', 'Shipping'], ['zone_scope' => 'shipping']);

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -51,7 +51,6 @@
         "doctrine/orm": "^2.18 || ^3.3",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "php-http/message-factory": "^1.1",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5",
         "symfony/dependency-injection": "^6.4.1 || ^7.2",
         "symfony/dotenv": "^6.4 || ^7.2"

--- a/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
@@ -15,10 +15,8 @@ namespace Tests\Sylius\Bundle\AdminBundle\Notification;
 
 use GuzzleHttp\Exception\ConnectException;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -34,19 +32,17 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class HubNotificationProviderTest extends TestCase
 {
-    use ProphecyTrait;
+    private ClientInterface&MockObject $client;
 
-    private ClientInterface|ObjectProphecy $client;
+    private RequestStack&MockObject $requestStack;
 
-    private ObjectProphecy|RequestStack $requestStack;
+    private RequestFactoryInterface&MockObject $requestFactory;
 
-    private ObjectProphecy|RequestFactoryInterface $requestFactory;
+    private StreamFactoryInterface&MockObject $streamFactory;
 
-    private ObjectProphecy|StreamFactoryInterface $streamFactory;
+    private CacheInterface&MockObject $cache;
 
-    private CacheInterface|ObjectProphecy $cache;
-
-    private ClockInterface|ObjectProphecy $clock;
+    private ClockInterface&MockObject $clock;
 
     private HubNotificationProvider $hubNotificationsProvider;
 
@@ -56,20 +52,20 @@ final class HubNotificationProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->client = $this->prophesize(ClientInterface::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->requestFactory = $this->prophesize(RequestFactoryInterface::class);
-        $this->streamFactory = $this->prophesize(StreamFactoryInterface::class);
-        $this->cache = $this->prophesize(CacheInterface::class);
-        $this->clock = $this->prophesize(ClockInterface::class);
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->clock = $this->createMock(ClockInterface::class);
 
         $this->hubNotificationsProvider = new HubNotificationProvider(
-            $this->client->reveal(),
-            $this->requestStack->reveal(),
-            $this->requestFactory->reveal(),
-            $this->streamFactory->reveal(),
-            $this->cache->reveal(),
-            $this->clock->reveal(),
+            $this->client,
+            $this->requestStack,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->cache,
+            $this->clock,
             self::$hubUri,
             'prod',
             true,
@@ -80,20 +76,51 @@ final class HubNotificationProviderTest extends TestCase
     #[Test]
     public function it_returns_an_empty_array_if_client_exception_occurs(): void
     {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
 
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
+        $this->cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('latest_sylius_version', $this->isType('callable'))
+            ->willReturnCallback(fn ($key, $callback) => $callback());
 
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn(new Request());
 
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
+        $this->clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn(new \DateTimeImmutable());
 
-        $this->client->sendRequest(Argument::cetera())->willThrow(ConnectException::class);
+        $this->streamFactory
+            ->expects($this->once())
+            ->method('createStream')
+            ->willReturn($stream);
+
+        $this->requestFactory
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn($request);
+
+        $request
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Content-Type', 'application/json')
+            ->willReturn($request);
+
+        $request
+            ->expects($this->once())
+            ->method('withBody')
+            ->with($stream)
+            ->willReturn($request);
+
+        $this->client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willThrowException(new ConnectException('Connection failed', $this->createMock(\Psr\Http\Message\RequestInterface::class)));
 
         $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
     }
@@ -101,25 +128,63 @@ final class HubNotificationProviderTest extends TestCase
     #[Test]
     public function it_returns_an_empty_array_if_the_current_version_is_the_same_as_latest(): void
     {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $externalResponse = $this->createMock(ResponseInterface::class);
 
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
+        $this->cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('latest_sylius_version', $this->isType('callable'))
+            ->willReturnCallback(fn ($key, $callback) => $callback());
 
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn(new Request());
+
+        $this->clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn(new \DateTimeImmutable());
+
+        $this->streamFactory
+            ->expects($this->once())
+            ->method('createStream')
+            ->willReturn($stream);
 
         $content = json_encode(['version' => SyliusCoreBundle::VERSION]);
-        $stream->getContents()->willReturn($content);
+        $stream
+            ->expects($this->once())
+            ->method('getContents')
+            ->willReturn($content);
 
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
+        $this->requestFactory
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn($request);
 
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
+        $request
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Content-Type', 'application/json')
+            ->willReturn($request);
+
+        $request
+            ->expects($this->once())
+            ->method('withBody')
+            ->with($stream)
+            ->willReturn($request);
+
+        $externalResponse
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $this->client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($externalResponse);
 
         $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
     }
@@ -127,25 +192,63 @@ final class HubNotificationProviderTest extends TestCase
     #[Test]
     public function it_returns_a_notification_if_the_current_version_is_different_than_latest(): void
     {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
+        $request = $this->createMock(RequestInterface::class);
+        $stream = $this->createMock(StreamInterface::class);
+        $externalResponse = $this->createMock(ResponseInterface::class);
 
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
+        $this->cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('latest_sylius_version', $this->isType('callable'))
+            ->willReturnCallback(fn ($key, $callback) => $callback());
 
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn(new Request());
+
+        $this->clock
+            ->expects($this->once())
+            ->method('now')
+            ->willReturn(new \DateTimeImmutable());
+
+        $this->streamFactory
+            ->expects($this->once())
+            ->method('createStream')
+            ->willReturn($stream);
 
         $content = json_encode(['version' => '1.0.0']);
-        $stream->getContents()->willReturn($content);
+        $stream
+            ->expects($this->once())
+            ->method('getContents')
+            ->willReturn($content);
 
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
+        $this->requestFactory
+            ->expects($this->once())
+            ->method('createRequest')
+            ->willReturn($request);
 
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
+        $request
+            ->expects($this->once())
+            ->method('withHeader')
+            ->with('Content-Type', 'application/json')
+            ->willReturn($request);
+
+        $request
+            ->expects($this->once())
+            ->method('withBody')
+            ->with($stream)
+            ->willReturn($request);
+
+        $externalResponse
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn($stream);
+
+        $this->client
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($externalResponse);
 
         $notifications = $this->hubNotificationsProvider->getNotifications();
 

--- a/src/Sylius/Bundle/AdminBundle/tests/Twig/Component/Shared/Navbar/NotificationsComponentTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Twig/Component/Shared/Navbar/NotificationsComponentTest.php
@@ -14,17 +14,14 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\AdminBundle\Twig\Component\Shared\Navbar;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Bundle\AdminBundle\Notification\NotificationProviderInterface;
 use Sylius\Bundle\AdminBundle\Twig\Component\Shared\Navbar\NotificationsComponent;
 
 final class NotificationsComponentTest extends TestCase
 {
-    use ProphecyTrait;
-
-    private NotificationProviderInterface|ObjectProphecy $notificationProvider;
+    private NotificationProviderInterface&MockObject $notificationProvider;
 
     private NotificationsComponent $notificationsComponent;
 
@@ -34,15 +31,15 @@ final class NotificationsComponentTest extends TestCase
     {
         parent::setUp();
 
-        $this->notificationProvider = $this->prophesize(NotificationProviderInterface::class);
+        $this->notificationProvider = $this->createMock(NotificationProviderInterface::class);
 
-        $this->notificationsComponent = new NotificationsComponent($this->notificationProvider->reveal(), true);
+        $this->notificationsComponent = new NotificationsComponent($this->notificationProvider, true);
     }
 
     #[Test]
     public function it_gets_notifications_from_provider(): void
     {
-        $this->notificationProvider->getNotifications()->willReturn(['version' => ['message' => 'sylius.ui.notifications.new_version_of_sylius_available']]);
+        $this->notificationProvider->method('getNotifications')->willReturn(['version' => ['message' => 'sylius.ui.notifications.new_version_of_sylius_available']]);
 
         $notifications = $this->notificationsComponent->getNotifications();
 

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -38,7 +38,6 @@
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "nelmio/alice": "^3.13",
         "phparkitect/phparkitect": "^0.6",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "^6.4 || ^7.2",
         "symfony/debug-bundle": "^6.4 || ^7.2",

--- a/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/ApiLoaderTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/ApiLoaderTest.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\ApiBundle\ApiPlatform\Routing;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Bundle\ApiBundle\ApiPlatform\Routing\ApiLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
@@ -24,18 +23,16 @@ use Symfony\Component\Routing\RouteCollection;
 
 final class ApiLoaderTest extends TestCase
 {
-    use ProphecyTrait;
-
-    private LoaderInterface|ObjectProphecy $baseApiLoader;
+    private LoaderInterface&MockObject $baseApiLoader;
 
     private LoaderInterface $apiLoader;
 
     protected function setUp(): void
     {
-        $this->baseApiLoader = $this->prophesize(LoaderInterface::class);
+        $this->baseApiLoader = $this->createMock(LoaderInterface::class);
 
         $this->apiLoader = new ApiLoader(
-            $this->baseApiLoader->reveal(),
+            $this->baseApiLoader,
             [
                 'sylius_api_shop_currency_get',
                 'sylius_api_shop_currency_get_collection',
@@ -52,24 +49,33 @@ final class ApiLoaderTest extends TestCase
     #[Test]
     public function it_removes_routes_from_route_collection_loaded_by_base_api_loader(): void
     {
-        $routeCollection = $this->prophesize(RouteCollection::class);
+        $routeCollection = $this->createMock(RouteCollection::class);
 
-        $this->baseApiLoader->load('.', 'api_platform')->willReturn($routeCollection);
+        $this->baseApiLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with('.', 'api_platform')
+            ->willReturn($routeCollection);
+
         $routeCollection
-            ->remove([
+            ->expects($this->once())
+            ->method('remove')
+            ->with([
                 'sylius_api_shop_currency_get',
                 'sylius_api_shop_currency_get_collection',
-            ])
-            ->shouldBeCalled()
-        ;
+            ]);
 
-        $this->assertSame($routeCollection->reveal(), $this->apiLoader->load('.', 'api_platform'));
+        $this->assertSame($routeCollection, $this->apiLoader->load('.', 'api_platform'));
     }
 
     #[Test]
     public function it_uses_base_api_loader_for_supports_method(): void
     {
-        $this->baseApiLoader->supports('.', 'api_platform')->willReturn(true);
+        $this->baseApiLoader
+            ->expects($this->once())
+            ->method('supports')
+            ->with('.', 'api_platform')
+            ->willReturn(true);
 
         $this->assertTrue($this->apiLoader->supports('.', 'api_platform'));
     }
@@ -77,20 +83,26 @@ final class ApiLoaderTest extends TestCase
     #[Test]
     public function it_uses_base_api_loader_to_get_resolver(): void
     {
-        $loaderResolver = $this->prophesize(LoaderResolverInterface::class);
+        $loaderResolver = $this->createMock(LoaderResolverInterface::class);
 
-        $this->baseApiLoader->getResolver()->willReturn($loaderResolver);
+        $this->baseApiLoader
+            ->expects($this->once())
+            ->method('getResolver')
+            ->willReturn($loaderResolver);
 
-        $this->assertSame($loaderResolver->reveal(), $this->apiLoader->getResolver());
+        $this->assertSame($loaderResolver, $this->apiLoader->getResolver());
     }
 
     #[Test]
     public function it_uses_base_api_loader_to_set_resolver(): void
     {
-        $loaderResolver = $this->prophesize(LoaderResolverInterface::class);
+        $loaderResolver = $this->createMock(LoaderResolverInterface::class);
 
-        $this->baseApiLoader->setResolver($loaderResolver->reveal())->shouldBeCalled();
+        $this->baseApiLoader
+            ->expects($this->once())
+            ->method('setResolver')
+            ->with($loaderResolver);
 
-        $this->apiLoader->setResolver($loaderResolver->reveal());
+        $this->apiLoader->setResolver($loaderResolver);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/CommandHandler/AddPaymentRequestHandlerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/CommandHandler/AddPaymentRequestHandlerTest.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\ApiBundle\CommandHandler;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Bundle\ApiBundle\Command\Payment\AddPaymentRequest;
 use Sylius\Bundle\ApiBundle\CommandHandler\Payment\AddPaymentRequestHandler;
 use Sylius\Bundle\ApiBundle\Exception\PaymentMethodNotFoundException;
@@ -33,38 +32,36 @@ use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 
 final class AddPaymentRequestHandlerTest extends TestCase
 {
-    use ProphecyTrait;
+    private PaymentMethodRepositoryInterface&MockObject $paymentMethodRepository;
 
-    private ObjectProphecy|PaymentMethodRepositoryInterface $paymentMethodRepository;
+    private PaymentRepositoryInterface&MockObject $paymentRepository;
 
-    private ObjectProphecy|PaymentRepositoryInterface $paymentRepository;
+    private PaymentRequestFactoryInterface&MockObject $paymentRequestFactory;
 
-    private ObjectProphecy|PaymentRequestFactoryInterface $paymentRequestFactory;
+    private PaymentRequestRepositoryInterface&MockObject $paymentRequestRepository;
 
-    private ObjectProphecy|PaymentRequestRepositoryInterface $paymentRequestRepository;
+    private DefaultActionProviderInterface&MockObject $defaultActionProvider;
 
-    private DefaultActionProviderInterface|ObjectProphecy $defaultActionProvider;
-
-    private DefaultPayloadProviderInterface|ObjectProphecy $defaultPayloadProvider;
+    private DefaultPayloadProviderInterface&MockObject $defaultPayloadProvider;
 
     private AddPaymentRequestHandler $addPaymentRequestHandler;
 
     protected function setUp(): void
     {
-        $this->paymentMethodRepository = $this->prophesize(PaymentMethodRepositoryInterface::class);
-        $this->paymentRepository = $this->prophesize(PaymentRepositoryInterface::class);
-        $this->paymentRequestFactory = $this->prophesize(PaymentRequestFactoryInterface::class);
-        $this->paymentRequestRepository = $this->prophesize(PaymentRequestRepositoryInterface::class);
-        $this->defaultActionProvider = $this->prophesize(DefaultActionProviderInterface::class);
-        $this->defaultPayloadProvider = $this->prophesize(DefaultPayloadProviderInterface::class);
+        $this->paymentMethodRepository = $this->createMock(PaymentMethodRepositoryInterface::class);
+        $this->paymentRepository = $this->createMock(PaymentRepositoryInterface::class);
+        $this->paymentRequestFactory = $this->createMock(PaymentRequestFactoryInterface::class);
+        $this->paymentRequestRepository = $this->createMock(PaymentRequestRepositoryInterface::class);
+        $this->defaultActionProvider = $this->createMock(DefaultActionProviderInterface::class);
+        $this->defaultPayloadProvider = $this->createMock(DefaultPayloadProviderInterface::class);
 
         $this->addPaymentRequestHandler = new AddPaymentRequestHandler(
-            $this->paymentMethodRepository->reveal(),
-            $this->paymentRepository->reveal(),
-            $this->paymentRequestFactory->reveal(),
-            $this->paymentRequestRepository->reveal(),
-            $this->defaultActionProvider->reveal(),
-            $this->defaultPayloadProvider->reveal(),
+            $this->paymentMethodRepository,
+            $this->paymentRepository,
+            $this->paymentRequestFactory,
+            $this->paymentRequestRepository,
+            $this->defaultActionProvider,
+            $this->defaultPayloadProvider,
         );
     }
 
@@ -73,7 +70,7 @@ final class AddPaymentRequestHandlerTest extends TestCase
     {
         self::expectException(PaymentNotFoundException::class);
 
-        $this->paymentRepository->findOneByOrderToken(1, 'token')->willReturn(null);
+        $this->paymentRepository->method('findOneByOrderToken')->with(1, 'token')->willReturn(null);
 
         $this->addPaymentRequestHandler->__invoke(new AddPaymentRequest('token', 1, 'bank_transfer'));
     }
@@ -83,10 +80,10 @@ final class AddPaymentRequestHandlerTest extends TestCase
     {
         self::expectException(PaymentMethodNotFoundException::class);
 
-        $payment = $this->prophesize(PaymentInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
 
-        $this->paymentRepository->findOneByOrderToken(1, 'token')->willReturn($payment->reveal());
-        $this->paymentMethodRepository->findOneBy(['code' => 'bank_transfer'])->willReturn(null);
+        $this->paymentRepository->method('findOneByOrderToken')->with(1, 'token')->willReturn($payment);
+        $this->paymentMethodRepository->method('findOneBy')->with(['code' => 'bank_transfer'])->willReturn(null);
 
         $this->addPaymentRequestHandler->__invoke(new AddPaymentRequest('token', 1, 'bank_transfer'));
     }
@@ -94,21 +91,21 @@ final class AddPaymentRequestHandlerTest extends TestCase
     #[Test]
     public function it_creates_a_payment_request(): void
     {
-        $payment = $this->prophesize(PaymentInterface::class);
-        $paymentMethod = $this->prophesize(PaymentMethodInterface::class);
-        $paymentRequest = $this->prophesize(PaymentRequestInterface::class);
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentMethod = $this->createMock(PaymentMethodInterface::class);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
 
-        $this->paymentRepository->findOneByOrderToken(1, 'token')->willReturn($payment->reveal());
-        $this->paymentMethodRepository->findOneBy(['code' => 'bank_transfer'])->willReturn($paymentMethod->reveal());
-        $this->defaultActionProvider->getAction($paymentRequest)->willReturn('authorize');
-        $this->defaultPayloadProvider->getPayload($paymentRequest)->willReturn(['foo' => 'bar']);
+        $this->paymentRepository->method('findOneByOrderToken')->with(1, 'token')->willReturn($payment);
+        $this->paymentMethodRepository->method('findOneBy')->with(['code' => 'bank_transfer'])->willReturn($paymentMethod);
+        $this->defaultActionProvider->method('getAction')->with($paymentRequest)->willReturn('authorize');
+        $this->defaultPayloadProvider->method('getPayload')->with($paymentRequest)->willReturn(['foo' => 'bar']);
 
-        $this->paymentRequestFactory->create($payment->reveal(), $paymentMethod->reveal())->willReturn($paymentRequest->reveal());
-        $paymentRequest->setAction('authorize')->shouldBeCalled();
-        $paymentRequest->setPayload(['foo' => 'bar'])->shouldBeCalled();
+        $this->paymentRequestFactory->method('create')->with($payment, $paymentMethod)->willReturn($paymentRequest);
+        $paymentRequest->expects($this->once())->method('setAction')->with('authorize');
+        $paymentRequest->expects($this->once())->method('setPayload')->with(['foo' => 'bar']);
 
         self::assertSame(
-            $paymentRequest->reveal(),
+            $paymentRequest,
             $this->addPaymentRequestHandler->__invoke(
                 new AddPaymentRequest('token', 1, 'bank_transfer'),
             ),

--- a/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
@@ -217,7 +217,7 @@ final class IriToIdentifierConverterTest extends TestCase
 
         $operation = $this->createMock(HttpOperation::class);
         $operation
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getClass')
             ->willReturn(AddProductReview::class);
 
@@ -258,7 +258,7 @@ final class IriToIdentifierConverterTest extends TestCase
     {
         $operation = $this->createMock(HttpOperation::class);
         $operation
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getClass')
             ->willReturn(AddProductReview::class);
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Converter/IriToIdentifierConverterTest.php
@@ -20,10 +20,8 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\UriVariablesConverterInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview;
 use Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverter;
 use Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface;
@@ -33,26 +31,24 @@ use Symfony\Component\Routing\RouterInterface;
 
 final class IriToIdentifierConverterTest extends TestCase
 {
-    use ProphecyTrait;
+    private RouterInterface&MockObject $router;
 
-    private ObjectProphecy|RouterInterface $router;
+    private ResourceMetadataCollectionFactoryInterface&MockObject $metadataFactory;
 
-    private ObjectProphecy|ResourceMetadataCollectionFactoryInterface $metadataFactory;
-
-    private ObjectProphecy|UriVariablesConverterInterface $uriVariablesConverter;
+    private UriVariablesConverterInterface&MockObject $uriVariablesConverter;
 
     private IriToIdentifierConverterInterface $converter;
 
     protected function setUp(): void
     {
-        $this->router = $this->prophesize(RouterInterface::class);
-        $this->metadataFactory = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $this->uriVariablesConverter = $this->prophesize(UriVariablesConverterInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->metadataFactory = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $this->uriVariablesConverter = $this->createMock(UriVariablesConverterInterface::class);
 
         $this->converter = new IriToIdentifierConverter(
-            $this->router->reveal(),
-            $this->metadataFactory->reveal(),
-            $this->uriVariablesConverter->reveal(),
+            $this->router,
+            $this->metadataFactory,
+            $this->uriVariablesConverter,
         );
     }
 
@@ -60,7 +56,9 @@ final class IriToIdentifierConverterTest extends TestCase
     #[Test]
     public function it_treats_non_string_values_as_not_identifiers(mixed $invalidValue): void
     {
-        $this->router->match(Argument::any())->shouldNotBeCalled();
+        $this->router
+            ->expects($this->never())
+            ->method('match');
 
         $this->assertFalse($this->converter->isIdentifier($invalidValue));
     }
@@ -68,7 +66,11 @@ final class IriToIdentifierConverterTest extends TestCase
     #[Test]
     public function it_treats_not_matched_strings_as_not_identifiers(): void
     {
-        $this->router->match('test')->willThrow(new SymfonyRouteNotFoundException());
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('test')
+            ->willThrowException(new SymfonyRouteNotFoundException());
 
         $this->assertFalse($this->converter->isIdentifier('test'));
     }
@@ -76,7 +78,11 @@ final class IriToIdentifierConverterTest extends TestCase
     #[Test]
     public function it_treats_strings_matched_on_routes_with_no_resource_class_parameter_as_not_identifiers(): void
     {
-        $this->router->match('test')->willReturn([]);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('test')
+            ->willReturn([]);
 
         $this->assertFalse($this->converter->isIdentifier('test'));
     }
@@ -84,9 +90,13 @@ final class IriToIdentifierConverterTest extends TestCase
     #[Test]
     public function it_treats_strings_matched_on_routes_with_resource_class_parameter_as_identifiers(): void
     {
-        $this->router->match('test')->willReturn([
-            '_api_resource_class' => 'test',
-        ]);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('test')
+            ->willReturn([
+                '_api_resource_class' => 'test',
+            ]);
 
         $this->assertTrue($this->converter->isIdentifier('test'));
     }
@@ -96,9 +106,11 @@ final class IriToIdentifierConverterTest extends TestCase
     public function it_sanitizes_url_before_matching_for_various_characters(string $rawUrl): void
     {
         $sanitized = filter_var($rawUrl, \FILTER_SANITIZE_URL);
-        $this->router->match(Argument::that(fn ($arg) => $arg === $sanitized))
-            ->willReturn(['_api_resource_class' => 'test'])
-            ->shouldBeCalled();
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with($sanitized)
+            ->willReturn(['_api_resource_class' => 'test']);
 
         $this->assertTrue($this->converter->isIdentifier($rawUrl));
     }
@@ -109,9 +121,11 @@ final class IriToIdentifierConverterTest extends TestCase
     {
         $sanitized = filter_var($rawUrl, \FILTER_SANITIZE_URL);
 
-        $this->router->match(Argument::that(fn ($arg) => $arg === $sanitized))
-            ->willThrow(new SymfonyRouteNotFoundException())
-            ->shouldBeCalled();
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with($sanitized)
+            ->willThrowException(new SymfonyRouteNotFoundException());
 
         $this->assertFalse($this->converter->isIdentifier($rawUrl));
     }
@@ -122,9 +136,11 @@ final class IriToIdentifierConverterTest extends TestCase
         $rawUrl = "api/v2/produc\nts/2";
         $sanitized = filter_var($rawUrl, \FILTER_SANITIZE_URL);
 
-        $this->router->match(Argument::that(fn ($arg) => $arg === $sanitized))
-            ->willReturn(['_api_resource_class' => 'test'])
-            ->shouldBeCalled();
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with($sanitized)
+            ->willReturn(['_api_resource_class' => 'test']);
 
         $this->assertTrue($this->converter->isIdentifier($rawUrl));
     }
@@ -135,9 +151,11 @@ final class IriToIdentifierConverterTest extends TestCase
         $rawUrl = "api/v2/produc\nts/3";
         $sanitized = filter_var($rawUrl, \FILTER_SANITIZE_URL);
 
-        $this->router->match(Argument::that(fn ($arg) => $arg === $sanitized))
-            ->willThrow(new SymfonyRouteNotFoundException())
-            ->shouldBeCalled();
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with($sanitized)
+            ->willThrowException(new SymfonyRouteNotFoundException());
 
         $this->assertFalse($this->converter->isIdentifier($rawUrl));
     }
@@ -148,7 +166,11 @@ final class IriToIdentifierConverterTest extends TestCase
         self::expectException(ApiRouteNotFoundException::class);
         self::expectExceptionMessage('No route matches "/users/3".');
 
-        $this->router->match('/users/3')->willThrow(new SymfonyRouteNotFoundException())->shouldBeCalledTimes(1);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('/users/3')
+            ->willThrowException(new SymfonyRouteNotFoundException());
 
         $this->converter->getIdentifier('/users/3');
     }
@@ -159,9 +181,13 @@ final class IriToIdentifierConverterTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('No resource associated to "/users/3".');
 
-        $this->router->match('/users/3')->willReturn([
-            '_api_operation_name' => 'get',
-        ])->shouldBeCalledTimes(1);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('/users/3')
+            ->willReturn([
+                '_api_operation_name' => 'get',
+            ]);
 
         $this->converter->getIdentifier('/users/3');
     }
@@ -172,9 +198,13 @@ final class IriToIdentifierConverterTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('No resource associated to "/users/3".');
 
-        $this->router->match('/users/3')->willReturn([
-            '_api_resource_class' => AddProductReview::class,
-        ])->shouldBeCalledTimes(1);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('/users/3')
+            ->willReturn([
+                '_api_resource_class' => AddProductReview::class,
+            ]);
 
         $this->converter->getIdentifier('/users/3');
     }
@@ -185,51 +215,81 @@ final class IriToIdentifierConverterTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('IriToIdentifierConverter does not support subresources');
 
-        $operation = $this->prophesize(HttpOperation::class);
-        $operation->getClass()->willReturn(AddProductReview::class);
-        $operation->getUriVariables()->willReturn([
-            'id' => new Link('id', identifiers: ['id'], compositeIdentifier: true),
-            'nextId' => new Link('nextId', identifiers: ['nextId'], compositeIdentifier: true),
-        ]);
+        $operation = $this->createMock(HttpOperation::class);
+        $operation
+            ->expects($this->once())
+            ->method('getClass')
+            ->willReturn(AddProductReview::class);
 
-        $this->router->match('/users/3/nexts/5')->willReturn([
-            '_api_resource_class' => AddProductReview::class,
-            '_api_operation_name' => 'get',
-            'id' => 3,
-            'nextId' => 5,
-        ])->shouldBeCalledTimes(1);
+        $operation
+            ->expects($this->once())
+            ->method('getUriVariables')
+            ->willReturn([
+                'id' => new Link('id', identifiers: ['id'], compositeIdentifier: true),
+                'nextId' => new Link('nextId', identifiers: ['nextId'], compositeIdentifier: true),
+            ]);
 
-        $this->uriVariablesConverter->convert(
-            ['id' => 3, 'nextId' => 5],
-            AddProductReview::class,
-            Argument::cetera(),
-        )->willReturn(['3', '5']);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('/users/3/nexts/5')
+            ->willReturn([
+                '_api_resource_class' => AddProductReview::class,
+                '_api_operation_name' => 'get',
+                'id' => 3,
+                'nextId' => 5,
+            ]);
 
-        $this->converter->getIdentifier('/users/3/nexts/5', $operation->reveal());
+        $this->uriVariablesConverter
+            ->expects($this->once())
+            ->method('convert')
+            ->with(
+                ['id' => 3, 'nextId' => 5],
+                AddProductReview::class,
+                $this->anything(),
+            )
+            ->willReturn(['3', '5']);
+
+        $this->converter->getIdentifier('/users/3/nexts/5', $operation);
     }
 
     #[Test]
     public function it_gets_identifier(): void
     {
-        $operation = $this->prophesize(HttpOperation::class);
-        $operation->getClass()->willReturn(AddProductReview::class);
-        $operation->getUriVariables()->willReturn([
-            'id' => new Link('id', identifiers: ['id'], compositeIdentifier: true),
-        ]);
+        $operation = $this->createMock(HttpOperation::class);
+        $operation
+            ->expects($this->once())
+            ->method('getClass')
+            ->willReturn(AddProductReview::class);
 
-        $this->router->match('/users/3')->willReturn([
-            '_api_resource_class' => AddProductReview::class,
-            '_api_operation_name' => 'get',
-            'id' => 3,
-        ])->shouldBeCalledTimes(1);
+        $operation
+            ->expects($this->once())
+            ->method('getUriVariables')
+            ->willReturn([
+                'id' => new Link('id', identifiers: ['id'], compositeIdentifier: true),
+            ]);
 
-        $this->uriVariablesConverter->convert(
-            ['id' => 3],
-            AddProductReview::class,
-            Argument::cetera(),
-        )->willReturn(['3']);
+        $this->router
+            ->expects($this->once())
+            ->method('match')
+            ->with('/users/3')
+            ->willReturn([
+                '_api_resource_class' => AddProductReview::class,
+                '_api_operation_name' => 'get',
+                'id' => 3,
+            ]);
 
-        $this->assertSame('3', $this->converter->getIdentifier('/users/3', $operation->reveal()));
+        $this->uriVariablesConverter
+            ->expects($this->once())
+            ->method('convert')
+            ->with(
+                ['id' => 3],
+                AddProductReview::class,
+                $this->anything(),
+            )
+            ->willReturn(['3']);
+
+        $this->assertSame('3', $this->converter->getIdentifier('/users/3', $operation));
     }
 
     public static function invalidIdentifierValues(): iterable

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -37,7 +37,6 @@
         "doctrine/doctrine-bundle": "^2.13",
         "doctrine/orm": "^2.18 || ^3.3",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "^6.4 || ^7.2",
         "symfony/dependency-injection": "^6.4.1 || ^7.2",

--- a/src/Sylius/Bundle/AttributeBundle/tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
+++ b/src/Sylius/Bundle/AttributeBundle/tests/Form/Type/AttributeType/SelectAttributeTypeTest.php
@@ -15,8 +15,7 @@ namespace Tests\Sylius\Bundle\AttributeBundle\Form\Type\AttributeType;
 
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\SelectAttributeType;
 use Sylius\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
@@ -25,9 +24,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 
 final class SelectAttributeTypeTest extends TypeTestCase
 {
-    use ProphecyTrait;
-
-    private ObjectProphecy $translationProvider;
+    private TranslationLocaleProviderInterface&MockObject $translationProvider;
 
     #[Test]
     public function it_return_all_choices(): void
@@ -44,15 +41,15 @@ final class SelectAttributeTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
-        $this->translationProvider = $this->prophesize(TranslationLocaleProviderInterface::class);
-        $this->translationProvider->getDefaultLocaleCode()->willReturn('en_GB');
+        $this->translationProvider = $this->createMock(TranslationLocaleProviderInterface::class);
+        $this->translationProvider->method('getDefaultLocaleCode')->willReturn('en_GB');
 
         parent::setUp();
     }
 
     protected function getExtensions(): array
     {
-        $type = new SelectAttributeType($this->translationProvider->reveal());
+        $type = new SelectAttributeType($this->translationProvider);
 
         return [
             new PreloadedExtension([$type], []),

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -77,7 +77,6 @@
         "hwi/oauth-bundle": "^2.2",
         "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
-        "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5",
         "symfony/dependency-injection": "^6.4.1 || ^7.2",
         "symfony/dotenv": "^6.4 || ^7.2",

--- a/src/Sylius/Bundle/CoreBundle/tests/EventListener/MigrationSkipListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/EventListener/MigrationSkipListenerTest.php
@@ -25,39 +25,39 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 use Sylius\Bundle\CoreBundle\Doctrine\Migrations\MigrationSkipInterface;
 use Sylius\Bundle\CoreBundle\EventListener\MigrationSkipListener;
 
 final class MigrationSkipListenerTest extends TestCase
 {
-    use ProphecyTrait;
+    private MetadataStorage&MockObject $metadataStorage;
 
-    private MetadataStorage|ObjectProphecy $metadataStorage;
-
-    private DependencyFactory|ObjectProphecy $dependencyFactory;
+    private DependencyFactory&MockObject $dependencyFactory;
 
     private MigrationSkipListener $listener;
 
     protected function setUp(): void
     {
-        $this->metadataStorage = $this->prophesize(MetadataStorage::class);
-        $this->dependencyFactory = $this->prophesize(DependencyFactory::class);
+        $this->metadataStorage = $this->createMock(MetadataStorage::class);
+        $this->dependencyFactory = $this->createMock(DependencyFactory::class);
 
-        $this->dependencyFactory->getMetadataStorage()->willReturn($this->metadataStorage);
+        $this->dependencyFactory
+            ->method('getMetadataStorage')
+            ->willReturn($this->metadataStorage);
 
-        $this->listener = new MigrationSkipListener($this->dependencyFactory->reveal());
+        $this->listener = new MigrationSkipListener($this->dependencyFactory);
     }
 
     #[DataProvider('getInvalidSkipConditions')]
     #[Test]
     public function it_does_nothing_when_conditions_are_not_met(bool $isUp, bool $isMigrationSkip, bool $skipped): void
     {
-        $this->dependencyFactory->getMetadataStorage()->shouldNotBeCalled();
-        $this->metadataStorage->complete(Argument::any())->shouldNotBeCalled();
+        $this->metadataStorage
+            ->expects($this->never())
+            ->method('complete');
 
         $this->listener->onMigrationsVersionSkipped($this->createEvent(
             $isUp,
@@ -69,8 +69,9 @@ final class MigrationSkipListenerTest extends TestCase
     #[Test]
     public function it_completed_the_skipped_migration(): void
     {
-        $this->dependencyFactory->getMetadataStorage()->shouldBeCalled();
-        $this->metadataStorage->complete(Argument::any())->shouldBeCalled();
+        $this->metadataStorage
+            ->expects($this->once())
+            ->method('complete');
 
         $this->listener->onMigrationsVersionSkipped($this->createEvent(true, true, true));
     }
@@ -97,23 +98,40 @@ final class MigrationSkipListenerTest extends TestCase
         $migrationResult = new ExecutionResult($version, $direction);
         $migrationResult->setSkipped($skipped);
 
-        $migration = $this->prophesize(AbstractMigration::class);
         if ($isMigrationSkip) {
-            $migration->willImplement(MigrationSkipInterface::class);
+            $migration = new class($this->createMock(Connection::class), $this->createMock(LoggerInterface::class)) extends AbstractMigration implements MigrationSkipInterface {
+                public function up(\Doctrine\DBAL\Schema\Schema $schema): void
+                {
+                }
+
+                public function down(\Doctrine\DBAL\Schema\Schema $schema): void
+                {
+                }
+            };
+        } else {
+            $migration = new class($this->createMock(Connection::class), $this->createMock(LoggerInterface::class)) extends AbstractMigration {
+                public function up(\Doctrine\DBAL\Schema\Schema $schema): void
+                {
+                }
+
+                public function down(\Doctrine\DBAL\Schema\Schema $schema): void
+                {
+                }
+            };
         }
 
         $plan = new MigrationPlan(
             $version,
-            $migration->reveal(),
+            $migration,
             $direction,
         );
 
         $plan->markAsExecuted($migrationResult);
 
         return new MigrationsVersionEventArgs(
-            $this->prophesize(Connection::class)->reveal(),
+            $this->createMock(Connection::class),
             $plan,
-            $this->prophesize(MigratorConfiguration::class)->reveal(),
+            $this->createMock(MigratorConfiguration::class),
         );
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/Fixture/OptionsResolver/LazyOptionTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Fixture/OptionsResolver/LazyOptionTest.php
@@ -14,10 +14,8 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Fixture\OptionsResolver;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sylius\Bundle\CoreBundle\Fixture\OptionsResolver\LazyOption;
 use Sylius\Bundle\CoreBundle\Fixture\OptionsResolver\ResourceNotFoundException;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -26,61 +24,61 @@ use Symfony\Component\OptionsResolver\Options;
 
 final class LazyOptionTest extends TestCase
 {
-    use ProphecyTrait;
-
     #[Test]
     public function it_gets_object_from_provided_repository(): void
     {
-        /** @var RepositoryInterface|ObjectProphecy $repository */
-        $repository = $this->prophesize(RepositoryInterface::class);
-        $resource = $this->prophesize(ResourceInterface::class);
-        $options = $this->prophesize(Options::class);
+        /** @var RepositoryInterface&MockObject $repository */
+        $repository = $this->createMock(RepositoryInterface::class);
+        $resource = $this->createMock(ResourceInterface::class);
+        $options = $this->createMock(Options::class);
 
-        $repository->findOneBy(['code' => 'OBJECT_CODE'])->willReturn($resource->reveal());
+        $repository->method('findOneBy')->with(['code' => 'OBJECT_CODE'])->willReturn($resource);
 
-        $closure = LazyOption::getOneBy($repository->reveal(), 'code');
+        $closure = LazyOption::getOneBy($repository, 'code');
 
-        self::assertSame($resource->reveal(), $closure($options->reveal(), 'OBJECT_CODE'));
+        self::assertSame($resource, $closure($options, 'OBJECT_CODE'));
     }
 
     #[Test]
     public function it_finds_an_object_from_provided_repository_or_returns_null(): void
     {
-        /** @var RepositoryInterface|ObjectProphecy $repository */
-        $repository = $this->prophesize(RepositoryInterface::class);
-        $resource = $this->prophesize(ResourceInterface::class);
-        $options = $this->prophesize(Options::class);
+        /** @var RepositoryInterface&MockObject $repository */
+        $repository = $this->createMock(RepositoryInterface::class);
+        $resource = $this->createMock(ResourceInterface::class);
+        $options = $this->createMock(Options::class);
 
-        $repository->findOneBy(['code' => 'OBJECT_CODE'])->willReturn($resource->reveal());
-        $repository->findOneBy(['code' => 'NOT_EXISTING_OBJECT_CODE'])->willReturn(null);
+        $repository->method('findOneBy')->willReturnMap([
+            [['code' => 'OBJECT_CODE'], $resource],
+            [['code' => 'NOT_EXISTING_OBJECT_CODE'], null],
+        ]);
 
-        $closure = LazyOption::findOneBy($repository->reveal(), 'code');
+        $closure = LazyOption::findOneBy($repository, 'code');
 
-        self::assertSame($resource->reveal(), $closure($options->reveal(), 'OBJECT_CODE'));
-        self::assertNull($closure($options->reveal(), 'NOT_EXISTING_OBJECT_CODE'));
+        self::assertSame($resource, $closure($options, 'OBJECT_CODE'));
+        self::assertNull($closure($options, 'NOT_EXISTING_OBJECT_CODE'));
     }
 
     #[Test]
     public function it_returns_previous_value_if_it_is_an_object_null_or_empty_array(): void
     {
-        /** @var RepositoryInterface|ObjectProphecy $repository */
-        $repository = $this->prophesize(RepositoryInterface::class);
-        $resource = $this->prophesize(ResourceInterface::class);
-        $options = $this->prophesize(Options::class);
+        /** @var RepositoryInterface&MockObject $repository */
+        $repository = $this->createMock(RepositoryInterface::class);
+        $resource = $this->createMock(ResourceInterface::class);
+        $options = $this->createMock(Options::class);
 
-        $repository->findOneBy(Argument::any())->shouldNotBeCalled();
+        $repository->expects($this->never())->method('findOneBy');
 
-        $getOneByClosure = LazyOption::getOneBy($repository->reveal(), 'code');
+        $getOneByClosure = LazyOption::getOneBy($repository, 'code');
 
-        self::assertSame($resource->reveal(), $getOneByClosure($options->reveal(), $resource->reveal()));
-        self::assertNull($getOneByClosure($options->reveal(), []));
-        self::assertNull($getOneByClosure($options->reveal(), null));
+        self::assertSame($resource, $getOneByClosure($options, $resource));
+        self::assertNull($getOneByClosure($options, []));
+        self::assertNull($getOneByClosure($options, null));
 
-        $findOneByClosure = LazyOption::findOneBy($repository->reveal(), 'code');
+        $findOneByClosure = LazyOption::findOneBy($repository, 'code');
 
-        self::assertSame($resource->reveal(), $findOneByClosure($options->reveal(), $resource->reveal()));
-        self::assertNull($findOneByClosure($options->reveal(), []));
-        self::assertNull($findOneByClosure($options->reveal(), null));
+        self::assertSame($resource, $findOneByClosure($options, $resource));
+        self::assertNull($findOneByClosure($options, []));
+        self::assertNull($findOneByClosure($options, null));
     }
 
     #[Test]
@@ -88,15 +86,15 @@ final class LazyOptionTest extends TestCase
     {
         $this->expectException(ResourceNotFoundException::class);
 
-        /** @var RepositoryInterface|ObjectProphecy $repository */
-        $repository = $this->prophesize(RepositoryInterface::class);
-        $options = $this->prophesize(Options::class);
+        /** @var RepositoryInterface&MockObject $repository */
+        $repository = $this->createMock(RepositoryInterface::class);
+        $options = $this->createMock(Options::class);
 
-        $repository->findOneBy(['code' => 'OBJECT_CODE'])->willReturn(null);
-        $repository->getClassName()->willReturn('App\\Entity');
+        $repository->method('findOneBy')->with(['code' => 'OBJECT_CODE'])->willReturn(null);
+        $repository->method('getClassName')->willReturn('App\\Entity');
 
-        $closure = LazyOption::getOneBy($repository->reveal(), 'code');
+        $closure = LazyOption::getOneBy($repository, 'code');
 
-        $closure($options->reveal(), 'OBJECT_CODE');
+        $closure($options, 'OBJECT_CODE');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Form/Type/CatalogPromotion/CatalogPromotionActionTypeTest.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotion;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
-use Prophecy\Prophecy\ProphecyInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotionAction\ChannelBasedFixedDiscountActionConfigurationType;
 use Sylius\Bundle\CoreBundle\Form\Type\ChannelCollectionType;
 use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionAction\PercentageDiscountActionConfigurationType;
@@ -34,19 +31,17 @@ use Symfony\Component\Validator\Validation;
 
 final class CatalogPromotionActionTypeTest extends TypeTestCase
 {
-    use ProphecyTrait;
+    private ChannelInterface&MockObject $channel;
 
-    private ChannelInterface|ProphecyInterface $channel;
-
-    private ObjectProphecy $channelRepository;
+    private ChannelRepositoryInterface&MockObject $channelRepository;
 
     #[Test]
     public function it_updates_amount_of_fixed_discount(): void
     {
         $fixedDiscount = $this->setupFixedDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
@@ -72,8 +67,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $percentageDiscount = $this->setupPercentageDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
@@ -97,8 +92,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $percentageDiscount = $this->setupPercentageDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
@@ -124,8 +119,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $fixedDiscount = $this->setupFixedDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
@@ -149,8 +144,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $fixedDiscount = $this->setupFixedDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
@@ -174,8 +169,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $percentageDiscount = $this->setupPercentageDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
@@ -201,8 +196,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $fixedDiscount = $this->setupFixedDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
@@ -228,8 +223,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $fixedDiscount = $this->setupFixedDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $fixedDiscount);
@@ -255,8 +250,8 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
     {
         $percentageDiscount = $this->setupPercentageDiscount();
 
-        $this->channelRepository->findAll(Argument::any())->willReturn(
-            [$this->channel->reveal()],
+        $this->channelRepository->method('findAll')->willReturn(
+            [$this->channel],
         );
 
         $form = $this->factory->create(CatalogPromotionActionType::class, $percentageDiscount);
@@ -277,15 +272,15 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
 
     protected function setUp(): void
     {
-        $this->channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
+        $this->channelRepository = $this->createMock(ChannelRepositoryInterface::class);
 
-        $currency = $this->prophesize(CurrencyInterface::class);
-        $currency->getCode()->willReturn('USD');
+        $currency = $this->createMock(CurrencyInterface::class);
+        $currency->method('getCode')->willReturn('USD');
 
-        $channel = $this->prophesize(ChannelInterface::class);
-        $channel->getCode()->willReturn('WEB_US');
-        $channel->getName()->willReturn('United States');
-        $channel->getBaseCurrency()->willReturn($currency->reveal());
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getCode')->willReturn('WEB_US');
+        $channel->method('getName')->willReturn('United States');
+        $channel->method('getBaseCurrency')->willReturn($currency);
         $this->channel = $channel;
 
         parent::setUp();
@@ -303,7 +298,7 @@ final class CatalogPromotionActionTypeTest extends TypeTestCase
         );
 
         $channelCollectionType = new ChannelCollectionType(
-            $this->channelRepository->reveal(),
+            $this->channelRepository,
         );
 
         $validator = Validation::createValidatorBuilder()->getValidator();

--- a/src/Sylius/Bundle/CoreBundle/tests/Form/Type/Taxon/ProductTaxonAutocompleteChoiceTypeTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Form/Type/Taxon/ProductTaxonAutocompleteChoiceTypeTest.php
@@ -15,8 +15,7 @@ namespace Tests\Sylius\Bundle\CoreBundle\Form\Type\Taxon;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Form\Type\Taxon\ProductTaxonAutocompleteChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -31,19 +30,17 @@ use Symfony\Component\Form\Test\TypeTestCase;
 
 final class ProductTaxonAutocompleteChoiceTypeTest extends TypeTestCase
 {
-    use ProphecyTrait;
+    private ServiceRegistryInterface&MockObject $resourceRepositoryRegistry;
 
-    private ObjectProphecy $resourceRepositoryRegistry;
+    private FactoryInterface&MockObject $productTaxonFactory;
 
-    private ObjectProphecy $productTaxonFactory;
-
-    private ObjectProphecy $productTaxonRepository;
+    private RepositoryInterface&MockObject $productTaxonRepository;
 
     protected function setUp(): void
     {
-        $this->resourceRepositoryRegistry = $this->prophesize(ServiceRegistryInterface::class);
-        $this->productTaxonFactory = $this->prophesize(FactoryInterface::class);
-        $this->productTaxonRepository = $this->prophesize(RepositoryInterface::class);
+        $this->resourceRepositoryRegistry = $this->createMock(ServiceRegistryInterface::class);
+        $this->productTaxonFactory = $this->createMock(FactoryInterface::class);
+        $this->productTaxonRepository = $this->createMock(RepositoryInterface::class);
 
         parent::setUp();
     }
@@ -51,10 +48,10 @@ final class ProductTaxonAutocompleteChoiceTypeTest extends TypeTestCase
     protected function getExtensions(): array
     {
         $productTaxonAutoCompleteType = new ProductTaxonAutocompleteChoiceType(
-            $this->productTaxonFactory->reveal(),
-            $this->productTaxonRepository->reveal(),
+            $this->productTaxonFactory,
+            $this->productTaxonRepository,
         );
-        $resourceAutoCompleteType = new ResourceAutocompleteChoiceType($this->resourceRepositoryRegistry->reveal());
+        $resourceAutoCompleteType = new ResourceAutocompleteChoiceType($this->resourceRepositoryRegistry);
 
         return [
             new PreloadedExtension([$productTaxonAutoCompleteType, $resourceAutoCompleteType], []),
@@ -64,104 +61,108 @@ final class ProductTaxonAutocompleteChoiceTypeTest extends TypeTestCase
     #[Test]
     public function it_creates_new_product_taxons_based_on_given_product_and_passed_taxon_codes(): void
     {
-        $taxon = $this->prophesize(TaxonInterface::class);
-        $product = $this->prophesize(ProductInterface::class);
+        $taxon = $this->createMock(TaxonInterface::class);
+        $product = $this->createMock(ProductInterface::class);
 
-        /** @var ObjectProphecy|TaxonRepositoryInterface $taxonRepository */
-        $taxonRepository = $this->prophesize(TaxonRepositoryInterface::class);
+        /** @var TaxonRepositoryInterface&MockObject $taxonRepository */
+        $taxonRepository = $this->createMock(TaxonRepositoryInterface::class);
 
-        $this->resourceRepositoryRegistry->get('sylius.taxon')->willReturn($taxonRepository);
-        $taxonRepository->findOneBy(['code' => 'mug'])->willReturn($taxon);
-        $taxonRepository->findOneBy(['code' => 'book'])->willReturn($taxon);
-        $this->productTaxonRepository->findOneBy(['product' => $product, 'taxon' => $taxon])->willReturn(null);
+        $this->resourceRepositoryRegistry->method('get')->with('sylius.taxon')->willReturn($taxonRepository);
+        $taxonRepository->method('findOneBy')->willReturnMap([
+            [['code' => 'mug'], $taxon],
+            [['code' => 'book'], $taxon],
+        ]);
+        $this->productTaxonRepository->method('findOneBy')->with(['product' => $product, 'taxon' => $taxon])->willReturn(null);
 
-        $productTaxon = $this->prophesize(ProductTaxonInterface::class);
+        $productTaxon = $this->createMock(ProductTaxonInterface::class);
 
-        $this->productTaxonFactory->createNew()->willReturn($productTaxon);
+        $this->productTaxonFactory->method('createNew')->willReturn($productTaxon);
 
         $form = $this->factory->create(ProductTaxonAutocompleteChoiceType::class, new ArrayCollection(), [
             'label' => 'sylius.form.product.taxons',
-            'product' => $product->reveal(),
+            'product' => $product,
             'multiple' => true,
         ]);
 
         $form->submit('mug,book');
-        $this->assertEquals(new ArrayCollection([$productTaxon->reveal(), $productTaxon->reveal()]), $form->getData());
+        $this->assertEquals(new ArrayCollection([$productTaxon, $productTaxon]), $form->getData());
     }
 
     #[Test]
     public function it_returns_existing_product_taxons_based_on_given_product_and_passed_taxon_codes(): void
     {
-        $taxon = $this->prophesize(TaxonInterface::class);
-        $product = $this->prophesize(ProductInterface::class);
-        $productTaxon = $this->prophesize(ProductTaxonInterface::class);
+        $taxon = $this->createMock(TaxonInterface::class);
+        $product = $this->createMock(ProductInterface::class);
+        $productTaxon = $this->createMock(ProductTaxonInterface::class);
 
-        /** @var ObjectProphecy|TaxonRepositoryInterface $taxonRepository */
-        $taxonRepository = $this->prophesize(TaxonRepositoryInterface::class);
+        /** @var TaxonRepositoryInterface&MockObject $taxonRepository */
+        $taxonRepository = $this->createMock(TaxonRepositoryInterface::class);
 
-        $this->resourceRepositoryRegistry->get('sylius.taxon')->willReturn($taxonRepository);
-        $taxonRepository->findOneBy(['code' => 'mug'])->willReturn($taxon);
-        $taxonRepository->findOneBy(['code' => 'book'])->willReturn($taxon);
-        $this->productTaxonRepository->findOneBy(['product' => $product, 'taxon' => $taxon])->willReturn($productTaxon);
+        $this->resourceRepositoryRegistry->method('get')->with('sylius.taxon')->willReturn($taxonRepository);
+        $taxonRepository->method('findOneBy')->willReturnMap([
+            [['code' => 'mug'], $taxon],
+            [['code' => 'book'], $taxon],
+        ]);
+        $this->productTaxonRepository->method('findOneBy')->with(['product' => $product, 'taxon' => $taxon])->willReturn($productTaxon);
 
         $form = $this->factory->create(ProductTaxonAutocompleteChoiceType::class, new ArrayCollection(), [
             'label' => 'sylius.form.product.taxons',
-            'product' => $product->reveal(),
+            'product' => $product,
             'multiple' => true,
         ]);
 
         $form->submit('mug,book');
-        $this->assertEquals(new ArrayCollection([$productTaxon->reveal(), $productTaxon->reveal()]), $form->getData());
+        $this->assertEquals(new ArrayCollection([$productTaxon, $productTaxon]), $form->getData());
     }
 
     #[Test]
     public function it_returns_new_product_taxon_based_on_given_product_and_passed_taxon_code(): void
     {
-        $taxon = $this->prophesize(TaxonInterface::class);
-        $product = $this->prophesize(ProductInterface::class);
+        $taxon = $this->createMock(TaxonInterface::class);
+        $product = $this->createMock(ProductInterface::class);
 
-        /** @var ObjectProphecy|TaxonRepositoryInterface $taxonRepository */
-        $taxonRepository = $this->prophesize(TaxonRepositoryInterface::class);
+        /** @var TaxonRepositoryInterface&MockObject $taxonRepository */
+        $taxonRepository = $this->createMock(TaxonRepositoryInterface::class);
 
-        $this->resourceRepositoryRegistry->get('sylius.taxon')->willReturn($taxonRepository);
-        $taxonRepository->findOneBy(['code' => 'mug'])->willReturn($taxon);
-        $this->productTaxonRepository->findOneBy(['product' => $product, 'taxon' => $taxon])->willReturn(null);
+        $this->resourceRepositoryRegistry->method('get')->with('sylius.taxon')->willReturn($taxonRepository);
+        $taxonRepository->method('findOneBy')->with(['code' => 'mug'])->willReturn($taxon);
+        $this->productTaxonRepository->method('findOneBy')->with(['product' => $product, 'taxon' => $taxon])->willReturn(null);
 
-        $productTaxon = $this->prophesize(ProductTaxonInterface::class);
+        $productTaxon = $this->createMock(ProductTaxonInterface::class);
 
-        $this->productTaxonFactory->createNew()->willReturn($productTaxon);
+        $this->productTaxonFactory->method('createNew')->willReturn($productTaxon);
 
         $form = $this->factory->create(ProductTaxonAutocompleteChoiceType::class, null, [
             'label' => 'sylius.form.product.taxons',
-            'product' => $product->reveal(),
+            'product' => $product,
             'multiple' => false,
         ]);
 
         $form->submit('mug');
-        $this->assertEquals($productTaxon->reveal(), $form->getData());
+        $this->assertEquals($productTaxon, $form->getData());
     }
 
     #[Test]
     public function it_returns_existing_product_taxon_based_on_given_product_and_passed_taxon_code(): void
     {
-        $taxon = $this->prophesize(TaxonInterface::class);
-        $product = $this->prophesize(ProductInterface::class);
-        $productTaxon = $this->prophesize(ProductTaxonInterface::class);
+        $taxon = $this->createMock(TaxonInterface::class);
+        $product = $this->createMock(ProductInterface::class);
+        $productTaxon = $this->createMock(ProductTaxonInterface::class);
 
-        /** @var ObjectProphecy|TaxonRepositoryInterface $taxonRepository */
-        $taxonRepository = $this->prophesize(TaxonRepositoryInterface::class);
+        /** @var TaxonRepositoryInterface&MockObject $taxonRepository */
+        $taxonRepository = $this->createMock(TaxonRepositoryInterface::class);
 
-        $this->resourceRepositoryRegistry->get('sylius.taxon')->willReturn($taxonRepository);
-        $taxonRepository->findOneBy(['code' => 'mug'])->willReturn($taxon);
-        $this->productTaxonRepository->findOneBy(['product' => $product, 'taxon' => $taxon])->willReturn($productTaxon);
+        $this->resourceRepositoryRegistry->method('get')->with('sylius.taxon')->willReturn($taxonRepository);
+        $taxonRepository->method('findOneBy')->with(['code' => 'mug'])->willReturn($taxon);
+        $this->productTaxonRepository->method('findOneBy')->with(['product' => $product, 'taxon' => $taxon])->willReturn($productTaxon);
 
         $form = $this->factory->create(ProductTaxonAutocompleteChoiceType::class, null, [
             'label' => 'sylius.form.product.taxons',
-            'product' => $product->reveal(),
+            'product' => $product,
             'multiple' => false,
         ]);
 
         $form->submit('mug');
-        $this->assertEquals($productTaxon->reveal(), $form->getData());
+        $this->assertEquals($productTaxon, $form->getData());
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/Installation/Setup/LocaleSetupTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Installation/Setup/LocaleSetupTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Installation\Setup;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetup;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -29,19 +28,17 @@ use Symfony\Component\Yaml\Yaml;
 
 final class LocaleSetupTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
-    private $filesystem;
+    private Filesystem $filesystem;
 
     private string $originalLocale;
 
-    private $localeRepository;
+    private RepositoryInterface&MockObject $localeRepository;
 
-    private $localeFactory;
+    private FactoryInterface&MockObject $localeFactory;
 
-    private $localeSetup;
+    private LocaleSetup $localeSetup;
 
-    private $localeParameterFilePath;
+    private string $localeParameterFilePath;
 
     protected function setUp(): void
     {
@@ -52,14 +49,14 @@ final class LocaleSetupTest extends KernelTestCase
         \Locale::setDefault('en_US');
 
         $this->filesystem = new Filesystem();
-        $this->localeRepository = $this->prophesize(RepositoryInterface::class);
-        $this->localeFactory = $this->prophesize(FactoryInterface::class);
+        $this->localeRepository = $this->createMock(RepositoryInterface::class);
+        $this->localeFactory = $this->createMock(FactoryInterface::class);
         $this->localeParameterFilePath = self::$kernel->getProjectDir() . '/var/temporary_services_file.yaml';
         $this->createTemporaryServicesFile(['parameters' => ['locale' => 'en_US']]);
 
         $this->localeSetup = new LocaleSetup(
-            $this->localeRepository->reveal(),
-            $this->localeFactory->reveal(),
+            $this->localeRepository,
+            $this->localeFactory,
             'en_US',
             $this->filesystem,
             $this->localeParameterFilePath,
@@ -76,19 +73,39 @@ final class LocaleSetupTest extends KernelTestCase
     #[Test]
     public function it_updates_locale_with_a_given_one_if_it_is_different_than_default_one(): void
     {
-        $questionHelper = $this->prophesize(QuestionHelper::class);
-        $questionHelper->ask(Argument::cetera())->willReturn('fr_FR');
-        $locale = $this->prophesize(LocaleInterface::class);
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $questionHelper
+            ->expects($this->once())
+            ->method('ask')
+            ->willReturn('fr_FR');
 
-        $this->localeRepository->findOneBy(['code' => 'fr_FR'])->willReturn(null);
-        $this->localeFactory->createNew()->willReturn($locale->reveal());
-        $locale->setCode('fr_FR')->shouldBeCalled();
-        $this->localeRepository->add($locale->reveal())->shouldBeCalled();
+        $locale = $this->createMock(LocaleInterface::class);
+
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'fr_FR'])
+            ->willReturn(null);
+
+        $this->localeFactory
+            ->expects($this->once())
+            ->method('createNew')
+            ->willReturn($locale);
+
+        $locale
+            ->expects($this->once())
+            ->method('setCode')
+            ->with('fr_FR');
+
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('add')
+            ->with($locale);
 
         $this->localeSetup->setup(
-            $this->prophesize(InputInterface::class)->reveal(),
-            $this->prophesize(OutputInterface::class)->reveal(),
-            $questionHelper->reveal(),
+            $this->createMock(InputInterface::class),
+            $this->createMock(OutputInterface::class),
+            $questionHelper,
         );
 
         $fileContent = Yaml::parseFile($this->localeParameterFilePath);
@@ -100,19 +117,36 @@ final class LocaleSetupTest extends KernelTestCase
     #[Test]
     public function it_does_not_update_locale_with_existing_locale(): void
     {
-        $questionHelper = $this->prophesize(QuestionHelper::class);
-        $questionHelper->ask(Argument::cetera())->willReturn('en_US');
-        $locale = $this->prophesize(LocaleInterface::class);
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $questionHelper
+            ->expects($this->once())
+            ->method('ask')
+            ->willReturn('en_US');
 
-        $this->localeRepository->findOneBy(['code' => 'en_US'])->willReturn($locale->reveal());
-        $this->localeFactory->createNew()->shouldNotBeCalled();
-        $locale->setCode('en_US')->shouldNotBeCalled();
-        $this->localeRepository->add($locale->reveal())->shouldNotBeCalled();
+        $locale = $this->createMock(LocaleInterface::class);
+
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'en_US'])
+            ->willReturn($locale);
+
+        $this->localeFactory
+            ->expects($this->never())
+            ->method('createNew');
+
+        $locale
+            ->expects($this->never())
+            ->method('setCode');
+
+        $this->localeRepository
+            ->expects($this->never())
+            ->method('add');
 
         $this->localeSetup->setup(
-            $this->prophesize(InputInterface::class)->reveal(),
-            $this->prophesize(OutputInterface::class)->reveal(),
-            $questionHelper->reveal(),
+            $this->createMock(InputInterface::class),
+            $this->createMock(OutputInterface::class),
+            $questionHelper,
         );
 
         $this->assertEquals('en_US', Yaml::parseFile($this->localeParameterFilePath)['parameters']['locale']);
@@ -125,24 +159,49 @@ final class LocaleSetupTest extends KernelTestCase
     {
         unlink($this->localeParameterFilePath);
 
-        $questionHelper = $this->prophesize(QuestionHelper::class);
-        $questionHelper->ask(Argument::cetera())->willReturn('fr_FR');
-        $locale = $this->prophesize(LocaleInterface::class);
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $questionHelper
+            ->expects($this->once())
+            ->method('ask')
+            ->willReturn('fr_FR');
 
-        $this->localeRepository->findOneBy(['code' => 'fr_FR'])->willReturn(null);
-        $this->localeFactory->createNew()->willReturn($locale->reveal());
-        $locale->setCode('fr_FR')->shouldBeCalled();
-        $this->localeRepository->add($locale->reveal())->shouldBeCalled();
+        $locale = $this->createMock(LocaleInterface::class);
 
-        $output = $this->prophesize(OutputInterface::class);
-        $output->writeln('Adding <info>French</info> Language.')->shouldBeCalled();
-        $output->writeln('Adding <info>fr_FR</info> locale.')->shouldBeCalled();
-        $output->writeln('<info>You may also need to add this locale into config/parameters.yaml configuration.</info>')->shouldBeCalled();
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'fr_FR'])
+            ->willReturn(null);
+
+        $this->localeFactory
+            ->expects($this->once())
+            ->method('createNew')
+            ->willReturn($locale);
+
+        $locale
+            ->expects($this->once())
+            ->method('setCode')
+            ->with('fr_FR');
+
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('add')
+            ->with($locale);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects($this->exactly(3))
+            ->method('writeln')
+            ->with($this->logicalOr(
+                'Adding <info>French</info> Language.',
+                'Adding <info>fr_FR</info> locale.',
+                '<info>You may also need to add this locale into config/parameters.yaml configuration.</info>',
+            ));
 
         $this->localeSetup->setup(
-            $this->prophesize(InputInterface::class)->reveal(),
-            $output->reveal(),
-            $questionHelper->reveal(),
+            $this->createMock(InputInterface::class),
+            $output,
+            $questionHelper,
         );
     }
 
@@ -150,8 +209,8 @@ final class LocaleSetupTest extends KernelTestCase
     public function it_does_not_update_locale_if_file_is_not_writable(): void
     {
         $this->localeSetup = new LocaleSetup(
-            $this->localeRepository->reveal(),
-            $this->localeFactory->reveal(),
+            $this->localeRepository,
+            $this->localeFactory,
             'en_US',
             $this->filesystem,
             $this->localeParameterFilePath,
@@ -159,24 +218,49 @@ final class LocaleSetupTest extends KernelTestCase
 
         $this->filesystem->chmod($this->localeParameterFilePath, 0444);
 
-        $questionHelper = $this->prophesize(QuestionHelper::class);
-        $questionHelper->ask(Argument::cetera())->willReturn('fr_FR');
-        $locale = $this->prophesize(LocaleInterface::class);
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $questionHelper
+            ->expects($this->once())
+            ->method('ask')
+            ->willReturn('fr_FR');
 
-        $this->localeRepository->findOneBy(['code' => 'fr_FR'])->willReturn(null);
-        $this->localeFactory->createNew()->willReturn($locale->reveal());
-        $locale->setCode('fr_FR')->shouldBeCalled();
-        $this->localeRepository->add($locale->reveal())->shouldBeCalled();
+        $locale = $this->createMock(LocaleInterface::class);
 
-        $output = $this->prophesize(OutputInterface::class);
-        $output->writeln('Adding <info>French</info> Language.')->shouldBeCalled();
-        $output->writeln('Adding <info>fr_FR</info> locale.')->shouldBeCalled();
-        $output->writeln('<info>You may also need to add this locale into config/parameters.yaml configuration.</info>')->shouldBeCalled();
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'fr_FR'])
+            ->willReturn(null);
+
+        $this->localeFactory
+            ->expects($this->once())
+            ->method('createNew')
+            ->willReturn($locale);
+
+        $locale
+            ->expects($this->once())
+            ->method('setCode')
+            ->with('fr_FR');
+
+        $this->localeRepository
+            ->expects($this->once())
+            ->method('add')
+            ->with($locale);
+
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects($this->exactly(3))
+            ->method('writeln')
+            ->with($this->logicalOr(
+                'Adding <info>French</info> Language.',
+                'Adding <info>fr_FR</info> locale.',
+                '<info>You may also need to add this locale into config/parameters.yaml configuration.</info>',
+            ));
 
         $this->localeSetup->setup(
-            $this->prophesize(InputInterface::class)->reveal(),
-            $output->reveal(),
-            $questionHelper->reveal(),
+            $this->createMock(InputInterface::class),
+            $output,
+            $questionHelper,
         );
 
         $this->assertEquals('en_US', Yaml::parseFile($this->localeParameterFilePath)['parameters']['locale']);

--- a/src/Sylius/Bundle/CoreBundle/tests/Mailer/AccountRegistrationEmailManagerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Mailer/AccountRegistrationEmailManagerTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Mailer;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Mailer\AccountRegistrationEmailManagerInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\User\Model\UserInterface;
@@ -24,8 +23,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AccountRegistrationEmailManagerTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     #[Test]
     public function it_sends_account_registration_email(): void
     {
@@ -37,17 +34,17 @@ final class AccountRegistrationEmailManagerTest extends KernelTestCase
         /** @var AccountRegistrationEmailManagerInterface $accountRegistrationEmailManager */
         $accountRegistrationEmailManager = $container->get(AccountRegistrationEmailManagerInterface::class);
 
-        /** @var UserInterface|ObjectProphecy $user */
-        $user = $this->prophesize(UserInterface::class);
-        $user->getUsername()->willReturn('username');
-        $user->getEmail()->willReturn('customer@example.com');
-        $user->getEmailVerificationToken()->willReturn('token');
-        /** @var ChannelInterface|ObjectProphecy $channel */
-        $channel = $this->prophesize(ChannelInterface::class);
+        /** @var UserInterface&MockObject $user */
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getUsername')->willReturn('username');
+        $user->method('getEmail')->willReturn('customer@example.com');
+        $user->method('getEmailVerificationToken')->willReturn('token');
+        /** @var ChannelInterface&MockObject $channel */
+        $channel = $this->createMock(ChannelInterface::class);
 
         $accountRegistrationEmailManager->sendAccountRegistrationEmail(
-            $user->reveal(),
-            $channel->reveal(),
+            $user,
+            $channel,
             'en_US',
         );
 

--- a/src/Sylius/Bundle/CoreBundle/tests/Mailer/AccountVerificationEmailManagerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Mailer/AccountVerificationEmailManagerTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Mailer;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Mailer\AccountVerificationEmailManagerInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\User\Model\UserInterface;
@@ -24,8 +23,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AccountVerificationEmailManagerTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     #[Test]
     public function it_sends_account_verification_token_email(): void
     {
@@ -36,17 +33,17 @@ final class AccountVerificationEmailManagerTest extends KernelTestCase
 
         $accountVerificationEmailManager = $container->get(AccountVerificationEmailManagerInterface::class);
 
-        /** @var UserInterface|ObjectProphecy $user */
-        $user = $this->prophesize(UserInterface::class);
-        $user->getUsername()->willReturn('username');
-        $user->getEmail()->willReturn('customer@example.com');
-        $user->getEmailVerificationToken()->willReturn('token');
-        /** @var ChannelInterface|ObjectProphecy $channel */
-        $channel = $this->prophesize(ChannelInterface::class);
+        /** @var UserInterface&MockObject $user */
+        $user = $this->createMock(UserInterface::class);
+        $user->method('getUsername')->willReturn('username');
+        $user->method('getEmail')->willReturn('customer@example.com');
+        $user->method('getEmailVerificationToken')->willReturn('token');
+        /** @var ChannelInterface&MockObject $channel */
+        $channel = $this->createMock(ChannelInterface::class);
 
         $accountVerificationEmailManager->sendAccountVerificationEmail(
-            $user->reveal(),
-            $channel->reveal(),
+            $user,
+            $channel,
             'en_US',
         );
 

--- a/src/Sylius/Bundle/CoreBundle/tests/Mailer/ContactEmailManagerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Mailer/ContactEmailManagerTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Mailer;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Mailer\ContactEmailManager;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -24,8 +23,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ContactEmailManagerTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     #[Test]
     public function it_sends_contact_request(): void
     {
@@ -36,22 +33,22 @@ final class ContactEmailManagerTest extends KernelTestCase
 
         $emailSender = $container->get('sylius.email_sender');
 
-        /** @var ChannelRepositoryInterface|ObjectProphecy $channelRepository */
-        $channelRepository = $this->prophesize(ChannelRepositoryInterface::class);
-        /** @var ChannelInterface|ObjectProphecy $channel */
-        $channel = $this->prophesize(ChannelInterface::class);
+        /** @var ChannelRepositoryInterface&MockObject $channelRepository */
+        $channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+        /** @var ChannelInterface&MockObject $channel */
+        $channel = $this->createMock(ChannelInterface::class);
 
-        $channel->getHostname()->willReturn('Channel.host');
-        $channel->getContactEmail()->willReturn('shop@example.com');
+        $channel->method('getHostname')->willReturn('Channel.host');
+        $channel->method('getContactEmail')->willReturn('shop@example.com');
 
-        $channelRepository->findOneByCode('CHANNEL_CODE')->willReturn($channel->reveal());
+        $channelRepository->method('findOneByCode')->with('CHANNEL_CODE')->willReturn($channel);
 
         $contactEmailManager = new ContactEmailManager($emailSender);
 
         $contactEmailManager->sendContactRequest(
             ['email' => 'shop@example.com', 'message' => 'Hello contact request!'],
             ['shop@example.com'],
-            $channel->reveal(),
+            $channel,
             'en_US',
         );
 

--- a/src/Sylius/Bundle/CoreBundle/tests/Mailer/OrderEmailManagerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Mailer/OrderEmailManagerTest.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Bundle\CoreBundle\Mailer;
 
 use PHPUnit\Framework\Attributes\Test;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sylius\Bundle\CoreBundle\Mailer\OrderEmailManagerInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -25,8 +24,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class OrderEmailManagerTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     private const RECIPIENT_EMAIL = 'test@example.com';
 
     private const LOCALE_CODE = 'en_US';
@@ -43,21 +40,21 @@ final class OrderEmailManagerTest extends KernelTestCase
 
         /** @var OrderEmailManagerInterface $orderEmailManager */
         $orderEmailManager = $container->get('sylius.mailer.order_email_manager');
-        /** @var OrderInterface|ObjectProphecy $order */
-        $order = $this->prophesize(OrderInterface::class);
-        /** @var CustomerInterface|ObjectProphecy $customer */
-        $customer = $this->prophesize(CustomerInterface::class);
-        $customer->getEmail()->willReturn(self::RECIPIENT_EMAIL);
-        /** @var ChannelInterface|ObjectProphecy $channel */
-        $channel = $this->prophesize(ChannelInterface::class);
+        /** @var OrderInterface&MockObject $order */
+        $order = $this->createMock(OrderInterface::class);
+        /** @var CustomerInterface&MockObject $customer */
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getEmail')->willReturn(self::RECIPIENT_EMAIL);
+        /** @var ChannelInterface&MockObject $channel */
+        $channel = $this->createMock(ChannelInterface::class);
 
-        $order->getCustomer()->willReturn($customer->reveal());
-        $order->getChannel()->willReturn($channel->reveal());
-        $order->getLocaleCode()->willReturn(self::LOCALE_CODE);
-        $order->getNumber()->willReturn(self::ORDER_NUMBER);
-        $order->getTokenValue()->willReturn('ASFAFA4654AF');
+        $order->method('getCustomer')->willReturn($customer);
+        $order->method('getChannel')->willReturn($channel);
+        $order->method('getLocaleCode')->willReturn(self::LOCALE_CODE);
+        $order->method('getNumber')->willReturn(self::ORDER_NUMBER);
+        $order->method('getTokenValue')->willReturn('ASFAFA4654AF');
 
-        $orderEmailManager->sendConfirmationEmail($order->reveal());
+        $orderEmailManager->sendConfirmationEmail($order);
 
         self::assertEmailCount(1);
         $email = self::getMailerMessage();


### PR DESCRIPTION
## Summary
- Remove phpspec/prophecy-phpunit from main composer.json
- Remove phpspec/prophecy-phpunit from AddressingBundle, AdminBundle, ApiBundle, AttributeBundle, and CoreBundle composer.json files

## Rationale
This package is no longer needed as the project has migrated away from Prophecy mocking in favor of PHPUnit's native mocking capabilities.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced Prophecy-based test tooling with native PHPUnit mocks and expectations across the test suite, modernizing tests and improving reliability.

* **Chores**
  * Removed a legacy phpspec/prophecy-phpunit dev dependency to simplify development and CI maintenance; no runtime or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->