### PR TITLE
[CI] Remove `DOCTRINE_ORM_VERSION` from packages workflow

### DIFF
--- a/.github/workflows/ci_packages.yaml
+++ b/.github/workflows/ci_packages.yaml
@@ -44,7 +44,7 @@ jobs:
     test:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}${{ matrix.orm != '' && format(', ORM {0}', matrix.orm) || '' }}"
+        name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
         timeout-minutes: 25
 
         strategy:
@@ -54,7 +54,6 @@ jobs:
         env:
             COMPOSER_ROOT_VERSION: "dev-main"
             SYMFONY_VERSION: "${{ matrix.symfony }}"
-            DOCTRINE_ORM_VERSION: "${{ matrix.orm }}"
             UNSTABLE: "no"
 
         steps:
@@ -97,6 +96,6 @@ jobs:
                 run: |
                     wget https://github.com/consolidation/Robo/releases/latest/download/robo.phar
                     chmod +x robo.phar && sudo mv robo.phar /tmp/robo
-                    
+
             -   name: "Run pipeline"
                 run: find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c . | xargs -0 /tmp/robo ci:packages

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,19 +1,31 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 use Robo\Exception\TaskException;
 use Robo\Result;
 use Robo\Symfony\ConsoleIO;
 use Robo\Tasks;
+use RuntimeException;
 
 class RoboFile extends Tasks
 {
-    const ROOT_DIR = __DIR__;
+    private const ROOT_DIR = __DIR__;
 
-    const SUCCESS = 'success';
+    private const SUCCESS = 'success';
 
-    const FAILED = 'failed';
+    private const FAILED = 'failed';
 
-    const YES = 'yes';
+    private const YES = 'yes';
 
     public function ciPackages(ConsoleIO $io, string $packagesJson): ?Result
     {
@@ -26,40 +38,34 @@ class RoboFile extends Tasks
 
             try {
                 $processResult = $this->processPackagePipeline($package);
-                $result[$package] = null !== $processResult && $processResult->wasSuccessful() ? self::SUCCESS : self::FAILED;
+                $result[$package] = $processResult->wasSuccessful() ? self::SUCCESS : self::FAILED;
             } catch (TaskException) {
                 $result[$package] = self::FAILED;
             }
+
+            $this->endGroup();
         }
 
-        $this->endGroup();
-
         foreach ($result as $packageName => $value) {
-            printf("%s %s%s", $value === self::SUCCESS ? '✅' : '❌', $packageName, PHP_EOL);
+            printf('%s %s%s', $value === self::SUCCESS ? '✅' : '❌', $packageName, PHP_EOL);
             $failed = $failed || $value === self::FAILED;
         }
 
-        exit(false === $failed ? 0 : 1);
+        exit($failed ? 1 : 0);
     }
 
     /**
      * @throws TaskException
      */
-    private function processPackagePipeline(string $package): ?Result
+    private function processPackagePipeline(string $package): Result
     {
         $symfonyVersion = getenv('SYMFONY_VERSION');
-        $doctrineORMVersion = getenv('DOCTRINE_ORM_VERSION');
         $unstable = getenv('UNSTABLE');
         $packagePath = sprintf('%s/src/Sylius/%s', self::ROOT_DIR, $package);
         $composerJsonPath = sprintf('%s/composer.json', $packagePath);
-        $requiresDoctrineORM = false;
 
         if (false === $symfonyVersion) {
             throw new RuntimeException('SYMFONY_VERSION environment variable is not set.');
-        }
-
-        if (false === $doctrineORMVersion) {
-            throw new RuntimeException('DOCTRINE_ORM_VERSION environment variable is not set.');
         }
 
         if (!file_exists($composerJsonPath)) {
@@ -75,24 +81,6 @@ class RoboFile extends Tasks
         if (self::YES === $unstable) {
             $task->exec('composer config minimum-stability dev');
             $task->exec('composer config prefer-stable true');
-        }
-
-        $composerData = json_decode(file_get_contents($composerJsonPath), true);
-        $require = $composerData['require'] ?? [];
-        $requireDev = $composerData['require-dev'] ?? [];
-
-        $existsOnRequire = array_key_exists('doctrine/orm', $require);
-        $existsOnRequireDev = array_key_exists('doctrine/orm', $requireDev);
-
-        $requiresDoctrineORM = $existsOnRequire || $existsOnRequireDev;
-
-        if ('' !== $doctrineORMVersion && $requiresDoctrineORM) {
-            $task
-                ->exec(sprintf(
-                    'composer require %s doctrine/orm "%s" --no-update --no-scripts --no-interaction',
-                    $existsOnRequireDev ? '--dev' : '',
-                    $doctrineORMVersion,
-                ));
         }
 
         $task


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

1. Removes `DOCTRINE_ORM_VERSION` support from packages CI workflow as we no longer use it.
2. Refactors `RoboFile` slightly.
