### PR TITLE
[CI] Allow triggering full CI via branch name prefix

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -1,6 +1,12 @@
 name: Continuous Integration 1.14 (Full)
 
 on:
+    pull_request:
+        branches:
+            - '1.14'
+    push:
+        branches:
+            - 'full-ci/**'
     schedule:
         -
             cron: "0 1 * * *" # Run every day at 1am
@@ -15,6 +21,7 @@ permissions:
 
 jobs:
     static-checks:
+        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["1.14"]

--- a/.github/workflows/ci__full_2_1.yaml
+++ b/.github/workflows/ci__full_2_1.yaml
@@ -1,6 +1,12 @@
 name: Continuous Integration 2.1 (Full)
 
 on:
+    pull_request:
+        branches:
+            - '2.1'
+    push:
+        branches:
+            - 'full-ci/**'
     schedule:
         -
             cron: "0 2 * * *" # Run every day at 2am
@@ -15,6 +21,7 @@ permissions:
 
 jobs:
     static-checks:
+        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["2.1"]

--- a/.github/workflows/ci__full_2_2.yaml
+++ b/.github/workflows/ci__full_2_2.yaml
@@ -1,6 +1,12 @@
 name: Continuous Integration 2.2 (Full)
 
 on:
+    pull_request:
+        branches:
+            - '2.2'
+    push:
+        branches:
+            - 'full-ci/**'
     schedule:
         -
             cron: "0 3 * * *" # Run every day at 3am
@@ -15,6 +21,7 @@ permissions:
 
 jobs:
     static-checks:
+        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["2.2"]

--- a/.github/workflows/ci__minimal.yaml
+++ b/.github/workflows/ci__minimal.yaml
@@ -10,6 +10,7 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+            - 'full-ci/**'
             - 'upmerge/**'
 
 concurrency:
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
     static-checks:
+        if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'full-ci/') }}
         name: Static checks
         uses: ./.github/workflows/ci_static-checks.yaml
         with:


### PR DESCRIPTION
Adds support for triggering full CI workflows by pushing to branches with the `full-ci/` prefix.

Changes:
- Full CI workflows (`ci__full_1_14.yaml`, `ci__full_2_1.yaml`, `ci__full_2_2.yaml`) now trigger on pushes to `full-ci/**` branches
- Jobs are conditionally executed only when triggered by a `full-ci/` branch or non-PR events
- Minimal CI workflow also triggers on `full-ci/**` branches to prevent redundant runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline triggers across multiple workflow configurations to expand when automated checks run.
  * Modified static checks to selectively run based on branch patterns and event types, optimizing CI/CD efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->