### PR TITLE
[Behat] Fix flaky tests by correcting LiveComponent loading state detection

### DIFF
--- a/src/Sylius/Behat/Context/Ui/Admin/Helper/ValidationTrait.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/Helper/ValidationTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin\Helper;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Behaviour\SpecifiesItsField;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Webmozart\Assert\Assert;
 
@@ -53,7 +53,7 @@ trait ValidationTrait
     }
 
     /**
-     * @return SymfonyPageInterface&SpecifiesItsField
+     * @return SyliusPageInterface&SpecifiesItsField
      */
-    abstract protected function resolveCurrentPage(): SymfonyPageInterface;
+    abstract protected function resolveCurrentPage(): SyliusPageInterface;
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\CatalogPromotion\FilterElementInterface;
 use Sylius\Behat\Element\Admin\CatalogPromotion\FormElementInterface;
@@ -23,6 +22,7 @@ use Sylius\Behat\Page\Admin\CatalogPromotion\CreatePageInterface;
 use Sylius\Behat\Page\Admin\CatalogPromotion\ShowPageInterface;
 use Sylius\Behat\Page\Admin\CatalogPromotion\UpdatePageInterface;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\FixedDiscountPriceCalculator;
@@ -1197,7 +1197,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->createPage->create();
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->createPage;
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\Channel\DiscountedProductsCheckingPeriodInputElementInterface;
 use Sylius\Behat\Element\Admin\Channel\ExcludeTaxonsFromShowingLowestPriceInputElementInterface;
@@ -24,6 +23,7 @@ use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Channel\CreatePageInterface;
 use Sylius\Behat\Page\Admin\Channel\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Channel\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -722,7 +722,7 @@ final class ManagingChannelsContext implements Context
         return str_repeat('a@', 128);
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -15,11 +15,11 @@ namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Behat\Page\Admin\PaymentMethod\CreatePageInterface;
 use Sylius\Behat\Page\Admin\PaymentMethod\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
@@ -468,7 +468,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::true($this->indexPage->isEnabledFilterApplied());
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\ProductVariant\CreatePageInterface;
 use Sylius\Behat\Page\Admin\ProductVariant\GeneratePageInterface;
 use Sylius\Behat\Page\Admin\ProductVariant\IndexPageInterface;
 use Sylius\Behat\Page\Admin\ProductVariant\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -804,7 +804,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($currentPage->getValidationMessage($element), $message);
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\Promotion\FormElementInterface;
 use Sylius\Behat\NotificationType;
@@ -22,6 +21,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as IndexPageCouponInterface;
 use Sylius\Behat\Page\Admin\Promotion\CreatePageInterface;
 use Sylius\Behat\Page\Admin\Promotion\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Promotion\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -959,7 +959,7 @@ final class ManagingPromotionsContext implements Context
         Assert::false($this->updatePage->hasResourceValues([$field => 1]));
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Behat\Page\Admin\ShippingCategory\CreatePageInterface;
 use Sylius\Behat\Page\Admin\ShippingCategory\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Webmozart\Assert\Assert;
 
@@ -218,7 +218,7 @@ class ManagingShippingCategoriesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->createPage;
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\TaxRate\FilterElementInterface;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
 use Sylius\Behat\Page\Admin\TaxRate\CreatePageInterface;
 use Sylius\Behat\Page\Admin\TaxRate\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Component\Core\Model\TaxRateInterface;
 use Webmozart\Assert\Assert;
@@ -404,7 +404,7 @@ final class ManagingTaxRateContext implements Context
         );
     }
 
-    protected function resolveCurrentPage(): SymfonyPageInterface
+    protected function resolveCurrentPage(): SyliusPageInterface
     {
         return $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
     }

--- a/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Shop\Account\AddressBook\CreatePageInterface;
 use Sylius\Behat\Page\Shop\Account\AddressBook\IndexPageInterface;
 use Sylius\Behat\Page\Shop\Account\AddressBook\UpdatePageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -376,7 +376,7 @@ final class AddressBookContext implements Context
     }
 
     /**
-     * @return SymfonyPageInterface
+     * @return SyliusPageInterface
      */
     private function getCurrentPage()
     {

--- a/src/Sylius/Behat/Element/Admin/Account/ResetElement.php
+++ b/src/Sylius/Behat/Element/Admin/Account/ResetElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Account;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class ResetElement extends Element implements ResetElementInterface
+class ResetElement extends SyliusElement implements ResetElementInterface
 {
     public function reset(): void
     {

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FilterElement.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\CatalogPromotion;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 use Sylius\Component\Core\Model\ChannelInterface;
 
-class FilterElement extends Element implements FilterElementInterface
+class FilterElement extends SyliusElement implements FilterElementInterface
 {
     protected const BOOLEAN_FILTER_TRUE = 'Yes';
 

--- a/src/Sylius/Behat/Element/Admin/Channel/DiscountedProductsCheckingPeriodInputElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/DiscountedProductsCheckingPeriodInputElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Channel;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class DiscountedProductsCheckingPeriodInputElement extends Element implements DiscountedProductsCheckingPeriodInputElementInterface
+class DiscountedProductsCheckingPeriodInputElement extends SyliusElement implements DiscountedProductsCheckingPeriodInputElementInterface
 {
     public function specifyPeriod(int $period): void
     {

--- a/src/Sylius/Behat/Element/Admin/Channel/LowestPriceFlagElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/LowestPriceFlagElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Channel;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class LowestPriceFlagElement extends Element implements LowestPriceFlagElementInterface
+class LowestPriceFlagElement extends SyliusElement implements LowestPriceFlagElementInterface
 {
     public function enable(): void
     {

--- a/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShippingAddressInCheckoutRequiredElement.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Admin\Channel;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 use Webmozart\Assert\Assert;
 
-class ShippingAddressInCheckoutRequiredElement extends Element implements ShippingAddressInCheckoutRequiredElementInterface
+class ShippingAddressInCheckoutRequiredElement extends SyliusElement implements ShippingAddressInCheckoutRequiredElementInterface
 {
     protected const ADDRESS_TYPE_BILLING = 'billing';
 

--- a/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Channel;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class ShopBillingDataElement extends Element implements ShopBillingDataElementInterface
+class ShopBillingDataElement extends SyliusElement implements ShopBillingDataElementInterface
 {
     public function specifyCompany(string $company): void
     {

--- a/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Crud/FormElement.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Element\Admin\Crud;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class FormElement extends Element implements FormElementInterface
+class FormElement extends SyliusElement implements FormElementInterface
 {
     public function fillElement(string $value, string $element, array $parameters = []): void
     {

--- a/src/Sylius/Behat/Element/Admin/Crud/Index/SearchFilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/Crud/Index/SearchFilterElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Crud\Index;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class SearchFilterElement extends Element implements SearchFilterElementInterface
+class SearchFilterElement extends SyliusElement implements SearchFilterElementInterface
 {
     public function searchWith(string $phrase): void
     {

--- a/src/Sylius/Behat/Element/Admin/NotificationsElement.php
+++ b/src/Sylius/Behat/Element/Admin/NotificationsElement.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Admin;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 use Sylius\Behat\Service\DriverHelper;
 
-class NotificationsElement extends Element implements NotificationsElementInterface
+class NotificationsElement extends SyliusElement implements NotificationsElementInterface
 {
     public function hasNotification(string $type, string $message): bool
     {

--- a/src/Sylius/Behat/Element/Admin/ProductAttribute/FilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/ProductAttribute/FilterElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\ProductAttribute;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class FilterElement extends Element implements FilterElementInterface
+class FilterElement extends SyliusElement implements FilterElementInterface
 {
     public function chooseType(string $type): void
     {

--- a/src/Sylius/Behat/Element/Admin/TaxRate/FilterElement.php
+++ b/src/Sylius/Behat/Element/Admin/TaxRate/FilterElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\TaxRate;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class FilterElement extends Element implements FilterElementInterface
+class FilterElement extends SyliusElement implements FilterElementInterface
 {
     public function specifyDateFrom(string $dateType, string $date): void
     {

--- a/src/Sylius/Behat/Element/Admin/Taxon/TreeElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/TreeElement.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin\Taxon;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element as BaseElement;
+use Sylius\Behat\Element\SyliusElement;
 use Sylius\Behat\Service\DriverHelper;
 
-class TreeElement extends BaseElement implements TreeElementInterface
+class TreeElement extends SyliusElement implements TreeElementInterface
 {
     public function getTaxonsNames(): array
     {

--- a/src/Sylius/Behat/Element/Admin/TopBarElement.php
+++ b/src/Sylius/Behat/Element/Admin/TopBarElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Admin;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class TopBarElement extends Element implements TopBarElementInterface
+class TopBarElement extends SyliusElement implements TopBarElementInterface
 {
     public function hasAvatarInMainBar(string $avatarPath): bool
     {

--- a/src/Sylius/Behat/Element/BrowserElement.php
+++ b/src/Sylius/Behat/Element/BrowserElement.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
-
-class BrowserElement extends Element implements BrowserElementInterface
+class BrowserElement extends SyliusElement implements BrowserElementInterface
 {
     public function goBack(): void
     {

--- a/src/Sylius/Behat/Element/Product/IndexPage/VerticalMenuElement.php
+++ b/src/Sylius/Behat/Element/Product/IndexPage/VerticalMenuElement.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Product\IndexPage;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class VerticalMenuElement extends Element implements VerticalMenuElementInterface
+class VerticalMenuElement extends SyliusElement implements VerticalMenuElementInterface
 {
     public function getMenuItems(): array
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/AssociationsElement.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Product\ShowPage;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class AssociationsElement extends Element implements AssociationsElementInterface
+class AssociationsElement extends SyliusElement implements AssociationsElementInterface
 {
     public function hasAssociation(string $associationName): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/AttributesElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/AttributesElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class AttributesElement extends Element implements AttributesElementInterface
+class AttributesElement extends SyliusElement implements AttributesElementInterface
 {
     public function hasAttributeInLocale(string $attribute, string $localeCode, string $value): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class DetailsElement extends Element implements DetailsElementInterface
+class DetailsElement extends SyliusElement implements DetailsElementInterface
 {
     public function getProductCode(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/LowestPriceInformationElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/LowestPriceInformationElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class LowestPriceInformationElement extends Element implements LowestPriceInformationElementInterface
+class LowestPriceInformationElement extends SyliusElement implements LowestPriceInformationElementInterface
 {
     public function isThereInformationAboutProductLowestPriceWithPrice(string $lowestPriceBeforeDiscount): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/MediaElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/MediaElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class MediaElement extends Element implements MediaElementInterface
+class MediaElement extends SyliusElement implements MediaElementInterface
 {
     public function isImageDisplayed(): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/OptionsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/OptionsElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class OptionsElement extends Element implements OptionsElementInterface
+class OptionsElement extends SyliusElement implements OptionsElementInterface
 {
     public function isOptionDefined(string $optionName): bool
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Element\Product\ShowPage;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class PricingElement extends Element implements PricingElementInterface
+class PricingElement extends SyliusElement implements PricingElementInterface
 {
     public function getPriceForChannel(string $channelCode): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/ShippingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/ShippingElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class ShippingElement extends Element implements ShippingElementInterface
+class ShippingElement extends SyliusElement implements ShippingElementInterface
 {
     public function getProductShippingCategory(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/TaxonomyElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/TaxonomyElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class TaxonomyElement extends Element implements TaxonomyElementInterface
+class TaxonomyElement extends SyliusElement implements TaxonomyElementInterface
 {
     public function getProductMainTaxon(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/TranslationsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/TranslationsElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class TranslationsElement extends Element implements TranslationsElementInterface
+class TranslationsElement extends SyliusElement implements TranslationsElementInterface
 {
     public function getDescription(): string
     {

--- a/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/VariantsElement.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Product\ShowPage;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class VariantsElement extends Element implements VariantsElementInterface
+class VariantsElement extends SyliusElement implements VariantsElementInterface
 {
     public function countVariantsOnPage(): int
     {

--- a/src/Sylius/Behat/Element/SaveElement.php
+++ b/src/Sylius/Behat/Element/SaveElement.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
 use Sylius\Behat\Service\DriverHelper;
 
-class SaveElement extends Element implements SaveElementInterface
+class SaveElement extends SyliusElement implements SaveElementInterface
 {
     public function saveChanges(): void
     {

--- a/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
+++ b/src/Sylius/Behat/Element/Shop/Account/RegisterElement.php
@@ -16,12 +16,12 @@ namespace Sylius\Behat\Element\Shop\Account;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
+use Sylius\Behat\Element\SyliusElement;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\SharedStorageInterface;
 
-class RegisterElement extends Element implements RegisterElementInterface
+class RegisterElement extends SyliusElement implements RegisterElementInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Element/Shop/CartWidgetElement.php
+++ b/src/Sylius/Behat/Element/Shop/CartWidgetElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Shop;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class CartWidgetElement extends Element implements CartWidgetElementInterface
+class CartWidgetElement extends SyliusElement implements CartWidgetElementInterface
 {
     public function getCartTotalQuantity(): int
     {

--- a/src/Sylius/Behat/Element/Shop/CheckoutSubtotalElement.php
+++ b/src/Sylius/Behat/Element/Shop/CheckoutSubtotalElement.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Shop;
 
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class CheckoutSubtotalElement extends Element implements CheckoutSubtotalElementInterface
+class CheckoutSubtotalElement extends SyliusElement implements CheckoutSubtotalElementInterface
 {
     public function getProductQuantity(string $productName): int
     {

--- a/src/Sylius/Behat/Element/Shop/MenuElement.php
+++ b/src/Sylius/Behat/Element/Shop/MenuElement.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Element\Shop;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Element\Element;
+use Sylius\Behat\Element\SyliusElement;
 
-class MenuElement extends Element implements MenuElementInterface
+class MenuElement extends SyliusElement implements MenuElementInterface
 {
     public function getMenuItems(): array
     {

--- a/src/Sylius/Behat/Element/SyliusElement.php
+++ b/src/Sylius/Behat/Element/SyliusElement.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element;
+
+use Behat\Mink\Element\NodeElement;
+use FriendsOfBehat\PageObjectExtension\Element\Element as BaseElement;
+use Sylius\Behat\Service\DriverHelper;
+
+abstract class SyliusElement extends BaseElement
+{
+    /** @param array<string, mixed> $parameters */
+    protected function getElement(string $name, array $parameters = []): NodeElement
+    {
+        $this->waitForLiveComponentToFinish();
+
+        return parent::getElement($name, $parameters);
+    }
+
+    protected function waitForLiveComponentToFinish(): void
+    {
+        if (DriverHelper::isJavascript($this->getDriver()) === false) {
+            return;
+        }
+
+        // Wait for ALL LiveComponents to complete their operations
+        // Returns immediately if condition is already met
+        // Max 10 seconds for: DOM ready, no loading indicators, no busy elements
+        $this->getSession()->wait(
+            10000,
+            "document.readyState === 'complete' && " .
+            "document.querySelectorAll('[data-live-is-loading]').length === 0 && " .
+            "document.querySelectorAll('[busy]').length === 0",
+        );
+    }
+}

--- a/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
@@ -15,11 +15,11 @@ namespace Sylius\Behat\Page\Admin\Account;
 
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class LoginPage extends SymfonyPage implements LoginPageInterface
+class LoginPage extends SyliusPage implements LoginPageInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Page/Admin/Account/LoginPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Account/LoginPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface LoginPageInterface extends SymfonyPageInterface
+interface LoginPageInterface extends SyliusPageInterface
 {
     public function hasValidationErrorWith(string $message): bool;
 

--- a/src/Sylius/Behat/Page/Admin/Account/RequestPasswordResetPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/RequestPasswordResetPage.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class RequestPasswordResetPage extends SymfonyPage implements RequestPasswordResetPageInterface
+class RequestPasswordResetPage extends SyliusPage implements RequestPasswordResetPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/Account/RequestPasswordResetPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Account/RequestPasswordResetPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface RequestPasswordResetPageInterface extends SymfonyPageInterface
+interface RequestPasswordResetPageInterface extends SyliusPageInterface
 {
     public function specifyEmail(string $email): void;
 

--- a/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPage.php
@@ -16,11 +16,11 @@ namespace Sylius\Behat\Page\Admin\Account;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterface
+class ResetPasswordPage extends SyliusPage implements ResetPasswordPageInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Account/ResetPasswordPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ResetPasswordPageInterface extends SymfonyPageInterface
+interface ResetPasswordPageInterface extends SyliusPageInterface
 {
     public function checkValidationMessageFor(string $element, string $message): bool;
 

--- a/src/Sylius/Behat/Page/Admin/Administrator/ImpersonateUserPage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/ImpersonateUserPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Administrator;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class ImpersonateUserPage extends SymfonyPage implements ImpersonateUserPageInterface
+class ImpersonateUserPage extends SyliusPage implements ImpersonateUserPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/Administrator/ImpersonateUserPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/ImpersonateUserPageInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Administrator;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ImpersonateUserPageInterface extends SymfonyPageInterface
+interface ImpersonateUserPageInterface extends SyliusPageInterface
 {
 }

--- a/src/Sylius/Behat/Page/Admin/CatalogPromotion/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/CatalogPromotion/ShowPage.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\CatalogPromotion;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -18,11 +18,11 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 use Symfony\Component\Routing\RouterInterface;
 
-class CreatePage extends SymfonyPage implements CreatePageInterface
+class CreatePage extends SyliusPage implements CreatePageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Crud;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface CreatePageInterface extends SymfonyPageInterface
+interface CreatePageInterface extends SyliusPageInterface
 {
     /**
      * @throws ElementNotFoundException

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -16,12 +16,12 @@ namespace Sylius\Behat\Page\Admin\Crud;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Webmozart\Assert\Assert;
 
-class IndexPage extends SymfonyPage implements IndexPageInterface
+class IndexPage extends SyliusPage implements IndexPageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Crud;
 
 use Behat\Mink\Element\NodeElement;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface IndexPageInterface extends SymfonyPageInterface
+interface IndexPageInterface extends SyliusPageInterface
 {
     public function isSingleResourceOnPage(array $parameters): bool;
 

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -18,12 +18,12 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Symfony\Component\Routing\RouterInterface;
 
-class UpdatePage extends SymfonyPage implements UpdatePageInterface
+class UpdatePage extends SyliusPage implements UpdatePageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Crud;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface UpdatePageInterface extends SymfonyPageInterface
+interface UpdatePageInterface extends SyliusPageInterface
 {
     /**
      * @throws ElementNotFoundException

--- a/src/Sylius/Behat/Page/Admin/Customer/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/ShowPage.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Customer;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function deleteAccount(): void
     {

--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -15,12 +15,12 @@ namespace Sylius\Behat\Page\Admin;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class DashboardPage extends SymfonyPage implements DashboardPageInterface
+class DashboardPage extends SyliusPage implements DashboardPageInterface
 {
     /**
      * @template TKey of array-key

--- a/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 
-interface DashboardPageInterface extends SymfonyPageInterface
+interface DashboardPageInterface extends SyliusPageInterface
 {
     public function getTotalSales(): string;
 

--- a/src/Sylius/Behat/Page/Admin/EditToShowPageSwitcherInterface.php
+++ b/src/Sylius/Behat/Page/Admin/EditToShowPageSwitcherInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface EditToShowPageSwitcherInterface extends SymfonyPageInterface
+interface EditToShowPageSwitcherInterface extends SyliusPageInterface
 {
     public function switchToShowPage(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Order/HistoryPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/HistoryPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Order;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class HistoryPage extends SymfonyPage implements HistoryPageInterface
+class HistoryPage extends SyliusPage implements HistoryPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/Order/HistoryPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/HistoryPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface HistoryPageInterface extends SymfonyPageInterface
+interface HistoryPageInterface extends SyliusPageInterface
 {
     public function countBillingAddressChanges(): int;
 

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -16,13 +16,13 @@ namespace Sylius\Behat\Page\Admin\Order;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
-interface ShowPageInterface extends SymfonyPageInterface
+interface ShowPageInterface extends SyliusPageInterface
 {
     public function hasCustomer(string $customerEmail): bool;
 

--- a/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/ShowPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Payment\PaymentRequest;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Payment/PaymentRequest/ShowPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Payment\PaymentRequest;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ShowPageInterface extends SymfonyPageInterface
+interface ShowPageInterface extends SyliusPageInterface
 {
     public function getFieldText(string $fieldName): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/ShowPage.php
@@ -16,11 +16,11 @@ namespace Sylius\Behat\Page\Admin\Product;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\NavigationTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     use NavigationTrait;
 

--- a/src/Sylius/Behat/Page/Admin/Product/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/ShowPageInterface.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Product;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 use Sylius\Behat\Page\Admin\ShowToEditPageSwitcherInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
-interface ShowPageInterface extends SymfonyPageInterface, ShowToEditPageSwitcherInterface
+interface ShowPageInterface extends SyliusPageInterface, ShowToEditPageSwitcherInterface
 {
     /** @return string[] */
     public function getAppliedCatalogPromotionsLinks(string $variantName, string $channelName): array;

--- a/src/Sylius/Behat/Page/Admin/Shipment/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Shipment/ShowPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Shipment;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Admin/ShowPageButtonCheckerInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShowPageButtonCheckerInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ShowPageButtonCheckerInterface extends SymfonyPageInterface
+interface ShowPageButtonCheckerInterface extends SyliusPageInterface
 {
     public function hasShowPageButton(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ShowToEditPageSwitcherInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShowToEditPageSwitcherInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ShowToEditPageSwitcherInterface extends SymfonyPageInterface
+interface ShowToEditPageSwitcherInterface extends SyliusPageInterface
 {
     public function hasEditPageButton(): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
@@ -15,11 +15,11 @@ namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
 use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Core\Model\AddressInterface;
 
-class CreatePage extends SymfonyPage implements CreatePageInterface
+class CreatePage extends SyliusPage implements CreatePageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePageInterface.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 
-interface CreatePageInterface extends SymfonyPageInterface
+interface CreatePageInterface extends SyliusPageInterface
 {
     public function fillAddressData(AddressInterface $address): void;
 

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/IndexPage.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 use Webmozart\Assert\Assert;
 
-class IndexPage extends SymfonyPage implements IndexPageInterface
+class IndexPage extends SyliusPage implements IndexPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/IndexPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface IndexPageInterface extends SymfonyPageInterface
+interface IndexPageInterface extends SyliusPageInterface
 {
     public function getAddressesCount(): int;
 

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -15,10 +15,10 @@ namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
 use Behat\Mink\Exception\DriverException;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\JQueryHelper;
 
-class UpdatePage extends SymfonyPage implements UpdatePageInterface
+class UpdatePage extends SyliusPage implements UpdatePageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface UpdatePageInterface extends SymfonyPageInterface
+interface UpdatePageInterface extends SyliusPageInterface
 {
     public function fillField(string $field, ?string $value): void;
 

--- a/src/Sylius/Behat/Page/Shop/Account/ChangePasswordPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ChangePasswordPage.php
@@ -16,11 +16,11 @@ namespace Sylius\Behat\Page\Shop\Account;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ChangePasswordPage extends SymfonyPage implements ChangePasswordPageInterface
+class ChangePasswordPage extends SyliusPage implements ChangePasswordPageInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Page/Shop/Account/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/DashboardPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class DashboardPage extends SymfonyPage implements DashboardPageInterface
+class DashboardPage extends SyliusPage implements DashboardPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
@@ -15,13 +15,13 @@ namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class LoginPage extends SymfonyPage implements LoginPageInterface
+class LoginPage extends SyliusPage implements LoginPageInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Page/Shop/Account/LoginPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/LoginPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface LoginPageInterface extends SymfonyPageInterface
+interface LoginPageInterface extends SyliusPageInterface
 {
     public function hasValidationErrorWith(string $message): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Account/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/IndexPage.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account\Order;
 
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class IndexPage extends SymfonyPage implements IndexPageInterface
+class IndexPage extends SyliusPage implements IndexPageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Shop/Account/Order/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/IndexPageInterface.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
-interface IndexPageInterface extends SymfonyPageInterface
+interface IndexPageInterface extends SyliusPageInterface
 {
     public function countOrders(): int;
 

--- a/src/Sylius/Behat/Page/Shop/Account/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/ShowPage.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account\Order;
 
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Shop/Account/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/Order/ShowPageInterface.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 
-interface ShowPageInterface extends SymfonyPageInterface
+interface ShowPageInterface extends SyliusPageInterface
 {
     public function getNumber(): string;
 

--- a/src/Sylius/Behat/Page/Shop/Account/ProfileUpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ProfileUpdatePage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class ProfileUpdatePage extends SymfonyPage implements ProfileUpdatePageInterface
+class ProfileUpdatePage extends SyliusPage implements ProfileUpdatePageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/RegisterPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RegisterPage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Component\Core\Formatter\StringInflector;
 
-class RegisterPage extends SymfonyPage implements RegisterPageInterface
+class RegisterPage extends SyliusPage implements RegisterPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/RegisterPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RegisterPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface RegisterPageInterface extends SymfonyPageInterface
+interface RegisterPageInterface extends SyliusPageInterface
 {
     public function getRouteName(): string;
 

--- a/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class RegisterThankYouPage extends SymfonyPage implements RegisterThankYouPageInterface
+class RegisterThankYouPage extends SyliusPage implements RegisterThankYouPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RegisterThankYouPageInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface RegisterThankYouPageInterface extends SymfonyPageInterface
+interface RegisterThankYouPageInterface extends SyliusPageInterface
 {
 }

--- a/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPage.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class RequestPasswordResetPage extends SymfonyPage implements RequestPasswordResetPageInterface
+class RequestPasswordResetPage extends SyliusPage implements RequestPasswordResetPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface RequestPasswordResetPageInterface extends SymfonyPageInterface
+interface RequestPasswordResetPageInterface extends SyliusPageInterface
 {
     public function checkValidationMessageFor(string $element, string $message): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
@@ -16,11 +16,11 @@ namespace Sylius\Behat\Page\Shop\Account;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterface
+class ResetPasswordPage extends SyliusPage implements ResetPasswordPageInterface
 {
     use SecurePasswordTrait;
 

--- a/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ResetPasswordPageInterface extends SymfonyPageInterface
+interface ResetPasswordPageInterface extends SyliusPageInterface
 {
     public function reset(): void;
 

--- a/src/Sylius/Behat/Page/Shop/Account/VerificationPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/VerificationPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class VerificationPage extends SymfonyPage implements VerificationPageInterface
+class VerificationPage extends SyliusPage implements VerificationPageInterface
 {
     public function verifyAccount(string $token): void
     {

--- a/src/Sylius/Behat/Page/Shop/Account/VerificationPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/VerificationPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface VerificationPageInterface extends SymfonyPageInterface
+interface VerificationPageInterface extends SyliusPageInterface
 {
     public function verifyAccount(string $token): void;
 }

--- a/src/Sylius/Behat/Page/Shop/Account/WellKnownPasswordChangePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/WellKnownPasswordChangePage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class WellKnownPasswordChangePage extends SymfonyPage implements WellKnownPasswordChangePageInterface
+class WellKnownPasswordChangePage extends SyliusPage implements WellKnownPasswordChangePageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Account/WellKnownPasswordChangePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/WellKnownPasswordChangePageInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Account;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface WellKnownPasswordChangePageInterface extends SymfonyPageInterface
+interface WellKnownPasswordChangePageInterface extends SyliusPageInterface
 {
 }

--- a/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/CompletePage.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Page\Shop\Checkout;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
 use Sylius\Behat\Service\DriverHelper;
 use Sylius\Component\Core\Model\AddressInterface;
@@ -24,7 +24,7 @@ use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Routing\RouterInterface;
 
-class CompletePage extends SymfonyPage implements CompletePageInterface
+class CompletePage extends SyliusPage implements CompletePageInterface
 {
     public function __construct(
         Session $session,

--- a/src/Sylius/Behat/Page/Shop/Checkout/CompletePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/CompletePageInterface.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Checkout;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 
-interface CompletePageInterface extends SymfonyPageInterface
+interface CompletePageInterface extends SyliusPageInterface
 {
     public function hasItemWithProductAndQuantity(string $productName, string $quantity): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectPaymentPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectPaymentPage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Checkout;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class SelectPaymentPage extends SymfonyPage implements SelectPaymentPageInterface
+class SelectPaymentPage extends SyliusPage implements SelectPaymentPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectPaymentPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectPaymentPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Checkout;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface SelectPaymentPageInterface extends SymfonyPageInterface
+interface SelectPaymentPageInterface extends SyliusPageInterface
 {
     public function selectPaymentMethod(string $paymentMethod): void;
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Checkout;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterface
+class SelectShippingPage extends SyliusPage implements SelectShippingPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Checkout;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface SelectShippingPageInterface extends SymfonyPageInterface
+interface SelectShippingPageInterface extends SyliusPageInterface
 {
     public function selectShippingMethod(string $shippingMethod): void;
 

--- a/src/Sylius/Behat/Page/Shop/HomePage.php
+++ b/src/Sylius/Behat/Page/Shop/HomePage.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Page\Shop;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class HomePage extends SymfonyPage implements HomePageInterface
+class HomePage extends SyliusPage implements HomePageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/HomePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/HomePageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface HomePageInterface extends SymfonyPageInterface
+interface HomePageInterface extends SyliusPageInterface
 {
     public function getContent(): string;
 

--- a/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Order;
 
 use Behat\Mink\Element\NodeElement;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SyliusPage implements ShowPageInterface
 {
     public function hasPayAction(): bool
     {

--- a/src/Sylius/Behat/Page/Shop/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ShowPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ShowPageInterface extends SymfonyPageInterface
+interface ShowPageInterface extends SyliusPageInterface
 {
     public function hasPayAction(): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Order/ThankYouPage.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ThankYouPage.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Order;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\DriverHelper;
 
-class ThankYouPage extends SymfonyPage implements ThankYouPageInterface
+class ThankYouPage extends SyliusPage implements ThankYouPageInterface
 {
     public function goToTheChangePaymentMethodPage(): void
     {

--- a/src/Sylius/Behat/Page/Shop/Order/ThankYouPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ThankYouPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\Order;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface ThankYouPageInterface extends SymfonyPageInterface
+interface ThankYouPageInterface extends SyliusPageInterface
 {
     public function goToTheChangePaymentMethodPage(): void;
 

--- a/src/Sylius/Behat/Page/Shop/Page.php
+++ b/src/Sylius/Behat/Page/Shop/Page.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Page\Shop;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-abstract class Page extends SymfonyPage implements PageInterface
+abstract class Page extends SyliusPage implements PageInterface
 {
     public function fillElement(string $value, string $element, array $parameters = []): void
     {

--- a/src/Sylius/Behat/Page/Shop/PaymentRequest/PaymentRequestNotifyPage.php
+++ b/src/Sylius/Behat/Page/Shop/PaymentRequest/PaymentRequestNotifyPage.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\PaymentRequest;
 
 use Behat\Mink\Driver\BrowserKitDriver;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 
-class PaymentRequestNotifyPage extends SymfonyPage implements PaymentRequestNotifyPageInterface
+class PaymentRequestNotifyPage extends SyliusPage implements PaymentRequestNotifyPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Product;
 
 use Behat\Mink\Exception\ElementNotFoundException;
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class IndexPage extends SymfonyPage implements IndexPageInterface
+class IndexPage extends SyliusPage implements IndexPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/Shop/ProductReview/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/ProductReview/IndexPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Shop\ProductReview;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class IndexPage extends SymfonyPage implements IndexPageInterface
+class IndexPage extends SyliusPage implements IndexPageInterface
 {
     public function getRouteName(): string
     {

--- a/src/Sylius/Behat/Page/SyliusPage.php
+++ b/src/Sylius/Behat/Page/SyliusPage.php
@@ -17,7 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage as BaseSymfonyPage;
 use Sylius\Behat\Service\DriverHelper;
 
-abstract class SymfonyPage extends BaseSymfonyPage implements SymfonyPageInterface
+abstract class SyliusPage extends BaseSymfonyPage implements SyliusPageInterface
 {
     protected function getElement(string $name, array $parameters = []): NodeElement
     {

--- a/src/Sylius/Behat/Page/SyliusPageInterface.php
+++ b/src/Sylius/Behat/Page/SyliusPageInterface.php
@@ -15,6 +15,6 @@ namespace Sylius\Behat\Page;
 
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface as BaseSymfonyPageInterface;
 
-interface SymfonyPageInterface extends BaseSymfonyPageInterface
+interface SyliusPageInterface extends BaseSymfonyPageInterface
 {
 }

--- a/src/Sylius/Behat/Page/TestPlugin/MainPage.php
+++ b/src/Sylius/Behat/Page/TestPlugin/MainPage.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\TestPlugin;
 
-use Sylius\Behat\Page\SymfonyPage;
+use Sylius\Behat\Page\SyliusPage;
 
-class MainPage extends SymfonyPage implements MainPageInterface
+class MainPage extends SyliusPage implements MainPageInterface
 {
     public function getContent(): string
     {

--- a/src/Sylius/Behat/Page/TestPlugin/MainPageInterface.php
+++ b/src/Sylius/Behat/Page/TestPlugin/MainPageInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\TestPlugin;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
-interface MainPageInterface extends SymfonyPageInterface
+interface MainPageInterface extends SyliusPageInterface
 {
     public function getContent(): string;
 }

--- a/src/Sylius/Behat/Service/DriverHelper.php
+++ b/src/Sylius/Behat/Service/DriverHelper.php
@@ -34,7 +34,7 @@ abstract class DriverHelper
     public static function waitForPageToLoad(Session $session): void
     {
         if (self::isJavascript($session->getDriver())) {
-            $session->wait(1000, "document.readyState === 'complete' && !document.querySelector('[data-live-loading=true]')");
+            $session->wait(1000, "document.readyState === 'complete' && !document.querySelector('[data-live-is-loading]')");
         }
     }
 }

--- a/src/Sylius/Behat/Service/JQueryHelper.php
+++ b/src/Sylius/Behat/Service/JQueryHelper.php
@@ -20,13 +20,13 @@ abstract class JQueryHelper
 {
     public static function waitForAsynchronousActionsToFinish(Session $session): void
     {
-        $session->wait(1000, "!document.querySelector('[data-live-loading=true]')");
+        $session->wait(1000, "!document.querySelector('[data-live-is-loading]')");
     }
 
-    public static function waitForFormToStopLoading(DocumentElement $document, int $timeout = 10): void
+    public static function waitForFormToStopLoading(DocumentElement $document, int $timeout = 1000): void
     {
         if (DriverHelper::isJavascript($document->getSession()->getDriver())) {
-            $document->getSession()->wait(500, "document.readyState === 'complete' && !document.querySelector('[data-live-loading=true]')");
+            $document->getSession()->wait($timeout, "document.readyState === 'complete' && !document.querySelector('[data-live-is-loading]')");
         }
     }
 }

--- a/src/Sylius/Behat/Service/Resolver/CurrentPageResolver.php
+++ b/src/Sylius/Behat/Service/Resolver/CurrentPageResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Service\Resolver;
 
 use Behat\Mink\Session;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Webmozart\Assert\Assert;
 
@@ -29,11 +29,11 @@ final class CurrentPageResolver implements CurrentPageResolverInterface
     /**
      * @throws \LogicException
      */
-    public function getCurrentPageWithForm(array $pages): SymfonyPageInterface
+    public function getCurrentPageWithForm(array $pages): SyliusPageInterface
     {
         $routeParameters = $this->urlMatcher->match(parse_url($this->session->getCurrentUrl(), \PHP_URL_PATH));
 
-        Assert::allIsInstanceOf($pages, SymfonyPageInterface::class);
+        Assert::allIsInstanceOf($pages, SyliusPageInterface::class);
 
         foreach ($pages as $page) {
             if ($routeParameters['_route'] === $page->getRouteName()) {

--- a/src/Sylius/Behat/Service/Resolver/CurrentPageResolverInterface.php
+++ b/src/Sylius/Behat/Service/Resolver/CurrentPageResolverInterface.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Resolver;
 
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 
 interface CurrentPageResolverInterface
 {
     /**
-     * @param SymfonyPageInterface[] $pages
+     * @param SyliusPageInterface[] $pages
      */
-    public function getCurrentPageWithForm(array $pages): SymfonyPageInterface;
+    public function getCurrentPageWithForm(array $pages): SyliusPageInterface;
 }

--- a/src/Sylius/Behat/tests/Service/Resolver/CurrentPageResolverTest.php
+++ b/src/Sylius/Behat/tests/Service/Resolver/CurrentPageResolverTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\Behat\Service\Resolver;
 
 use Behat\Mink\Session;
-use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
+use Sylius\Behat\Page\SyliusPageInterface;
 use LogicException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -45,10 +45,10 @@ final class CurrentPageResolverTest extends TestCase
 
     public function testReturnsCurrentPageBasedOnMatchedRoute(): void
     {
-        /** @var SymfonyPageInterface&MockObject $createPage */
-        $createPage = $this->createMock(SymfonyPageInterface::class);
-        /** @var SymfonyPageInterface&MockObject $updatePage */
-        $updatePage = $this->createMock(SymfonyPageInterface::class);
+        /** @var SyliusPageInterface&MockObject $createPage */
+        $createPage = $this->createMock(SyliusPageInterface::class);
+        /** @var SyliusPageInterface&MockObject $updatePage */
+        $updatePage = $this->createMock(SyliusPageInterface::class);
 
         $this->session->expects($this->once())->method('getCurrentUrl')->willReturn('https://sylius.com/resource/new');
         $this->urlMatcher->expects($this->once())->method('match')->with('/resource/new')->willReturn(['_route' => 'sylius_resource_create']);
@@ -60,10 +60,10 @@ final class CurrentPageResolverTest extends TestCase
 
     public function testThrowsAnExceptionIfNeitherCreateNorUpdateKeyWordHasBeenFound(): void
     {
-        /** @var SymfonyPageInterface&MockObject $createPage */
-        $createPage = $this->createMock(SymfonyPageInterface::class);
-        /** @var SymfonyPageInterface&MockObject $updatePage */
-        $updatePage = $this->createMock(SymfonyPageInterface::class);
+        /** @var SyliusPageInterface&MockObject $createPage */
+        $createPage = $this->createMock(SyliusPageInterface::class);
+        /** @var SyliusPageInterface&MockObject $updatePage */
+        $updatePage = $this->createMock(SyliusPageInterface::class);
 
         $this->session->expects($this->once())->method('getCurrentUrl')->willReturn('https://sylius.com/resource/show');
         $this->urlMatcher->expects($this->once())->method('match')->with('/resource/show')->willReturn(['_route' => 'sylius_resource_show']);


### PR DESCRIPTION
## Problem

Behat tests with LiveComponents are flaky on CI. The root cause is incorrect LiveComponent loading state detection - Sylius has been checking for `[data-live-loading=true]` which **never existed** in Symfony UX LiveComponent.

## Root Cause Analysis

### Incorrect Attribute History

1. **Before March 25, 2025**: Sylius used jQuery AJAX detection
   ```javascript
   $session->wait(1000, 'typeof jQuery !== "undefined" && 0 === jQuery.active');
   ```

2. **March 25, 2025** ([PR](https://github.com/Sylius/Sylius/pull/17771/files#diff-349e9740d261d061dac05b4bae2fdddbae9284425042cba1fb06757959d2436eR37): Changed it to:
   ```javascript
   $session->wait(1000, "!document.querySelector('[data-live-loading=true]')");
   ```
   This attribute was never part of Symfony UX LiveComponent, causing waits to complete immediately even when LiveComponents were still loading.

### Correct Attributes (Symfony UX LiveComponent v2.30.0)

According to [symfony/ux-live-component source code](https://github.com/symfony/ux-live-component/blob/v2.30.0/assets/dist/live_controller.js#L2415):

```javascript
handleLoadingToggle(component, isLoading, targetElement, backendRequest) {
  if (isLoading) {
    this.addAttributes(targetElement, ["busy"]);
    this.addAttributes(element, ["data-live-is-loading"]);
  }
}
```

The correct attributes are:
- `[busy]` - set on target element during loading
- `[data-live-is-loading]` - set on elements with `data-loading` directives

## Solution

This PR fixes the issue by:

1. **Fixing loading state detection** across all Behat helpers:
   - `DriverHelper::waitForPageToLoad()` - fixed to use `[data-live-is-loading]`
   - `JQueryHelper` methods - fixed to use `[data-live-is-loading]`

2. **Adding centralized wait logic** in `SyliusElement::getElement()`:
   - Automatically waits for ALL LiveComponents to finish before element interaction
   - Checks `document.readyState`, `[data-live-is-loading]`, and `[busy]` attributes
   - Returns immediately if no loading is detected (fast path)
   - Max 5 second timeout to prevent hanging

3. **Renaming base classes** for clarity:
   - `SymfonyElement` → `SyliusElement` (contains Sylius-specific LiveComponent logic)
   - `SymfonyPage` → `SyliusPage` (contains Sylius-specific page behavior)

## Impact

- ✅ Fixes flaky Behat tests with LiveComponents
- ✅ Reduces false negatives on CI
- ✅ Tests now properly wait for LiveComponent AJAX requests to complete
- ✅ No behavior change for non-LiveComponent pages (fast path)

## References

- Symfony UX LiveComponent: https://github.com/symfony/ux-live-component/tree/v2.30.0
- Loading state implementation: https://github.com/symfony/ux-live-component/blob/v2.30.0/assets/dist/live_controller.js#L2409-2417
- Original incorrect change: https://github.com/Sylius/Sylius/commit/04a222ba6764d64452519ac61697005e7cd9d423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated testing framework architecture with improved component synchronization and state detection, enhancing test reliability and execution stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->