### PR TITLE
[Behat] Migrate shop `promotion` scenarios to chromedriver

### DIFF
--- a/features/shop/promotion/applying_catalog_promotions/applying_catalog_promotions_for_product.feature
+++ b/features/shop/promotion/applying_catalog_promotions/applying_catalog_promotions_for_product.feature
@@ -16,7 +16,7 @@ Feature: Applying catalog promotions for product
         When I view "PHP T-Shirt" variant of the "T-Shirt" product
         Then I should see this variant is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Applying simple catalog promotion on another variant
         When I view "Java T-Shirt" variant of the "T-Shirt" product
         Then I should see this variant is discounted from "$30.00" to "$15.00" with "Winter sale" promotion

--- a/features/shop/promotion/applying_catalog_promotions/e2e/ui/seeing_applied_catalog_promotion_on_products_with_options.feature
+++ b/features/shop/promotion/applying_catalog_promotions/e2e/ui/seeing_applied_catalog_promotion_on_products_with_options.feature
@@ -20,20 +20,20 @@ Feature: Seeing applied catalog promotions on products configured with the optio
         When I view product "T-Shirt"
         Then I should see this product is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing applied catalog promotion on the product with non default option
         When I view product "T-Shirt"
         And I select its "Size" as "L"
         Then I should see this product is discounted from "$50.00" to "$37.50" with "Surprise sale" promotion
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing applied catalog promotion on the product after changing the options multiple times
         When I view product "T-Shirt"
         And I select its "Size" as "L"
         And I select its "Size" as "S"
         Then I should see this product is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing no applied catalog promotion on the product option without applied catalog promotion
         When I view product "T-Shirt"
         And I select its "Size" as "M"

--- a/features/shop/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_variant.feature
+++ b/features/shop/promotion/applying_catalog_promotions/seeing_applied_catalog_promotion_on_variant.feature
@@ -16,7 +16,7 @@ Feature: Seeing applied catalog promotions on variant
         When I view "PHP T-Shirt" variant of the "T-Shirt" product
         Then I should see this variant is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Seeing no applied catalog promotion on variant
         When I view "Sylius T-Shirt" variant of the "T-Shirt" product
         Then I should see this variant is not discounted

--- a/features/shop/promotion/applying_promotion_coupon/e2e/applying_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/e2e/applying_promotion_coupon.feature
@@ -11,7 +11,7 @@ Feature: Applying promotion coupon
         And this promotion gives "$10.00" discount to every order
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Receiving fixed discount for my cart
         Given I added product "PHP T-Shirt" to the cart
         When I check the details of my cart
@@ -19,7 +19,7 @@ Feature: Applying promotion coupon
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Receiving no discount if promotion for the applied coupon is invalid
         Given I added product "PHP T-Shirt" to the cart
         When I check the details of my cart

--- a/features/shop/promotion/applying_promotion_coupon/e2e/removing_promotion_coupon.feature
+++ b/features/shop/promotion/applying_promotion_coupon/e2e/removing_promotion_coupon.feature
@@ -11,7 +11,7 @@ Feature: Removing promotion coupon
         And this promotion gives "$10.00" discount to every order
         And I am a logged in customer
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Removing coupon code from cart
         Given I added product "PHP T-Shirt" to the cart
         And this cart has promotion applied with coupon "SANTA2016"


### PR DESCRIPTION
Migrates shop promotion tests from `Panther` to `ChromeDriver`. The goal is to fully migrate to a single driver.