### PR TITLE
Add conflict for broken Doctrine ORM version 2.20.7

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -41,3 +41,10 @@ This document explains why certain conflicts were added to `composer.json` and r
 
   This version introduces a change in method signature that is not compatible with API Platform 2.7 and leads to a fatal error:
   `PHP Fatal error:  Declaration of ApiPlatform\Serializer\AbstractItemNormalizer::getAllowedAttributes($classOrObject, array $context, $attributesAsString = false) must be compatible with Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::getAllowedAttributes(object|string $classOrObject, array $context, bool $attributesAsString = false): array|bool in /home/runner/work/Sylius/Sylius/vendor/api-platform/core/src/Serializer/AbstractItemNormalizer.php on line 493`
+
+- `doctrine/orm:2.20.7`:
+
+  These versions contain a regression that breaks queries with empty arrays, causing SQL syntax errors when methods like `EntityRepository::findById([])` are called with an empty array.
+  This leads to invalid SQL queries like `WHERE t0.id IN ()`.
+
+  References: https://github.com/doctrine/orm/issues/12245

--- a/composer.json
+++ b/composer.json
@@ -188,6 +188,7 @@
     "conflict": {
         "api-platform/core": "2.7.17",
         "behat/gherkin": "^4.13.0",
+        "doctrine/orm": "2.20.7",
         "lexik/jwt-authentication-bundle": "^2.18",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "symfony/serializer": "6.4.23",


### PR DESCRIPTION
| Q               | A                                                            |
|-----------------|--------------------------------------------------------------|
| Branch?         | 1.14                                                         |
| Bug fix?        | yes                                                          |
| New feature?    | no                                                           |
| BC breaks?      | no                                                           |
| Deprecations?   | no                                                           |
| Related tickets | https://github.com/doctrine/orm/issues/12245                 |
| License         | MIT                                                          |

## Summary

Doctrine ORM versions 2.20.7 and 3.5.3 contain a regression that breaks queries with empty arrays, causing SQL syntax errors like `WHERE t0.id IN ()`.

This PR adds these versions to the `conflict` section of composer.json to prevent them from being installed until the upstream issue is fixed.
