### PR TITLE
Fix twice calculation rating review

### DIFF
--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -8,7 +8,7 @@ This change affects the `sylius_product_review` state machine configuration in t
 
 The average rating updater callback had priority `-100` and was being executed twice, which has now been fixed by disabling this specific callback.
 
-```yaml
+```diff
         callbacks:
             after:
                 sylius_update_rating:
@@ -16,7 +16,7 @@ The average rating updater callback had priority `-100` and was being executed t
                     do: ["@sylius.product_review.average_rating_updater", "updateFromReview"]
                     args: ["object"]
                     priority: -100
-                    disabled: true
++                   disabled: true
 ```
 # UPGRADE FROM `v1.14.11` TO `v1.14.12`
 

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1,3 +1,23 @@
+# UPGRADE FROM `v1.14.12` TO `v1.14.13`
+
+## State Machine
+
+1. Product Review Average Rating Update
+The `after` callback for updating average ratings when a review is accepted has been disabled to prevent duplicate calculations.
+This change affects the `sylius_product_review` state machine configuration in the `accept` transition.
+
+The average rating updater callback had priority `-100` and was being executed twice, which has now been fixed by disabling this specific callback.
+
+```yaml
+        callbacks:
+            after:
+                sylius_update_rating:
+                    on: ["accept"]
+                    do: ["@sylius.product_review.average_rating_updater", "updateFromReview"]
+                    args: ["object"]
+                    priority: -100
+                    disabled: true
+```
 # UPGRADE FROM `v1.14.11` TO `v1.14.12`
 
 ## Configuration

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_product_review.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_product_review.yml
@@ -22,3 +22,4 @@ winzou_state_machine:
                     do: ["@sylius.product_review.average_rating_updater", "updateFromReview"]
                     args: ["object"]
                     priority: -100
+                    disabled: true


### PR DESCRIPTION
This is connected with https://github.com/Sylius/Sylius/pull/18574
| Q               | A
|-----------------|-----
| Branch?         | 1.14 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/16120
| License         | MIT


  The \Sylius\Bundle\ReviewBundle\EventListener\ReviewChangeListener (registered as Doctrine event listener) already handles rating recalculation for all review changes (postPersist, postUpdate, preRemove), making the
  state machine callback redundant.

  Solution

  Disable the sylius_update_rating callback by adding disabled: true instead of removing it entirely.

  Why disabled: true instead of removal?

  1. No BC break - the updateFromReview() method called by this callback remains intact, preserving the ReviewableRatingUpdaterInterface and service definitions
  2. Flexibility - users who rely on this callback (e.g., for custom priority ordering with their own callbacks) can re-enable it in their configuration with disabled: false
  3. Transparency - the callback definition remains visible in configuration, documenting what was disabled and why, which helps with debugging and understanding the system's
  history

