### PR TITLE
Use invokable grids

### DIFF
--- a/phparkitect.php
+++ b/phparkitect.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 use Arkitect\ClassSet;
 use Arkitect\CLI\Config;
 use Arkitect\Expression\ForClasses\HaveNameMatching;
+use Arkitect\Expression\ForClasses\Implement;
 use Arkitect\Expression\ForClasses\IsFinal;
 use Arkitect\Expression\ForClasses\NotDependsOnTheseNamespaces;
 use Arkitect\Expression\ForClasses\ResideInOneOfTheseNamespaces;
 use Arkitect\Rules\Rule;
+use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 return static function (Config $config): void
 {
@@ -20,6 +22,15 @@ return static function (Config $config): void
             ->that(new HaveNameMatching('*Test'))
             ->should(new IsFinal())
             ->because('Tests should not be extendable')
+        ,
+    );
+
+    $config->add(
+        $testsClassSet,
+        Rule::allClasses()
+            ->that(new Implement(GridInterface::class))
+            ->should(new IsFinal())
+            ->because('Grids should only be decorated')
         ,
     );
 

--- a/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGrid.php
@@ -35,7 +35,7 @@ final class AdminUserGrid extends AbstractGrid implements AdminUserGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->adminUserClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface AdminUserGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGrid.php
@@ -39,7 +39,7 @@ final class CatalogPromotionGrid extends AbstractGrid implements CatalogPromotio
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->catalogPromotionClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CatalogPromotionGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelGrid.php
@@ -34,7 +34,7 @@ final class ChannelGrid extends AbstractGrid implements ChannelGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->channelClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ChannelGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGrid.php
@@ -28,7 +28,7 @@ final class ChannelPricingLogEntryGrid extends AbstractGrid implements ChannelPr
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->channelPricingLogEntryClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ChannelPricingLogEntryGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CountryGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CountryGrid.php
@@ -34,7 +34,7 @@ final class CountryGrid extends AbstractGrid implements CountryGridInterface
         return 'sylius_admin_country';
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->countryClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CountryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CountryGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CountryGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGrid.php
@@ -30,7 +30,7 @@ final class CurrencyGrid extends AbstractGrid implements CurrencyGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->currencyClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CurrencyGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGrid.php
@@ -36,7 +36,7 @@ final class CustomerGrid extends AbstractGrid implements CustomerGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->customerClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CustomerGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGrid.php
@@ -33,7 +33,7 @@ final class CustomerGroupGrid extends AbstractGrid implements CustomerGroupGridI
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->customerGroupClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CustomerGroupGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGrid.php
@@ -27,7 +27,7 @@ final class CustomerOrderGrid extends AbstractGrid implements CustomerOrderGridI
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->orderClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface CustomerOrderGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGrid.php
@@ -34,7 +34,7 @@ final class ExchangeRateGrid extends AbstractGrid implements ExchangeRateGridInt
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->exchangeRateClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ExchangeRateGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/InventoryGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/InventoryGrid.php
@@ -32,7 +32,7 @@ final class InventoryGrid extends AbstractGrid implements InventoryGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productVariantClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/InventoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/InventoryGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface InventoryGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/LocaleGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/LocaleGrid.php
@@ -31,7 +31,7 @@ final class LocaleGrid extends AbstractGrid implements LocaleGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->localeClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/LocaleGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/LocaleGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface LocaleGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/OrderGrid.php
@@ -37,7 +37,7 @@ final class OrderGrid extends AbstractGrid implements OrderGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->orderClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/OrderGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/OrderGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface OrderGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentGrid.php
@@ -30,7 +30,7 @@ final class PaymentGrid extends AbstractGrid implements PaymentGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->paymentGrid)

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface PaymentGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGrid.php
@@ -35,7 +35,7 @@ final class PaymentMethodGrid extends AbstractGrid implements PaymentMethodGridI
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->paymentMethodClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface PaymentMethodGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGrid.php
@@ -33,7 +33,7 @@ final class PaymentRequestGrid extends AbstractGrid implements PaymentRequestGri
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder->setDriverOption('class', $this->paymentRequestClass);
         $gridBuilder->setRepositoryMethod('createQueryBuilderForPayment', [

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface PaymentRequestGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGrid.php
@@ -34,7 +34,7 @@ final class ProductAssociationTypeGrid extends AbstractGrid implements ProductAs
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productAssociationTypeClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductAssociationTypeGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGrid.php
@@ -44,7 +44,7 @@ final class ProductAttributeGrid extends AbstractGrid implements ProductAttribut
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productAttributeClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductAttributeGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductGrid.php
@@ -39,7 +39,7 @@ final class ProductGrid extends AbstractGrid implements ProductGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGrid.php
@@ -34,7 +34,7 @@ final class ProductOptionGrid extends AbstractGrid implements ProductOptionGridI
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productOptionClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductOptionGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGrid.php
@@ -40,7 +40,7 @@ final class ProductReviewGrid extends AbstractGrid implements ProductReviewGridI
         return 'sylius_admin_product_review';
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productReviewClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductReviewGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGrid.php
@@ -36,7 +36,7 @@ final class ProductTaxonGrid extends AbstractGrid implements ProductTaxonGridInt
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productTaxonClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductTaxonGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGrid.php
@@ -36,7 +36,7 @@ final class ProductVariantGrid extends AbstractGrid implements ProductVariantGri
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productVariantClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductVariantGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGrid.php
@@ -33,7 +33,7 @@ final class ProductVariantWithCatalogPromotionGrid extends AbstractGrid implemen
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->productVariantClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ProductVariantWithCatalogPromotionGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGrid.php
@@ -36,7 +36,7 @@ final class PromotionCouponGrid extends AbstractGrid implements PromotionCouponG
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->promotionClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface PromotionCouponGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionGrid.php
@@ -37,7 +37,7 @@ final class PromotionGrid extends AbstractGrid implements PromotionGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->promotionClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionGridInterface.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 interface PromotionGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGrid.php
@@ -33,7 +33,7 @@ final class ShipmentGrid extends AbstractGrid implements ShipmentGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->shipmentClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGridInterface.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 interface ShipmentGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGrid.php
@@ -33,7 +33,7 @@ final class ShippingCategoryGrid extends AbstractGrid implements ShippingCategor
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->shippingCategoryClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ShippingCategoryGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGrid.php
@@ -37,7 +37,7 @@ final class ShippingMethodGrid extends AbstractGrid implements ShippingMethodGri
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->shippingMethodClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ShippingMethodGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGrid.php
@@ -33,7 +33,7 @@ final class TaxCategoryGrid extends AbstractGrid implements TaxCategoryGridInter
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->taxCategoryClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface TaxCategoryGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGrid.php
@@ -36,7 +36,7 @@ final class TaxRateGrid extends AbstractGrid implements TaxRateGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->taxRateClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface TaxRateGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ZoneGrid.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ZoneGrid.php
@@ -33,7 +33,7 @@ final class ZoneGrid extends AbstractGrid implements ZoneGridInterface
     ) {
     }
 
-    public function buildGrid(GridBuilderInterface $gridBuilder): void
+    public function __invoke(GridBuilderInterface $gridBuilder): void
     {
         $gridBuilder
             ->setDriverOption('class', $this->resourceClass)

--- a/src/Sylius/Bundle/AdminBundle/Grid/ZoneGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ZoneGridInterface.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Grid;
 
+use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
 use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
 interface ZoneGridInterface extends GridInterface
 {
+    public function __invoke(GridBuilderInterface $gridBuilder): void;
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | php-grid-configuration
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |partially #18136 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

```php
#[AsDecorator('sylius_admin.grid.product')]
#[AsGrid(name: 'sylius_admin_product')]
final class AdminProductGrid extends AbstractGrid implements ProductGridInterface
{
    public function __construct(private readonly ProductGridInterface $productGrid)
    {
    }

    public function __invoke(GridBuilderInterface $gridBuilder): void
    {
        ($this->productGrid)($gridBuilder);

        $gridBuilder
            ->orderBy('name', 'desc')
            ->removeField('code')
            ->setLimits([5, 10])
        ;
    }
}
```
