### PR TITLE
Add ternary operator to fix bug related with empty key

### DIFF
--- a/features/admin/product/managing_products/browsing_products_with_main_taxon_without_name.feature
+++ b/features/admin/product/managing_products/browsing_products_with_main_taxon_without_name.feature
@@ -1,0 +1,19 @@
+@managing_products
+Feature: Browsing products with main taxon that has no name in the current locale
+    In order to browse products in the admin panel
+    As an Administrator
+    I want to be able to browse products even when their main taxon has no name translation
+
+    Background:
+        Given the store operates on a single channel in "Dutch (Netherlands)" locale
+        And the store classifies its products as "T-Shirts"
+        And the store has a "T-Shirt" product
+        And the product "T-Shirt" has a main taxon "T-Shirts"
+        And the "T-Shirts" taxon has an empty name in the "Dutch (Netherlands)" locale
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Browsing products when main taxon has no name in admin locale should not cause an error
+        Given I am using "Dutch (Netherlands)" locale for my panel
+        When I browse products
+        Then I should see the product "T-Shirt" in the list

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -146,6 +146,16 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
+    /**
+     * @Given /^the ("[^"]+" taxon) has an empty name in the ("[^"]+" locale)$/
+     */
+    public function theTaxonHasEmptyNameInLocale(TaxonInterface $taxon, string $localeCode): void
+    {
+        $taxon->getTranslation($localeCode)->setName('');
+
+        $this->objectManager->flush();
+    }
+
     private function createTaxon(string $name): TaxonInterface
     {
         /** @var TaxonInterface $taxon */

--- a/src/Sylius/Bundle/AdminBundle/templates/product/grid/field/main_taxon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product/grid/field/main_taxon.html.twig
@@ -1,5 +1,5 @@
 {% if data.fullname is defined %}
-    {% set categories = data.fullname|replace({ (data.name): '' }) %}
+    {% set categories = data.name ? data.fullname|replace({ (data.name): '' }) : data.fullname %}
 
     {% if categories %}
         <span class="text-muted cursor-default" data-bs-toggle="tooltip" data-bs-title="{{ categories[:-2] }}">.. /</span>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/17718
| License         | MIT

I reproduced error when chose nl_NL and ran command bin/console sylius:install. Bug was caused lack translations for taxons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin product list now correctly handles products whose main category has no name — tooltips and category display no longer error or show incorrect content.

* **Tests**
  * Added a UI scenario and step coverage to verify browsing products with unnamed main categories in the admin interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->