### PR TITLE
[CI] Parallelize non-JS tests execution

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -133,58 +133,103 @@ jobs:
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
 
-            -   name: Setup parallel test databases
-                run: |
-                    # Create separate databases for each test suite
-                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_cli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_api CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_ui CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-
-                    # Copy database structure and data
-                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_phpunit
-                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_cli
-                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_api
-                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_ui
-
             -   name: Run all non-JS tests in parallel
                 run: |
                     set -o pipefail
 
-                    # Run all test suites in parallel with separate databases and prefixed output
+                    # Create a base database dump for faster cloning
+                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius > /tmp/sylius_base.sql
+
+                    # Run all test suites in parallel with TEST_TOKEN isolation
 
                     # PHPUnit all tests
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_phpunit?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        export TEST_TOKEN="phpunit_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
-                        echo $? > /tmp/exit_phpunit
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_phpunit
                     ) &
                     PID_PHPUNIT=$!
 
                     # CLI Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
-                        echo $? > /tmp/exit_cli
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_cli
                     ) &
                     PID_CLI=$!
 
                     # API/Domain Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
-                        echo $? > /tmp/exit_api
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_api
                     ) &
                     PID_API=$!
 
                     # UI (non-JS) Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
-                        echo $? > /tmp/exit_ui
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_ui
                     ) &
                     PID_UI=$!
 
@@ -212,25 +257,55 @@ jobs:
                     if [ "${EXIT_CLI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_API:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_UI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -P 3307 -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     exit $FINAL_EXIT

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -52,7 +52,7 @@ jobs:
 
         env:
             APP_ENV: test_cached
-            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+            DATABASE_URL: "mysql://root:root@127.0.0.1:3307/sylius?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
             TEST_SYLIUS_STATE_MACHINE_ADAPTER: "${{ matrix.state_machine_adapter }}"
 
         steps:

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -164,6 +164,7 @@ jobs:
                     # CLI Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
                         echo $? > /tmp/exit_cli
                     ) &
@@ -172,6 +173,7 @@ jobs:
                     # API/Domain Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
                         echo $? > /tmp/exit_api
                     ) &
@@ -180,6 +182,7 @@ jobs:
                     # UI (non-JS) Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
                         echo $? > /tmp/exit_ui
                     ) &
@@ -210,6 +213,7 @@ jobs:
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -217,6 +221,7 @@ jobs:
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -224,6 +229,7 @@ jobs:
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
                     fi
 

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -130,6 +130,9 @@ jobs:
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
+            -   name: Test installer
+                run: bin/console sylius:install --no-interaction -vvv
+
             -   name: Setup parallel test databases
                 run: |
                     # Create separate databases for each test suite

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -130,19 +130,101 @@ jobs:
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
-            -   name: Run PHPUnit
+            -   name: Setup parallel test databases
                 run: |
-                    vendor/bin/phpunit --testsuite all --colors=always
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
+                    # Create separate databases for each test suite
+                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_cli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_api CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -P 3307 -e "CREATE DATABASE IF NOT EXISTS sylius_ui CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
-            -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                    # Copy database structure and data
+                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_phpunit
+                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_cli
+                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_api
+                    mysqldump -h 127.0.0.1 -u root -proot -P 3307 sylius | mysql -h 127.0.0.1 -u root -proot -P 3307 sylius_ui
 
-            -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
+            -   name: Run all non-JS tests in parallel
+                run: |
+                    set -o pipefail
 
-            -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                    # Run all test suites in parallel with separate databases and prefixed output
+
+                    # PHPUnit all tests
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_phpunit?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
+                        echo $? > /tmp/exit_phpunit
+                    ) &
+                    PID_PHPUNIT=$!
+
+                    # CLI Behat
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
+                        echo $? > /tmp/exit_cli
+                    ) &
+                    PID_CLI=$!
+
+                    # API/Domain Behat
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
+                        echo $? > /tmp/exit_api
+                    ) &
+                    PID_API=$!
+
+                    # UI (non-JS) Behat
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
+                        echo $? > /tmp/exit_ui
+                    ) &
+                    PID_UI=$!
+
+                    # Wait for all processes to complete
+                    wait $PID_PHPUNIT
+                    wait $PID_CLI
+                    wait $PID_API
+                    wait $PID_UI
+
+                    # Read exit codes from files
+                    EXIT_PHPUNIT=$(cat /tmp/exit_phpunit 2>/dev/null || echo 1)
+                    EXIT_CLI=$(cat /tmp/exit_cli 2>/dev/null || echo 1)
+                    EXIT_API=$(cat /tmp/exit_api 2>/dev/null || echo 1)
+                    EXIT_UI=$(cat /tmp/exit_ui 2>/dev/null || echo 1)
+
+                    # Handle failures and reruns
+                    FINAL_EXIT=0
+
+                    if [ "${EXIT_PHPUNIT:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UNIT] PHPUnit tests failed (exit code: ${EXIT_PHPUNIT})"
+                        FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_CLI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[CLI] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_cli?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_API:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[API] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_api?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_UI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UI] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1:3307/sylius_ui?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+                    fi
+
+                    exit $FINAL_EXIT
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -118,67 +118,73 @@ jobs:
             -   name: Setup parallel test databases
                 run: |
                     # Create separate databases for each test suite
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit2 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
                     mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_cli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
                     mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_api CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
                     mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_ui CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
                     # Copy database structure and data
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit1
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit2
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit
                     mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_cli
                     mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_api
                     mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_ui
 
             -   name: Run all non-JS tests in parallel
                 run: |
+                    set -o pipefail
+
                     # Run all test suites in parallel with separate databases and prefixed output
 
-                    # PHPUnit test suite "all"
-                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit1?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                    vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT1] /' &
-                    PID_PHPUNIT1=$!
-
-                    # PHPUnit "Sylius Test Suite"
-                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit2?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always 2>&1 | sed 's/^/[UNIT2] /' &
-                    PID_PHPUNIT2=$!
+                    # PHPUnit all tests
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
+                        echo $? > /tmp/exit_phpunit
+                    ) &
+                    PID_PHPUNIT=$!
 
                     # CLI Behat
-                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /' &
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
+                        echo $? > /tmp/exit_cli
+                    ) &
                     PID_CLI=$!
 
                     # API/Domain Behat
-                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /' &
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
+                        echo $? > /tmp/exit_api
+                    ) &
                     PID_API=$!
 
                     # UI (non-JS) Behat
-                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /' &
+                    (
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
+                        echo $? > /tmp/exit_ui
+                    ) &
                     PID_UI=$!
 
-                    # Wait for all processes and capture exit codes
-                    wait $PID_PHPUNIT1 || EXIT_PHPUNIT1=$?
-                    wait $PID_PHPUNIT2 || EXIT_PHPUNIT2=$?
-                    wait $PID_CLI || EXIT_CLI=$?
-                    wait $PID_API || EXIT_API=$?
-                    wait $PID_UI || EXIT_UI=$?
+                    # Wait for all processes to complete
+                    wait $PID_PHPUNIT
+                    wait $PID_CLI
+                    wait $PID_API
+                    wait $PID_UI
+
+                    # Read exit codes from files
+                    EXIT_PHPUNIT=$(cat /tmp/exit_phpunit 2>/dev/null || echo 1)
+                    EXIT_CLI=$(cat /tmp/exit_cli 2>/dev/null || echo 1)
+                    EXIT_API=$(cat /tmp/exit_api 2>/dev/null || echo 1)
+                    EXIT_UI=$(cat /tmp/exit_ui 2>/dev/null || echo 1)
 
                     # Handle failures and reruns
                     FINAL_EXIT=0
 
-                    if [ "${EXIT_PHPUNIT1:-0}" -ne 0 ]; then
+                    if [ "${EXIT_PHPUNIT:-0}" -ne 0 ]; then
                         echo ""
-                        echo "::error::[UNIT1] PHPUnit 'all' test suite failed (exit code: ${EXIT_PHPUNIT1})"
-                        FINAL_EXIT=1
-                    fi
-
-                    if [ "${EXIT_PHPUNIT2:-0}" -ne 0 ]; then
-                        echo ""
-                        echo "::error::[UNIT2] PHPUnit 'Sylius Test Suite' failed (exit code: ${EXIT_PHPUNIT2})"
+                        echo "::error::[UNIT] PHPUnit tests failed (exit code: ${EXIT_PHPUNIT})"
                         FINAL_EXIT=1
                     fi
 

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -115,19 +115,95 @@ jobs:
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
 
-            -   name: Run PHPUnit
+            -   name: Setup parallel test databases
                 run: |
-                    vendor/bin/phpunit --testsuite all --colors=always
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
+                    # Create separate databases for each test suite
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit1 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit2 CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_cli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_api CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_ui CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 
-            -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                    # Copy database structure and data
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit1
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit2
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_cli
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_api
+                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_ui
 
-            -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
+            -   name: Run all non-JS tests in parallel
+                run: |
+                    # Run all test suites in parallel with separate databases and prefixed output
 
-            -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                    # PHPUnit test suite "all"
+                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit1?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                    vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT1] /' &
+                    PID_PHPUNIT1=$!
+
+                    # PHPUnit "Sylius Test Suite"
+                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit2?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always 2>&1 | sed 's/^/[UNIT2] /' &
+                    PID_PHPUNIT2=$!
+
+                    # CLI Behat
+                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /' &
+                    PID_CLI=$!
+
+                    # API/Domain Behat
+                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /' &
+                    PID_API=$!
+
+                    # UI (non-JS) Behat
+                    DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /' &
+                    PID_UI=$!
+
+                    # Wait for all processes and capture exit codes
+                    wait $PID_PHPUNIT1 || EXIT_PHPUNIT1=$?
+                    wait $PID_PHPUNIT2 || EXIT_PHPUNIT2=$?
+                    wait $PID_CLI || EXIT_CLI=$?
+                    wait $PID_API || EXIT_API=$?
+                    wait $PID_UI || EXIT_UI=$?
+
+                    # Handle failures and reruns
+                    FINAL_EXIT=0
+
+                    if [ "${EXIT_PHPUNIT1:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UNIT1] PHPUnit 'all' test suite failed (exit code: ${EXIT_PHPUNIT1})"
+                        FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_PHPUNIT2:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UNIT2] PHPUnit 'Sylius Test Suite' failed (exit code: ${EXIT_PHPUNIT2})"
+                        FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_CLI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[CLI] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_API:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[API] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_UI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UI] Tests failed, retrying..."
+                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+                    fi
+
+                    exit $FINAL_EXIT
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -146,6 +146,7 @@ jobs:
                     # CLI Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
                         echo $? > /tmp/exit_cli
                     ) &
@@ -154,6 +155,7 @@ jobs:
                     # API/Domain Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
                         echo $? > /tmp/exit_api
                     ) &
@@ -162,6 +164,7 @@ jobs:
                     # UI (non-JS) Behat
                     (
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
                         echo $? > /tmp/exit_ui
                     ) &
@@ -192,6 +195,7 @@ jobs:
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -199,6 +203,7 @@ jobs:
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -206,6 +211,7 @@ jobs:
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
                         DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
                     fi
 

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -115,58 +115,103 @@ jobs:
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
 
-            -   name: Setup parallel test databases
-                run: |
-                    # Create separate databases for each test suite
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_phpunit CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_cli CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_api CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-                    mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE IF NOT EXISTS sylius_ui CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-
-                    # Copy database structure and data
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_phpunit
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_cli
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_api
-                    mysqldump -h 127.0.0.1 -u root -proot sylius | mysql -h 127.0.0.1 -u root -proot sylius_ui
-
-            -   name: Run all non-JS tests in parallel
+            -   name: Run non-JS tests (partially parallel)
                 run: |
                     set -o pipefail
 
-                    # Run all test suites in parallel with separate databases and prefixed output
+                    # Create a base database dump for faster cloning
+                    mysqldump -h 127.0.0.1 -u root -proot sylius > /tmp/sylius_base.sql
+
+                    # Run all test suites in parallel with TEST_TOKEN isolation
 
                     # PHPUnit all tests
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_phpunit?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
+                        export TEST_TOKEN="phpunit_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
-                        echo $? > /tmp/exit_phpunit
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_phpunit
                     ) &
                     PID_PHPUNIT=$!
 
                     # CLI Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
-                        echo $? > /tmp/exit_cli
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_cli
                     ) &
                     PID_CLI=$!
 
                     # API/Domain Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
-                        echo $? > /tmp/exit_api
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_api
                     ) &
                     PID_API=$!
 
                     # UI (non-JS) Behat
                     (
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
-                        echo $? > /tmp/exit_ui
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_ui
                     ) &
                     PID_UI=$!
 
@@ -194,25 +239,55 @@ jobs:
                     if [ "${EXIT_CLI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_cli?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_API:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_api?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_UI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
-                        DATABASE_URL="mysql://root:root@127.0.0.1/sylius_ui?charset=utf8mb4&serverVersion=${{ matrix.mysql }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_retry_$$"
+                        export DATABASE_URL="mysql://root:root@127.0.0.1/sylius_${TEST_TOKEN}?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE sylius_${TEST_TOKEN} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+                        mysql -h 127.0.0.1 -u root -proot sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+
+                        mysql -h 127.0.0.1 -u root -proot -e "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     exit $FINAL_EXIT

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -104,19 +104,101 @@ jobs:
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
-            -   name: Run PHPUnit
+            -   name: Setup parallel test databases
                 run: |
-                    vendor/bin/phpunit --testsuite all --colors=always
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
+                    # Create separate databases for each test suite
+                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_phpunit;"
+                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_cli;"
+                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_api;"
+                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_ui;"
 
-            -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                    # Copy database structure and data
+                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_phpunit
+                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_cli
+                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_api
+                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_ui
 
-            -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" --rerun
+            -   name: Run all non-JS tests in parallel
+                run: |
+                    set -o pipefail
 
-            -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" --rerun
+                    # Run all test suites in parallel with separate databases and prefixed output
+
+                    # PHPUnit all tests
+                    (
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_phpunit?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
+                        echo $? > /tmp/exit_phpunit
+                    ) &
+                    PID_PHPUNIT=$!
+
+                    # CLI Behat
+                    (
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
+                        echo $? > /tmp/exit_cli
+                    ) &
+                    PID_CLI=$!
+
+                    # API/Domain Behat (excluding no-postgres tests)
+                    (
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
+                        echo $? > /tmp/exit_api
+                    ) &
+                    PID_API=$!
+
+                    # UI (non-JS) Behat (excluding no-postgres tests)
+                    (
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
+                        echo $? > /tmp/exit_ui
+                    ) &
+                    PID_UI=$!
+
+                    # Wait for all processes to complete
+                    wait $PID_PHPUNIT
+                    wait $PID_CLI
+                    wait $PID_API
+                    wait $PID_UI
+
+                    # Read exit codes from files
+                    EXIT_PHPUNIT=$(cat /tmp/exit_phpunit 2>/dev/null || echo 1)
+                    EXIT_CLI=$(cat /tmp/exit_cli 2>/dev/null || echo 1)
+                    EXIT_API=$(cat /tmp/exit_api 2>/dev/null || echo 1)
+                    EXIT_UI=$(cat /tmp/exit_ui 2>/dev/null || echo 1)
+
+                    # Handle failures and reruns
+                    FINAL_EXIT=0
+
+                    if [ "${EXIT_PHPUNIT:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UNIT] PHPUnit tests failed (exit code: ${EXIT_PHPUNIT})"
+                        FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_CLI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[CLI] Tests failed, retrying..."
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_API:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[API] Tests failed, retrying..."
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+                    fi
+
+                    if [ "${EXIT_UI:-0}" -ne 0 ]; then
+                        echo ""
+                        echo "::error::[UI] Tests failed, retrying..."
+                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
+                        vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+                    fi
+
+                    exit $FINAL_EXIT
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -138,6 +138,7 @@ jobs:
                     # CLI Behat
                     (
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
                         echo $? > /tmp/exit_cli
                     ) &
@@ -146,6 +147,7 @@ jobs:
                     # API/Domain Behat (excluding no-postgres tests)
                     (
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
                         echo $? > /tmp/exit_api
                     ) &
@@ -154,6 +156,7 @@ jobs:
                     # UI (non-JS) Behat (excluding no-postgres tests)
                     (
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
                         echo $? > /tmp/exit_ui
                     ) &
@@ -184,6 +187,7 @@ jobs:
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -191,6 +195,7 @@ jobs:
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
                     fi
 
@@ -198,6 +203,7 @@ jobs:
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
                         DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
+                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
                     fi
 

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -104,6 +104,9 @@ jobs:
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
+            -   name: Test installer
+                run: bin/console sylius:install --no-interaction -vvv
+
             -   name: Setup parallel test databases
                 run: |
                     # Create separate databases for each test suite

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -113,10 +113,10 @@ jobs:
                     psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_ui;"
 
                     # Copy database structure and data
-                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_phpunit
-                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_cli
-                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_api
-                    pg_dump -h 127.0.0.1 -U postgres sylius_test | psql -h 127.0.0.1 -U postgres sylius_ui
+                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_phpunit
+                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_cli
+                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_api
+                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_ui
 
             -   name: Run all non-JS tests in parallel
                 run: |

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -107,60 +107,104 @@ jobs:
             -   name: Test installer
                 run: bin/console sylius:install --no-interaction -vvv
 
-            -   name: Setup parallel test databases
-                run: |
-                    export PGPASSWORD=postgres
-
-                    # Create separate databases for each test suite
-                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_phpunit;"
-                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_cli;"
-                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_api;"
-                    psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_ui;"
-
-                    # Copy database structure and data
-                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_phpunit
-                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_cli
-                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_api
-                    pg_dump -h 127.0.0.1 -U postgres sylius | psql -h 127.0.0.1 -U postgres sylius_ui
-
             -   name: Run all non-JS tests in parallel
                 run: |
                     set -o pipefail
+                    export PGPASSWORD=postgres
 
-                    # Run all test suites in parallel with separate databases and prefixed output
+                    # Create a base database dump for faster cloning
+                    pg_dump -h 127.0.0.1 -U postgres sylius > /tmp/sylius_base.sql
+
+                    # Run all test suites in parallel with TEST_TOKEN isolation
 
                     # PHPUnit all tests
                     (
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_phpunit?serverVersion=${{ matrix.postgres }}" \
+                        export TEST_TOKEN="phpunit_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+
+                        # Create isolated database
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/phpunit --testsuite all --colors=always 2>&1 | sed 's/^/[UNIT] /'
-                        echo $? > /tmp/exit_phpunit
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_phpunit
                     ) &
                     PID_PHPUNIT=$!
 
                     # CLI Behat
                     (
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" 2>&1 | sed 's/^/[CLI  ] /'
-                        echo $? > /tmp/exit_cli
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_cli
                     ) &
                     PID_CLI=$!
 
                     # API/Domain Behat (excluding no-postgres tests)
                     (
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" 2>&1 | sed 's/^/[API  ] /'
-                        echo $? > /tmp/exit_api
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_api
                     ) &
                     PID_API=$!
 
                     # UI (non-JS) Behat (excluding no-postgres tests)
                     (
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        # Create isolated database
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" 2>&1 | sed 's/^/[UI   ] /'
-                        echo $? > /tmp/exit_ui
+                        EXIT_CODE=$?
+
+                        # Cleanup
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
+
+                        echo $EXIT_CODE > /tmp/exit_ui
                     ) &
                     PID_UI=$!
 
@@ -188,25 +232,55 @@ jobs:
                     if [ "${EXIT_CLI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[CLI] Tests failed, retrying..."
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_cli?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_cli_cache"}}}' \
+                        export TEST_TOKEN="cli_retry_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun 2>&1 | sed 's/^/[CLI-RETRY] /' || FINAL_EXIT=1
+
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_API:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[API] Tests failed, retrying..."
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_api?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_api_cache"}}}' \
+                        export TEST_TOKEN="api_retry_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" --rerun 2>&1 | sed 's/^/[API-RETRY] /' || FINAL_EXIT=1
+
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     if [ "${EXIT_UI:-0}" -ne 0 ]; then
                         echo ""
                         echo "::error::[UI] Tests failed, retrying..."
-                        DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_ui?serverVersion=${{ matrix.postgres }}" \
-                        BEHAT_PARAMS='{"extensions":{"Behat\\Gherkin\\ServiceContainer\\Extension":{"cache":"/tmp/behat_ui_cache"}}}' \
+                        export TEST_TOKEN="ui_retry_$$"
+                        export DATABASE_URL="postgresql://postgres:postgres@127.0.0.1/sylius_${TEST_TOKEN}?serverVersion=${{ matrix.postgres }}"
+                        export SYMFONY_CACHE_DIR="/tmp/cache_${TEST_TOKEN}"
+                        export SYMFONY_LOG_DIR="/tmp/log_${TEST_TOKEN}"
+                        export BEHAT_PARAMS="{\"extensions\":{\"Behat\\\\Gherkin\\\\ServiceContainer\\\\Extension\":{\"cache\":\"/tmp/behat_${TEST_TOKEN}\"}}}"
+
+                        psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_${TEST_TOKEN};"
+                        psql -h 127.0.0.1 -U postgres sylius_${TEST_TOKEN} < /tmp/sylius_base.sql
+
                         vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" --rerun 2>&1 | sed 's/^/[UI-RETRY ] /' || FINAL_EXIT=1
+
+                        psql -h 127.0.0.1 -U postgres -c "DROP DATABASE IF EXISTS sylius_${TEST_TOKEN};" 2>/dev/null || true
+                        rm -rf /tmp/cache_${TEST_TOKEN} /tmp/log_${TEST_TOKEN} /tmp/behat_${TEST_TOKEN} 2>/dev/null || true
                     fi
 
                     exit $FINAL_EXIT

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -109,6 +109,8 @@ jobs:
 
             -   name: Setup parallel test databases
                 run: |
+                    export PGPASSWORD=postgres
+
                     # Create separate databases for each test suite
                     psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_phpunit;"
                     psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE sylius_cli;"

--- a/.github/workflows/test-sequential.yaml
+++ b/.github/workflows/test-sequential.yaml
@@ -1,0 +1,57 @@
+name: Test Sequential vs Parallel
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-approach:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+        ports:
+          - 3306:3306
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test reduced parallelism (2 at a time)
+        run: |
+          # Create test databases
+          mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE test1;"
+          mysql -h 127.0.0.1 -u root -proot -e "CREATE DATABASE test2;"
+
+          # Run only 2 processes in parallel instead of 4
+          (
+            echo "[TEST1] Starting..." && sleep 5 && echo "[TEST1] Done"
+          ) 2>&1 | sed 's/^/[TEST1] /' &
+          PID1=$!
+
+          (
+            echo "[TEST2] Starting..." && sleep 3 && echo "[TEST2] Done"
+          ) 2>&1 | sed 's/^/[TEST2] /' &
+          PID2=$!
+
+          wait $PID1 $PID2
+          echo "First batch completed"
+
+          # Then run next 2
+          (
+            echo "[TEST3] Starting..." && sleep 4 && echo "[TEST3] Done"
+          ) 2>&1 | sed 's/^/[TEST3] /' &
+          PID3=$!
+
+          (
+            echo "[TEST4] Starting..." && sleep 2 && echo "[TEST4] Done"
+          ) 2>&1 | sed 's/^/[TEST4] /' &
+          PID4=$!
+
+          wait $PID3 $PID4
+          echo "Second batch completed"


### PR DESCRIPTION
## Summary
- Run PHPUnit and non-JS Behat tests in parallel with separate databases
- Create 5 isolated MySQL databases for concurrent test execution
- Add output prefixes ([UNIT1], [CLI], [API], etc.) for clarity
- Maintain proper error handling and retry mechanism for Behat tests

This optimization should significantly reduce CI execution time by running multiple test suites simultaneously instead of sequentially.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD pipeline to parallelize test suite execution for substantially faster feedback cycles
  * Implemented concurrent testing with dedicated resources for each suite
  * Enhanced failure visibility with improved error reporting and intelligent retry handling for greater pipeline reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->