### PR TITLE
[CI] Parametrize Behat commands in E2E workflows

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -54,6 +54,13 @@ jobs:
             APP_ENV: test_cached
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
             TEST_SYLIUS_STATE_MACHINE_ADAPTER: "${{ matrix.state_machine_adapter }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_CLI_TAGS: "@cli&&~@todo"
+            BEHAT_CLI_SUITES: "@cli"
+            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
+            BEHAT_NON_UI_SUITES: "@api,@domain"
+            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
+            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
 
         steps:
             -   name: Set variables
@@ -136,13 +143,13 @@ jobs:
                     vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
 
             -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
 
             -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -53,6 +53,13 @@ jobs:
         env:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_CLI_TAGS: "@cli&&~@todo"
+            BEHAT_CLI_SUITES: "@cli"
+            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
+            BEHAT_NON_UI_SUITES: "@api,@domain"
+            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
+            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
 
         steps:
             -   name: Set variables
@@ -121,13 +128,13 @@ jobs:
                     vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
 
             -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
 
             -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
@@ -152,6 +159,10 @@ jobs:
         env:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+            BEHAT_SUITES: "@hybrid,@ui"
+            BEHAT_FAILING_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
 
         steps:
             -   name: Set variables
@@ -207,15 +218,15 @@ jobs:
 
             -   name: Run Behat (Chromedriver)
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
                 continue-on-error: true
 
             -   name: Upload logs
@@ -241,6 +252,9 @@ jobs:
         env:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
+            BEHAT_SUITES: "@hybrid,@ui"
 
         steps:
             -   name: Set variables
@@ -312,7 +326,10 @@ jobs:
                     chrome_version: stable
 
             -   name: Run Behat (Panther)
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -53,6 +53,13 @@ jobs:
         env:
             APP_ENV: test_cached
             DATABASE_URL: "pgsql://postgres:postgres@127.0.0.1/sylius?charset=utf8&serverVersion=${{ matrix.postgres }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_CLI_TAGS: "@cli&&~@todo"
+            BEHAT_CLI_SUITES: "@cli"
+            BEHAT_NON_UI_TAGS: "~@todo&&~@cli&&~@no-postgres"
+            BEHAT_NON_UI_SUITES: "@api,@domain"
+            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres"
+            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
 
         steps:
             -   name: Set variables
@@ -110,13 +117,13 @@ jobs:
                     vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
 
             -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
 
             -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -31,6 +31,13 @@ jobs:
         env:
             APP_ENV: test_cached
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_CLI_TAGS: "@cli&&~@todo"
+            BEHAT_CLI_SUITES: "@cli"
+            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
+            BEHAT_NON_UI_SUITES: "@api,@domain"
+            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
+            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
 
         steps:
             -
@@ -69,13 +76,13 @@ jobs:
                 run: vendor/bin/phpunit --testsuite all --colors=always
 
             -   name: Run CLI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="@cli&&~@todo" --suite-tags="@cli" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
 
             -   name: Run non-UI Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@todo&&~@cli" --suite-tags="@api,@domain" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
 
             -   name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
@@ -104,6 +111,10 @@ jobs:
         env:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+            BEHAT_SUITES: "@hybrid,@ui"
+            BEHAT_FAILING_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
 
         steps:
             -   name: "Checkout (With Branch)"
@@ -147,15 +158,15 @@ jobs:
 
             -   name: Run Behat (Chromedriver)
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" --rerun
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
                 run: |
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun || \
-                    vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" --rerun
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
                 continue-on-error: true
 
             -   name: Upload logs
@@ -185,6 +196,9 @@ jobs:
         env:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
+            BEHAT_SUITES: "@hybrid,@ui"
 
         steps:
             -   name: "Checkout (With Branch)"
@@ -229,7 +243,10 @@ jobs:
                     chrome_version: stable
 
             -   name: Run Behat (Panther)
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
+                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Refactored E2E workflow files to use environment variables for Behat commands, significantly improving readability and maintainability.

All Behat command invocations now use parametrized variables defined in the job `env` section:
- `BEHAT_BASE_CMD` - base command with common flags
- `BEHAT_*_TAGS` - test tags for different test suites
- `BEHAT_*_SUITES` - suite tags

Changes applied to:
- `ci_e2e-mysql.yaml` (3 jobs)
- `ci_e2e-mariadb.yaml` (1 job)
- `ci_e2e-pgsql.yaml` (1 job)
- `ci_e2e-unstable.yaml` (3 jobs)

This makes it much easier to modify Behat configurations and reduces duplication across retry logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD testing workflows by introducing centralized, parameterized configurations for test execution across multiple database environments, reducing redundancy and improving consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->