### PR TITLE
[php-grid-configuration] Remove coupling interfaces to grid ones

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/AdminUserGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface AdminUserGridInterface extends GridInterface
+interface AdminUserGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CatalogPromotionGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CatalogPromotionGridInterface extends GridInterface
+interface CatalogPromotionGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ChannelGridInterface extends GridInterface
+interface ChannelGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ChannelPricingLogEntryGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ChannelPricingLogEntryGridInterface extends GridInterface
+interface ChannelPricingLogEntryGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CountryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CountryGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CountryGridInterface extends GridInterface
+interface CountryGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CurrencyGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CurrencyGridInterface extends GridInterface
+interface CurrencyGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CustomerGridInterface extends GridInterface
+interface CustomerGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerGroupGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CustomerGroupGridInterface extends GridInterface
+interface CustomerGroupGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/CustomerOrderGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface CustomerOrderGridInterface extends GridInterface
+interface CustomerOrderGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ExchangeRateGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ExchangeRateGridInterface extends GridInterface
+interface ExchangeRateGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/InventoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/InventoryGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface InventoryGridInterface extends GridInterface
+interface InventoryGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/LocaleGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/LocaleGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface LocaleGridInterface extends GridInterface
+interface LocaleGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/OrderGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/OrderGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface OrderGridInterface extends GridInterface
+interface OrderGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface PaymentGridInterface extends GridInterface
+interface PaymentGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentMethodGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface PaymentMethodGridInterface extends GridInterface
+interface PaymentMethodGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PaymentRequestGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface PaymentRequestGridInterface extends GridInterface
+interface PaymentRequestGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAssociationTypeGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductAssociationTypeGridInterface extends GridInterface
+interface ProductAssociationTypeGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductAttributeGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductAttributeGridInterface extends GridInterface
+interface ProductAttributeGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductGridInterface extends GridInterface
+interface ProductGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductOptionGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductOptionGridInterface extends GridInterface
+interface ProductOptionGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductReviewGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductReviewGridInterface extends GridInterface
+interface ProductReviewGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductTaxonGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductTaxonGridInterface extends GridInterface
+interface ProductTaxonGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductVariantGridInterface extends GridInterface
+interface ProductVariantGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ProductVariantWithCatalogPromotionGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductVariantWithCatalogPromotionGridInterface extends GridInterface
+interface ProductVariantWithCatalogPromotionGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionCouponGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface PromotionCouponGridInterface extends GridInterface
+interface PromotionCouponGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/PromotionGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/PromotionGridInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
-interface PromotionGridInterface extends GridInterface
+/** @experimental */
+interface PromotionGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShipmentGridInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
-interface ShipmentGridInterface extends GridInterface
+/** @experimental */
+interface ShipmentGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingCategoryGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ShippingCategoryGridInterface extends GridInterface
+interface ShippingCategoryGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ShippingMethodGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ShippingMethodGridInterface extends GridInterface
+interface ShippingMethodGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxCategoryGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface TaxCategoryGridInterface extends GridInterface
+interface TaxCategoryGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/TaxRateGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface TaxRateGridInterface extends GridInterface
+interface TaxRateGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Grid/ZoneGridInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Grid/ZoneGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ZoneGridInterface extends GridInterface
+interface ZoneGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGridInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Grid/Account/OrderGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\Grid\Account;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface OrderGridInterface extends GridInterface
+interface OrderGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }

--- a/src/Sylius/Bundle/ShopBundle/Grid/ProductGridInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Grid/ProductGridInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\Grid;
 
 use Sylius\Bundle\GridBundle\Builder\GridBuilderInterface;
-use Sylius\Bundle\GridBundle\Grid\GridInterface;
 
 /** @experimental */
-interface ProductGridInterface extends GridInterface
+interface ProductGridInterface
 {
     public function __invoke(GridBuilderInterface $gridBuilder): void;
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | php-grid-configuration
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |  partially #18136
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.0 branch
 - Features and deprecations must be submitted against the 2.1 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The Grids were still relying on an interface tightly coupled to the Grid system, creating unnecessary dependencies between the Sylius interfaces and the Grid one.
When decorating a grid, only the __invoke() method needs to be called, making the extra interface redundant.

### ✅ What’s changed

Removed a Grid-specific interface that introduced unnecessary coupling.

### 🎯 Motivation

Improves separation of concerns by making grids more independent from specific Grid abstractions.

Reduces rigid coupling and aligns the implementation with cleaner, more flexible architecture principles.

### 📎 Related

Partially addresses issue #18136.