### PR TITLE
Fix autocomplete in admin to be case-insensitive

### DIFF
--- a/features/admin/taxonomy/managing_taxons/ui/case_insensitive_parent_search.feature
+++ b/features/admin/taxonomy/managing_taxons/ui/case_insensitive_parent_search.feature
@@ -1,0 +1,49 @@
+@managing_taxons
+Feature: Case-insensitive parent taxon autocomplete search
+    In order to easily find parent taxons regardless of typing case
+    As an Administrator
+    I want to search for parent taxons in a case-insensitive manner
+
+    Background:
+        Given the store is available in "English (United States)"
+        And the store classifies its products as "Tech Gadgets" with "TECH_GADGETS" code
+        And the store classifies its products as "Home Decor" with "home_DECOR" code
+        And the store classifies its products as "Sports Equipment" with "SPORTS_equipment" code
+        And the store classifies its products as "Office Supplies" with "office_supplies" code
+        And I am logged in as an administrator
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon by lowercase code when taxon code has uppercase letters
+        When I want to create a new taxon
+        And I search for parent taxon "tech_gadgets"
+        Then I should see "Tech Gadgets" in the found results
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon by uppercase code when taxon code has lowercase letters
+        When I want to create a new taxon
+        And I search for parent taxon "HOME_DECOR"
+        Then I should see "Home Decor" in the found results
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon by mixed case code when taxon code has different case
+        When I want to create a new taxon
+        And I search for parent taxon "sports_EQUIPMENT"
+        Then I should see "Sports Equipment" in the found results
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon by lowercase name when taxon name has mixed case
+        When I want to create a new taxon
+        And I search for parent taxon "office supplies"
+        Then I should see "Office Supplies" in the found results
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon by uppercase name when taxon name has mixed case
+        When I want to create a new taxon
+        And I search for parent taxon "TECH GADGETS"
+        Then I should see "Tech Gadgets" in the found results
+
+    @no-api @ui @mink:chromedriver
+    Scenario: Searching for parent taxon with partial match case-insensitive on code
+        When I want to create a new taxon
+        And I search for parent taxon "SPORTS"
+        Then I should see "Sports Equipment" in the found results

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ImageInterface;
@@ -39,13 +40,11 @@ final class TaxonomyContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has :firstTaxonName taxonomy
-     * @Given the store classifies its products as :firstTaxonName
-     * @Given the store classifies its products as :firstTaxonName and :secondTaxonName
-     * @Given the store classifies its products as :firstTaxonName, :secondTaxonName and :thirdTaxonName
-     * @Given the store classifies its products as :firstTaxonName, :secondTaxonName, :thirdTaxonName and :fourthTaxonName
-     */
+    #[Given('the store has :firstTaxonName taxonomy')]
+    #[Given('the store classifies its products as :firstTaxonName')]
+    #[Given('the store classifies its products as :firstTaxonName and :secondTaxonName')]
+    #[Given('the store classifies its products as :firstTaxonName, :secondTaxonName and :thirdTaxonName')]
+    #[Given('the store classifies its products as :firstTaxonName, :secondTaxonName, :thirdTaxonName and :fourthTaxonName')]
     public function storeClassifiesItsProductsAs(...$taxonsNames)
     {
         foreach ($taxonsNames as $taxonName) {
@@ -53,9 +52,13 @@ final class TaxonomyContext implements Context
         }
     }
 
-    /**
-     * @Given /^the store has taxonomy named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^the store classifies its products as :taxonName with :taxonCode code$/')]
+    public function storeClassifiesItsProductsAsWithCode(string $taxonName, string $taxonCode): void
+    {
+        $this->taxonRepository->add($this->createTaxonWithCode($taxonName, $taxonCode));
+    }
+
+    #[Given('/^the store has taxonomy named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/')]
     public function theStoreHasTaxonomyNamedInAndIn($firstName, $firstLocale, $secondName, $secondLocale)
     {
         $translationMap = [
@@ -66,9 +69,7 @@ final class TaxonomyContext implements Context
         $this->taxonRepository->add($this->createTaxonInManyLanguages($translationMap));
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon) has child taxon "([^"]+)" in many locales$/
-     */
+    #[Given('/^the ("[^"]+" taxon) has child taxon "([^"]+)" in many locales$/')]
     public function theTaxonHasChildrenTaxonsInManyLocales(TaxonInterface $taxon, string $childTaxonName): void
     {
         $translationMap = [
@@ -91,9 +92,7 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
-     */
+    #[Given('/^the ("[^"]+" taxon)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/')]
     public function theTaxonHasAnImageWithType(TaxonInterface $taxon, $imagePath, $imageType)
     {
         $filesPath = $this->getParameter('files_path');
@@ -110,12 +109,10 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon) has child taxon "([^"]+)"$/
-     * @Given /^the ("[^"]+" taxon) has children taxon "([^"]+)" and "([^"]+)"$/
-     * @Given /^the ("[^"]+" taxon) has children taxons "([^"]+)" and "([^"]+)"$/
-     * @Given /^the ("[^"]+" taxon) has children taxons "([^"]+)", "([^"]+)" and "([^"]+)"$/
-     */
+    #[Given('/^the ("[^"]+" taxon) has child taxon "([^"]+)"$/')]
+    #[Given('/^the ("[^"]+" taxon) has children taxon "([^"]+)" and "([^"]+)"$/')]
+    #[Given('/^the ("[^"]+" taxon) has children taxons "([^"]+)" and "([^"]+)"$/')]
+    #[Given('/^the ("[^"]+" taxon) has children taxons "([^"]+)", "([^"]+)" and "([^"]+)"$/')]
     public function theTaxonHasChildrenTaxonAnd(TaxonInterface $taxon, string ...$taxonsNames): void
     {
         foreach ($taxonsNames as $taxonName) {
@@ -126,9 +123,7 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon)(?:| also) is enabled/
-     */
+    #[Given('/^the ("[^"]+" taxon)(?:| also) is enabled/')]
     public function theTaxonIsEnabled(TaxonInterface $taxon): void
     {
         $taxon->setEnabled(true);
@@ -136,9 +131,7 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon)(?:| also) is disabled$/
-     */
+    #[Given('/^the ("[^"]+" taxon)(?:| also) is disabled$/')]
     public function theTaxonIsDisabled(TaxonInterface $taxon): void
     {
         $taxon->setEnabled(false);
@@ -157,6 +150,17 @@ final class TaxonomyContext implements Context
         return $taxon;
     }
 
+    private function createTaxonWithCode(string $name, string $code): TaxonInterface
+    {
+        /** @var TaxonInterface $taxon */
+        $taxon = $this->taxonFactory->createNew();
+        $taxon->setName($name);
+        $taxon->setCode($code);
+        $taxon->setSlug($this->taxonSlugGenerator->generate($taxon));
+
+        return $taxon;
+    }
+
     private function createChildTaxon(string $name, TaxonInterface $parent): TaxonInterface
     {
         $child = $this->createTaxon($name);
@@ -166,10 +170,7 @@ final class TaxonomyContext implements Context
         return $child;
     }
 
-    /**
-     * @return TaxonInterface
-     */
-    private function createTaxonInManyLanguages(array $names)
+    private function createTaxonInManyLanguages(array $names): TaxonInterface
     {
         /** @var TaxonInterface $taxon */
         $taxon = $this->taxonFactory->createNew();

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\When;
 use Sylius\Behat\Element\Admin\Product\TaxonomyFormElementInterface;
 use Sylius\Behat\Element\Admin\Taxon\FormElementInterface;
 use Sylius\Behat\Element\Admin\Taxon\ImageFormElementInterface;
@@ -228,6 +229,16 @@ final readonly class ManagingTaxonsContext implements Context
     {
         $this->updatePage->open(['id' => $taxon->getId()]);
         Assert::same($this->formElement->getCode(), $taxon->getCode());
+    }
+
+    /**
+     * @Given /^I search for parent taxon "([^"]*)"$/
+     */
+    public function iSearchForParentTaxon(string $searchTerm)
+    {
+        $this->sharedStorage->set('autocompleteSearchResults', $this->formElement->searchParentTaxon($searchTerm));
+
+        return $this->formElement->searchParentTaxon($searchTerm);
     }
 
     /**
@@ -486,5 +497,21 @@ final readonly class ManagingTaxonsContext implements Context
     public function itShouldBeDisabled(): void
     {
         Assert::false($this->formElement->isEnabled());
+    }
+
+    /**
+     * @Then /^I should see "([^"]*)" in the found results$/
+     */
+    public function iShouldSeeInTheFoundResults(string $taxonName)
+    {
+        $autocompleteSearchResults = $this->sharedStorage->get('autocompleteSearchResults');
+        Assert::true(
+            in_array($taxonName, $autocompleteSearchResults, true),
+            sprintf(
+                'Expected to see "%s" in autocomplete results, but found: %s',
+                $taxonName,
+                implode(', ', $autocompleteSearchResults),
+            ),
+        );
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -141,4 +141,17 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
         $translationAccordion->click();
     }
+
+    public function searchParentTaxon(string $searchTerm): array
+    {
+        DriverHelper::waitForPageToLoad($this->getSession());
+
+        $searchResults = $this->autocompleteHelper->search(
+            $this->getDriver(),
+            $this->getElement('parent')->getXpath(),
+            $searchTerm
+        );
+
+        return is_array($searchResults) ? array_values($searchResults) : [];
+    }
 }

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
@@ -45,4 +45,6 @@ interface FormElementInterface extends BaseFormElementInterface
     public function disable(): void;
 
     public function isEnabled(): bool;
+
+    public function searchParentTaxon(string $searchTerm): array;
 }

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
@@ -112,7 +112,7 @@ final class TranslatableAutocompleteType extends AbstractType
     private static function getComparisons(Expr $expr, array $fields): iterable
     {
         foreach ($fields as $field) {
-            yield $expr->like($field, ':query');
+            yield $expr->like((string) $expr->lower($field), 'LOWER(:query)');
         }
     }
 }


### PR DESCRIPTION
This is a continuation of pull request #18393.

| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #18384
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Case-insensitive autocomplete search for parent taxons now supports uppercase, lowercase, mixed case, and partial matches.

* **Bug Fixes**
  * Improved error responses for cart operations with clearer, more specific error messages.

* **Tests**
  * Added automated tests for case-insensitive taxon search functionality.
  * Enhanced test infrastructure for more reliable test execution and reduced flakiness.

* **Chores**
  * Updated Symfony beta versions in CI pipelines.
  * Improved test infrastructure and removed outdated testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->