### PR TITLE
[CI] Split Chromedriver tests into parallel jobs

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -80,7 +80,7 @@ jobs:
     notify-about-build-status:
         if: ${{ always() }}
         name: "Notify about build status"
-        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, packages]
+        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, frontend, packages]
         runs-on: ubuntu-latest
         timeout-minutes: 5
 
@@ -107,6 +107,7 @@ jobs:
                         ${{ needs.e2e-mariadb.result == 'success' && ':+1:' || ':x:' }} End-to-End (MariaDB)
                         ${{ needs.e2e-mysql.result == 'success' && ':+1:' || ':x:' }} End-to-End (MySQL)
                         ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} End-to-End (PostgreSQL)
+                        ${{ needs.frontend.result == 'success' && ':+1:' || ':x:' }} Frontend
                         ${{ needs.packages.result == 'success' && ':+1:' || ':x:' }} Packages
 
                         _ _ _ _ _ _ _

--- a/.github/workflows/ci__full_2_1.yaml
+++ b/.github/workflows/ci__full_2_1.yaml
@@ -34,7 +34,7 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.1"]
-        name: "[${{ matrix.branch }}] End-to-end tests (MariaDB)"
+        name: "[${{ matrix.branch }}] Tests (MariaDB)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mariadb.yaml
         with:
@@ -44,7 +44,7 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.1"]
-        name: "[${{ matrix.branch }}] End-to-end tests (MySQL)"
+        name: "[${{ matrix.branch }}] Tests (MySQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mysql.yaml
         with:
@@ -54,9 +54,19 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.1"]
-        name: "[${{ matrix.branch }}] End-to-end tests (PostgreSQL)"
+        name: "[${{ matrix.branch }}] Tests (PostgreSQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-pgsql.yaml
+        with:
+            branch: ${{ matrix.branch }}
+            type: full
+    e2e-js:
+        strategy:
+            matrix:
+                branch: ["2.1"]
+        name: "[${{ matrix.branch }}] Javascript Tests (MySQL)"
+        needs: static-checks
+        uses: ./.github/workflows/ci_js.yaml
         with:
             branch: ${{ matrix.branch }}
             type: full
@@ -80,7 +90,7 @@ jobs:
     notify-about-build-status:
         if: ${{ always() }}
         name: "Notify about build status"
-        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, packages]
+        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
         timeout-minutes: 5
 
@@ -104,9 +114,11 @@ jobs:
                         *<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} | ${{ github.workflow }} #${{ github.run_number }} build on ${{ github.repository }} repository has been completed for ${{ steps.process-data.outputs.branch }} branch.>*
 
                         ${{ needs.static-checks.result == 'success' && ':+1:' || ':x:' }} Static Checks
-                        ${{ needs.e2e-mariadb.result == 'success' && ':+1:' || ':x:' }} End-to-End (MariaDB)
-                        ${{ needs.e2e-mysql.result == 'success' && ':+1:' || ':x:' }} End-to-End (MySQL)
-                        ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} End-to-End (PostgreSQL)
+                        ${{ needs.e2e-mariadb.result == 'success' && ':+1:' || ':x:' }} Tests (MariaDB)
+                        ${{ needs.e2e-mysql.result == 'success' && ':+1:' || ':x:' }} Tests (MySQL)
+                        ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} Tests (PostgreSQL)
+                        ${{ needs.e2e-js.result == 'success' && ':+1:' || ':x:' }} Javascript Tests (MySQL)
+                        ${{ needs.frontend.result == 'success' && ':+1:' || ':x:' }} Frontend
                         ${{ needs.packages.result == 'success' && ':+1:' || ':x:' }} Packages
 
                         _ _ _ _ _ _ _

--- a/.github/workflows/ci__full_2_2.yaml
+++ b/.github/workflows/ci__full_2_2.yaml
@@ -34,7 +34,7 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.2"]
-        name: "[${{ matrix.branch }}] End-to-end tests (MariaDB)"
+        name: "[${{ matrix.branch }}] Tests (MariaDB)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mariadb.yaml
         with:
@@ -44,7 +44,7 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.2"]
-        name: "[${{ matrix.branch }}] End-to-end tests (MySQL)"
+        name: "[${{ matrix.branch }}] Tests (MySQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mysql.yaml
         with:
@@ -54,9 +54,19 @@ jobs:
         strategy:
             matrix:
                 branch: ["2.2"]
-        name: "[${{ matrix.branch }}] End-to-end tests (PostgreSQL)"
+        name: "[${{ matrix.branch }}] Tests (PostgreSQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-pgsql.yaml
+        with:
+            branch: ${{ matrix.branch }}
+            type: full
+    e2e-js:
+        strategy:
+            matrix:
+                branch: ["2.2"]
+        name: "[${{ matrix.branch }}] Javascript Tests (MySQL)"
+        needs: static-checks
+        uses: ./.github/workflows/ci_js.yaml
         with:
             branch: ${{ matrix.branch }}
             type: full
@@ -80,7 +90,7 @@ jobs:
     notify-about-build-status:
         if: ${{ always() }}
         name: "Notify about build status"
-        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, packages]
+        needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
         timeout-minutes: 5
 
@@ -104,9 +114,11 @@ jobs:
                         *<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} | ${{ github.workflow }} #${{ github.run_number }} build on ${{ github.repository }} repository has been completed for ${{ steps.process-data.outputs.branch }} branch.>*
 
                         ${{ needs.static-checks.result == 'success' && ':+1:' || ':x:' }} Static Checks
-                        ${{ needs.e2e-mariadb.result == 'success' && ':+1:' || ':x:' }} End-to-End (MariaDB)
-                        ${{ needs.e2e-mysql.result == 'success' && ':+1:' || ':x:' }} End-to-End (MySQL)
-                        ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} End-to-End (PostgreSQL)
+                        ${{ needs.e2e-mariadb.result == 'success' && ':+1:' || ':x:' }} Tests (MariaDB)
+                        ${{ needs.e2e-mysql.result == 'success' && ':+1:' || ':x:' }} Tests (MySQL)
+                        ${{ needs.e2e-pgsql.result == 'success' && ':+1:' || ':x:' }} Tests (PostgreSQL)
+                        ${{ needs.e2e-js.result == 'success' && ':+1:' || ':x:' }} Javascript Tests (MySQL)
+                        ${{ needs.frontend.result == 'success' && ':+1:' || ':x:' }} Frontend
                         ${{ needs.packages.result == 'success' && ':+1:' || ':x:' }} Packages
 
                         _ _ _ _ _ _ _

--- a/.github/workflows/ci__minimal.yaml
+++ b/.github/workflows/ci__minimal.yaml
@@ -28,19 +28,25 @@ jobs:
         with:
             type: minimal
     e2e-mariadb:
-        name: End-to-end tests (MariaDB)
+        name: Tests (MariaDB)
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mariadb.yaml
         with:
             type: minimal
     e2e-mysql:
-        name: End-to-end tests (MySQL)
+        name: Tests (MySQL)
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mysql.yaml
         with:
             type: minimal
+    e2e-js:
+        name: Javascript Tests (MySQL)
+        needs: static-checks
+        uses: ./.github/workflows/ci_js.yaml
+        with:
+            type: minimal
     e2e-pgsql:
-        name: End-to-end tests (PostgreSQL)
+        name: Tests (PostgreSQL)
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-pgsql.yaml
         with:

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -1,4 +1,4 @@
-name: End-to-End (MariaDB)
+name: Tests (MariaDB)
 
 on:
     workflow_dispatch: ~
@@ -41,10 +41,10 @@ jobs:
                     path: '.github/workflows/matrix.json'
                     prop_path: '${{ inputs.type }}.e2e-mariadb'
 
-    behat-no-js:
+    phpunit-cli-api:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
+        name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -55,12 +55,7 @@ jobs:
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
             TEST_SYLIUS_STATE_MACHINE_ADAPTER: "${{ matrix.state_machine_adapter }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_CLI_TAGS: "@cli&&~@todo"
-            BEHAT_CLI_SUITES: "@cli"
-            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
-            BEHAT_NON_UI_SUITES: "@api,@domain"
-            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
-            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -   name: Set variables
@@ -87,8 +82,8 @@ jobs:
             -   name: Require Winzou State Machine
                 if: "${{ matrix.state_machine_adapter == 'winzou_state_machine' }}"
                 run: |
-                    composer require winzou/state-machine:^0.4 --no-update   
-                    composer require winzou/state-machine-bundle:^0.6 --no-update   
+                    composer require winzou/state-machine:^0.4 --no-update
+                    composer require winzou/state-machine-bundle:^0.6 --no-update
 
             -   name: Prepare manifest.json files
                 if: "${{ inputs.branch != '1.14' }}"
@@ -101,7 +96,7 @@ jobs:
                     echo "{}" > public/build/shop/manifest.json
                     echo "{}" > public/build/app/admin/manifest.json
                     echo "{}" > public/build/app/shop/manifest.json
-                    
+
             -   name: Require Api Platform packages
                 if: ${{ matrix.api_platform != '' && matrix.api_platform != null }}
                 run: |
@@ -141,19 +136,125 @@ jobs:
                     vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="@cli&&~@todo" --suite-tags="@cli" || \
+                    $BEHAT_RERUN_CMD --tags="@cli&&~@todo" --suite-tags="@cli"
 
-            -   name: Run non-UI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
-
-            -   name: Run non-JS Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
+            -   name: Run API Behat
+                run: |
+                    $BEHAT_BASE_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || \
+                    $BEHAT_RERUN_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    path: |
+                        etc/build/
+                        var/log
+                    if-no-files-found: ignore
+                    overwrite: true
+
+    behat-ui:
+        needs: get-matrix
+        runs-on: ubuntu-latest
+        name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
+        timeout-minutes: 45
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+
+        env:
+            APP_ENV: test_cached
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=mariadb-${{ matrix.mariadb }}"
+            TEST_SYLIUS_STATE_MACHINE_ADAPTER: "${{ matrix.state_machine_adapter }}"
+            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
+
+        steps:
+            -   name: Set variables
+                shell: bash
+                env:
+                    BRANCH: ${{ inputs.branch }}
+                run: |
+                    if [ "$BRANCH" == "1.14" ]; then
+                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
+                    else
+                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
+                    fi
+
+            -   name: "Checkout (With Branch)"
+                if: "${{ inputs.branch != '' }}"
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ inputs.branch }}
+
+            -   name: "Checkout"
+                if: "${{ inputs.branch == '' }}"
+                uses: actions/checkout@v4
+
+            -   name: Require Winzou State Machine
+                if: "${{ matrix.state_machine_adapter == 'winzou_state_machine' }}"
+                run: |
+                    composer require winzou/state-machine:^0.4 --no-update
+                    composer require winzou/state-machine-bundle:^0.6 --no-update
+
+            -   name: Prepare manifest.json files
+                if: "${{ inputs.branch != '1.14' }}"
+                run: |
+                    mkdir -p public/build/admin
+                    mkdir -p public/build/shop
+                    mkdir -p public/build/app/admin
+                    mkdir -p public/build/app/shop
+                    echo "{}" > public/build/admin/manifest.json
+                    echo "{}" > public/build/shop/manifest.json
+                    echo "{}" > public/build/app/admin/manifest.json
+                    echo "{}" > public/build/app/shop/manifest.json
+
+            -   name: Require Api Platform packages
+                if: ${{ matrix.api_platform != '' && matrix.api_platform != null }}
+                run: |
+                    REQ="${{ matrix.api_platform }}"
+                    composer require --no-update \
+                        api-platform/doctrine-common:${REQ} \
+                        api-platform/doctrine-orm:${REQ} \
+                        api-platform/documentation:${REQ} \
+                        api-platform/http-cache:${REQ} \
+                        api-platform/hydra:${REQ} \
+                        api-platform/json-schema:${REQ} \
+                        api-platform/jsonld:${REQ} \
+                        api-platform/metadata:${REQ} \
+                        api-platform/openapi:${REQ} \
+                        api-platform/serializer:${REQ} \
+                        api-platform/state:${REQ} \
+                        api-platform/symfony:${REQ} \
+                        api-platform/validator:${REQ}
+
+            -   name: Build application
+                uses: SyliusLabs/BuildTestAppAction@v3.0.1
+                with:
+                    build_type: "sylius"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-apip-${{ matrix.api_platform || 'none' }}-"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-apip-${{ matrix.api_platform || 'none' }}-"
+                    e2e: "yes"
+                    database: "mariadb"
+                    database_version: ${{ matrix.mariadb }}
+                    php_version: ${{ matrix.php }}
+                    symfony_version: ${{ matrix.symfony }}
+                    node_version: ${{ env.NODE_VERSION }}
+                    chrome_version: stable
+
+            -   name: Run UI Behat
+                run: |
+                    $BEHAT_BASE_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui"
+
+            -   name: Upload logs
+                uses: actions/upload-artifact@v4
+                if: failure()
+                with:
+                    name: "Logs (UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -1,4 +1,4 @@
-name: End-to-End (MySQL)
+name: Tests (MySQL)
 
 on:
     workflow_dispatch: ~
@@ -41,10 +41,10 @@ jobs:
                     path: '.github/workflows/matrix.json'
                     prop_path: '${{ inputs.type }}.e2e-mysql'
 
-    behat-no-js:
+    phpunit-cli-api:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
+        name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -54,12 +54,7 @@ jobs:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_CLI_TAGS: "@cli&&~@todo"
-            BEHAT_CLI_SUITES: "@cli"
-            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
-            BEHAT_NON_UI_SUITES: "@api,@domain"
-            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
-            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -   name: Set variables
@@ -126,29 +121,30 @@ jobs:
                     vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
 
             -   name: Run CLI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="@cli&&~@todo" --suite-tags="@cli" || \
+                    $BEHAT_RERUN_CMD --tags="@cli&&~@todo" --suite-tags="@cli"
 
-            -   name: Run non-UI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
-
-            -   name: Run non-JS Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
+            -   name: Run API Behat
+                run: |
+                    $BEHAT_BASE_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || \
+                    $BEHAT_RERUN_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log
                     if-no-files-found: ignore
                     overwrite: true
 
-    behat-ui-js-chromedriver:
+    behat-ui:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
+        name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
         timeout-minutes: 45
         strategy:
             fail-fast: false
@@ -158,9 +154,7 @@ jobs:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
-            BEHAT_SUITES: "@hybrid,@ui"
-            BEHAT_FAILING_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -   name: Set variables
@@ -184,152 +178,45 @@ jobs:
                 if: "${{ inputs.branch == '' }}"
                 uses: actions/checkout@v4
 
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: "Restore dependencies"
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-
             -   name: Restrict Twig
                 if: matrix.twig == '^2.12'
                 run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
-            -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v3.0.1
-                with:
-                    build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    e2e: "yes"
-                    e2e_js: "yes"
-                    database_version: ${{ matrix.mysql }}
-                    php_version: ${{ matrix.php }}
-                    symfony_version: ${{ matrix.symfony }}
-                    node_version: ${{ env.NODE_VERSION }}
-
-            -   name: Run Behat (Chromedriver)
-                run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
-
-            -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
-                run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
-                continue-on-error: true
-
-            -   name: Upload logs
-                uses: actions/upload-artifact@v4
-                if: failure()
-                with:
-                    name: "Logs (JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
-                    path: |
-                        etc/build/
-                        var/log
-                    if-no-files-found: ignore
-                    overwrite: true
-
-    behat-ui-js-panther:
-        needs: get-matrix
-        runs-on: ubuntu-latest
-        name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }}, Twig ${{ matrix.twig }}"
-        timeout-minutes: 45
-        strategy:
-            fail-fast: false
-            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
-
-        env:
-            APP_ENV: ${{ matrix.env || 'test_cached' }}
-            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
-            BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
-            BEHAT_SUITES: "@hybrid,@ui"
-
-        steps:
-            -   name: Set variables
-                shell: bash
-                env:
-                    BRANCH: ${{ inputs.branch }}
-                run: |
-                    if [ "$BRANCH" == "1.14" ]; then
-                        echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    else
-                        echo "NODE_VERSION=24.x" >> $GITHUB_ENV
-                    fi
-
-            -   name: "Checkout (With Branch)"
-                if: "${{ inputs.branch != '' }}"
-                uses: actions/checkout@v4
-                with:
-                    ref: ${{ inputs.branch }}
-
-            -   name: "Checkout"
-                if: "${{ inputs.branch == '' }}"
-                uses: actions/checkout@v4
-
-            -   name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -   name: "Restore dependencies"
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-
-            -   name: Restrict Twig
-                if: matrix.twig == '^2.12'
-                run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
-
-            -   name: Build application for Full 1.14 build
-                if: "${{ inputs.branch == '1.14' }}"
-                uses: SyliusLabs/BuildTestAppAction@v3.0.1
-                with:
-                    build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
-                    e2e: "yes"
-                    e2e_js: "yes"
-                    database_version: ${{ matrix.mysql }}
-                    php_version: ${{ matrix.php }}
-                    symfony_version: ${{ matrix.symfony }}
-                    node_version: ${{ env.NODE_VERSION }}
-                    chrome_version: stable
-
-            -   name: Build application
+            -   name: Prepare manifest.json files
                 if: "${{ inputs.branch != '1.14' }}"
+                run: |
+                    mkdir -p public/build/admin
+                    mkdir -p public/build/shop
+                    mkdir -p public/build/app/admin
+                    mkdir -p public/build/app/shop
+                    echo "{}" > public/build/admin/manifest.json
+                    echo "{}" > public/build/shop/manifest.json
+                    echo "{}" > public/build/app/admin/manifest.json
+                    echo "{}" > public/build/app/shop/manifest.json
+
+            -   name: Build application
                 uses: SyliusLabs/BuildTestAppAction@v3.0.1
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
-                    e2e_js: "yes"
+                    database: "mysql"
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
-                    chrome_version: stable
 
-            -   name: Run Behat (Panther)
+            -   name: Run UI Behat
                 run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
+                    $BEHAT_BASE_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, Twig ${{ matrix.twig }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -32,12 +32,7 @@ jobs:
             APP_ENV: test_cached
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_CLI_TAGS: "@cli&&~@todo"
-            BEHAT_CLI_SUITES: "@cli"
-            BEHAT_NON_UI_TAGS: "~@todo&&~@cli"
-            BEHAT_NON_UI_SUITES: "@api,@domain"
-            BEHAT_NON_JS_TAGS: "~@javascript&&~@mink:chromedriver&&~@todo&&~@cli"
-            BEHAT_NON_JS_SUITES: "@hybrid,@ui"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -
@@ -66,6 +61,7 @@ jobs:
                     cache_key:  "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
                     cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
                     e2e: "yes"
+                    database: "mysql"
                     database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
@@ -76,13 +72,19 @@ jobs:
                 run: vendor/bin/phpunit --testsuite all --colors=always
 
             -   name: Run CLI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_CLI_TAGS" --suite-tags="$BEHAT_CLI_SUITES" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="@cli&&~@todo" --suite-tags="@cli" || \
+                    $BEHAT_RERUN_CMD --tags="@cli&&~@todo" --suite-tags="@cli"
 
             -   name: Run non-UI Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_UI_TAGS" --suite-tags="$BEHAT_NON_UI_SUITES" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain" || \
+                    $BEHAT_RERUN_CMD --tags="~@todo&&~@cli" --suite-tags="@api,@domain"
 
             -   name: Run non-JS Behat
-                run: $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" || $BEHAT_BASE_CMD --tags="$BEHAT_NON_JS_TAGS" --suite-tags="$BEHAT_NON_JS_SUITES" --rerun
+                run: |
+                    $BEHAT_BASE_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli" --suite-tags="@hybrid,@ui"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
@@ -112,9 +114,7 @@ jobs:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&~@failing"
-            BEHAT_SUITES: "@hybrid,@ui"
-            BEHAT_FAILING_TAGS: "@mink:chromedriver&&~@todo&&~@cli&&@failing"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -   name: "Checkout (With Branch)"
@@ -158,15 +158,15 @@ jobs:
 
             -   name: Run Behat (Chromedriver)
                 run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
+                    $BEHAT_BASE_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&~@failing" --suite-tags="@hybrid,@ui"
 
             -   name: Run Behat (Chromedriver) for randomly failing scenarios (@failing)
                 run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_FAILING_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
+                    $BEHAT_BASE_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@mink:chromedriver&&~@todo&&~@cli&&@failing" --suite-tags="@hybrid,@ui"
                 continue-on-error: true
 
             -   name: Upload logs
@@ -197,8 +197,7 @@ jobs:
             APP_ENV: ${{ matrix.env || 'test_cached' }}
             DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
-            BEHAT_TAGS: "@javascript&&~@todo&&~@cli"
-            BEHAT_SUITES: "@hybrid,@ui"
+            BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
         steps:
             -   name: "Checkout (With Branch)"
@@ -244,9 +243,9 @@ jobs:
 
             -   name: Run Behat (Panther)
                 run: |
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun || \
-                    $BEHAT_BASE_CMD --tags="$BEHAT_TAGS" --suite-tags="$BEHAT_SUITES" --rerun
+                    $BEHAT_BASE_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_js.yaml
+++ b/.github/workflows/ci_js.yaml
@@ -1,4 +1,4 @@
-name: Tests (PostgreSQL)
+name: Javascript Tests (MySQL)
 
 on:
     workflow_dispatch: ~
@@ -23,6 +23,7 @@ jobs:
         name: "Get matrix"
         outputs:
             matrix: ${{ steps.matrix.outputs.prop }}
+            panther-matrix: ${{ steps.panther-matrix.outputs.prop }}
         steps:
             -   name: "Checkout (With Branch)"
                 if: "${{ inputs.branch != '' }}"
@@ -39,20 +40,27 @@ jobs:
                 uses: notiz-dev/github-action-json-property@release
                 with:
                     path: '.github/workflows/matrix.json'
-                    prop_path: '${{ inputs.type }}.e2e-pgsql'
+                    prop_path: '${{ inputs.type }}.js'
 
-    phpunit-cli-api:
+            -   name: "Get panther matrix"
+                id: panther-matrix
+                uses: notiz-dev/github-action-json-property@release
+                with:
+                    path: '.github/workflows/matrix.json'
+                    prop_path: '${{ inputs.type }}.js-panther'
+
+    behat-js:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 45
+        name: "[${{ matrix.group }}] [PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}]"
+        timeout-minutes: 10
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
 
         env:
-            APP_ENV: test_cached
-            DATABASE_URL: "pgsql://postgres:postgres@127.0.0.1/sylius?charset=utf8&serverVersion=${{ matrix.postgres }}"
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
             BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
@@ -78,70 +86,64 @@ jobs:
                 if: "${{ inputs.branch == '' }}"
                 uses: actions/checkout@v4
 
-            -   name: Prepare manifest.json files
-                if: "${{ inputs.branch != '1.14' }}"
-                run: |
-                    mkdir -p public/build/admin
-                    mkdir -p public/build/shop
-                    mkdir -p public/build/app/admin
-                    mkdir -p public/build/app/shop
-                    echo "{}" > public/build/admin/manifest.json
-                    echo "{}" > public/build/shop/manifest.json
-                    echo "{}" > public/build/app/admin/manifest.json
-                    echo "{}" > public/build/app/shop/manifest.json
+            -   name: Get Composer cache directory
+                id: composer-cache
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: "Restore dependencies"
+                uses: actions/cache@v4
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+
+            -   name: Restrict Twig
+                if: matrix.twig == '^2.12'
+                run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
             -   name: Build application
                 uses: SyliusLabs/BuildTestAppAction@v3.0.1
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
-                    database: "postgresql"
-                    database_version: ${{ matrix.postgres }}
+                    e2e_js: "yes"
+                    database: "mysql"
+                    database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
-                    chrome_version: stable
 
-            -   name: Run PHPUnit
+            -   name: Run Behat (${{ matrix.group }})
                 run: |
-                    vendor/bin/phpunit --testsuite all --colors=always
-                    vendor/bin/phpunit --testsuite="Sylius Test Suite" --colors=always
-
-            -   name: Run CLI Behat
-                run: |
-                    $BEHAT_BASE_CMD --tags="@cli&&~@todo" --suite-tags="@cli" || \
-                    $BEHAT_RERUN_CMD --tags="@cli&&~@todo" --suite-tags="@cli"
-
-            -   name: Run API Behat
-                run: |
-                    $BEHAT_BASE_CMD --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain" || \
-                    $BEHAT_RERUN_CMD --tags="~@todo&&~@cli&&~@no-postgres" --suite-tags="@api,@domain"
+                    $BEHAT_BASE_CMD --tags="${{ matrix.tags }}" --suite-tags="@hybrid,@ui" || \
+                    BEHAT_STEP_DELAY=5000 $BEHAT_RERUN_CMD --tags="${{ matrix.tags }}" --suite-tags="@hybrid,@ui" || \
+                    BEHAT_STEP_DELAY=5000 $BEHAT_RERUN_CMD --tags="${{ matrix.tags }}" --suite-tags="@hybrid,@ui"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (${{ matrix.group }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log
                     if-no-files-found: ignore
                     overwrite: true
 
-    behat-ui:
+    behat-panther:
         needs: get-matrix
         runs-on: ubuntu-latest
-        name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 45
+        name: "Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        timeout-minutes: 10
         strategy:
             fail-fast: false
-            matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
+            matrix: ${{ fromJson(needs.get-matrix.outputs.panther-matrix) }}
 
         env:
-            APP_ENV: test_cached
-            DATABASE_URL: "pgsql://postgres:postgres@127.0.0.1/sylius?charset=utf8&serverVersion=${{ matrix.postgres }}"
+            APP_ENV: ${{ matrix.env || 'test_cached' }}
+            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?charset=utf8mb4&serverVersion=${{ matrix.mysql }}"
             BEHAT_BASE_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f progress"
             BEHAT_RERUN_CMD: "vendor/bin/behat --colors --strict --no-interaction -vvv -f pretty --rerun"
 
@@ -167,42 +169,46 @@ jobs:
                 if: "${{ inputs.branch == '' }}"
                 uses: actions/checkout@v4
 
-            -   name: Prepare manifest.json files
-                if: "${{ inputs.branch != '1.14' }}"
-                run: |
-                    mkdir -p public/build/admin
-                    mkdir -p public/build/shop
-                    mkdir -p public/build/app/admin
-                    mkdir -p public/build/app/shop
-                    echo "{}" > public/build/admin/manifest.json
-                    echo "{}" > public/build/shop/manifest.json
-                    echo "{}" > public/build/app/admin/manifest.json
-                    echo "{}" > public/build/app/shop/manifest.json
+            -   name: Get Composer cache directory
+                id: composer-cache
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: "Restore dependencies"
+                uses: actions/cache@v4
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    restore-keys: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+
+            -   name: Restrict Twig
+                if: matrix.twig == '^2.12'
+                run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
             -   name: Build application
                 uses: SyliusLabs/BuildTestAppAction@v3.0.1
                 with:
                     build_type: "sylius"
-                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
-                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"
+                    cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
+                    cache_restore_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
                     e2e: "yes"
-                    database: "postgresql"
-                    database_version: ${{ matrix.postgres }}
+                    e2e_js: "yes"
+                    database_version: ${{ matrix.mysql }}
                     php_version: ${{ matrix.php }}
                     symfony_version: ${{ matrix.symfony }}
                     node_version: ${{ env.NODE_VERSION }}
                     chrome_version: stable
 
-            -   name: Run UI Behat
+            -   name: Run Behat (Panther)
                 run: |
-                    $BEHAT_BASE_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui" || \
-                    $BEHAT_RERUN_CMD --tags="~@javascript&&~@mink:chromedriver&&~@todo&&~@cli&&~@no-postgres" --suite-tags="@hybrid,@ui"
+                    $BEHAT_BASE_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui" || \
+                    $BEHAT_RERUN_CMD --tags="@javascript&&~@todo&&~@cli" --suite-tags="@hybrid,@ui"
 
             -   name: Upload logs
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Logs (UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}) - ${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Logs (Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}) - ${{ github.run_id }}-${{ github.run_number }}"
                     path: |
                         etc/build/
                         var/log

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -51,6 +51,54 @@
         }
       ]
     },
+    "js": {
+      "include": [
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0",
+          "group": "Managing Products",
+          "tags": "@mink:chromedriver&&@managing_products&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0",
+          "group": "Taxons, Shipping Methods, Countries, Zones",
+          "tags": "@managing_taxons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_shipping_methods&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_countries&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_zones&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0",
+          "group": "Promotions, Catalog Promotions, Coupons",
+          "tags": "@managing_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@applying_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_promotion_coupons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0",
+          "group": "Checkout, Cart, Address Book",
+          "tags": "@checkout&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@shopping_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@cart_inventory&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@accessing_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@address_book&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0",
+          "group": "Remaining",
+          "tags": "@mink:chromedriver&&~@managing_products&&~@managing_taxons&&~@managing_shipping_methods&&~@managing_countries&&~@managing_zones&&~@managing_promotions&&~@managing_catalog_promotions&&~@applying_catalog_promotions&&~@managing_promotion_coupons&&~@checkout&&~@shopping_cart&&~@cart_inventory&&~@accessing_cart&&~@address_book&&~@todo&&~@cli&&~@failing"
+        }
+      ]
+    },
+    "js-panther": {
+      "include": [
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.0"
+        }
+      ]
+    },
     "e2e-pgsql": {
       "include": [
         {
@@ -144,6 +192,54 @@
           "symfony": "~7.3.0",
           "mysql": "8.0",
           "twig": "^3.3"
+        }
+      ]
+    },
+    "js": {
+      "include": [
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4",
+          "group": "Managing Products",
+          "tags": "@mink:chromedriver&&@managing_products&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4",
+          "group": "Taxons, Shipping Methods, Countries, Zones",
+          "tags": "@managing_taxons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_shipping_methods&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_countries&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_zones&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4",
+          "group": "Promotions, Catalog Promotions, Coupons",
+          "tags": "@managing_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@applying_catalog_promotions&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@managing_promotion_coupons&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4",
+          "group": "Checkout, Cart, Address Book",
+          "tags": "@checkout&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@shopping_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@cart_inventory&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@accessing_cart&&@mink:chromedriver&&~@todo&&~@cli&&~@failing,@address_book&&@mink:chromedriver&&~@todo&&~@cli&&~@failing"
+        },
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4",
+          "group": "Remaining",
+          "tags": "@mink:chromedriver&&~@managing_products&&~@managing_taxons&&~@managing_shipping_methods&&~@managing_countries&&~@managing_zones&&~@managing_promotions&&~@managing_catalog_promotions&&~@applying_catalog_promotions&&~@managing_promotion_coupons&&~@checkout&&~@shopping_cart&&~@cart_inventory&&~@accessing_cart&&~@address_book&&~@todo&&~@cli&&~@failing"
+        }
+      ]
+    },
+    "js-panther": {
+      "include": [
+        {
+          "php": "8.4",
+          "symfony": "~7.4.0",
+          "mysql": "8.4"
         }
       ]
     },

--- a/src/Sylius/Behat/Context/Hook/BadGatewayContext.php
+++ b/src/Sylius/Behat/Context/Hook/BadGatewayContext.php
@@ -33,4 +33,14 @@ final class BadGatewayContext implements Context
             exit(1);
         }
     }
+
+    #[AfterStep]
+    public function delayAfterStep(): void
+    {
+        $delay = (int) (getenv('BEHAT_STEP_DELAY') ?: 0);
+
+        if ($delay > 0) {
+            usleep($delay * 1000);
+        }
+    }
 }


### PR DESCRIPTION
Running all scenarios at once makes the build less stable, so splitting them into smaller parts should help us pinpoint which scenarios are flaky. It also means any required reruns will be faster.

The only drawback is that we currently build the same test app in multiple jobs, but the next step is to see if we can build it once and pass it as an artifact to the jobs that need it.

Overall, the build should be faster for anyone running the workflow. The queue might sometimes be a bit longer, but each job will finish sooner, so the total time should still go down.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed job labels from "End-to-end tests" to "Tests" across DB variants for clarity.
  * Added a JavaScript test suite with grouped test flows and a browser automation (Panther) variant.
  * Simplified and unified non‑UI/UI test flows, introduced rerun-enabled Behat execution and configurable per-step delay for test stability.
  * CI status notifications now include Frontend status.

* **Chores**
  * Updated CI workflows, matrices and log/manifest preparation steps to support the new JS tests and flow changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->