### PR TITLE
[Behat] Show debug errors only when scenario fails

### DIFF
--- a/src/Sylius/Behat/Context/Api/DebugContext.php
+++ b/src/Sylius/Behat/Context/Api/DebugContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Api;
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -47,21 +48,31 @@ final class DebugContext implements Context
     }
 
     /** @AfterScenario */
-    public function afterScenario(): void
+    public function afterScenario(AfterScenarioScope $scope): void
     {
-        if (!empty($this->errorStack)) {
-            $output = new ConsoleOutput();
-            $styleKey = new OutputFormatterStyle('cyan');
-            $styleValue = new OutputFormatterStyle('green');
-            $output->getFormatter()->setStyle('key', $styleKey);
-            $output->getFormatter()->setStyle('value', $styleValue);
-
-            $json = json_encode($this->errorStack, \JSON_PRETTY_PRINT);
-
-            $formattedJson = preg_replace('/"([^"]+)":/', '<key>"$1"</key>:', $json);
-            $formattedJson = preg_replace('/: "([^"]+)"/', ': <value>"$1"</value>', $formattedJson);
-
-            $output->writeln($formattedJson);
+        if (empty($this->errorStack)) {
+            return;
         }
+
+        if ($scope->getTestResult()->isPassed()) {
+            $this->errorStack = [];
+
+            return;
+        }
+
+        $output = new ConsoleOutput();
+        $styleKey = new OutputFormatterStyle('cyan');
+        $styleValue = new OutputFormatterStyle('green');
+        $output->getFormatter()->setStyle('key', $styleKey);
+        $output->getFormatter()->setStyle('value', $styleValue);
+
+        $json = json_encode($this->errorStack, \JSON_PRETTY_PRINT);
+
+        $formattedJson = preg_replace('/"([^"]+)":/', '<key>"$1"</key>:', $json);
+        $formattedJson = preg_replace('/: "([^"]+)"/', ': <value>"$1"</value>', $formattedJson);
+
+        $output->writeln($formattedJson);
+
+        $this->errorStack = [];
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

`DebugContext` now only outputs API response errors when a scenario actually fails, not on every passing test. Previously, error blocks like validation messages were printed to console even when tests passed successfully, creating noise in CI output.

Before: 
<img width="1320" height="638" alt="image" src="https://github.com/user-attachments/assets/d0f3943c-173f-4ae9-b73f-a663e09d30c4" />

After:
<img width="1323" height="629" alt="image" src="https://github.com/user-attachments/assets/49630ad0-83f0-4ff8-91a9-c785aeb7bd0e" />
