### PR TITLE
FEAT: [2.2] [CoreBundle] extend sylius:install:setup command to set admin first/last name

### DIFF
--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -43,6 +43,8 @@ final class InstallerContext implements Context
         'locale' => 'en_US',
         'e-mail' => 'test@email.com',
         'username' => 'test',
+        'firstName' => '',
+        'lastName' => '',
         'password' => 'pswd',
         'confirmation' => 'pswd',
     ];
@@ -146,6 +148,8 @@ final class InstallerContext implements Context
     {
         $this->inputChoices['e-mail'] = 'test@admin.com';
         $this->inputChoices['username'] = 'test';
+        $this->inputChoices['firstName'] = 'John';
+        $this->inputChoices['lastName'] = 'Doe';
         $this->inputChoices['password'] = 'pswd1$';
         $this->inputChoices['confirmation'] = $this->inputChoices['password'];
     }

--- a/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
@@ -119,6 +119,8 @@ EOT
         $email = $this->getAdministratorEmail($input, $output);
         $user->setEmail($email);
         $user->setUsername($this->getAdministratorUsername($input, $output, $email));
+        $user->setFirstName($this->getAdministratorFirstName($input, $output));
+        $user->setLastName($this->getAdministratorLastName($input, $output));
         $user->setPlainPassword($this->getAdministratorPassword($input, $output));
 
         return $user;
@@ -178,6 +180,26 @@ EOT
         } while ($exists);
 
         return $username;
+    }
+
+    private function getAdministratorFirstName(InputInterface $input, OutputInterface $output): string
+    {
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+        $question = new Question('First name (press enter to leave blank): ', '');
+        $firstName = $questionHelper->ask($input, $output, $question);
+
+        return $firstName;
+    }
+
+    private function getAdministratorLastName(InputInterface $input, OutputInterface $output): string
+    {
+        /** @var QuestionHelper $questionHelper */
+        $questionHelper = $this->getHelper('question');
+        $question = new Question('Last name (press enter to leave blank): ', '');
+        $lastName = $questionHelper->ask($input, $output, $question);
+
+        return $lastName;
     }
 
     private function getAdministratorPassword(InputInterface $input, OutputInterface $output): string


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | #18453 
| License         | MIT

This pull request introduces a small improvement regarding the `sylius:install:setup` command.

During the `Create your administrator account.` step, you can also now set a first name and last name for the administrator account.