### PR TITLE
Add deprecation note to `sylius_admin_address_log_entry` configuration

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/address_log_entry.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/address_log_entry.yml
@@ -1,3 +1,5 @@
+# This configuration is deprecated. The address log entries are no longer rendered with Sylius grids.
+# This will be removed in Sylius 3.0
 sylius_grid:
     grids:
         sylius_admin_address_log_entry:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | -
| License         | MIT

Adding a note that this configuration is no longer used so that people don't get confused when they edit it and nothing happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Address log entry grid rendering is deprecated and will be removed in Sylius 3.0. Current behavior is unchanged for now; only deprecation notices were added. Users should review and prepare their configurations for upcoming removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->