### PR TITLE
BUGFIX: [2.0] [AdminBundle] add label option too CustomerType form class to load translations

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/CustomerType.php
@@ -26,9 +26,11 @@ final class CustomerType extends AbstractType
     {
         $builder
             ->add('firstName', TextType::class, [
+                'label' => 'sylius.form.customer.first_name',
                 'required' => false,
             ])
             ->add('lastName', TextType::class, [
+                'label' => 'sylius.form.customer.last_name',
                 'required' => false,
             ])
             ->add('user', ShopUserType::class, [


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #18482, partially #Y, mentioned in #Z
| License         | MIT

As described in #18482 i added the `label` key too the options for the `firstName` and `lastName` childs of the CustomerType form class so that the translations for `sylius.form.customer.first_name` / `sylius.form.customer.last_name` are correctly displayed again when creating/updating a customer in the sylius backend.
