### PR TITLE
[CI] Split Chromedriver tests into parallel jobs

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -241,6 +241,11 @@ jobs:
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
 
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
+
             -   name: Debug - List directory structure and test behat
                 run: |
                     echo "=== Current directory ==="
@@ -256,11 +261,6 @@ jobs:
                     vendor/bin/behat --suite-tags="@ui" features/admin --dry-run | head -20 || echo "Failed!"
                     echo "=== Try our command ==="
                     vendor/bin/behat --suite-tags="@ui" features/admin/product --dry-run | head -20 || echo "Failed!"
-
-            -   name: Restore file permissions
-                run: |
-                    chmod +x vendor/bin/*
-                    chmod +x bin/console
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -265,31 +265,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
@@ -334,22 +328,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -358,22 +349,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -421,31 +409,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun
                 continue-on-error: true
 

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -233,6 +233,11 @@ jobs:
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
 
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
+
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
@@ -293,6 +298,11 @@ jobs:
                 uses: actions/download-artifact@v4
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
 
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
@@ -372,6 +382,11 @@ jobs:
                 uses: actions/download-artifact@v4
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -210,7 +210,15 @@ jobs:
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
                     path: |
-                        .
+                        .env
+                        .env.test
+                        .env.test.local
+                        vendor/
+                        var/
+                        public/build/
+                        public/media/
+                        bin/
+                        config/
                     retention-days: 1
                     overwrite: true
 
@@ -228,6 +236,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:
@@ -294,6 +305,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:
@@ -378,6 +392,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -265,26 +265,26 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" || \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" --rerun || \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" --rerun
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        features/admin/product features/admin/promotion --rerun
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" || \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" --rerun || \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" --rerun
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
             -   name: Upload logs
@@ -328,19 +328,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -349,19 +349,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -409,25 +409,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun
                 continue-on-error: true
 

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -241,6 +241,17 @@ jobs:
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
 
+            -   name: Debug - List directory structure
+                run: |
+                    echo "=== Current directory ==="
+                    pwd
+                    echo "=== Top level files ==="
+                    ls -la
+                    echo "=== Features directory ==="
+                    ls -la features/ || echo "features/ not found!"
+                    echo "=== Vendor directory ==="
+                    ls -d vendor/ || echo "vendor/ not found!"
+
             -   name: Restore file permissions
                 run: |
                     chmod +x vendor/bin/*

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -215,7 +215,7 @@ jobs:
                     overwrite: true
 
     behat-ui-js-chromedriver-admin-part1:
-        needs: build-chromedriver-env
+        needs: [get-matrix, build-chromedriver-env]
         runs-on: ubuntu-latest
         name: "Admin Part 1 (Product+Promotion), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 30
@@ -276,7 +276,7 @@ jobs:
                     overwrite: true
 
     behat-ui-js-chromedriver-admin-part2:
-        needs: build-chromedriver-env
+        needs: [get-matrix, build-chromedriver-env]
         runs-on: ubuntu-latest
         name: "Admin Part 2 (Others), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 25
@@ -355,7 +355,7 @@ jobs:
                     overwrite: true
 
     behat-ui-js-chromedriver-shop:
-        needs: build-chromedriver-env
+        needs: [get-matrix, build-chromedriver-env]
         runs-on: ubuntu-latest
         name: "Shop & Others, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 20

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -241,16 +241,21 @@ jobs:
                 with:
                     name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
 
-            -   name: Debug - List directory structure
+            -   name: Debug - List directory structure and test behat
                 run: |
                     echo "=== Current directory ==="
                     pwd
-                    echo "=== Top level files ==="
-                    ls -la
-                    echo "=== Features directory ==="
-                    ls -la features/ || echo "features/ not found!"
-                    echo "=== Vendor directory ==="
-                    ls -d vendor/ || echo "vendor/ not found!"
+                    echo "=== Behat config ==="
+                    ls -la behat.yml* || echo "behat.yml not found!"
+                    cat behat.yml.dist | head -20
+                    echo "=== Features/admin/product ==="
+                    ls features/admin/product/ | head -5
+                    echo "=== Test behat directly ==="
+                    vendor/bin/behat --version
+                    echo "=== Try local working command ==="
+                    vendor/bin/behat --suite-tags="@ui" features/admin --dry-run | head -20 || echo "Failed!"
+                    echo "=== Try our command ==="
+                    vendor/bin/behat --suite-tags="@ui" features/admin/product --dry-run | head -20 || echo "Failed!"
 
             -   name: Restore file permissions
                 run: |

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -215,10 +215,7 @@ jobs:
                         .env.test.local
                         vendor/
                         var/
-                        public/build/
-                        public/media/
-                        bin/
-                        config/
+                        public/
                     retention-days: 1
                     overwrite: true
 

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -220,7 +220,7 @@ jobs:
                     overwrite: true
 
     behat-ui-js-chromedriver-admin-part1:
-        needs: [get-matrix, build-chromedriver-env]
+        needs: [get-matrix]
         runs-on: ubuntu-latest
         name: "Admin Part 1 (Product+Promotion), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 30
@@ -233,18 +233,18 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
-            -   name: "Checkout"
-                uses: actions/checkout@v4
-
-            -   name: Download built application
-                uses: actions/download-artifact@v4
+            -   name: Build application
+                uses: SyliusLabs/BuildTestAppAction@v3.0.1
                 with:
-                    name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
-
-            -   name: Restore file permissions
-                run: |
-                    chmod +x vendor/bin/*
-                    chmod +x bin/console
+                    build_type: "sylius"
+                    cache_key: "${{ github.run_id }}-${{ github.run_attempt }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    e2e: "yes"
+                    e2e_js: "yes"
+                    database_version: ${{ matrix.mysql }}
+                    php_version: ${{ matrix.php }}
+                    symfony_version: ${{ matrix.symfony }}
+                    node_version: ${{ env.NODE_VERSION }}
 
             -   name: Debug - List directory structure and test behat
                 run: |

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -140,11 +140,11 @@ jobs:
                     if-no-files-found: ignore
                     overwrite: true
 
-    behat-ui-js-chromedriver:
+    build-chromedriver-env:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
-        timeout-minutes: 45
+        name: "Build Chromedriver environment, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -205,24 +205,210 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
 
-            -   name: Run Behat (Chromedriver)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+            -   name: Upload built application
+                uses: actions/upload-artifact@v4
+                with:
+                    name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+                    path: |
+                        .
+                    retention-days: 1
+                    overwrite: true
 
-            -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
+    behat-ui-js-chromedriver-admin-part1:
+        needs: build-chromedriver-env
+        runs-on: ubuntu-latest
+        name: "Admin Part 1 (Product+Promotion), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun
+
+            -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (Chromedriver Admin Part 1, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
+                    path: |
+                        etc/build/
+                        var/log
+                    if-no-files-found: ignore
+                    overwrite: true
+
+    behat-ui-js-chromedriver-admin-part2:
+        needs: build-chromedriver-env
+        runs-on: ubuntu-latest
+        name: "Admin Part 2 (Others), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 25
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Admin Others
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun
+
+            -   name: Run Behat (Chromedriver) - Admin Others (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun
+                continue-on-error: true
+
+            -   name: Upload logs
+                uses: actions/upload-artifact@v4
+                if: failure()
+                with:
+                    name: "Logs (Chromedriver Admin Part 2, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
+                    path: |
+                        etc/build/
+                        var/log
+                    if-no-files-found: ignore
+                    overwrite: true
+
+    behat-ui-js-chromedriver-shop:
+        needs: build-chromedriver-env
+        runs-on: ubuntu-latest
+        name: "Shop & Others, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 20
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Shop & Hybrid
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun
+
+            -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun
+                continue-on-error: true
+
+            -   name: Upload logs
+                uses: actions/upload-artifact@v4
+                if: failure()
+                with:
+                    name: "Logs (Chromedriver Shop, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -265,26 +265,26 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
-                        features/admin/product features/admin/promotion || \
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
-                        features/admin/product features/admin/promotion --rerun || \
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
-                        features/admin/product features/admin/promotion --rerun
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" --rerun
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
-                        features/admin/product features/admin/promotion || \
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
-                        features/admin/product features/admin/promotion --rerun || \
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
-                        features/admin/product features/admin/promotion --rerun
+                        --suite ui_accessing_price_history,ui_adding_product_review,ui_managing_product_association_types,ui_managing_product_attributes,ui_managing_product_options,ui_managing_product_reviews,ui_managing_product_variants,ui_managing_products,ui_viewing_product_reviews,ui_viewing_products,ui_applying_catalog_promotions,ui_applying_promotion_coupon,ui_applying_promotion_rules,ui_managing_catalog_promotions,ui_managing_promotion_coupons,ui_managing_promotions,ui_receiving_discount,ui_removing_catalog_promotions \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" --rerun
                 continue-on-error: true
 
             -   name: Upload logs

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -194,31 +194,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
@@ -268,22 +262,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -292,22 +283,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -360,31 +348,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
-                        --suite-tags="@hybrid,@ui" \
+                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun
                 continue-on-error: true
 

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -178,6 +178,11 @@ jobs:
                 with:
                     name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
 
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
+
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
@@ -243,6 +248,11 @@ jobs:
                 uses: actions/download-artifact@v4
                 with:
                     name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
 
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
@@ -327,6 +337,11 @@ jobs:
                 uses: actions/download-artifact@v4
                 with:
                     name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Restore file permissions
+                run: |
+                    chmod +x vendor/bin/*
+                    chmod +x bin/console
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -155,10 +155,7 @@ jobs:
                         .env.test.local
                         vendor/
                         var/
-                        public/build/
-                        public/media/
-                        bin/
-                        config/
+                        public/
                     retention-days: 1
                     overwrite: true
 

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -88,10 +88,10 @@ jobs:
                     if-no-files-found: ignore
                     overwrite: true
 
-    behat-ui-js-chromedriver-unstable:
+    build-chromedriver-env-unstable:
         runs-on: ubuntu-latest
-        name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        name: "Build Chromedriver environment (Unstable), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:
@@ -145,24 +145,225 @@ jobs:
                     symfony_version: ${{ matrix.symfony }}
                     node_version: "24.x"
 
-            -   name: Run Behat (Chromedriver)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+            -   name: Upload built application
+                uses: actions/upload-artifact@v4
+                with:
+                    name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+                    path: |
+                        .
+                    retention-days: 1
+                    overwrite: true
 
-            -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
+    behat-ui-js-chromedriver-admin-part1-unstable:
+        needs: build-chromedriver-env-unstable
+        runs-on: ubuntu-latest
+        name: "Admin Part 1 (Product+Promotion) (Unstable), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -
+                        php: "8.3"
+                        symfony: "^7.4@beta"
+                        mysql: "8.4"
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun
+
+            -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (Chromedriver Admin Part 1 Unstable, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
+                    path: |
+                        etc/build/
+                        var/log
+                    if-no-files-found: ignore
+                    overwrite: true
+
+    behat-ui-js-chromedriver-admin-part2-unstable:
+        needs: build-chromedriver-env-unstable
+        runs-on: ubuntu-latest
+        name: "Admin Part 2 (Others) (Unstable), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 25
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -
+                        php: "8.3"
+                        symfony: "^7.4@beta"
+                        mysql: "8.4"
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Admin Others
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun
+
+            -   name: Run Behat (Chromedriver) - Admin Others (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@ui" \
+                        features/admin/taxonomy features/admin/addressing features/admin/shipping \
+                        features/admin/order features/admin/channel features/admin/user \
+                        features/admin/currency features/admin/payment features/admin/locale \
+                        features/admin/taxation features/admin/inventory --rerun
+                continue-on-error: true
+
+            -   name: Upload logs
+                uses: actions/upload-artifact@v4
+                if: failure()
+                with:
+                    name: "Logs (Chromedriver Admin Part 2 Unstable, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
+                    path: |
+                        etc/build/
+                        var/log
+                    if-no-files-found: ignore
+                    overwrite: true
+
+    behat-ui-js-chromedriver-shop-unstable:
+        needs: build-chromedriver-env-unstable
+        runs-on: ubuntu-latest
+        name: "Shop & Others (Unstable), PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 20
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -
+                        php: "8.3"
+                        symfony: "^7.4@beta"
+                        mysql: "8.4"
+
+        env:
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+
+        steps:
+            -   name: Download built application
+                uses: actions/download-artifact@v4
+                with:
+                    name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
+
+            -   name: Run Behat (Chromedriver) - Shop & Hybrid
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun
+
+            -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
+                run: |
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun || \
+                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
+                        --suite-tags="@hybrid,@ui" \
+                        features/shop features/hybrid --rerun
+                continue-on-error: true
+
+            -   name: Upload logs
+                uses: actions/upload-artifact@v4
+                if: failure()
+                with:
+                    name: "Logs (Chromedriver Shop Unstable, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -194,25 +194,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/product features/admin/promotion --rerun
 
             -   name: Run Behat (Chromedriver) - Admin Product & Promotion (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/product features/admin/promotion --rerun
                 continue-on-error: true
 
@@ -262,19 +262,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -283,19 +283,19 @@ jobs:
             -   name: Run Behat (Chromedriver) - Admin Others (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
                         features/admin/taxation features/admin/inventory --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&@ui&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/admin/taxonomy features/admin/addressing features/admin/shipping \
                         features/admin/order features/admin/channel features/admin/user \
                         features/admin/currency features/admin/payment features/admin/locale \
@@ -348,25 +348,25 @@ jobs:
             -   name: Run Behat (Chromedriver) - Shop & Hybrid
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&~@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&~@failing" \
                         features/shop features/hybrid --rerun
 
             -   name: Run Behat (Chromedriver) - Shop & Hybrid (@failing)
                 run: |
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun || \
                     vendor/bin/behat --colors --strict --no-interaction -vvv -f progress \
-                        --tags="(@mink:chromedriver||@javascript)&&(@ui||@hybrid)&&~@todo&&~@cli&&@failing" \
+                        --tags="(@mink:chromedriver||@javascript)&&~@todo&&~@cli&&@failing" \
                         features/shop features/hybrid --rerun
                 continue-on-error: true
 

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -150,7 +150,15 @@ jobs:
                 with:
                     name: "chromedriver-env-unstable-php${{ matrix.php }}-sf${{ matrix.symfony }}-mysql${{ matrix.mysql }}-${{ github.run_id }}"
                     path: |
-                        .
+                        .env
+                        .env.test
+                        .env.test.local
+                        vendor/
+                        var/
+                        public/build/
+                        public/media/
+                        bin/
+                        config/
                     retention-days: 1
                     overwrite: true
 
@@ -173,6 +181,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:
@@ -244,6 +255,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:
@@ -333,6 +347,9 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
 
         steps:
+            -   name: "Checkout"
+                uses: actions/checkout@v4
+
             -   name: Download built application
                 uses: actions/download-artifact@v4
                 with:


### PR DESCRIPTION
## Summary

This PR splits Chromedriver/JavaScript UI tests into parallel jobs to avoid the 45-minute timeout.

**Problem:** Single Chromedriver test job times out after 45 minutes
**Solution:** Split tests into parallel jobs sharing a common build artifact

## Test Distribution Analysis

### Total Counts
- **Total scenarios:** 433 (330 @mink:chromedriver + 103 @javascript with @ui)
- **Total steps:** 5,222
- **Current execution time:** ~45 minutes (timeout)

### Breakdown by Area

| Area | Scenarios | Steps | % of Steps |
|------|-----------|-------|------------|
| **Admin** | 322 | 4,048 | 77% |
| Product | 119 | 1,593 | 31% |
| Promotion | 59 | 766 | 15% |
| Shipping | 27 | 345 | 7% |
| Taxonomy | 41 | 374 | 7% |
| Order | 13 | 243 | 5% |
| Others | 63 | 727 | 14% |
| **Shop** | 108 | 1,174 | 23% |

### Split Options

#### Option 1: Split into 2 jobs (Admin / Shop)
- Job 1 - Admin: 322 scenarios / 4,048 steps (~77%)
- Job 2 - Shop: 108 scenarios / 1,174 steps (~23%)
- **Estimated time:** ~35 min (admin still heavy)

#### Option 2: Split into 3 jobs ⭐ Recommended
- Job 1 - Product: 119 scenarios / 1,593 steps (31%)
- Job 2 - Promo+Ship+Tax: ~100 scenarios / 1,485 steps (28%)
- Job 3 - Rest+Shop: ~211 scenarios / 2,144 steps (41%)
- **Estimated time:** ~19 min (longest job)

#### Option 3: Split into 4 jobs ⭐ Recommended
- Job 1 - Product: 119 scenarios / 1,593 steps (31%)
- Job 2 - Promotion: 59 scenarios / 766 steps (15%)
- Job 3 - Taxonomy+Ship+Order: ~100 scenarios / 962 steps (18%)
- Job 4 - Rest+Shop: ~152 scenarios / 1,901 steps (36%)
- **Estimated time:** ~16 min (longest job)

#### Option 4: Split into 5 jobs
- Job 1 - Product: 119 scenarios / 1,593 steps (31%)
- Job 2 - Promotion+Ship: 86 scenarios / 1,111 steps (21%)
- Job 3 - Taxonomy+Order: 49 scenarios / 617 steps (12%)
- Job 4 - Rest Admin: 68 scenarios / 727 steps (14%)
- Job 5 - Shop: 108 scenarios / 1,174 steps (22%)
- **Estimated time:** ~14 min (longest job)

### Coverage Verification

**Note:** When counting with paths (`features/admin/` + `features/shop/`), we get 430 scenarios vs 433 baseline. The 3-scenario difference may be due to:
- Scenarios in other directories (account, checkout, locale)
- Tag overlap causing double-counting
- Behat counting differently with/without paths

**Verification script** available to ensure 100% coverage before merging.

## Implementation

- Build job: Creates shared build artifact once (~3-5 min)
- Test jobs: Download artifact and run tests in parallel
- Total time savings: Build once instead of N times = ~30 min saved

---

**Status:** Work in progress - determining optimal split strategy