### PR TITLE
Add retry action for Behat JS tests

### DIFF
--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -206,16 +206,26 @@ jobs:
                     node_version: ${{ env.NODE_VERSION }}
 
             -   name: Run Behat (Chromedriver)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
                 continue-on-error: true
 
             -   name: Upload logs
@@ -312,7 +322,15 @@ jobs:
                     chrome_version: stable
 
             -   name: Run Behat (Panther)
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -146,16 +146,26 @@ jobs:
                     node_version: "24.x"
 
             -   name: Run Behat (Chromedriver)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
-                run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
                 continue-on-error: true
 
             -   name: Upload logs
@@ -229,7 +239,15 @@ jobs:
                     chrome_version: stable
 
             -   name: Run Behat (Panther)
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                uses: nick-fields/retry@v3
+                env:
+                    BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+                    BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
+                    BEHAT_SUITES: "@hybrid,@ui"
+                with:
+                    timeout_minutes: 45
+                    max_attempts: 3
+                    command: $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Replaces manual retry logic in Behat JS test workflows with  action. This provides better visibility into retry attempts and standardizes the retry mechanism across CI jobs.

Changes:
- Use  for Chromedriver and Panther Behat steps
- Extract repeated Behat commands to environment variables for clarity
- Keep  fallback within retry attempts
- Set  and  per job

Affects  and  workflows.

Ref: https://github.com/nick-fields/retry