### PR TITLE
FEATURE: [2.2] [AdminBundle] make search menu in admin sidebar component hookable

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/component/sidebar.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/common/component/sidebar.yaml
@@ -15,3 +15,11 @@ sylius_twig_hooks:
             image:
                 template: '@SyliusAdmin/shared/crud/common/sidebar/logo/image.html.twig'
                 priority: 0
+
+        'sylius_admin.common.component.sidebar.menu':
+            search:
+                template: '@SyliusAdmin/shared/crud/common/sidebar/search.html.twig'
+                priority: 100
+            items:
+                template: '@SyliusAdmin/shared/crud/common/sidebar/menu/items.html.twig'
+                priority: 0

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu.html.twig
@@ -1,4 +1,3 @@
 <div class="collapse navbar-collapse" id="sidebar-menu">
-    {% include '@SyliusAdmin/shared/crud/common/sidebar/search.html.twig' %}
-    {{ knp_menu_render('sylius_admin.main', {'template': '@SyliusAdmin/shared/crud/common/sidebar/menu/menu.html.twig', 'currentClass': 'active'}) }}
+    {% hook 'menu' %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/common/sidebar/menu/items.html.twig
@@ -1,0 +1,1 @@
+{{ knp_menu_render('sylius_admin.main', {'template': '@SyliusAdmin/shared/crud/common/sidebar/menu/menu.html.twig', 'currentClass': 'active'}) }}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18494,
| License         | MIT

This pull request enhances the extendability of the sidebar component in the Sylius admin UI by allowing the search menu to be disabled via the twig hooks functionality.

This can be archieved like this for example:

```yaml
# config/packages/sylius_admin_twig_hooks.yaml
sylius_twig_hooks:
    enable_autoprefixing: true
    hooks:
      'sylius_admin.common.component.sidebar.menu':
        search:
          enabled: false
```
