### PR TITLE
BUGFIX: [2.1] [UserBundle] [Console] adjust wording in description for Demote User Command

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Console/Command/DemoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Console/Command/DemoteUserCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'sylius:user:demote',
-    description: 'Demotes a user by removing a role.',
+    description: 'Demotes a user by removing roles.',
 )]
 class DemoteUserCommand extends AbstractRoleCommand
 {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | _not really_
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #18455, partially #Y, mentioned in #Z
| License         | MIT

This PR adjusts the wording for the description in the `sylius:demote:user` command.

As i mentioned in #18455 in the `sylius:user:promote` command the description also says:

```
Promotes a user by adding roles.
```


So i would keep it consistent and adjust the description for this command too in the oposite way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command help text to clarify that the user demotion command removes multiple roles, not just a single role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->