### PR TITLE
Mark method as deprecated because it is not use already

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -27,6 +27,14 @@
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
+        },
+        {
+          "php": "8.5",
+          "symfony": "^7.3",
+          "mariadb": "11.4.7",
+          "dbal": "^3.0",
+          "state_machine_adapter": "symfony_workflow",
+          "api_platform": "~4.1.7"
         }
       ]
     },

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -19,12 +19,14 @@
     )
 ```
 
-1. Direct usage of `loader.svg` and `loader.gif` assets is deprecated.
+2. Direct usage of `loader.svg` and `loader.gif` assets is deprecated.
    Use `@SyliusAdmin/shared/helper/loader.html.twig` or `@SyliusShop/shared/macro/loader.html.twig` instead.
+
+
+3. The `Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface::updateFromReview()` method has been deprecated and will be removed in Sylius 3.0. Use state machine mechanism implemented by Symfony Workflow instead.
 
 ### Translations
 
 1. The `TranslationLocaleProvider` now ensures that the default locale (configured as `locale` in `config/parameters.yaml`)
    is always placed at the beginning of the returned locales array.  
    Other locales remain in the same order as returned by the repository.
-

--- a/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
+++ b/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
@@ -31,8 +31,18 @@ class AverageRatingUpdater implements ReviewableRatingUpdaterInterface
         $this->modifyReviewSubjectAverageRating($reviewSubject);
     }
 
+    /**
+     * @deprecated since Sylius 2.2, will be removed in Sylius 3.0. Use state machine mechanism implemented by Symfony Workflow instead.
+     */
     public function updateFromReview(ReviewInterface $review): void
     {
+        trigger_deprecation(
+            'sylius/review-bundle',
+            '2.2',
+            'The "%s()" method is deprecated since Sylius 2.2 and will be removed in Sylius 3.0. Use state machine mechanism implemented by Symfony Workflow instead.',
+            __METHOD__,
+        );
+
         $this->modifyReviewSubjectAverageRating($review->getReviewSubject());
     }
 

--- a/src/Sylius/Bundle/ReviewBundle/Updater/ReviewableRatingUpdaterInterface.php
+++ b/src/Sylius/Bundle/ReviewBundle/Updater/ReviewableRatingUpdaterInterface.php
@@ -20,5 +20,8 @@ interface ReviewableRatingUpdaterInterface
 {
     public function update(ReviewableInterface $reviewSubject): void;
 
+    /**
+     * @deprecated since Sylius 2.2, will be removed in Sylius 3.0. Use state machine mechanism implemented by Symfony Workflow instead.
+     */
     public function updateFromReview(ReviewInterface $review): void;
 }


### PR DESCRIPTION
This is connected with https://github.com/Sylius/Sylius/pull/18567
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | https://github.com/Sylius/Sylius/issues/16120
| License         | MIT



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade guide documenting the deprecation of a method used for updating ratings, with removal scheduled for version 3.0.

* **Deprecations**
  * A method for updating average ratings is now deprecated. Users should transition to using the Symfony Workflow state machine mechanism as the recommended approach for rating updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->