### PR TITLE
[Behat] Migrate shop `product` scenarios to chromedriver

### DIFF
--- a/features/shop/product/adding_product_reviews/adding_product_review_as_a_customer.feature
+++ b/features/shop/product/adding_product_reviews/adding_product_review_as_a_customer.feature
@@ -8,7 +8,7 @@ Feature: Adding product review as a customer
         Given the store operates on a single channel in "United States"
         And the store has a product "Necronomicon"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Adding product reviews as a logged in customer
         Given I am a logged in customer
         When I want to review product "Necronomicon"
@@ -18,7 +18,7 @@ Feature: Adding product review as a customer
         Then I should be notified that my review is waiting for the acceptation
         And the "Scary but astonishing" product review of "Necronomicon" product should not be visible for customers
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Adding product reviews as a logged in customer with remember me option
         Given I am a logged in customer by using remember me option
         When I want to review product "Necronomicon"

--- a/features/shop/product/adding_product_reviews/adding_product_review_as_a_guest.feature
+++ b/features/shop/product/adding_product_reviews/adding_product_review_as_a_guest.feature
@@ -8,7 +8,7 @@ Feature: Adding product review as a guest
         Given the store operates on a single channel in "United States"
         And the store has a product "Necronomicon"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Adding product reviews as a guest
         When I want to review product "Necronomicon"
         And I leave a comment "I'm never gonna read this terrible book again.", titled "Never again" as "castiel@heaven.com"

--- a/features/shop/product/adding_product_reviews/product_review_validation.feature
+++ b/features/shop/product/adding_product_reviews/product_review_validation.feature
@@ -8,7 +8,7 @@ Feature: Product review validation
         Given the store operates on a single channel in "United States"
         And the store has a product "Necronomicon"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review without specifying a rate
         When I want to review product "Necronomicon"
         And I leave a comment "This book made me sad, but plot was fine.", titled "Not good, not bad" as "bartholomew@heaven.com"
@@ -16,7 +16,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that I must check review rating
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review without specifying a title
         When I want to review product "Necronomicon"
         And I leave a comment "This book made me sad, but plot was fine." as "bartholomew@heaven.com"
@@ -24,7 +24,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that title is required
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review with too short title
         When I want to review product "Necronomicon"
         And I leave a comment "This book made me sad, but plot was fine.", titled "X" as "bartholomew@heaven.com"
@@ -32,7 +32,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that title must have at least 2 characters
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review with too long title
         When I want to review product "Necronomicon"
         And I leave a comment "This book made me sad, but plot was fine." as "bartholomew@heaven.com"
@@ -41,7 +41,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that title must have at most 255 characters
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review without specifying a comment
         When I want to review product "Necronomicon"
         And I leave a review titled "Not good, not bad" as "bartholomew@heaven.com"
@@ -49,7 +49,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that comment is required
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review without specifying an author email
         When I want to review product "Necronomicon"
         And I leave a comment "Not good, not bad", titled "Not good, not bad"
@@ -57,7 +57,7 @@ Feature: Product review validation
         And I try to add it
         Then I should be notified that I must enter my email
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Trying to add a product review with specifying already registered author email
         Given there is a customer account "sam@winchester.com" identified by "familybusiness"
         When I want to review product "Necronomicon"

--- a/features/shop/product/show/options/viewing_diagonal_variant_options.feature
+++ b/features/shop/product/show/options/viewing_diagonal_variant_options.feature
@@ -23,7 +23,7 @@ Feature: Viewing diagonal variants options
         Then I should be able to select the "Yellow" and "Blue" Color option values
         And I should be able to select the "Small" and "Large" Size option values
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Viewing an "Unavailable" message when selecting an unavailable combination
         When I view product "Extra Cool T-Shirt"
         And I select its color as "Blue"

--- a/features/shop/product/show/prices/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_option.feature
+++ b/features/shop/product/show/prices/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_option.feature
@@ -21,19 +21,19 @@ Feature: Seeing the corresponding lowest price before the discount when selectin
         And there is a catalog promotion "Summer sale" with priority 1 that reduces price by "50%" and applies on "Bocian Vodka variant 0" variant
 
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting first option value from the list
         When I view product "Wyborowa Vodka"
         And I select its "Taste" as "Exquisite"
         Then I should see "$20.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting another option value from the list
         When I view product "Wyborowa Vodka"
         And I select its "Taste" as "Lemon"
         Then I should see "$25.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting last option value from the list after selecting another option value from the list
         When I view product "Wyborowa Vodka"
         And I select its "Taste" as "Lemon"
@@ -41,14 +41,14 @@ Feature: Seeing the corresponding lowest price before the discount when selectin
         And I select its "Taste" as "Bitter"
         Then I should see "$35.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when having discounted variant with more than one option value
         When I view product "Bocian Vodka"
         And I select its "Color" as "Blue"
         And I select its "Size" as "Small"
         Then I should see "$10.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Not seeing the lowest price when having variant with more than one option value and without discount
         When I view product "Bocian Vodka"
         And I select its "Color" as "Blue"

--- a/features/shop/product/show/prices/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_variant.feature
+++ b/features/shop/product/show/prices/seeing_corresponding_lowest_price_before_discount_when_selecting_different_product_variant.feature
@@ -12,19 +12,19 @@ Feature: Seeing the corresponding lowest price before the discount when selectin
         And the product "Wyborowa Vodka" has "Wyborowa Vodka 30%" variant priced at "$60.00"
         And there is a catalog promotion "Winter sale" with priority 1 that reduces price by "50%" and applies on "Wyborowa Vodka" product
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting first variant from the list
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Vodka 40%" variant
         Then I should see "$40.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting another variant from the list
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Vodka 50%" variant
         Then I should see "$50.00" as its lowest price before the discount
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Seeing correct lowest price when selecting first variant from the list after selecting another variant
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Vodka 50%" variant

--- a/features/shop/product/show/prices/viewing_different_discounted_price_for_different_product_variants.feature
+++ b/features/shop/product/show/prices/viewing_different_discounted_price_for_different_product_variants.feature
@@ -19,14 +19,14 @@ Feature: Viewing different discounted price for different product variants
         Then the product price should be "$40.00"
         And I should not see any original price
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Viewing a detailed page with product's discount price for different variant
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Apple" variant
         Then the product variant price should be "$12.55"
         And the product original price should be "$20.00"
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Not seeing the discount when a variant's original price is lower than current price
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Pear" variant

--- a/features/shop/product/show/prices/viewing_different_price_for_different_product_variants.feature
+++ b/features/shop/product/show/prices/viewing_different_price_for_different_product_variants.feature
@@ -17,7 +17,7 @@ Feature: Viewing different price for different product variants
         When I view product "Wyborowa Vodka"
         Then the product price should be "$40.00"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Viewing a detailed page with product's price for different variant
         When I view product "Wyborowa Vodka"
         And I select "Wyborowa Apple" variant

--- a/features/shop/product/show/prices/viewing_different_price_for_different_product_variants_selected_with_options.feature
+++ b/features/shop/product/show/prices/viewing_different_price_for_different_product_variants_selected_with_options.feature
@@ -16,7 +16,7 @@ Feature: Viewing different price for different product variants selected with op
         When I view product "Wyborowa Vodka"
         Then I should see the product price "$20.00"
 
-    @no-api @ui @javascript
+    @no-api @ui @mink:chromedriver
     Scenario: Viewing a detailed page with product's price for different option
         When I view product "Wyborowa Vodka"
         And I select its volume as "0,7L"

--- a/features/shop/product/show/viewing_product_images.feature
+++ b/features/shop/product/show/viewing_product_images.feature
@@ -10,13 +10,13 @@ Feature: Viewing a product's images on a product details page
         And this product has an image "lamborghini.jpg" with "other" type at position 2
         And this product has an image "lamborghini.jpg" with "main" type at position 1
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Viewing a product's main image on a product details page
         When I view product "Lamborghini Gallardo Model"
         Then I should see the product name "Lamborghini Gallardo Model"
         And I should be able to see a main image of type "main"
 
-    @api @ui @javascript
+    @api @ui @mink:chromedriver
     Scenario: Viewing a products images in correct order
         When I view product "Lamborghini Gallardo Model"
         Then I should see the product name "Lamborghini Gallardo Model"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Replaces deprecated `@javascript` Behat tag with the more explicit `@mink:chromedriver` tag in shop product feature files. This standardizes the driver configuration for browser-based tests.

Affects:
- Product review features (adding reviews as customer/guest, validation)
- Product variant price display features
- Product image viewing feature
- Diagonal variant options feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated test execution metadata to use the Mink Chromedriver for product reviews, images, pricing, variant and option scenarios.
  * No functional or UI behavior changes — only test runner/driver annotations were adjusted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->