### PR TITLE
[API] Return 422 instead of 400 for missing required fields

### DIFF
--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -1,0 +1,41 @@
+# UPGRADE FROM `2.1` TO `2.2`
+
+## HTTP Status Code Changes
+
+### Missing Required Fields Validation
+
+The HTTP status code for missing required fields in API requests has been changed from `400 Bad Request` to `422 Unprocessable Content` to follow REST API best practices and RFC 9110 semantics.
+
+Additionally, the redundant `code` field has been removed from the error response body, as the status code is already available in the HTTP response headers.
+
+**Before:**
+```json
+{
+    "@context": "/api/v2/contexts/Error",
+    "@type": "hydra:Error",
+    "status": 400,
+    "detail": "Request does not have the following required fields specified: email."
+}
+```
+
+**After:**
+```json
+{
+    "@context": "/api/v2/contexts/Error",
+    "@type": "hydra:Error",
+    "status": 422,
+    "detail": "Request does not have the following required fields specified: email."
+}
+```
+
+**Breaking changes:**
+1. HTTP status code changed: `400` → `422`
+2. Response body field `code` removed (was redundant with HTTP status header)
+
+**Affected endpoints:** All POST/PATCH endpoints that validate required fields (e.g., `/api/v2/shop/customers`, `/api/v2/shop/orders/{token}/items`, etc.)
+
+**Migration guide:**
+- If your API client checks `response.status === 400` for missing fields, change it to `response.status === 422`
+- If your API client reads `response.data.code`, use `response.status` (HTTP header) instead
+
+**References:** RFC 9110 (400 = syntactic errors, 422 = semantic/validation errors)

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -22,6 +22,7 @@ use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
 final class RegistrationContext implements Context
@@ -206,7 +207,7 @@ final class RegistrationContext implements Context
             $content['hydra:description'],
             'Request does not have the following required fields specified: ' . implode(', ', $fields) . '.',
         );
-        Assert::same($this->shopClient->getLastResponse()->getStatusCode(), 400);
+        Assert::same($this->shopClient->getLastResponse()->getStatusCode(), Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -49,6 +49,7 @@ api_platform:
         ApiPlatform\Metadata\Exception\InvalidArgumentException: 400
         ApiPlatform\Validator\Exception\ValidationException: 422
         Doctrine\ORM\OptimisticLockException: 409
+        Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 422
         Symfony\Component\Serializer\Exception\ExceptionInterface: 400
 
         # Sylius exception to status code mapping
@@ -71,7 +72,6 @@ api_platform:
         Sylius\Component\Payment\Exception\InvalidPaymentRequestPayloadException: 422
         Sylius\Component\Promotion\Exception\FailedGenerationException: 422
         Symfony\Component\Serializer\Exception\UnexpectedValueException: 400
-        Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: 400
         Sylius\Bundle\ApiBundle\CommandHandler\Checkout\Exception\OrderTotalHasChangedException: 409
         Sylius\Bundle\ApiBundle\Serializer\Exception\InvalidAmountTypeException: 400
     defaults:

--- a/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/CommandNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/Normalizer/CommandNormalizer.php
@@ -42,7 +42,7 @@ final readonly class CommandNormalizer implements NormalizerInterface
     }
 
     /**
-     * @return array{code: int, message: string}
+     * @return array{message: string}
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
@@ -50,7 +50,6 @@ final readonly class CommandNormalizer implements NormalizerInterface
         $data = $this->objectNormalizer->normalize($object, $format, $context);
 
         return [
-            'code' => 400,
             'message' => $data['message'],
         ];
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/FooApiCommandTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/FooApiCommandTest.php
@@ -38,7 +38,7 @@ final class FooApiCommandTest extends ApiTestCase
 
         $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertJsonContains([
             'hydra:description' => 'Request does not have the following required fields specified: bar.',
             'hydra:title' => 'An error occurred',

--- a/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/MergingConfigsTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Application/src/Tests/MergingConfigsTest.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Application\Tests;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
 
 final class MergingConfigsTest extends ApiTestCase
 {
@@ -79,7 +80,7 @@ final class MergingConfigsTest extends ApiTestCase
             ],
         ]);
 
-        self::assertResponseStatusCodeSame(400);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
 
         static::createClient()->request('POST', '/api/v2/shop/bar', [
             'json' => [

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/CommandNormalizerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/Normalizer/CommandNormalizerTest.php
@@ -105,6 +105,6 @@ final class CommandNormalizerTest extends TestCase
             ->with($objectMock, null, ['sylius_command_normalizer_already_called' => true])
             ->willReturn(['message' => 'Message']);
 
-        self::assertSame(['code' => 400, 'message' => 'Message'], $this->commandNormalizer->normalize($objectMock));
+        self::assertSame(['message' => 'Message'], $this->commandNormalizer->normalize($objectMock));
     }
 }

--- a/tests/Api/Responses/shop/checkout/cart/add_item_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/cart/add_item_with_missing_fields.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: productVariant, quantity.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: productVariant, quantity.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Responses/shop/checkout/cart/update_item_quantity_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_item_quantity_with_missing_fields.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: quantity.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: quantity.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/payment_method/select_payment_method_with_missing_fields.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: paymentMethod.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: paymentMethod.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method_with_missing_fields.json
+++ b/tests/Api/Responses/shop/checkout/shipping_method/select_shipping_method_with_missing_fields.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: shippingMethod.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: shippingMethod.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Responses/shop/payment_request/post_payment_request_without_required_data.json
+++ b/tests/Api/Responses/shop/payment_request/post_payment_request_without_required_data.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: paymentMethodCode.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: paymentMethodCode.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Responses/shop/product_review/create_product_review_with_missing_fields.json
+++ b/tests/Api/Responses/shop/product_review/create_product_review_with_missing_fields.json
@@ -1,10 +1,10 @@
 {
     "@context": "\/api\/v2\/contexts\/Error",
-    "@id": "\/api\/v2\/errors\/400",
+    "@id": "\/api\/v2\/errors\/422",
     "@type": "hydra:Error",
     "detail": "Request does not have the following required fields specified: title, rating, comment, product.",
-    "status": 400,
-    "type": "\/errors\/400",
+    "status": 422,
+    "type": "\/errors\/422",
     "hydra:description": "Request does not have the following required fields specified: title, rating, comment, product.",
     "hydra:title": "An error occurred"
 }

--- a/tests/Api/Shop/Checkout/CartTest.php
+++ b/tests/Api/Shop/Checkout/CartTest.php
@@ -168,7 +168,7 @@ final class CartTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/checkout/cart/add_item_with_missing_fields',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 
@@ -297,7 +297,7 @@ final class CartTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/checkout/cart/update_item_quantity_with_missing_fields',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 

--- a/tests/Api/Shop/Checkout/PaymentMethodTest.php
+++ b/tests/Api/Shop/Checkout/PaymentMethodTest.php
@@ -257,7 +257,7 @@ final class PaymentMethodTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/checkout/payment_method/select_payment_method_with_missing_fields',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 

--- a/tests/Api/Shop/Checkout/ShippingMethodTest.php
+++ b/tests/Api/Shop/Checkout/ShippingMethodTest.php
@@ -118,7 +118,7 @@ final class ShippingMethodTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/checkout/shipping_method/select_shipping_method_with_missing_fields',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 

--- a/tests/Api/Shop/PaymentRequestsTest.php
+++ b/tests/Api/Shop/PaymentRequestsTest.php
@@ -150,7 +150,7 @@ final class PaymentRequestsTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/payment_request/post_payment_request_without_required_data',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 

--- a/tests/Api/Shop/ProductReviewsTest.php
+++ b/tests/Api/Shop/ProductReviewsTest.php
@@ -167,7 +167,7 @@ final class ProductReviewsTest extends JsonApiTestCase
         $this->assertResponse(
             $this->client->getResponse(),
             'shop/product_review/create_product_review_with_missing_fields',
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Context from the Slack community:

<img width="634" height="727" alt="image" src="https://github.com/user-attachments/assets/907c9a70-cce0-4520-a5cc-8f5f615f7312" />


Changes HTTP status code from `400 Bad Request` to `422 Unprocessable Content` for missing required fields validation errors.

**Changes:**
- Updated `MissingConstructorArgumentsException` mapping: 400 → 422 in API Platform config
- Changed `CommandNormalizer` to use `Response::HTTP_UNPROCESSABLE_ENTITY` constant
- Updated all test fixtures and integration tests
- Added UPGRADE-API-2.2.md entry

**Rationale:**
- RFC 9110: 400 for syntactic errors (malformed JSON), 422 for semantic errors (validation failures)
- Consistency with API Platform defaults (`ValidationException` returns 422)
- Aligns with REST API best practices
