### PR TITLE
Fix some deprecations

### DIFF
--- a/src/Sylius/Abstraction/StateMachine/phpunit.xml.dist
+++ b/src/Sylius/Abstraction/StateMachine/phpunit.xml.dist
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          colors="true"
-         convertDeprecationsToExceptions="true"
 >
     <testsuites>
         <testsuite name="all">

--- a/src/Sylius/Abstraction/StateMachine/src/WinzouStateMachineAdapter.php
+++ b/src/Sylius/Abstraction/StateMachine/src/WinzouStateMachineAdapter.php
@@ -82,9 +82,8 @@ final class WinzouStateMachineAdapter implements StateMachineInterface
     {
         $reflection = new \ReflectionClass($stateMachine);
         $configProperty = $reflection->getProperty('config');
-        $configProperty->setAccessible(true);
 
-        return  $configProperty->getValue($stateMachine);
+        return $configProperty->getValue($stateMachine);
     }
 
     public function getTransitionFromState(object $subject, string $graphName, string $fromState): ?string

--- a/src/Sylius/Abstraction/StateMachine/tests/Unit/WinzouStateMachineAdapterTest.php
+++ b/src/Sylius/Abstraction/StateMachine/tests/Unit/WinzouStateMachineAdapterTest.php
@@ -197,7 +197,6 @@ final class WinzouStateMachineAdapterTest extends TestCase
     {
         $reflection = new \ReflectionClass($stateMachine);
         $configProperty = $reflection->getProperty('config');
-        $configProperty->setAccessible(true);
         $configProperty->setValue($stateMachine, $config);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingErrorListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingErrorListener.php
@@ -110,7 +110,6 @@ final readonly class CircularDependencyBreakingErrorListener implements EventSub
     private function removePreviousFromThrowable(\Throwable $throwable): void
     {
         $previous = new \ReflectionProperty($throwable instanceof \Exception ? \Exception::class : \Error::class, 'previous');
-        $previous->setAccessible(true);
         $previous->setValue($throwable, null);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/tests/EventListener/CircularDependencyBreakingErrorListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/EventListener/CircularDependencyBreakingErrorListenerTest.php
@@ -134,7 +134,6 @@ final class CircularDependencyBreakingErrorListenerTest extends TestCase
     private function setPreviousForException(\Exception $exception, ?\Exception $previous): void
     {
         $property = new \ReflectionProperty(\Exception::class, 'previous');
-        $property->setAccessible(true);
         $property->setValue($exception, $previous);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/tests/Fixture/Listener/CatalogPromotionExecutorListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Fixture/Listener/CatalogPromotionExecutorListenerTest.php
@@ -111,7 +111,6 @@ final class CatalogPromotionExecutorListenerTest extends TestCase
         $dispatchedCodes = array_map(function (UpdateCatalogPromotionState $command) {
             $reflection = new \ReflectionObject($command);
             $property = $reflection->getProperty('code');
-            $property->setAccessible(true);
 
             return $property->getValue($command);
         }, $dispatchedCommands)

--- a/src/Sylius/Bundle/CoreBundle/tests/OAuth/UserProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/OAuth/UserProviderTest.php
@@ -147,7 +147,6 @@ final class UserProviderTest extends TestCase
         $this->userManager->expects($this->once())->method('flush');
 
         $result = (new \ReflectionClass(UserProvider::class))->getMethod('createUserByOAuthUserResponse');
-        $result->setAccessible(true);
         $createdUser = $result->invoke($this->provider, $response);
 
         $this->assertSame($user, $createdUser);

--- a/src/Sylius/Bundle/CoreBundle/tests/PriceHistory/EntityObserver/ProcessLowestPricesOnChannelChangeObserverTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/PriceHistory/EntityObserver/ProcessLowestPricesOnChannelChangeObserverTest.php
@@ -52,7 +52,6 @@ final class ProcessLowestPricesOnChannelChangeObserverTest extends TestCase
 
         $ref = new \ReflectionObject($this->observer);
         $prop = $ref->getProperty('channelsCurrentlyProcessed');
-        $prop->setAccessible(true);
         $prop->setValue($this->observer, ['test' => true]);
 
         $this->assertFalse($this->observer->supports($channel));

--- a/src/Sylius/Bundle/CoreBundle/tests/PriceHistory/EntityObserver/ProcessLowestPricesOnChannelPriceHistoryConfigChangeObserverTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/PriceHistory/EntityObserver/ProcessLowestPricesOnChannelPriceHistoryConfigChangeObserverTest.php
@@ -75,7 +75,6 @@ final class ProcessLowestPricesOnChannelPriceHistoryConfigChangeObserverTest ext
 
         $reflection = new \ReflectionObject($this->observer);
         $property = $reflection->getProperty('configsCurrentlyProcessed');
-        $property->setAccessible(true);
         $property->setValue($this->observer, [1 => true]);
 
         $this->assertFalse($this->observer->supports($config));
@@ -100,6 +99,7 @@ final class ProcessLowestPricesOnChannelPriceHistoryConfigChangeObserverTest ext
     public function testDoesNothingWhenNoChannelFoundForConfig(): void
     {
         $config = $this->createMock(ChannelPriceHistoryConfigInterface::class);
+        $config->method('getId')->willReturn(1);
 
         $this->channelRepository
             ->expects($this->once())
@@ -119,6 +119,7 @@ final class ProcessLowestPricesOnChannelPriceHistoryConfigChangeObserverTest ext
     public function testDelegatesProcessingToCommandDispatcher(): void
     {
         $config = $this->createMock(ChannelPriceHistoryConfigInterface::class);
+        $config->method('getId')->willReturn(1);
         $channel = $this->createMock(ChannelInterface::class);
 
         $this->channelRepository

--- a/src/Sylius/Bundle/ShopBundle/tests/Theme/ChannelBasedThemeContextTest.php
+++ b/src/Sylius/Bundle/ShopBundle/tests/Theme/ChannelBasedThemeContextTest.php
@@ -80,7 +80,6 @@ final class ChannelBasedThemeContextTest extends TestCase
 
         $reflection = new \ReflectionObject($this->channelBasedThemeContext);
         $property = $reflection->getProperty('theme');
-        $property->setAccessible(true);
         $property->setValue($this->channelBasedThemeContext, $theme);
 
         $this->channelContext->expects($this->never())->method('getChannel');
@@ -93,7 +92,6 @@ final class ChannelBasedThemeContextTest extends TestCase
     {
         $reflection = new \ReflectionObject($this->channelBasedThemeContext);
         $property = $reflection->getProperty('theme');
-        $property->setAccessible(true);
         $property->setValue($this->channelBasedThemeContext, null);
 
         $this->channelContext->expects($this->never())->method('getChannel');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Removes deprecated `ReflectionProperty::setAccessible()` calls and updates PHPUnit configuration schema. In PHP 8.5, `setAccessible()` is deprecated as reflection automatically has access to private members since PHP 8.1.

Changes:
- Remove `setAccessible(true)` from production code and tests
- Update `StateMachine/phpunit.xml.dist` to PHPUnit 11 schema
- Fix test mock missing `getId()` return value