### PR TITLE
[CI] Add PHP 8.5 support to workflows

### DIFF
--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -116,6 +116,7 @@ jobs:
                 run: vendor/bin/monorepo-builder validate
 
             -   name: Run PHPArkitect
+                if: matrix.php != '8.5'
                 run: vendor/bin/phparkitect check
 
             -   name: Run PHPStan

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -7,7 +7,7 @@
           "symfony": "^6.4"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3"
         }
       ]
@@ -22,14 +22,14 @@
           "state_machine_adapter": "winzou_state_machine"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
@@ -47,7 +47,7 @@
           "twig": "^3.3"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3",
           "mysql": "8.4",
           "twig": "^3.3"
@@ -62,7 +62,7 @@
           "postgres": "15.13"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3",
           "postgres": "17.5"
         }
@@ -78,7 +78,7 @@
           "symfony": "^6.4"
         },
         {
-          "php": "8.4",
+          "php": "8.5",
           "symfony": "^7.3"
         }
       ]
@@ -86,11 +86,11 @@
   },
   "full": {
     "static-checks": {
-      "php": ["8.3", "8.4"],
+      "php": ["8.3", "8.4", "8.5"],
       "symfony": ["^6.4", "~7.3.0"]
     },
     "e2e-mariadb": {
-      "php": ["8.3", "8.4"],
+      "php": ["8.3", "8.4", "8.5"],
       "symfony": ["^6.4", "~7.3.0"],
       "mariadb": ["11.4.7"],
       "state_machine_adapter": ["symfony_workflow"],
@@ -118,7 +118,7 @@
       ]
     },
     "e2e-pgsql": {
-      "php": ["8.3", "8.4"],
+      "php": ["8.3", "8.4", "8.5"],
       "symfony": ["^6.4", "~7.3.0"],
       "postgres": ["15.13", "16.9", "17.5"]
     },
@@ -126,7 +126,7 @@
       "node": ["22.x", "24.x"]
     },
     "packages": {
-      "php": ["8.3", "8.4"],
+      "php": ["8.3", "8.4", "8.5"],
       "symfony": ["^6.4", "~7.3.0"]
     }
   }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Added PHP 8.5 (released 2025-11-20) support to CI workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to support PHP 8.5 testing across multiple configurations (static-checks, e2e, frontend/packages).
  * Configured architecture checks to skip on PHP 8.5 while expanding test coverage to the latest PHP version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->