### PR TITLE
[API][PaymentRequest] Rename payment request operations for shop context

### DIFF
--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -1,5 +1,15 @@
 # UPGRADE FROM `2.1` TO `2.2`
 
+## Modified routes
+
+1. The routes for payment requests resource have been renamed to follow the shop API naming convention.
+
+| Old route                              | New route                              |
+|----------------------------------------|----------------------------------------|
+| `sylius_api_show_payment_request_get`  | `sylius_api_shop_payment_request_get`  |
+| `sylius_api_show_payment_request_post` | `sylius_api_shop_payment_request_post` |
+| `sylius_api_show_payment_request_put`  | `sylius_api_shop_payment_request_put`  |
+
 ## HTTP Status Code Changes
 
 ### Missing Required Fields Validation

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/PaymentRequest.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/PaymentRequest.xml
@@ -19,7 +19,7 @@
     <resource class="%sylius.model.payment_request.class%">
         <operations>
             <operation
-                name="sylius_api_show_payment_request_get"
+                name="sylius_api_shop_payment_request_get"
                 class="ApiPlatform\Metadata\Get"
                 uriTemplate="/shop/payment-requests/{hash}"
             >
@@ -35,7 +35,7 @@
             </operation>
 
             <operation
-                name="sylius_api_show_payment_request_post"
+                name="sylius_api_shop_payment_request_post"
                 class="ApiPlatform\Metadata\Post"
                 uriTemplate="/shop/orders/{tokenValue}/payment-requests"
                 itemUriTemplate="/shop/payment-requests/{hash}"
@@ -76,7 +76,7 @@
             </operation>
 
             <operation
-                name="sylius_api_show_payment_request_put"
+                name="sylius_api_shop_payment_request_put"
                 class="ApiPlatform\Metadata\Put"
                 uriTemplate="/shop/payment-requests/{hash}"
                 messenger="input"


### PR DESCRIPTION
This PR renames payment request API operations to follow the shop API naming convention.

Changes:
- Renamed `sylius_api_show_payment_request_get` to `sylius_api_shop_payment_request_get`
- Renamed `sylius_api_show_payment_request_post` to `sylius_api_shop_payment_request_post`
- Renamed `sylius_api_show_payment_request_put` to `sylius_api_shop_payment_request_put`
- Added upgrade documentation for route changes

This standardizes the naming convention for shop context payment request operations. Since the PaymentRequest component is experimental, these route renames are considered acceptable.

Ref: #18439
