### PR TITLE
Refactor CookieSetter to optimize browser navigation

### DIFF
--- a/src/Sylius/Behat/Service/Setter/CookieSetter.php
+++ b/src/Sylius/Behat/Service/Setter/CookieSetter.php
@@ -20,7 +20,7 @@ use DMore\ChromeDriver\ChromeDriver;
 use FriendsOfBehat\SymfonyExtension\Driver\SymfonyDriver;
 use Symfony\Component\BrowserKit\Cookie;
 
-final class CookieSetter implements CookieSetterInterface
+final readonly class CookieSetter implements CookieSetterInterface
 {
     public function __construct(
         private Session $minkSession,
@@ -28,17 +28,11 @@ final class CookieSetter implements CookieSetterInterface
     ) {
     }
 
-    public function setCookie($name, $value)
+    public function setCookie(string $name, string $value): void
     {
         $driver = $this->minkSession->getDriver();
 
-        if ($driver instanceof ChromeDriver || $driver instanceof PantherDriver) {
-            if (!$driver->isStarted()) {
-                $driver->start();
-            }
-        }
-
-        $this->prepareMinkSessionIfNeeded($this->minkSession);
+        $this->ensureDriverStarted($driver);
 
         if ($driver instanceof SymfonyDriver) {
             $driver->getClient()->getCookieJar()->set(
@@ -48,7 +42,15 @@ final class CookieSetter implements CookieSetterInterface
             return;
         }
 
+        $this->prepareMinkSessionIfNeeded($this->minkSession);
         $this->minkSession->setCookie($name, $value);
+    }
+
+    private function ensureDriverStarted(mixed $driver): void
+    {
+        if (($driver instanceof ChromeDriver || $driver instanceof PantherDriver) && !$driver->isStarted()) {
+            $driver->start();
+        }
     }
 
     private function prepareMinkSessionIfNeeded(Session $session): void
@@ -66,18 +68,19 @@ final class CookieSetter implements CookieSetterInterface
             return false;
         }
 
-        if ($driver instanceof Selenium2Driver && $driver->getWebDriverSession() === null) {
-            return true;
+        if ($driver instanceof Selenium2Driver) {
+            return $driver->getWebDriverSession() === null || $this->isPageNotLoaded($session->getCurrentUrl());
         }
 
         if ($driver instanceof ChromeDriver) {
-            return true;
+            return $this->isPageNotLoaded($session->getCurrentUrl());
         }
 
-        if (str_contains($session->getCurrentUrl(), $this->minkParameters['base_url'])) {
-            return false;
-        }
+        return !str_contains($session->getCurrentUrl(), $this->minkParameters['base_url']);
+    }
 
-        return true;
+    private function isPageNotLoaded(string $url): bool
+    {
+        return in_array($url, ['', 'about:blank', 'data:,'], true);
     }
 }

--- a/src/Sylius/Behat/Service/Setter/CookieSetterInterface.php
+++ b/src/Sylius/Behat/Service/Setter/CookieSetterInterface.php
@@ -15,9 +15,5 @@ namespace Sylius\Behat\Service\Setter;
 
 interface CookieSetterInterface
 {
-    /**
-     * @param string $name
-     * @param string $value
-     */
-    public function setCookie($name, $value);
+    public function setCookie(string $name, string $value): void;
 }


### PR DESCRIPTION
## Summary

Optimized cookie setter to avoid unnecessary page navigations in Behat tests

**Before:** ChromeDriver and Selenium2Driver always required visiting base_url before setting cookies, even when already on a valid page.

**After:** Smart detection checks current URL state - only visits base_url when truly needed (blank page states).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved automated testing reliability by strengthening cookie handling and browser session startup logic.
  * Added stricter typing and safety checks to test helpers to reduce flaky test runs.
  * Better detection of unloaded pages to ensure tests run against initialized browser sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->