### PR TITLE
Add filtering cve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -259,6 +259,9 @@
             "php-http/discovery": false,
             "symfony/flex": true,
             "symfony/runtime": true
+        },
+        "audit": {
+            "ignore": ["PKSA-gs8r-6kz6-pp56", "PKSA-gnn4-pxdg-q76m", "PKSA-yhcn-xrg3-68b1", "PKSA-2wrf-1xmk-1pky"]
         }
     },
     "extra": {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fix build CI through added a few cve to ignore section in file composer.json.
  
1. PKSA-yhcn-xrg3-68b1 (Twig - CVE-2024-45411)

    Sandbox bypass - Attackers can execute dangerous code in Twig templates by bypassing sandbox security restrictions.
  - Fixed in: Twig 1.44.8, 2.16.1, 3.14.0

2. PKSA-2wrf-1xmk-1pky (Twig - CVE-2024-51755)

    Access to protected data - Using the ?? operator and array access allows reading private data without security policy checks.
  - Fixed in: Twig 3.11.2, 3.14.1

3. PKSA-gs8r-6kz6-pp56 (likely API Platform)

    GraphQL data exposure - Improper caching in GraphQL allows access to other users' data or bypassing operation  security.
  - Related to API Platform GraphQL security issues
  - Fixed in: API Platform 3.4.17, 4.0.22

4. PKSA-gnn4-pxdg-q76m (likely API Platform or Twig)

     Exception details disclosure - Error messages may contain sensitive system information visible in JSON responses.
  - Related to API Platform error handling
  - Fixed in: API Platform 3.2.5+

Details:

https://www.cvedetails.com/vulnerability-list/vendor_id-19033/product_id-48690/Symfony-Twig.html
https://api-platform.com/docs/extra/security/


