### PR TITLE
Refine `.env` configs to satisfy Symfony 7.4

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,8 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_DEBUG=1
+APP_DEBUG=0
+APP_RUNTIME_MODE=web=1
 APP_SECRET=EDITME
 ###< symfony/framework-bundle ###
 

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 APP_SECRET='s$cretf0rt3st'
-
+APP_DEBUG=0
+APP_RUNTIME_MODE=web=1
 KERNEL_CLASS='App\Kernel'
 
 ###> lexik/jwt-authentication-bundle ###

--- a/.env.test_cached
+++ b/.env.test_cached
@@ -1,4 +1,5 @@
 APP_DEBUG=0
+APP_RUNTIME_MODE=web=1
 APP_SECRET='s$cretf0rt3st'
 
 KERNEL_CLASS='App\Kernel'

--- a/.env.test_cached_payum
+++ b/.env.test_cached_payum
@@ -1,4 +1,5 @@
 APP_DEBUG=0
+APP_RUNTIME_MODE=web=1
 APP_SECRET='s$cretf0rt3st'
 
 KERNEL_CLASS='App\Kernel'

--- a/src/Sylius/Bundle/CoreBundle/test/.env
+++ b/src/Sylius/Bundle/CoreBundle/test/.env
@@ -1,6 +1,6 @@
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_DEBUG=1
+APP_DEBUG=0
 ###< symfony/framework-bundle ###
 
 ###> symfony/messenger ###


### PR DESCRIPTION
Admin error page test fails in unstable CI because debug mode is enabled. The test expects a custom 404 error page but gets Symfony debug exception page instead.

Root cause: Starting with Symfony 7.4, the framework introduced kernel.runtime_mode parameters controlled by APP_RUNTIME_MODE env var. Without explicit APP_DEBUG=0 and APP_RUNTIME_MODE configuration, test environments default to debug mode enabled.

Changes:
- Set APP_DEBUG=0 in .env, .env.test, .env.test_cached, .env.test_cached_payum
- Add APP_RUNTIME_MODE=web=1 to all env files to explicitly configure runtime mode
- Ensures debug mode is disabled for test environments

Refs:
- https://symfony.com/doc/8.1/reference/configuration/kernel.html#kernel-runtime-mode
- https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpKernel/CHANGELOG.md#L83