### PR TITLE
Validate product's channel eligibility when finalizing an order

### DIFF
--- a/features/checkout/product_integrity_validation.feature
+++ b/features/checkout/product_integrity_validation.feature
@@ -31,3 +31,12 @@ Feature: Order products integrity
         When I confirm my order
         Then I should be informed that this variant has been disabled
         And I should not see the thank you page
+
+    @ui @api
+    Scenario: Preventing a customer from completing checkout when a product is no longer available in the current channel
+        Given I have product "PHP T-Shirt" added to the cart
+        And I have proceeded through checkout process
+        But this product is not available in "United States" channel
+        When I try to confirm my order
+        Then I should be informed that this product has been disabled
+        And I should not see the thank you page

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
@@ -55,7 +55,7 @@ final class CheckoutCompleteContext implements Context
         $lastResponseContent = $this->client->getLastResponse()->getContent();
 
         Assert::string($lastResponseContent);
-        Assert::contains($lastResponseContent, sprintf('This product %s has been disabled.', $productVariant->getName()));
+        Assert::contains($lastResponseContent, sprintf('The product %s is no longer available.', $productVariant->getName()));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -1046,7 +1046,7 @@ final class CheckoutContext implements Context
     {
         Assert::true($this->isViolationWithMessageInResponse(
             $this->client->getLastResponse(),
-            sprintf('This product %s has been disabled.', $product->getName()),
+            sprintf('The product %s is no longer available.', $product->getName()),
         ));
     }
 

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -1173,6 +1173,15 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^(this product) is not available in ("[^"]+" channel)$/
+     */
+    public function thisProductIsNotAvailableInChannel(ProductInterface $product, ChannelInterface $channel): void
+    {
+        $product->removeChannel($channel);
+        $this->saveProduct($product);
+    }
+
+    /**
      * @Given /^(this product) is configured with the option matching selection method$/
      */
     public function thisProductIsConfiguredWithTheOptionMatchingSelectionMethod(ProductInterface $product): void

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
@@ -318,7 +318,7 @@ final class CheckoutCompleteContext implements Context
         Assert::same(
             $this->completePage->getValidationErrors(),
             sprintf(
-                'This product %s has been disabled.',
+                'The product %s is no longer available.',
                 $product->getName(),
             ),
         );
@@ -352,7 +352,7 @@ final class CheckoutCompleteContext implements Context
         Assert::same(
             $this->completePage->getValidationErrors(),
             sprintf(
-                'This product %s has been disabled.',
+                'The product %s is no longer available.',
                 $productVariant->getName(),
             ),
         );

--- a/src/Sylius/Bundle/ApiBundle/Tests/Validator/Constraints/OrderProductEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Validator/Constraints/OrderProductEligibilityValidatorTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Tests\Validator\Constraints;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Validator\Constraints\OrderProductEligibility;
+use Sylius\Bundle\ApiBundle\Validator\Constraints\OrderProductEligibilityValidator;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+final class OrderProductEligibilityValidatorTest extends TestCase
+{
+    private MockObject|OrderRepositoryInterface $orderRepository;
+    private MockObject|ExecutionContextInterface $context;
+    private OrderProductEligibilityValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+        $this->context = $this->createMock(ExecutionContextInterface::class);
+        $this->validator = new OrderProductEligibilityValidator($this->orderRepository);
+        $this->validator->initialize($this->context);
+    }
+
+    public function test_it_adds_violation_when_variant_is_disabled(): void
+    {
+        $orderToken = 'ORDER_TOKEN';
+        $variantName = 'Variant 1';
+
+        $command = $this->createMock(OrderTokenValueAwareInterface::class);
+        $command->method('getOrderTokenValue')->willReturn($orderToken);
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('isEnabled')->willReturn(false);
+        $variant->method('getName')->willReturn($variantName);
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('isEnabled')->willReturn(true);
+        $product->method('hasChannel')->willReturn(true);
+
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getProduct')->willReturn($product);
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection([$orderItem]));
+        $order->method('getChannel')->willReturn($channel);
+
+        $this->orderRepository->method('findOneBy')->with(['tokenValue' => $orderToken])->willReturn($order);
+
+        $constraint = new OrderProductEligibility();
+
+        $this->context
+            ->expects($this->once())
+            ->method('addViolation')
+            ->with($constraint->message, ['%productName%' => $variantName]);
+
+        $this->validator->validate($command, $constraint);
+    }
+
+    public function test_it_adds_violation_when_product_is_disabled(): void
+    {
+        $orderToken = 'ORDER_TOKEN';
+        $productName = 'Product 2';
+
+        $command = $this->createMock(OrderTokenValueAwareInterface::class);
+        $command->method('getOrderTokenValue')->willReturn($orderToken);
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('isEnabled')->willReturn(true);
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('isEnabled')->willReturn(false);
+        $product->method('getName')->willReturn($productName);
+        $product->method('hasChannel')->willReturn(true);
+
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getProduct')->willReturn($product);
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection([$orderItem]));
+        $order->method('getChannel')->willReturn($channel);
+
+        $this->orderRepository->method('findOneBy')->with(['tokenValue' => $orderToken])->willReturn($order);
+
+        $constraint = new OrderProductEligibility();
+
+        $this->context
+            ->expects($this->once())
+            ->method('addViolation')
+            ->with($constraint->message, ['%productName%' => $productName]);
+
+        $this->validator->validate($command, $constraint);
+    }
+
+    public function test_it_adds_violation_when_product_is_not_assigned_to_channel(): void
+    {
+        $orderToken = 'ORDER_TOKEN';
+        $productName = 'Product 3';
+
+        $command = $this->createMock(OrderTokenValueAwareInterface::class);
+        $command->method('getOrderTokenValue')->willReturn($orderToken);
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('isEnabled')->willReturn(true);
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('isEnabled')->willReturn(true);
+        $product->method('getName')->willReturn($productName);
+        $product->method('hasChannel')->willReturn(false);
+
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getProduct')->willReturn($product);
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection([$orderItem]));
+        $order->method('getChannel')->willReturn($channel);
+
+        $this->orderRepository->method('findOneBy')->with(['tokenValue' => $orderToken])->willReturn($order);
+
+        $constraint = new OrderProductEligibility();
+
+        $this->context
+            ->expects($this->once())
+            ->method('addViolation')
+            ->with($constraint->message, ['%productName%' => $productName]);
+
+        $this->validator->validate($command, $constraint);
+    }
+
+    public function test_it_does_nothing_when_all_products_are_eligible(): void
+    {
+        $orderToken = 'ORDER_TOKEN';
+
+        $command = $this->createMock(OrderTokenValueAwareInterface::class);
+        $command->method('getOrderTokenValue')->willReturn($orderToken);
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $variant->method('isEnabled')->willReturn(true);
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('isEnabled')->willReturn(true);
+        $product->method('hasChannel')->willReturn(true);
+
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getProduct')->willReturn($product);
+
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getItems')->willReturn(new ArrayCollection([$orderItem]));
+        $order->method('getChannel')->willReturn($channel);
+
+        $this->orderRepository->method('findOneBy')->with(['tokenValue' => $orderToken])->willReturn($order);
+
+        $constraint = new OrderProductEligibility();
+
+        $this->context
+            ->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($command, $constraint);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -44,6 +45,7 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
 
         /** @var OrderItemInterface[] $orderItems */
         $orderItems = $order->getItems();
+        $channel = $order->getChannel();
 
         foreach ($orderItems as $orderItem) {
             if (!$orderItem->getVariant()->isEnabled()) {
@@ -52,6 +54,11 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
                     ['%productName%' => $orderItem->getVariant()->getName()],
                 );
             } elseif (!$orderItem->getProduct()->isEnabled()) {
+                $this->context->addViolation(
+                    $constraint->message,
+                    ['%productName%' => $orderItem->getProduct()->getName()],
+                );
+            } elseif (null !== $channel && !$orderItem->getProduct()->hasChannel($channel)) {
                 $this->context->addViolation(
                     $constraint->message,
                     ['%productName%' => $orderItem->getProduct()->getName()],

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ar.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ar.yml
@@ -101,7 +101,7 @@ sylius:
             not_valid: 'رمز العملة الذي أدخلته غير صالح.'
         invalid_state_transition: 'لا يمكن إتمام الطلب لأنه في حالة خاطئة. الحالة الحالية: %currentState%. التحولات الممكنة: %possibleTransitions%.'
         payment_method_eligibility: 'تم تعطيل طريقة الدفع هذه %paymentMethodName%. يرجى إعادة اختيار طريقة الدفع الخاصة بك.'
-        product_eligibility: 'تم تعطيل المنتج هذا %productName%.'
+        product_eligibility: 'المنتج %productName% لم يعد متاحًا.'
         shipping_method_eligibility: 'المنتج لا يتناسب مع متطلبات طريقة الشحن %shippingMethodName%. يرجى إعادة اختيار طريقة الشحن.'
         shipping_method_not_available: 'طريقة الشحن "%shippingMethodName%" غير متوفرة. يرجى إعادة اختيار طريقة الشحن.'
     resend_order_confirmation_email:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.bg.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.bg.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Въведеният от вас валутен код е невалиден.
         payment_method_eligibility: 'Този метод на плащане %paymentMethodName% не е активен. Моля изберете друг метод на плащане.'
-        product_eligibility: 'Този продукт %productName% не е активен.'
+        product_eligibility: 'Продуктът %productName% вече не е наличен.'
         shipping_method_eligibility: 'Продукт не покрива изисквания за метод на доставка %shippingMethodName%. Моля изберете друг метод на доставка.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.cs.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.cs.yml
@@ -41,7 +41,7 @@ sylius:
         currency_code:
             not_valid: Zadaný kód měny je neplatný.
         payment_method_eligibility: 'Tato platební metoda %paymentMethodName% byla zakázána. Prosím znovu vyberte způsob platby.'
-        product_eligibility: 'Tento produkt %productName% byl zakázán.'
+        product_eligibility: 'Produkt %productName% již není dostupný.'
         shipping_method_eligibility: 'Produkt se nevejde požadavky na %shippingMethodName% způsob dopravy. Prosím znovu vyberte způsob dopravy.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.da.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.da.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Valutakoden du indtastede er ugyldig.
         payment_method_eligibility: 'Denne betaling metode %paymentMethodName% er blevet deaktiveret. Venligst Vælg din betalingsmetode.'
-        product_eligibility: 'Dette produkt %productName% er blevet deaktiveret.'
+        product_eligibility: 'Produktet %productName% er ikke længere tilgængeligt.'
         shipping_method_eligibility: 'Produktet passer ikke krav til %shippingMethodName% forsendelsesmetode. Vælg venligst din forsendelsesmetode.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.de.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.de.yml
@@ -59,7 +59,7 @@ sylius:
         currency_code:
             not_valid: Der eingegebene Währungscode ist ungültig.
         payment_method_eligibility: 'Diese Zahlung Methode %paymentMethodName% wurde deaktiviert. Bitte wählen Sie eine andere Zahlungsart aus.'
-        product_eligibility: 'Dieses Produkt %productName% wurde deaktiviert.'
+        product_eligibility: 'Das Produkt %productName% ist nicht mehr verfügbar.'
         shipping_method_eligibility: 'Das Produkt erfüllt nicht die Voraussetzungen für die Versandart %shippingMethodName%. Bitte wählen Sie eine andere Versandart.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.de_CH.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.de_CH.yml
@@ -59,7 +59,7 @@ sylius:
         currency_code:
             not_valid: Der eingegebene Währungscode ist ungültig.
         payment_method_eligibility: 'Diese Zahlung Methode %paymentMethodName% wurde deaktiviert. Bitte wählen Sie eine andere Zahlungsart aus.'
-        product_eligibility: 'Dieses Produkt %productName% wurde deaktiviert.'
+        product_eligibility: 'Das Produkt %productName% ist nicht mehr verfügbar.'
         shipping_method_eligibility: 'Das Produkt erfüllt nicht die Voraussetzungen für die Versandart %shippingMethodName%. Bitte wählen Sie eine andere Versandart.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.el.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.el.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Ο κωδικός συναλλάγματος που έχετε εισάγει δεν είναι έγκυρος.
         payment_method_eligibility: 'Η %paymentMethodName% μέθοδος πληρωμής έχει απενεργοποιηθεί. Παρακαλώ επιλέξτε ξανά τη μέθοδο πληρωμής σας.'
-        product_eligibility: 'Αυτό το προϊόν %productName% έχει απενεργοποιηθεί.'
+        product_eligibility: 'Το προϊόν %productName% δεν είναι πλέον διαθέσιμο.'
         shipping_method_eligibility: 'Το προϊόν δεν ανταποκρίνεται στις απαιτήσεις για την μέθοδο αποστολής %shippingMethodName%. Παρακαλώ επιλέξτε ξανά τη μέθοδο αποστολής σας.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
@@ -98,7 +98,7 @@ sylius:
             not_valid: The currency code you entered is invalid.
         invalid_state_transition: 'Cannot complete as order is in a wrong state. Current: %currentState%. Possible transitions: %possibleTransitions%.'
         payment_method_eligibility: 'This payment method %paymentMethodName% has been disabled. Please reselect your payment method.'
-        product_eligibility: 'This product %productName% has been disabled.'
+        product_eligibility: 'The product %productName% is no longer available.'
         shipping_method_eligibility: 'Product does not fit requirements for %shippingMethodName% shipping method. Please reselect your shipping method.'
         shipping_method_not_available: 'The "%shippingMethodName%" shipping method is not available. Please reselect your shipping method.'
     resend_order_confirmation_email:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.es.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.es.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: El código de la moneda que ingreso no es válido.
         payment_method_eligibility: 'El método de pago %paymentMethodName% no está activo. Por favor, seleccione otro método de pago.'
-        product_eligibility: 'El producto %productName% ha sido desactivado.'
+        product_eligibility: 'El producto %productName% ya no está disponible.'
         shipping_method_eligibility: 'El producto no cumple los requisitos para el método de envío %shippingMethodName%. Por favor, seleccionar otro método de envío.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fa.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fa.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: کد واحد پول وارد شده نامعتبر است.
         payment_method_eligibility: 'این روش پرداخت %paymentMethodName% غیرفعال شده است. لطفا نحوه پرداخت را مجددا انتخاب کنید.'
-        product_eligibility: 'این محصول %productName% غیرفعال شده است.'
+        product_eligibility: 'محصول %productName% دیگر در دسترس نیست.'
     locale:
         enabled:
             cannot_disable_base: زبان پایه را نمی توانید غیر فعال کنید.

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fi.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fi.yml
@@ -18,6 +18,7 @@ sylius:
     order:
         currency_code:
             not_valid: Ilmoittamasi valuuttakoodi ei kelpaa.
+        product_eligibility: 'Tuote %productName% ei ole enää saatavilla.'
     review:
         author:
             not_blank: Kirjoita sähköpostiosoitteesi.

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.fr.yml
@@ -92,7 +92,7 @@ sylius:
             not_valid: Le code de devise que vous avez entré n’est pas valide.
         invalid_state_transition: 'Impossible de terminer car la commande est dans un mauvais état. Actuellement : %currentState%. Transitions possibles : %possibleTransitions%.'
         payment_method_eligibility: 'Cette méthode de paiement %paymentMethodName% a été désactivée. Veuillez sélectionner une nouvelle fois votre mode de paiement.'
-        product_eligibility: 'Le produit %productName% a été désactivé.'
+        product_eligibility: 'Le produit %productName% n’est plus disponible.'
         shipping_method_eligibility: 'Ce produit n''est pas éligible au mode de livraison %shippingMethodName%. Veuillez sélectionner une nouvelle fois votre mode de livraison.'
         shipping_method_not_available: 'Le mode d''expédition "%shippingMethodName%" n''est pas disponible. Veuillez sélectionner à nouveau votre mode de livraison.'
     resend_order_confirmation_email:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.hr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.hr.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Kod valute koji ste unjeli nije ispravan.
         payment_method_eligibility: 'Metoda plaćanja %paymentMethodName% je onemogućena. Molimo ponovo odaberite svoju metodu plaćanja.'
-        product_eligibility: 'Proizvod %productName% je onemogućen.'
+        product_eligibility: 'Proizvod %productName% više nije dostupan.'
         shipping_method_eligibility: 'Proizvod ne spada u tražene zahtjeve za %shippingMethodName% metodu dostave. Molimo ponovo odaberite svoju metodu dostave.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.hu.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.hu.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: A megadott pénznem érvénytelen.
         payment_method_eligibility: 'A %paymentMethodName% fizetési mód le van tiltva. Kérjük válasszon másik fizetési módot.'
-        product_eligibility: 'A %productName% termék le van tiltva.'
+        product_eligibility: 'A %productName% termék már nem elérhető.'
         shipping_method_eligibility: 'A termék nem felel meg a %shippingMethodName% kiszállítási mód feltételeinek. Kérjük válasszon másik kiszállítási módot.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.id.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.id.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Kode mata uang yang anda masukkan tidak valid.
         payment_method_eligibility: 'Metode pembayaran %paymentMethodName% ini telah dinonaktifkan. Silahkan pilih ulang metode pembayaran Anda.'
-        product_eligibility: 'Produk %productName% ini telah dinonaktifkan.'
+        product_eligibility: 'Produk %productName% tidak lagi tersedia.'
         shipping_method_eligibility: 'Produk tidak memenuhi persyaratan untuk pengiriman metode %shippingMethodName%. Silahkan memilih ulang metode pengiriman Anda.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.it.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.it.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Il codice valuta inserito non è valido.
         payment_method_eligibility: 'Questo metodo di pagamento %paymentMethodName% è stato disattivato. Riseleziona il tuo metodo di pagamento.'
-        product_eligibility: 'Questo prodotto %productName% è stato disattivato.'
+        product_eligibility: 'Il prodotto %productName% non è più disponibile.'
         shipping_method_eligibility: 'Il prodotto non risponde alle richieste di %shippingMethodName% metodo di spedizione. Riseleziona il tuo metodo di spedizione.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.mn.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.mn.yml
@@ -41,7 +41,7 @@ sylius:
         currency_code:
             not_valid: Таны оруулсан валютын код буруу байна.
         payment_method_eligibility: 'Энэ төлбөрийн хэрэгсэлийг  %paymentMethodName% идэвхгүй болгосон. Төлбөрийн хэрэгслээ дахин сонгоно уу.'
-        product_eligibility: 'Энэ бүтээгдэхүүнийг %productName% идэвхгүй болгосон.'
+        product_eligibility: 'Бүтээгдэхүүн %productName% дахин худалдаалагдахгүй байна.'
         shipping_method_eligibility: 'Бүтээгдэхүүн нь %shippingMethodName% хүргэлтийн төрлийн шаардлагад нийцэхгүй байна. Хүргэлтийн төрлийг дахин сонгоно уу.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.pl.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.pl.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Wprowadzony kod waluty jest nieprawidłowy.
         payment_method_eligibility: 'Metoda płatności o nazwie %paymentMethodName% została wyłączona. Wybierz ponownie metodę płatności.'
-        product_eligibility: 'Produkt o nazwie %productName% został dezaktywowany.'
+        product_eligibility: 'Produkt %productName% nie jest już dostępny.'
         shipping_method_eligibility: 'Wybrany produkt nie może być użyty z metodą wysyłki o nazwie %shippingMethodName%. Wybierz ponownie metodę wysyłki.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.pt_BR.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.pt_BR.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: O código de moeda que você inseriu é inválido.
         payment_method_eligibility: 'O meio de pagamento %paymentMethodName% foi desabilitado. Por favor selecione novamente sua forma de pagamento.'
-        product_eligibility: 'O produto %productName% foi desabilitado.'
+        product_eligibility: 'O produto %productName% não está mais disponível.'
         shipping_method_eligibility: 'O produto não satizfaz os requisitos do meio de pagamento %shippingMethodName%. Por favor selecione novamente seu meio de pagamento.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ro.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ro.yml
@@ -41,7 +41,7 @@ sylius:
         currency_code:
             not_valid: Codul valutei introdus este invalid.
         payment_method_eligibility: 'Metoda de plată %paymentMethodName% a fost dezactivată. Te rugăm să selectezi o altă metodă.'
-        product_eligibility: 'Produsul %productName% a fost dezactivat.'
+        product_eligibility: 'Produsul %productName% nu mai este disponibil.'
         shipping_method_eligibility: 'Metoda %shippingMethodName% nu poate fi folosită pentru acest produs. Te rugăm să selectezi o altă metodă de livrare.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ru.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.ru.yml
@@ -40,7 +40,7 @@ sylius:
         currency_code:
             not_valid: Код валюты, что вы ввели, неверный.
         payment_method_eligibility: 'Метод оплаты %paymentMethodName% был выключен. Пожалуйста выберете другой метод оплаты.'
-        product_eligibility: 'Продукт %productName% был выключен.'
+        product_eligibility: 'Продукт %productName% больше недоступен.'
         shipping_method_eligibility: 'Продукт не соответствует требованиям способа доставки %shippingMethodName%. Пожалуйста выберете другой способ доставки.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.sk.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.sk.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Zadaný kód meny nie je neplatný.
         payment_method_eligibility: 'Táto platba metóda %paymentMethodName% bola vypnutá. Vyberte iný spôsob platby.'
-        product_eligibility: 'Tento produkt %productName% bola vypnutý.'
+        product_eligibility: 'Produkt %productName% už nie je dostupný.'
         shipping_method_eligibility: 'Produkt nezodpovedá požiadavkám dopravy %shippingMethodName%. Prosím vyberte iný spôsob dopravy.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.sv.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.sv.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Valutakoden du angav är ogiltig.
         payment_method_eligibility: 'Den här betalningsmetoden %paymentMethodName% har inaktiverats. Vänligen välj en ny betalningsmetod.'
-        product_eligibility: 'Denna produkt %productName% har inaktiverats.'
+        product_eligibility: 'Produkten %productName% är inte längre tillgänglig.'
         shipping_method_eligibility: 'Produkten passar inte kraven för %shippingMethodName% leveransmetoden. Vänligen välj en ny leveransmetod.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.th.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.th.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: รหัสสกุลเงินที่คุณป้อนไม่ถูกต้อง
         payment_method_eligibility: '%paymentMethodName% วิธีการชำระเงินนี้ถูกปิดใช้งาน กรุณาเลือกวิธีการชำระเงินใหม่'
-        product_eligibility: '%productName% สินค้านี้ถูกปิดใช้งาน'
+        product_eligibility: 'สินค้า %productName% ไม่สามารถใช้งานได้อีกต่อไป.'
         shipping_method_eligibility: 'สินค้าไม่สามารถจัดส่งด้วยวิธีจัดส่ง %shippingMethodName% กรุณาเลือกวิธีการจัดส่งใหม่'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.tr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.tr.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: Girdiğiniz para birimi kodu geçersiz.
         payment_method_eligibility: 'Bu ödeme şekli %paymentMethodName% devre dışı bırakılmıştır. Lütfen ödeme şeklinizi tekrar seçiniz.'
-        product_eligibility: 'Bu ürün%productName% devre dışı bırakılmıştır.'
+        product_eligibility: 'Ürün %productName% artık mevcut değil.'
         shipping_method_eligibility: 'Ürün gereksinimleri %shippingMethodName% sevkiyat yöntemi için uygun değil. Lütfen, sevkiyat yöntemi yeniden seçin.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.uk.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.uk.yml
@@ -41,7 +41,7 @@ sylius:
         currency_code:
             not_valid: Код валюти, що ви ввели, не є вірним.
         payment_method_eligibility: 'Цей спосіб оплати %paymentMethodName% відключений. Будь ласка, повторно виберіть спосіб оплати.'
-        product_eligibility: 'Цей продукт %productName% був відключений.'
+        product_eligibility: 'Продукт %productName% більше недоступний.'
         shipping_method_eligibility: 'Продукт не відповідає вимогам для %shippingMethodName% способу доставки. Будь ласка, повторно виберіть метод доставки.'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.zh_CN.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.zh_CN.yml
@@ -39,7 +39,7 @@ sylius:
         currency_code:
             not_valid: 您输入的币种代码是无效的。
         payment_method_eligibility: '付款方式 %paymentMethodName% 已被禁用。请重新选择您的付款方式。'
-        product_eligibility: '产品 %productName% 已被禁用。'
+        product_eligibility: '产品 %productName% 已不再提供。'
         shipping_method_eligibility: '此产品并不适合 %shippingMethodName% 运输方式。请重新选择您的运输方式。'
     locale:
         enabled:

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Symfony\Component\Validator\Constraint;
@@ -34,6 +35,7 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
 
         /** @var OrderItemInterface[] $orderItems */
         $orderItems = $value->getItems();
+        $channel = $value->getChannel();
 
         foreach ($orderItems as $orderItem) {
             if (!$orderItem->getVariant()->isEnabled()) {
@@ -42,6 +44,11 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
                     ['%productName%' => $orderItem->getVariant()->getName()],
                 );
             } elseif (!$orderItem->getProduct()->isEnabled()) {
+                $this->context->addViolation(
+                    $constraint->message,
+                    ['%productName%' => $orderItem->getProduct()->getName()],
+                );
+            } elseif (null !== $channel && !$orderItem->getProduct()->hasChannel($channel)) {
                 $this->context->addViolation(
                     $constraint->message,
                     ['%productName%' => $orderItem->getProduct()->getName()],


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/Sylius/issues/17568
| License         | MIT

When finalizing an order, while checking whether products and variants are "isEnabled," a check has also been added to see if they are assigned to the current channel.