### PR TITLE
[Changelog] Fix obvious typos in 2.1 changelog

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -29,7 +29,7 @@
 - [#18287](https://github.com/Sylius/Sylius/pull/18287) [CS][DX] Refactor
 - [#18288](https://github.com/Sylius/Sylius/pull/18288) [CS][DX] Refactor
 - [#18291](https://github.com/Sylius/Sylius/pull/18291) [DOCUMENTATION] Synchronize 2.0-docs -> 2.0 ([@SyliusBot](https://github.com/SyliusBot))
-- [#18302](https://github.com/Sylius/Sylius/pull/18302) [Composer][1.14] More specific confflict with serializer ([@Jibbarth](https://github.com/Jibbarth))
+- [#18302](https://github.com/Sylius/Sylius/pull/18302) [Composer][1.14] More specific conflict with serializer ([@Jibbarth](https://github.com/Jibbarth))
 - [#18309](https://github.com/Sylius/Sylius/pull/18309) Add conflict to symfony-ux ^2.29 ([@TheMilek](https://github.com/TheMilek))
 - [#18182](https://github.com/Sylius/Sylius/pull/18182) [2.0] Dutch translations ([@SzymonFilipek](https://github.com/SzymonFilipek))
 - [#18303](https://github.com/Sylius/Sylius/pull/18303) [Promotion] Corrects order of amounts to apply correct promotion amount ([@k-kubacki](https://github.com/k-kubacki))

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -22,7 +22,7 @@
 #### Details
 
 - [#18293](https://github.com/Sylius/Sylius/pull/18293) Revert "[Fixtures] Make factory example constructor arguments protected" ([@GSadee](https://github.com/GSadee))
-- [#18286](https://github.com/Sylius/Sylius/pull/18286) [Shop] Image/File Uploud Buttons Size Fix ([@PiotrTulacz](https://github.com/PiotrTulacz))
+- [#18286](https://github.com/Sylius/Sylius/pull/18286) [Shop] Image/File Upload Buttons Size Fix ([@PiotrTulacz](https://github.com/PiotrTulacz))
 - [#18263](https://github.com/Sylius/Sylius/pull/18263) fix ([@maximehuran](https://github.com/maximehuran))
 - [#18290](https://github.com/Sylius/Sylius/pull/18290) [CS][DX] Refactor
 - [#18296](https://github.com/Sylius/Sylius/pull/18296) [Admin][Product] Fix not blank product code constraint message ([@SVillette](https://github.com/SVillette))

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -131,7 +131,7 @@
 - [#18174](https://github.com/Sylius/Sylius/pull/18174) [ApiBundle] Migrate remaining phpspec to PHPUnit tests ([@GSadee](https://github.com/GSadee))
 - [#18157](https://github.com/Sylius/Sylius/pull/18157) [Shop] Shop WCAG raport ([@PiotrTulacz](https://github.com/PiotrTulacz))
 - [#18177](https://github.com/Sylius/Sylius/pull/18177) Product image replace ([@PiotrTulacz](https://github.com/PiotrTulacz))
-- [#18180](https://github.com/Sylius/Sylius/pull/18180) [Shop] Html lables translation ([@PiotrTulacz](https://github.com/PiotrTulacz))
+- [#18180](https://github.com/Sylius/Sylius/pull/18180) [Shop] Html labels translation ([@PiotrTulacz](https://github.com/PiotrTulacz))
 - [#18181](https://github.com/Sylius/Sylius/pull/18181) Update translations for 2.1 keys ([@SyliusBot](https://github.com/SyliusBot))
 
 ## v2.1.1 (2025-06-04)

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -48,7 +48,7 @@
 - [#18339](https://github.com/Sylius/Sylius/pull/18339) Fixed placing order with not possible zone ([@pbalcerzak](https://github.com/pbalcerzak))
 - [#18343](https://github.com/Sylius/Sylius/pull/18343) [Fix][Admin] Fix order summary to show product name and options from time of purchase ([@tomkalon](https://github.com/tomkalon))
 - [#18345](https://github.com/Sylius/Sylius/pull/18345) Fix argument of ZoneEligibilityChecker to use the new service id ([@GSadee](https://github.com/GSadee))
-- [#18342](https://github.com/Sylius/Sylius/pull/18342) FEAT: [AdminBundle] Open shop preview and nessecary  user dropdown links in new tab ([@crydotsnake](https://github.com/crydotsnake))
+- [#18342](https://github.com/Sylius/Sylius/pull/18342) FEAT: [AdminBundle] Open shop preview and necessary user dropdown links in new tab ([@crydotsnake](https://github.com/crydotsnake))
 - [#18350](https://github.com/Sylius/Sylius/pull/18350) [CS][DX] Refactor
 - [#18351](https://github.com/Sylius/Sylius/pull/18351) [CS][DX] Refactor
 - [#18316](https://github.com/Sylius/Sylius/pull/18316) sort main and bulk actions by position ([@Florian-Merle](https://github.com/Florian-Merle))


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | –
| License         | MIT

### Summary
Fix four obvious typos in `CHANGELOG-2.1.md`:
- `Uploud` → `Upload` (v2.1.5, PR #18286)
- `confflict` → `conflict` (v2.1.5, PR #18302)
- `nessecary` → `necessary` (v2.1.5, PR #18342)
- `lables` → `labels` (v2.1.2, PR #18180)

### Notes
- Minimal diffs only; no punctuation/style changes.
- Code, identifiers, and formatting are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typos in changelog entries for improved readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->