### PR TITLE
Add info about disabled callback for state machine sylius_product_review

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -13,7 +13,7 @@ The average rating updater callback had priority `-100` and was being executed t
             after:
                 sylius_update_rating:
                     on: ["accept"]
-                    do: ["@sylius.product_review.average_rating_updater", "updateFromReview"]
+                    do: ["@sylius.updater.product_review.average_rating", "updateFromReview"]
                     args: ["object"]
                     priority: -100
 +                   disabled: true

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,3 +1,23 @@
+# UPGRADE FROM `2.1.7` TO `2.1.8`
+
+## State Machine
+
+1. Product Review Average Rating Update
+   The `after` callback for updating average ratings when a review is accepted has been disabled to prevent duplicate calculations.
+   This change affects the `sylius_product_review` state machine configuration in the `accept` transition.
+
+The average rating updater callback had priority `-100` and was being executed twice, which has now been fixed by disabling this specific callback.
+
+```diff
+        callbacks:
+            after:
+                sylius_update_rating:
+                    on: ["accept"]
+                    do: ["@sylius.product_review.average_rating_updater", "updateFromReview"]
+                    args: ["object"]
+                    priority: -100
++                   disabled: true
+```
 # UPGRADE FROM `2.1.5` TO `2.1.6`
 
 ### API Platform


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/16120
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate updates of product review average ratings so ratings are now updated once when a review is accepted.

* **Documentation**
  * Added upgrade notes for v2.1.8 explaining the change to review acceptance behavior to prevent duplicate rating calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->