### PR TITLE
Apply ecs fixes

### DIFF
--- a/tests/Api/Admin/ChannelsTest.php
+++ b/tests/Api/Admin/ChannelsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Admin;
 
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Sylius\Tests\Api\Utils\AdminUserLoginTrait;
@@ -110,8 +110,6 @@ final class ChannelsTest extends JsonApiTestCase
     }
 
     /**
-     *
-     *
      * @param array<string, string> $inputData
      * @param array<string, string> $validation
      */

--- a/tests/Api/Admin/OrdersTest.php
+++ b/tests/Api/Admin/OrdersTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Admin;
 
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
@@ -121,7 +121,6 @@ final class OrdersTest extends JsonApiTestCase
 
         $this->assertResponseSuccessful('admin/order/get_orders_for_customer');
     }
-
 
     #[DataProvider('provideOrderFilterDates')]
     #[Test]

--- a/tests/Api/Admin/ProductReviewsTest.php
+++ b/tests/Api/Admin/ProductReviewsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Admin;
 
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Core\Model\ProductReviewerInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
@@ -133,7 +133,6 @@ final class ProductReviewsTest extends JsonApiTestCase
         );
     }
 
-    
     #[DataProvider('invalidRatingRangeDataProvider')]
     #[Test]
     public function it_does_not_allow_to_update_a_product_review_with_invalid_rating(int $rating): void

--- a/tests/Api/Admin/StatisticsTest.php
+++ b/tests/Api/Admin/StatisticsTest.php
@@ -30,7 +30,6 @@ final class StatisticsTest extends JsonApiTestCase
         $this->setUpOrderPlacer();
     }
 
-
     #[DataProvider('getIntervals')]
     #[Test]
     public function it_gets_fulfilled_orders_in_specific_year_statistics(string $interval): void
@@ -180,7 +179,6 @@ final class StatisticsTest extends JsonApiTestCase
             ],
         );
     }
-
 
     #[DataProvider('missingQueryParameters')]
     #[DataProvider('emptyQueryParameters')]

--- a/tests/Api/Shop/PaymentRequestsTest.php
+++ b/tests/Api/Shop/PaymentRequestsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Shop;
 
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Sylius\Tests\Api\Utils\OrderPlacerTrait;
@@ -58,8 +58,6 @@ final class PaymentRequestsTest extends JsonApiTestCase
     }
 
     /**
-     *
-     *
      * @param string[] $fixturesPaths
      *
      * @throws \JsonException
@@ -196,8 +194,6 @@ final class PaymentRequestsTest extends JsonApiTestCase
     }
 
     /**
-     *
-     *
      * @param array<string> $fixturesPaths
      *
      * @throws \JsonException

--- a/tests/Api/Shop/ProductsTest.php
+++ b/tests/Api/Shop/ProductsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Shop;
 
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -56,7 +56,6 @@ final class ProductsTest extends JsonApiTestCase
             Response::HTTP_OK,
         );
     }
-
 
     #[DataProvider('getGermanLocales')]
     #[Test]

--- a/tests/Controller/XFrameOptionsTest.php
+++ b/tests/Controller/XFrameOptionsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Controller;
 
-use PHPUnit\Framework\Attributes\Test;
 use ApiTestCase\JsonApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 final class XFrameOptionsTest extends JsonApiTestCase
 {

--- a/tests/Functional/AbstractOrmTestCase.php
+++ b/tests/Functional/AbstractOrmTestCase.php
@@ -36,7 +36,7 @@ abstract class AbstractOrmTestCase extends TestCase
             ORMSetup::createAttributeMetadataConfiguration(
                 [],
                 true,
-            )->getMetadataDriverImpl()
+            )->getMetadataDriverImpl(),
         );
 
         return $config;

--- a/tests/Functional/AdminSectionNotFoundPageTest.php
+++ b/tests/Functional/AdminSectionNotFoundPageTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
+use ApiTestCase\JsonApiTestCase;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use ApiTestCase\JsonApiTestCase;
 
 final class AdminSectionNotFoundPageTest extends JsonApiTestCase
 {
@@ -31,7 +31,6 @@ final class AdminSectionNotFoundPageTest extends JsonApiTestCase
         $this->client->followRedirects();
     }
 
-    
     #[DataProvider('getSyliusResourcesUrlPart')]
     #[Test]
     public function it_shows_admin_not_found_page_for_a_logged_in_admin_when_accessing_nonexistent_resource_edit_page(

--- a/tests/Functional/Bundles/LocaleBundle/Context/LocaleResolvingTest.php
+++ b/tests/Functional/Bundles/LocaleBundle/Context/LocaleResolvingTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional\Bundles\LocaleBundle\Context;
 
-use PHPUnit\Framework\Attributes\Test;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/Functional/CartCollectorTest.php
+++ b/tests/Functional/CartCollectorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\Test;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\CoreBundle\Collector\CartCollector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/tests/Functional/CatalogPromotionAnnouncerTest.php
+++ b/tests/Functional/CatalogPromotionAnnouncerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\Test;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Announcer\CatalogPromotionAnnouncer;
 use Sylius\Component\Core\Model\CatalogPromotion;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;

--- a/tests/Functional/CatalogPromotionRemovalAnnouncerTest.php
+++ b/tests/Functional/CatalogPromotionRemovalAnnouncerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\Test;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\CoreBundle\CatalogPromotion\Announcer\CatalogPromotionRemovalAnnouncerInterface;
 use Sylius\Component\Core\Model\CatalogPromotion;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;

--- a/tests/Functional/Doctrine/Dump/CompositeKeysModel.php
+++ b/tests/Functional/Doctrine/Dump/CompositeKeysModel.php
@@ -23,12 +23,10 @@ class CompositeKeysModel
         #[ORM\Id]
         #[ORM\Column(length: 250)]
         public string $email,
-
         #[ORM\Id]
-        #[ORM\Column(name: "organization_name", type: "string")]
+        #[ORM\Column(name: 'organization_name', type: 'string')]
         public string $organizationName,
-
-        #[ORM\Column(name: "description", type: 'string')]
+        #[ORM\Column(name: 'description', type: 'string')]
         public string $description,
     ) {
     }

--- a/tests/Functional/Doctrine/Dump/Model.php
+++ b/tests/Functional/Doctrine/Dump/Model.php
@@ -24,7 +24,6 @@ class Model
         #[ORM\GeneratedValue]
         #[ORM\Column(type: 'integer')]
         public int $id,
-
         #[ORM\Column(type: 'string', length: 250)]
         public string $email,
     ) {

--- a/tests/Functional/EligibleCatalogPromotionsProcessorTest.php
+++ b/tests/Functional/EligibleCatalogPromotionsProcessorTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\Test;
-use Sylius\Bundle\PromotionBundle\Provider\EligibleCatalogPromotionsProviderInterface;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\PromotionBundle\Provider\EligibleCatalogPromotionsProvider;
+use Sylius\Bundle\PromotionBundle\Provider\EligibleCatalogPromotionsProviderInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

--- a/tests/Functional/Encryption/GatewayConfigEncryptionTest.php
+++ b/tests/Functional/Encryption/GatewayConfigEncryptionTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional\Encryption;
 
-use Sylius\Bundle\PayumBundle\Model\GatewayConfig;
-use PHPUnit\Framework\Attributes\Test;
 use Doctrine\ORM\EntityManagerInterface;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\PaymentBundle\Listener\GatewayConfigEncryptionListener;
+use Sylius\Bundle\PayumBundle\Model\GatewayConfig;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Sylius\Resource\Factory\FactoryInterface;

--- a/tests/Functional/Encryption/PaymentRequestEncryptionTest.php
+++ b/tests/Functional/Encryption/PaymentRequestEncryptionTest.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional\Encryption;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Test;
 use Doctrine\ORM\EntityManagerInterface;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Factory\PaymentRequestFactoryInterface;
@@ -49,7 +49,6 @@ final class PaymentRequestEncryptionTest extends KernelTestCase
         ]);
     }
 
-    
     #[DataProvider('getPayload')]
     #[Test]
     public function it_covers_encryption_and_decryption_when_saving_and_loading_the_payload(mixed $payload): void
@@ -99,7 +98,6 @@ final class PaymentRequestEncryptionTest extends KernelTestCase
         self::assertNull($payloadFromDatabase);
     }
 
-    
     #[DataProvider('getResponseData')]
     #[Test]
     public function it_covers_encryption_and_decryption_when_saving_and_loading_the_response_data(

--- a/tests/Functional/OrderByIdentifierSqlWalkerTest.php
+++ b/tests/Functional/OrderByIdentifierSqlWalkerTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\Test;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
+use PHPUnit\Framework\Attributes\Test;
 use Sylius\Bundle\CoreBundle\Doctrine\ORM\SqlWalker\OrderByIdentifierSqlWalker;
 
 final class OrderByIdentifierSqlWalkerTest extends AbstractOrmTestCase
@@ -110,6 +110,6 @@ final class OrderByIdentifierSqlWalkerTest extends AbstractOrmTestCase
             ->setHint(Query::HINT_CUSTOM_TREE_WALKERS, $treeWalkers)
             ->useQueryCache(false)
             ->getSQL()
-            ;
+        ;
     }
 }


### PR DESCRIPTION
## Summary

- Applied ECS (Easy Coding Standard) fixes to the codebase by removing duplicate test files in UserBundle

The PR removes test files that were duplicated during an upmerge:
- Authentication/AuthenticationSuccessHandlerTest.php
- DependencyInjection/ConfigurationTest.php
- DependencyInjection/SyliusUserExtensionTest.php
- Event/UserEventTest.php
- EventListener/PasswordUpdaterListenerTest.php
- EventListener/UserDeleteListenerTest.php
- EventListener/UserLastLoginSubscriberTest.php
- EventListener/UserReloaderListenerTest.php
- Provider/AbstractUserProviderTest.php
- Provider/EmailProviderTest.php
- Provider/UsernameOrEmailProviderTest.php
- Provider/UsernameProviderTest.php
- Security/UserLoginTest.php
- Validator/UniqueUserValidatorTest.php


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized PHPUnit framework imports across test suite for improved consistency.
  * Removed unnecessary whitespace, blank lines, and simplified docblock formatting in multiple test files.

* **Refactor**
  * Standardized ORM attribute string literal formatting to use single quotes.
  * Updated constructor property definitions for improved code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->