### PR TITLE
BUGFIX: [2.1] [AdminBundle] adjust z-index in side navigation to prevent overlapping with header

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/product/form/side_navigation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/form/side_navigation.html.twig
@@ -1,5 +1,5 @@
 <div class="col-12 col-lg-3">
-    <div id="side-nav" class="sticky-md-top" style="top: 7.6rem;">
+    <div id="side-nav" class="sticky-md-top" style="top: 7.6rem; z-index: 990;">
         <div class="list-group bg-white mb-5" role="tablist">
             {% hook 'side_navigation' %}
         </div>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18514, partially #Y, mentioned in #Z
| License         | MIT


This pull request adjusts the `z-index` for the side_navigation. Because currently when you have many content on a page where the side_navigation is used, and its scrollable, the side navigation starts collapsing with the header. This was because the `z-index` was too high. 

## Before:

<img width="1242" height="1189" alt="image" src="https://github.com/user-attachments/assets/05e68e14-0587-4891-96e2-3d9823591238" />

## After:

<img width="1232" height="1131" alt="image" src="https://github.com/user-attachments/assets/07520f68-2257-4ea6-9d9a-3332cb4ad79d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed side navigation stacking order to ensure it displays correctly above other page elements, preventing visual overlap issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->