### PR TITLE
[Behat] Wait for notification elements to appear

### DIFF
--- a/src/Sylius/Behat/Service/Accessor/NotificationAccessor.php
+++ b/src/Sylius/Behat/Service/Accessor/NotificationAccessor.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Service\Accessor;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
+use Sylius\Behat\Service\DriverHelper;
 
 final readonly class NotificationAccessor implements NotificationAccessorInterface
 {
@@ -26,6 +27,8 @@ final readonly class NotificationAccessor implements NotificationAccessorInterfa
 
     public function getMessageElements(): array
     {
+        DriverHelper::waitForElement($this->session, $this->locator);
+
         $messageElements = $this->session->getPage()->findAll('css', $this->locator);
 
         if (empty($messageElements)) {

--- a/src/Sylius/Behat/Service/DriverHelper.php
+++ b/src/Sylius/Behat/Service/DriverHelper.php
@@ -37,4 +37,14 @@ abstract class DriverHelper
             $session->wait(1000, "document.readyState === 'complete' && !document.querySelector('[data-live-is-loading]')");
         }
     }
+
+    public static function waitForElement(Session $session, string $selector, int $timeout = 5000): void
+    {
+        if (self::isJavascript($session->getDriver())) {
+            $session->wait($timeout, sprintf(
+                'document.querySelector(%s) !== null',
+                json_encode($selector),
+            ));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add explicit wait for notification elements before accessing them
- Fixes race condition where tests try to access flash messages before they appear in DOM

## Context
In JavaScript-driven tests, flash messages may take time to appear in the DOM. Without waiting, `NotificationAccessor::getMessageElements()` could fail with `ElementNotFoundException` even though the notification would eventually appear.

This change adds a wait for up to 5 seconds for the notification element to exist before trying to access it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by implementing element availability verification for automated testing. Ensures DOM elements exist and are interactive before test actions are performed, significantly reducing flaky test failures and false negatives in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->