### PR TITLE
Pin Symfony versions to tilde constraints in CI

### DIFF
--- a/.github/workflows/ci_frontend.yaml
+++ b/.github/workflows/ci_frontend.yaml
@@ -79,7 +79,7 @@ jobs:
                     e2e_js: "yes"
                     database_version: "8.0"
                     php_version: "8.2"
-                    symfony_version: "6.4.*"
+                    symfony_version: "~6.4.0"
                     node_version: ${{ matrix.node }}
                     chrome_version: stable
                     

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -4,11 +4,11 @@
       "include": [
         {
           "php": "8.3",
-          "symfony": "^6.4"
+          "symfony": "~6.4.0"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3"
+          "symfony": "~7.3.0"
         }
       ]
     },
@@ -16,21 +16,21 @@
       "include": [
         {
           "php": "8.3",
-          "symfony": "^6.4",
+          "symfony": "~6.4.0",
           "mariadb": "10.11.13",
           "dbal": "^3.0",
           "state_machine_adapter": "winzou_state_machine"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3",
+          "symfony": "~7.3.0",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3",
+          "symfony": "~7.3.0",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
           "state_machine_adapter": "symfony_workflow",
@@ -42,13 +42,13 @@
       "include": [
         {
           "php": "8.3",
-          "symfony": "^6.4",
+          "symfony": "~6.4.0",
           "mysql": "8.0",
           "twig": "^3.3"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3",
+          "symfony": "~7.3.0",
           "mysql": "8.4",
           "twig": "^3.3"
         }
@@ -58,12 +58,12 @@
       "include": [
         {
           "php": "8.3",
-          "symfony": "^6.4",
+          "symfony": "~6.4.0",
           "postgres": "15.13"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3",
+          "symfony": "~7.3.0",
           "postgres": "17.5"
         }
       ]
@@ -75,11 +75,11 @@
       "include": [
         {
           "php": "8.3",
-          "symfony": "^6.4"
+          "symfony": "~6.4.0"
         },
         {
           "php": "8.5",
-          "symfony": "^7.3"
+          "symfony": "~7.3.0"
         }
       ]
     }
@@ -87,11 +87,11 @@
   "full": {
     "static-checks": {
       "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["^6.4", "~7.3.0"]
+      "symfony": ["~6.4.0", "~7.3.0"]
     },
     "e2e-mariadb": {
       "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["^6.4", "~7.3.0"],
+      "symfony": ["~6.4.0", "~7.3.0"],
       "mariadb": ["11.4.7"],
       "state_machine_adapter": ["symfony_workflow"],
       "include": [
@@ -105,7 +105,7 @@
     },
     "e2e-mysql": {
       "php": ["8.3", "8.4"],
-      "symfony": ["^6.4", "~7.3.0"],
+      "symfony": ["~6.4.0", "~7.3.0"],
       "mysql": ["8.4"],
       "twig": ["^3.3"],
       "include": [
@@ -119,7 +119,7 @@
     },
     "e2e-pgsql": {
       "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["^6.4", "~7.3.0"],
+      "symfony": ["~6.4.0", "~7.3.0"],
       "postgres": ["15.13", "16.9", "17.5"]
     },
     "frontend": {
@@ -127,7 +127,7 @@
     },
     "packages": {
       "php": ["8.3", "8.4", "8.5"],
-      "symfony": ["^6.4", "~7.3.0"]
+      "symfony": ["~6.4.0", "~7.3.0"]
     }
   }
 }


### PR DESCRIPTION
Switching from `^6.4` and `^7.3` to `~6.4.0` and `~7.3.0` for better control over CI stability. After a Symfony minor release, our tests keep running against the version we've verified. Version bumps are done explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Symfony version specifiers in CI/build matrices from broad caret ranges to tighter tilde ranges to improve consistency and reproducibility across pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->