### PR TITLE
Introduce `Symfony 7.4` compatibility

### DIFF
--- a/.github/workflows/ci_frontend.yaml
+++ b/.github/workflows/ci_frontend.yaml
@@ -78,8 +78,8 @@ jobs:
                     build_type: "sylius"
                     e2e_js: "yes"
                     database_version: "8.0"
-                    php_version: "8.2"
-                    symfony_version: "~6.4.0"
+                    php_version: "8.5"
+                    symfony_version: "~7.4.0"
                     node_version: ${{ matrix.node }}
                     chrome_version: stable
                     

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -7,15 +7,19 @@
           "symfony": "~6.4.0"
         },
         {
-          "php": "8.5",
+          "php": "8.4",
           "symfony": "~7.3.0"
+        },
+        {
+          "php": "8.5",
+          "symfony": "~7.4.0"
         }
       ]
     },
     "e2e-mariadb": {
       "include": [
         {
-          "php": "8.3",
+          "php": "8.4",
           "symfony": "~6.4.0",
           "mariadb": "10.11.13",
           "dbal": "^3.0",
@@ -23,14 +27,7 @@
         },
         {
           "php": "8.5",
-          "symfony": "~7.3.0",
-          "mariadb": "11.4.7",
-          "dbal": "^3.0",
-          "state_machine_adapter": "symfony_workflow"
-        },
-        {
-          "php": "8.5",
-          "symfony": "~7.3.0",
+          "symfony": "~7.4.0",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow",
@@ -41,14 +38,14 @@
     "e2e-mysql": {
       "include": [
         {
-          "php": "8.3",
+          "php": "8.4",
           "symfony": "~6.4.0",
           "mysql": "8.0",
           "twig": "^3.3"
         },
         {
           "php": "8.5",
-          "symfony": "~7.3.0",
+          "symfony": "~7.4.0",
           "mysql": "8.4",
           "twig": "^3.3"
         }
@@ -57,24 +54,26 @@
     "e2e-pgsql": {
       "include": [
         {
-          "php": "8.3",
+          "php": "8.4",
           "symfony": "~6.4.0",
           "postgres": "15.13"
         },
         {
           "php": "8.5",
-          "symfony": "~7.3.0",
+          "symfony": "~7.4.0",
           "postgres": "17.5"
         }
       ]
     },
     "frontend": {
-      "node": ["24.x"]
+      "node": [
+        "24.x"
+      ]
     },
     "packages": {
       "include": [
         {
-          "php": "8.3",
+          "php": "8.4",
           "symfony": "~6.4.0"
         },
         {
@@ -86,14 +85,34 @@
   },
   "full": {
     "static-checks": {
-      "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["~6.4.0", "~7.3.0"]
+      "php": [
+        "8.3",
+        "8.4",
+        "8.5"
+      ],
+      "symfony": [
+        "~6.4.0",
+        "~7.3.0",
+        "~7.4.0"
+      ]
     },
     "e2e-mariadb": {
-      "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["~6.4.0", "~7.3.0"],
-      "mariadb": ["11.4.7"],
-      "state_machine_adapter": ["symfony_workflow"],
+      "php": [
+        "8.3",
+        "8.4",
+        "8.5"
+      ],
+      "symfony": [
+        "~6.4.0",
+        "~7.3.0",
+        "~7.4.0"
+      ],
+      "mariadb": [
+        "11.4.7"
+      ],
+      "state_machine_adapter": [
+        "symfony_workflow"
+      ],
       "include": [
         {
           "php": "8.3",
@@ -104,10 +123,21 @@
       ]
     },
     "e2e-mysql": {
-      "php": ["8.3", "8.4"],
-      "symfony": ["~6.4.0", "~7.3.0"],
-      "mysql": ["8.4"],
-      "twig": ["^3.3"],
+      "php": [
+        "8.3",
+        "8.4"
+      ],
+      "symfony": [
+        "~6.4.0",
+        "~7.3.0",
+        "~7.4.0"
+      ],
+      "mysql": [
+        "8.4"
+      ],
+      "twig": [
+        "^3.3"
+      ],
       "include": [
         {
           "php": "8.3",
@@ -118,16 +148,39 @@
       ]
     },
     "e2e-pgsql": {
-      "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["~6.4.0", "~7.3.0"],
-      "postgres": ["15.13", "16.9", "17.5"]
+      "php": [
+        "8.3",
+        "8.4",
+        "8.5"
+      ],
+      "symfony": [
+        "~6.4.0",
+        "~7.3.0",
+        "~7.4.0"
+      ],
+      "postgres": [
+        "15.13",
+        "16.9",
+        "17.5"
+      ]
     },
     "frontend": {
-      "node": ["22.x", "24.x"]
+      "node": [
+        "22.x",
+        "24.x"
+      ]
     },
     "packages": {
-      "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["~6.4.0", "~7.3.0"]
+      "php": [
+        "8.3",
+        "8.4",
+        "8.5"
+      ],
+      "symfony": [
+        "~6.4.0",
+        "~7.3.0",
+        "~7.4.0"
+      ]
     }
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -33,6 +33,11 @@ parameters:
 
     ignoreErrors:
         - identifier: missingType.generics # This need to be fixed, too many classes are using generics without PHPDoc type
+        # Symfony 7.4 introduced generics on NodeBuilder which phpstan-symfony does not handle correctly yet
+        # See: https://github.com/phpstan/phpstan-symfony/issues/431
+        -
+            message: '#Call to method \w+Node\(\) on an unknown class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder<.*>#'
+            identifier: class.notFound
         - '/(Interface|Class) [a-zA-Z\\]+Repository[a-zA-Z\\]* specifies template type (\w+) of interface [a-zA-Z\\]+ as [a-zA-Z\\]+ (of [a-zA-Z\\]+ )?but it''s already specified as/' # turns off a weird generics check behavior for repositories
         - '/Method Sylius\\Bundle\\(Admin|Shop)Bundle\\Twig\\Component\\[a-zA-Z\\]+\:\:getDataModelValue\(\) is unused./'
         - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/AmountType.php
@@ -33,7 +33,7 @@ final class AmountType extends AbstractType
                 'currency' => $options['channel']->getBaseCurrency()->getCode(),
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
-                    new Type(['type' => 'integer', 'groups' => ['sylius']]),
+                    new Type(type: 'integer', groups: ['sylius']),
                     new GreaterThan(['value' => 0, 'groups' => ['sylius']]),
                 ],
             ])

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupConfigurationType.php
@@ -28,7 +28,7 @@ final class CustomerGroupConfigurationType extends AbstractType
                 'label' => 'sylius.form.promotion_rule.customer_group.group',
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
-                    new Type(['type' => 'string', 'groups' => ['sylius']]),
+                    new Type(type: 'string', groups: ['sylius']),
                 ],
             ])
         ;

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeFilterConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeFilterConfigurationType.php
@@ -27,14 +27,14 @@ final class PriceRangeFilterConfigurationType extends AbstractType
             ->add('min', MoneyType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                    new Type(type: 'numeric', groups: ['sylius']),
                 ],
                 'currency' => $options['currency'],
             ])
             ->add('max', MoneyType::class, [
                 'required' => false,
                 'constraints' => [
-                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                    new Type(type: 'numeric', groups: ['sylius']),
                 ],
                 'currency' => $options['currency'],
             ])

--- a/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
@@ -68,9 +68,7 @@ final class SelectAttributeType implements AttributeTypeInterface
 
         $constraints = [
             new All([
-                new Type([
-                    'type' => 'string',
-                ]),
+                new Type(type: 'string'),
             ]),
         ];
 


### PR DESCRIPTION
Let's test both Symfony ~7.3.0 and ~7.4.0 on the full build and switch to ~7.4.0 in the minimal 🚀 💃 


Symfony 7.4 introduced breaking changes that cause PHPStan failures:

- `Type` constraint constructor now uses named arguments instead of array options
- `NodeBuilder` now uses generics which phpstan-symfony doesn't handle correctly yet
