### PR TITLE
[Admin][Taxon] Add visual distinction for disabled taxon

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Doctrine/Query/Taxon/AllTaxons.php
+++ b/src/Sylius/Bundle/AdminBundle/Doctrine/Query/Taxon/AllTaxons.php
@@ -51,6 +51,7 @@ final class AllTaxons implements AllTaxonsInterface
                 'taxon.tree_right as tree_right',
                 'taxon.tree_level as tree_level',
                 'taxon.position as position',
+                'taxon.enabled as enabled',
                 'COALESCE(current_translation.name, fallback_translation.name) as name',
             ])
             ->from('sylius_taxon', 'taxon')

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/TaxonTreeController.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/TaxonTreeController.js
@@ -38,7 +38,7 @@ export default class extends Controller {
     }
 
     rowRenderer(node) {
-        const { id, name, children, state } = node;
+        const { id, name, children, state, enabled } = node;
         const { depth, open, path, total } = state;
         const more = node.hasChildren();
         const nodeMargin = 20;
@@ -57,6 +57,10 @@ export default class extends Controller {
         itemPrototyp.setAttribute('data-path', path);
         itemPrototyp.setAttribute('data-children', children.length);
         itemPrototyp.setAttribute('data-total', total);
+
+        if (!enabled) {
+            itemPrototyp.classList.add('taxon-disabled');
+        }
 
         togglerPrototyp.style.width = `${nodeMargin}px`;
         if (more) {

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_infinite-tree.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_infinite-tree.scss
@@ -32,6 +32,12 @@
             border: none;
         }
 
+        &.taxon-disabled {
+            .infinite-tree-title {
+                color: $text-secondary;
+            }
+        }
+
         .infinite-tree-node {
             display: flex;
             flex: 1;

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/TreeComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/TreeComponent.php
@@ -79,6 +79,7 @@ class TreeComponent
             $treeChild = [
                 'id' => $taxon['id'],
                 'name' => $taxon['name'],
+                'enabled' => (bool) $taxon['enabled'],
                 'children' => $children[$taxon['id']] ?? [],
             ];
 


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

This PR adds visual indication for disabled taxons in the admin panel taxonomy tree.
<img width="800" height="381" alt="image" src="https://github.com/user-attachments/assets/9cd5a3d1-e642-49fc-9d41-ff17859685c4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Disabled taxons are now visually distinguished in the admin taxonomy tree interface. Items marked as disabled display with distinct styling, making it easier to identify inactive taxonomy items when managing your structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->