### PR TITLE
Fix method filter for autocomplete type

### DIFF
--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_via_api.feature
@@ -1,0 +1,61 @@
+@managing_taxons
+Feature: Preventing circular parent reference via API when updating a taxon
+    In order to maintain a valid taxon tree structure
+    As an API client
+    I want to be prevented from setting a taxon or its ancestors as its parent via API
+
+    Background:
+        Given the store is available in "English (United States)"
+        And the store has "Category" taxonomy
+        And the "Category" taxon has children taxon "Clothing" and "Books"
+        And the "Clothing" taxon has children taxon "T-Shirts" and "Jeans"
+        And the "T-Shirts" taxon has children taxon "Men" and "Women"
+        And I am logged in as an administrator
+
+    @api
+    Scenario: Trying to set a taxon as its own parent via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "Clothing"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"
+
+    @api
+    Scenario: Trying to set a child taxon as parent via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "T-Shirts"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"
+
+    @api
+    Scenario: Trying to set a grandchild taxon as parent via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "Men"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"
+
+    @api
+    Scenario: Successfully changing parent to a valid taxon via API
+        When I want to modify the "Clothing" taxon
+        And I change its parent taxon to "Books"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Books"
+
+    @api
+    Scenario: Successfully setting a sibling as parent via API
+        When I want to modify the "T-Shirts" taxon
+        And I change its parent taxon to "Jeans"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Jeans"
+
+    @api
+    Scenario: Trying to create a circular reference by moving a parent under its child via API
+        When I want to modify the "Clothing" taxon
+        And I try to change its parent taxon to "T-Shirts"
+        And I try to save my changes
+        Then I should be notified that the parent relation is invalid
+        And this taxon should still belongs to "Category"

--- a/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
+++ b/features/admin/taxonomy/managing_taxons/preventing_circular_parent_reference_when_editing_taxon.feature
@@ -1,0 +1,67 @@
+@managing_taxons
+Feature: Preventing circular parent reference when editing a taxon
+    In order to maintain a valid taxon tree structure
+    As an Administrator
+    I want to be prevented from setting a taxon or its descendants as its parent
+
+    Background:
+        Given the store is available in "English (United States)"
+        And the store has "Category" taxonomy
+        And the "Category" taxon has children taxon "Clothing" and "Books"
+        And the "Clothing" taxon has children taxon "T-Shirts" and "Jeans"
+        And the "T-Shirts" taxon has children taxon "Men" and "Women"
+        And I am logged in as an administrator
+
+    @ui @mink:chromedriver
+    Scenario: A taxon cannot be set as its own parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Clothing" in the parent taxon autocomplete
+        Then I should not see "Clothing" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A child taxon cannot be set as parent of its ancestor
+        When I want to modify the "Clothing" taxon
+        And I try to search for "T-Shirts" in the parent taxon autocomplete
+        Then I should not see "T-Shirts" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A grandchild taxon cannot be set as parent of its ancestor
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Men" in the parent taxon autocomplete
+        Then I should not see "Men" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: All descendants are excluded from parent selection
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Jeans" in the parent taxon autocomplete
+        Then I should not see "Jeans" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Sibling taxons can be selected as parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Books" in the parent taxon autocomplete
+        Then I should see "Books" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Taxons from different branches can be selected as parent
+        When I want to modify the "Clothing" taxon
+        And I try to search for "Category" in the parent taxon autocomplete
+        Then I should see "Category" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: A leaf taxon excludes only itself from parent selection
+        When I want to modify the "Men" taxon
+        And I try to search for "Men" in the parent taxon autocomplete
+        Then I should not see "Men" in the parent taxon autocomplete results
+        And I try to search for "Women" in the parent taxon autocomplete
+        And I should see "Women" in the parent taxon autocomplete results
+        And I try to search for "T-Shirts" in the parent taxon autocomplete
+        And I should see "T-Shirts" in the parent taxon autocomplete results
+
+    @ui @mink:chromedriver
+    Scenario: Successfully changing parent to a valid taxon (not itself or descendant)
+        When I want to modify the "Clothing" taxon
+        And I change its parent taxon to "Books"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this taxon should belongs to "Books"

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -121,6 +121,7 @@ final readonly class ManagingTaxonsContext implements Context
     /**
      * @When I set its parent taxon to :parentTaxon
      * @When I change its parent taxon to :parentTaxon
+     * @When I try to change its parent taxon to :parentTaxon
      */
     public function iSetItsParentTaxonTo(TaxonInterface $parentTaxon): void
     {
@@ -246,6 +247,7 @@ final readonly class ManagingTaxonsContext implements Context
 
     /**
      * @Then /^(this taxon) should (belongs to "[^"]+")$/
+     * @Then /^(this taxon) should still (belongs to "[^"]+")$/
      */
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon, TaxonInterface $parentTaxon): void
     {
@@ -340,6 +342,17 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::contains(
             $this->responseChecker->getError($this->client->getLastResponse()),
             'code: Taxon with given code already exists.',
+        );
+    }
+
+    /**
+     * @Then I should be notified that the parent relation is invalid
+     */
+    public function iShouldBeNotifiedThatTheParentRelationIsInvalid(): void
+    {
+        Assert::contains(
+            $this->responseChecker->getError($this->client->getLastResponse()),
+            'parent:',
         );
     }
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -150,6 +150,7 @@ final readonly class ManagingTaxonsContext implements Context
     public function iChangeItsParentTaxonTo(TaxonInterface $taxon): void
     {
         $this->formElement->removeCurrentParent();
+        // Wait is handled by waitForFormUpdate() in removeCurrentParent()
         $this->formElement->chooseParent($taxon);
     }
 
@@ -486,5 +487,60 @@ final readonly class ManagingTaxonsContext implements Context
     public function itShouldBeDisabled(): void
     {
         Assert::false($this->formElement->isEnabled());
+    }
+
+    /**
+     * @When I try to search for :taxonName in the parent taxon autocomplete
+     */
+    public function iTryToSearchForInTheParentTaxonAutocomplete(string $taxonName): void
+    {
+        $this->sharedStorage->set('autocomplete_search_results', $this->formElement->searchInParentAutocomplete($taxonName));
+    }
+
+    /**
+     * @Then I should see :taxonName in the parent taxon autocomplete results
+     */
+    public function iShouldSeeInTheParentTaxonAutocompleteResults(string $taxonName): void
+    {
+        /** @var array<string, string> $results */
+        $results = $this->sharedStorage->get('autocomplete_search_results');
+
+        $found = false;
+        foreach ($results as $value => $name) {
+            if (str_contains($name, $taxonName)) {
+                $found = true;
+                break;
+            }
+        }
+
+        Assert::true($found, sprintf('Expected to find "%s" in autocomplete results, but it was not found.', $taxonName));
+    }
+
+    /**
+     * @Then I should not see :taxonName in the parent taxon autocomplete results
+     */
+    public function iShouldNotSeeInTheParentTaxonAutocompleteResults(string $taxonName): void
+    {
+        /** @var array<string, string> $results */
+        $results = $this->sharedStorage->get('autocomplete_search_results');
+
+        $found = false;
+        foreach ($results as $value => $name) {
+            if (str_contains($name, $taxonName)) {
+                $found = true;
+                break;
+            }
+        }
+
+        Assert::false($found, sprintf('Expected not to find "%s" in autocomplete results, but it was found.', $taxonName));
+    }
+
+    /**
+     * @Then I should be able to search for other taxons in the parent autocomplete
+     */
+    public function iShouldBeAbleToSearchForOtherTaxonsInTheParentAutocomplete(): void
+    {
+        $results = $this->formElement->searchInParentAutocomplete('');
+        Assert::notEmpty($results, 'Expected to find some taxons in the autocomplete, but none were found.');
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -84,9 +84,23 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
     public function chooseParent(TaxonInterface $taxon): void
     {
+        DriverHelper::waitForPageToLoad($this->getSession());
+
+        $parentElement = $this->getElement('parent');
+        $selector = $this->normalizeXPathForJavaScript($parentElement->getXpath());
+
+        // Wait for Tom Select to initialize
+        $this->getDriver()->wait(5000, sprintf(
+            '(function() {
+                let element = document.evaluate("%s", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+                return element && element.tomselect !== undefined;
+            })()',
+            $selector,
+        ));
+
         $this->autocompleteHelper->selectByName(
             $this->getDriver(),
-            $this->getElement('parent')->getXpath(),
+            $parentElement->getXpath(),
             $taxon->getName(),
         );
         $this->waitForFormUpdate();
@@ -94,8 +108,58 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
     public function removeCurrentParent(): void
     {
-        $this->autocompleteHelper->clear($this->getDriver(), $this->getElement('parent')->getXpath());
+        DriverHelper::waitForPageToLoad($this->getSession());
+
+        $parentElement = $this->getElement('parent');
+        $selector = $this->normalizeXPathForJavaScript($parentElement->getXpath());
+
+        // Wait for Tom Select to initialize
+        $this->getDriver()->wait(5000, sprintf(
+            '(function() {
+                let element = document.evaluate("%s", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+                return element && element.tomselect !== undefined;
+            })()',
+            $selector,
+        ));
+
+        $this->autocompleteHelper->clear($this->getDriver(), $parentElement->getXpath());
         $this->waitForFormUpdate();
+    }
+
+    public function searchInParentAutocomplete(string $searchString): array
+    {
+        // Wait for the parent element to appear in DOM
+        $this->getSession()->wait(10000, sprintf(
+            "document.querySelector('%s') !== null",
+            str_replace("'", "\\'", '[data-test-parent]'),
+        ));
+
+        // Now get the element through standard mechanism
+        $parentElement = $this->getElement('parent');
+
+        // Wait for Tom Select to be initialized
+        $this->getSession()->wait(10000, sprintf(
+            '(function() {
+                var container = document.querySelector(\'%s\');
+                if (!container) return false;
+                var select = container.querySelector(\'select\');
+                return select && select.tomselect !== undefined;
+            })()',
+            str_replace("'", "\\'", '[data-test-parent]'),
+        ));
+
+        $result = $this->autocompleteHelper->search(
+            $this->getDriver(),
+            $parentElement->getXpath(),
+            $searchString,
+        );
+
+        return is_array($result) ? $result : [];
+    }
+
+    private function normalizeXPathForJavaScript(string $xpath): string
+    {
+        return str_replace('"', '\\"', $xpath);
     }
 
     public function getTranslationFieldValue(string $element, string $localeCode): string

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElementInterface.php
@@ -38,6 +38,11 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function removeCurrentParent(): void;
 
+    /**
+     * @return array<string, string>
+     */
+    public function searchInParentAutocomplete(string $searchString): array;
+
     public function getTranslationFieldValue(string $element, string $localeCode): string;
 
     public function enable(): void;

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Form\Type;
 
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -33,10 +35,37 @@ final class TaxonAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->taxonClass,
+            'choice_label' => 'fullname',
+            'choice_value' => 'code',
+            'extra_options' => [],
         ]);
 
         $resolver->setDefault('choice_label', function (Options $options): string {
             return $options['extra_options']['choice_label'] ?? 'fullname';
+        });
+
+        $resolver->setAllowedTypes('extra_options', 'array');
+
+        $resolver->setNormalizer('filter_query', function (Options $options, ?callable $filterQuery): ?callable {
+            /** @var array<string, mixed> $extraOptions */
+            $extraOptions = $options['extra_options'];
+            /** @var array<string> $excludedCodes */
+            $excludedCodes = $extraOptions['excluded_taxon_codes'] ?? [];
+
+            if (empty($excludedCodes)) {
+                return $filterQuery;
+            }
+
+            return function (QueryBuilder $queryBuilder, string $query, EntityRepository $repository) use ($filterQuery, $excludedCodes): void {
+                if (null !== $filterQuery) {
+                    $filterQuery($queryBuilder, $query, $repository);
+                }
+
+                $queryBuilder
+                    ->andWhere('entity.code NOT IN (:excluded_codes)')
+                    ->setParameter('excluded_codes', $excludedCodes)
+                ;
+            };
         });
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -35,9 +35,6 @@ final class TaxonAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->taxonClass,
-            'choice_label' => 'fullname',
-            'choice_value' => 'code',
-            'extra_options' => [],
         ]);
 
         $resolver->setDefault('choice_label', function (Options $options): string {

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonType.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\AdminBundle\Form\Type;
 
 use Sylius\Bundle\CoreBundle\Form\Type\Taxon\TaxonImageType;
 use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonType as BaseTaxonType;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -24,6 +25,22 @@ final class TaxonType extends AbstractType
     /** @param array<string, mixed> $options */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var TaxonInterface|null $taxon */
+        $taxon = $builder->getData();
+        /** @var array<string> $excludedTaxonCodes */
+        $excludedTaxonCodes = [];
+
+        if (null !== $taxon) {
+            $taxonCode = $taxon->getCode();
+            if (null !== $taxonCode) {
+                $excludedTaxonCodes[] = $taxonCode;
+            }
+
+            foreach ($taxon->getChildren() as $child) {
+                $this->addDescendantCodes($child, $excludedTaxonCodes);
+            }
+        }
+
         $builder
             ->add('images', LiveCollectionType::class, [
                 'entry_type' => TaxonImageType::class,
@@ -41,6 +58,9 @@ final class TaxonType extends AbstractType
                 'label' => 'sylius.form.taxon.parent',
                 'multiple' => false,
                 'required' => false,
+                'extra_options' => [
+                    'excluded_taxon_codes' => $excludedTaxonCodes,
+                ],
             ])
         ;
     }
@@ -53,5 +73,22 @@ final class TaxonType extends AbstractType
     public function getParent(): string
     {
         return BaseTaxonType::class;
+    }
+
+    /**
+     * @param array<string> $excludedTaxonCodes
+     *
+     * @param-out array<string> $excludedTaxonCodes
+     */
+    private function addDescendantCodes(TaxonInterface $taxon, array &$excludedTaxonCodes): void
+    {
+        $taxonCode = $taxon->getCode();
+        if (null !== $taxonCode) {
+            $excludedTaxonCodes[] = $taxonCode;
+        }
+
+        foreach ($taxon->getChildren() as $child) {
+            $this->addDescendantCodes($child, $excludedTaxonCodes);
+        }
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/11793
| License         | MIT

Added logic to build list of excluded taxon codes:
    - Collects current taxon code and all descendant codes recursively
    - Passes excluded codes via extra_options to autocomplete field
Added filtering mechanism:
    - Added extra_options configuration
    - Implemented filter_query normalizer that excludes taxon codes from results
Prevents circular parent-child relationships in taxon hierarchy

Related PR: https://github.com/Sylius/Sylius/pull/18470



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parent selector now automatically excludes the current taxon and all its descendants to prevent circular parent choices in the admin UI.

* **Bug Fixes / UX**
  * Parent autocomplete search made more reliable and responsive; results correctly include or exclude taxa as expected.
  * API now rejects attempts to create circular parent relations and surfaces a clear invalid-parent notification.

* **Tests**
  * Added UI and API acceptance tests covering circular-parent prevention and parent-autocomplete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->