### PR TITLE
[CI] Disable OPcache in e2e_js workflows

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -151,7 +151,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -245,7 +245,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -215,6 +215,7 @@ jobs:
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
+                    opcache_enable: "no"
 
             -   name: Run Behat (Chromedriver)
                 run: |
@@ -309,6 +310,7 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
+                    opcache_enable: "no"
 
             -   name: Build application
                 if: "${{ inputs.branch != '1.14' }}"
@@ -324,6 +326,7 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
+                    opcache_enable: "no"
 
             -   name: Run Behat (Panther)
                 run: |

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -155,6 +155,7 @@ jobs:
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
                     node_version: "24.x"
+                    opcache_enable: "no"
 
             -   name: Run Behat (Chromedriver)
                 run: |
@@ -241,6 +242,7 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: "24.x"
                     chrome_version: stable
+                    opcache_enable: "no"
 
             -   name: Run Behat (Panther)
                 run: |

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -17,7 +17,7 @@ jobs:
     behat-no-js-unstable:
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 55
         continue-on-error: true
         strategy:
             fail-fast: false
@@ -98,7 +98,7 @@ jobs:
     behat-ui-js-chromedriver-unstable:
         runs-on: ubuntu-latest
         name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix:
@@ -184,7 +184,7 @@ jobs:
     behat-ui-js-panther-unstable:
         runs-on: ubuntu-latest
         name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 55
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci_frontend.yaml
+++ b/.github/workflows/ci_frontend.yaml
@@ -82,6 +82,7 @@ jobs:
                     symfony_version: "~6.4.0"
                     node_version: ${{ matrix.node }}
                     chrome_version: stable
+                    opcache_enable: "no"
                     
             -   name: "Run javascript linter"
                 run: yarn lint


### PR DESCRIPTION
Sometimes our JS builds fail unexpectedly. My investigation shows that PHP 8.2/8.3 can segfault when OPcache is enabled. This tweak will slow builds a bit, but it removes a whole class of failures and makes our builds more predictable.

<img width="1327" height="192" alt="image" src="https://github.com/user-attachments/assets/7238ada2-3bb5-48c1-acf2-28a874526c19" />

<img width="846" height="865" alt="image" src="https://github.com/user-attachments/assets/09420c45-5885-463d-9886-498ace82edbb" />

<img width="1331" height="188" alt="image" src="https://github.com/user-attachments/assets/cd1018a2-30ed-41e2-ac1d-b0c473044bd3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adjustment: PHP opcode caching disabled during many build/test steps to improve reliability across frontend, e2e, unstable and DB-specific pipelines.
* **Tests**
  * Extended CI job timeouts (45 → 55 minutes) for multiple end-to-end test jobs to reduce spurious timeouts and improve test stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->