### PR TITLE
Testing all new php grids if migrated

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/tests/Grid/Provider/OverridenGridsTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Grid/Provider/OverridenGridsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\CoreBundle\Grid\Provider;
 
-use Sylius\Component\Channel\Context\ChannelContextInterface;
-use Sylius\Component\Customer\Context\CustomerContextInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sylius\Component\Grid\Exception\UndefinedGridException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Sylius\Bundle\GridBundle\Provider\ServiceGridProvider;
 use Sylius\Component\Grid\Provider\ArrayGridProvider;
@@ -24,22 +24,31 @@ use Sylius\Component\Grid\Provider\ArrayGridProvider;
  */
 final class OverridenGridsTest extends KernelTestCase
 {
-    public function testPhpGridsHavingTheSameConfigurationAsYAMLGrids(): void
+    #[DataProvider('dataProviderGrids')]
+    public function testPhpGridsHavingTheSameConfigurationAsYAMLGrids(string $gridName): void
     {
-        $gridConfiguration = self::getContainer()->getParameter('sylius_core.grids_configuration')['grids'] ?? [];
-
         $container = self::getContainer();
-        $container->set(CustomerContextInterface::class, $this->createMock(CustomerContextInterface::class));
-        $container->set(ChannelContextInterface::class, $this->createMock(ChannelContextInterface::class));
 
         $arrayProvider = $container->get(ArrayGridProvider::class);
         $serviceProvider = $container->get(ServiceGridProvider::class);
 
-        foreach (array_keys($gridConfiguration) as $gridName) {
-            $yamlVersion = $arrayProvider->get($gridName);
+        try {
             $serviceVersion = $serviceProvider->get($gridName);
+        } catch (UndefinedGridException) {
+            $this->markTestSkipped($gridName. ' is not migrated yet');
+        }
+        $yamlVersion = $arrayProvider->get($gridName);
 
-            $this->assertEquals($yamlVersion, $serviceVersion);
+        $this->assertEquals($yamlVersion, $serviceVersion);
+    }
+
+    public static function dataProviderGrids(): \Generator
+    {
+        $gridConfiguration = self::getContainer()->getParameter('sylius.grids_definitions');
+        self::assertNotEmpty($gridConfiguration, 'No grid configuration found');
+
+        foreach (array_keys($gridConfiguration) as $gridName) {
+            yield $gridName => [$gridName];
         }
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
+++ b/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGrid.php
@@ -41,15 +41,15 @@ final class OrderGrid extends AbstractGrid
             ])
             ->setDriverOption('class', $this->resourceClass)
             ->orderBy('checkoutCompletedAt', 'desc')
+            ->setLimits([10, 25, 50])
             ->addField(
                 TwigField::create('number', '@SyliusShop/account/order/grid/field/number.html.twig')
                     ->setLabel('sylius.ui.number')
                     ->setSortable(true),
             )
             ->addField(
-                DateTimeField::create('checkoutCompletedAt', 'Y-m-d')
+                DateTimeField::create('checkoutCompletedAt', 'm/d/Y')
                     ->setLabel('sylius.ui.date')
-                    ->setSortable(true),
             )
             ->addField(
                 TwigField::create('shippingAddress', '@SyliusShop/account/order/grid/field/address.html.twig')
@@ -89,7 +89,7 @@ final class OrderGrid extends AbstractGrid
                             'link' => [
                                 'route' => 'sylius_shop_order_show',
                                 'parameters' => [
-                                    'tokenValue' => 'resource.tokenvalue',
+                                    'tokenValue' => 'resource.tokenValue',
                                 ],
                             ],
                         ]),

--- a/tests/Grid/OverridenGridsTest.php
+++ b/tests/Grid/OverridenGridsTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Sylius\Bundle\CoreBundle\Grid\Provider;
+namespace Sylius\Tests\Grid;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Sylius\Component\Grid\Exception\UndefinedGridException;

--- a/tests/Grid/OverridenGridsTest.php
+++ b/tests/Grid/OverridenGridsTest.php
@@ -39,6 +39,18 @@ final class OverridenGridsTest extends KernelTestCase
         }
         $yamlVersion = $arrayProvider->get($gridName);
 
+        foreach ($yamlVersion->getFields() as $field) {
+            // Prefilling the default values for datetime fields as they might not be set in YAML configuration
+            if ($field->getType() === 'datetime') {
+                $options = [
+                    'format' => 'Y-m-d H:i:s',
+                    'timezone' => null,
+                    ...$field->getOptions(),
+                ];
+                $field->setOptions($options);
+            }
+        }
+
         $this->assertEquals($yamlVersion, $serviceVersion);
     }
 


### PR DESCRIPTION
# What I did

* Replace the one test with a loop with a dataprovider (then it doesn't crash on the first error but checks all grids)
* Skipping the tests of unmigrated grids (nice to track the progress)
* Using the existing grids in Sylius as point of reference (not using the config for migrating stuff, but all sylius defined grids)

## Problems
There are some grids that work differently with php than in YAML. How do we want to deal with that?

cc @loic425 