### PR TITLE
Remove 2.0 branch references from CI workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@
 | License         | MIT
 
 <!--
- - Bug fixes must be submitted against the 1.14 or 2.0 branch
- - Features and deprecations must be submitted against the 2.1 branch
+ - Bug fixes must be submitted against the 1.14 or 2.1 branch
+ - Features and deprecations must be submitted against the 2.2 branch
  - Make sure that the correct base branch is set
 
  To be sure you are not breaking any Backward Compatibilities, check the documentation:

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -70,8 +70,6 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    elif [ "$BRANCH" == "2.0" ]; then
-                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -69,8 +69,6 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    elif [ "$BRANCH" == "2.0" ]; then
-                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
@@ -172,8 +170,6 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    elif [ "$BRANCH" == "2.0" ]; then
-                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi
@@ -264,8 +260,6 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    elif [ "$BRANCH" == "2.0" ]; then
-                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -69,8 +69,6 @@ jobs:
                 run: |
                     if [ "$BRANCH" == "1.14" ]; then
                         echo "NODE_VERSION=20.x" >> $GITHUB_ENV
-                    elif [ "$BRANCH" == "2.0" ]; then
-                        echo "NODE_VERSION=22.x" >> $GITHUB_ENV
                     else
                         echo "NODE_VERSION=24.x" >> $GITHUB_ENV
                     fi

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -123,7 +123,7 @@ jobs:
                 run: vendor/bin/phpstan analyse
 
             -   name: Run PHPSpec
-                if: ${{ inputs.branch == '1.14' || inputs.branch == '2.0' }}
+                if: ${{ inputs.branch == '1.14' }}
                 run: vendor/bin/phpspec run --ansi --no-interaction -f dot
 
             -   name: Run ComposerRequireChecker

--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -28,10 +28,10 @@ jobs:
                         branch: "1.14"
                         php: "8.1"
                     -
-                        branch: "2.0"
+                        branch: "2.1"
                         php: "8.2"
                     -
-                        branch: "2.1"
+                        branch: "2.2"
                         php: "8.2"
 
         steps:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

With the `2.0` branch reaching end of support, this removes references to it from CI workflows and updates the PR template guidance accordingly.

- Remove Node.js version detection for `2.0` branch in e2e workflows
- Update PHPSpec condition to only run on `1.14`
- Update refactor workflow matrix to target `2.1` and `2.2` instead of `2.0` and `2.1`
- Update PR template to reflect new branch targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and release guidance in project templates to reflect current branch targeting strategies.
  * Simplified CI/CD workflow configurations by streamlining build environment handling across multiple test pipelines.
  * Updated test execution conditions to optimize continuous integration processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->