### PR TITLE
Fix Symfony 7.4 compatibility

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,8 @@
         <!-- ###+ symfony/framework-bundle ### -->
         <env name="APP_DEBUG" value="0"/>
         <env name="APP_ENV" value="test"/>
+        <!-- See: https://github.com/symfony/framework-bundle/commit/0681ef3b829f9da165b6bcfe2bc0dd626a86c18d -->
+        <env name="APP_RUNTIME_MODE" value="web=1"/>
         <env name="SHELL_VERBOSITY" value="-1" />
         <!-- ###- symfony/framework-bundle ### -->
 


### PR DESCRIPTION
Fixes Symfony 7.4 compatibility issue in PHPUnit tests where KernelBrowser tests fail because error renderer selection changed.

## Problem

Symfony 7.4 introduced `RuntimeModeErrorRendererSelector` in FrameworkBundle that selects error renderer based on runtime mode:
- CLI context → plain text error output
- Web context → HTML error pages

PHPUnit runs in CLI, so Symfony 7.4 renders plain text errors. But `KernelBrowser` simulates web requests and tests expect HTML error pages, causing failures like:

```
Failed asserting that 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException...' 
contains "The page you are looking for does not exist."
```

Tests expected HTML but got plain text exception dumps.

## Solution

Set `APP_RUNTIME_MODE=web=1` in `phpunit.xml.dist` to force web mode for all PHPUnit tests.

This env var was introduced in Symfony 6.4 and sets the `kernel.runtime_mode.web` parameter:
- Format: query string `web=1&worker=0` 
- `web=1` → parsed to `kernel.runtime_mode.web: true`
- Backward compatible: exists in Symfony 6.4 but only affects error rendering in 7.4+

## Why this approach vs config parameter?

**Considered alternatives:**
1. ❌ `kernel.runtime_mode.web: true` in `config/packages/test/_sylius.yaml` - global, less flexible
2. ✅ `APP_RUNTIME_MODE=web=1` in `phpunit.xml.dist` - proper Symfony mechanism, test-level control

The env var approach is more idiomatic and allows per-test override if needed.

## References

- Symfony commit introducing RuntimeModeErrorRendererSelector: https://github.com/symfony/framework-bundle/commit/0681ef3b829f9da165b6bcfe2bc0dd626a86c18d
- kernel.runtime_mode docs: https://symfony.com/doc/current/reference/configuration/kernel.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to explicitly set the runtime mode to web during testing, ensuring consistent error rendering behavior in web mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->