### PR TITLE
[Behat] Add missing waits for page load in admin pages

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -18,6 +18,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Sylius\Behat\Page\SyliusPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
+use Sylius\Behat\Service\DriverHelper;
 use Symfony\Component\Routing\RouterInterface;
 use Webmozart\Assert\Assert;
 
@@ -157,6 +158,8 @@ class IndexPage extends SyliusPage implements IndexPageInterface
 
     public function isEnabledFilterApplied(): bool
     {
+        DriverHelper::waitForElement($this->getSession(), '[data-test-criterion-enabled]');
+
         return $this->getElement('enabled_filter')->getValue() === 'true';
     }
 

--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -52,6 +52,8 @@ class DashboardPage extends SyliusPage implements DashboardPageInterface
     /** @throws ElementNotFoundException */
     public function getNumberOfNewOrdersInTheList(): int
     {
+        $this->waitForElement('order_list');
+
         return $this->tableAccessor->countTableBodyRows($this->getElement('order_list'));
     }
 
@@ -64,6 +66,8 @@ class DashboardPage extends SyliusPage implements DashboardPageInterface
     /** @throws ElementNotFoundException */
     public function getNumberOfNewCustomersInTheList(): int
     {
+        $this->waitForElement('customer_list');
+
         return $this->tableAccessor->countTableBodyRows($this->getElement('customer_list'));
     }
 

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
@@ -15,6 +15,7 @@ namespace Sylius\Behat\Page\Admin\Product;
 
 use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Page\Admin\Crud\IndexPage as CrudIndexPage;
+use Sylius\Behat\Service\DriverHelper;
 use Webmozart\Assert\Assert;
 
 class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterface
@@ -56,6 +57,7 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
         $saveConfigurationButton->press();
 
         $this->getDocument()->waitFor(5, fn () => null === $saveConfigurationButton->find('css', '.loading'));
+        DriverHelper::waitForPageToLoad($this->getSession());
     }
 
     public function filterByName(string $name): void


### PR DESCRIPTION
## Summary
- Add wait for order and customer lists in DashboardPage before counting rows
- Add wait for page load after saving product positions in IndexPerTaxonPage
- Add wait for enabled filter element before checking its value in IndexPage

## Context
These changes fix race conditions in Behat tests where elements are accessed before they finish loading with LiveComponents:

1. **Dashboard statistics** - Order/customer lists may not be fully loaded when counting rows, leading to incorrect counts
2. **Product positioning** - After saving positions, the page needs to fully reload before checking results
3. **Filter redirects** - The enabled filter element may not be present when checking if it's applied after navigation

These issues manifest as flaky tests that sometimes pass and sometimes fail depending on page load timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of automated tests by adding synchronization checks to ensure page elements are properly loaded before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->