### PR TITLE
[Behat] Remove `@javascript` tag from taxon slug scenarios

### DIFF
--- a/features/admin/taxonomy/managing_taxons/editing_taxon_slug.feature
+++ b/features/admin/taxonomy/managing_taxons/editing_taxon_slug.feature
@@ -57,7 +57,7 @@ Feature: Editing taxon's slug
         And I add it
         Then this taxon slug should be "medieval-weapons/siege"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Not editing the slug while changing a taxon name
         Given the store has "Medieval weapons" taxonomy
         When I want to modify the "Medieval weapons" taxon
@@ -103,7 +103,7 @@ Feature: Editing taxon's slug
         And I save my changes
         Then the slug of the "Javelins" taxon should be "medieval-weapons/javelins"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Manually changing a root taxon's slug while editing a taxon's name
         Given the store has "Medieval weapons" taxonomy
         When I want to modify the "Medieval weapons" taxon
@@ -134,7 +134,7 @@ Feature: Editing taxon's slug
         And I save my changes
         Then the slug of the "Pikes" taxon should be "pikes"
 
-    @api @ui @javascript
+    @api @ui
     Scenario: Manually changing a child taxon's slug while editing a taxon's name
         Given the store has "Medieval weapons" taxonomy
         And the "Medieval weapons" taxon has child taxon "Pikes"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

## Description

This PR removes the `@javascript` tag from three scenarios in the taxon slug editing feature file. These scenarios test slug editing functionality that doesn't require JavaScript execution.

## Changes

- Removed `@javascript` tag from "Not editing the slug while changing a taxon name" scenario
- Removed `@javascript` tag from "Manually changing a root taxon's slug while editing a taxon's name" scenario  
- Removed `@javascript` tag from "Manually changing a child taxon's slug while editing a taxon's name" scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization metadata to streamline test execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->