### PR TITLE
[Shop] Remove test attribute from order summary table

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/templates/shared/order/show/summary/table_summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/templates/shared/order/show/summary/table_summary.html.twig
@@ -1,3 +1,3 @@
-<table class="table table-borderless align-middle ms-auto mb-6" style="--bs-border-style: dashed" {{ sylius_test_html_attribute('order-table') }}>
+<table class="table table-borderless align-middle ms-auto mb-6" style="--bs-border-style: dashed">
     {% hook 'table_summary' %}
 </table>


### PR DESCRIPTION
Removes the `sylius_test_html_attribute('order-table')` from the order summary table template.

This attribute is not used in any Behat scenarios and adds unnecessary test-specific markup to the production template.

Visual representation of an issue:

<img width="1675" height="951" alt="image" src="https://github.com/user-attachments/assets/9561a653-43cb-4895-9948-eccf6f4fc095" />


Fixes:

<img width="1670" height="698" alt="image" src="https://github.com/user-attachments/assets/af5ae27c-7b79-4a5d-a986-c0e72835eaa9" />

