### PR TITLE
[Admin] Fix StatisticsComponent to use ClockInterface for date calculations

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,3 +1,9 @@
+# UPGRADE FROM `2.1.8` TO `2.1.9`
+
+1. The `Sylius\Bundle\AdminBundle\Twig\Component\Dashboard\StatisticsComponent` constructor now requires
+   a `Symfony\Component\Clock\ClockInterface` as the third argument. Not passing it is deprecated
+   and will be prohibited in Sylius 3.0.
+
 # UPGRADE FROM `2.1.7` TO `2.1.8`
 
 ## State Machine

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -1043,6 +1043,8 @@ final readonly class OrderContext implements Context
 
             $this->payOrder($order);
 
+            $order->setCheckoutCompletedAt($this->clock->now());
+
             $this->objectManager->persist($order);
             $this->sharedStorage->set('order', $order);
         }
@@ -1077,6 +1079,8 @@ final readonly class OrderContext implements Context
                 $this->shipOrder($order);
             }
 
+            $order->setCheckoutCompletedAt($this->clock->now());
+
             $this->objectManager->persist($order);
         }
 
@@ -1104,6 +1108,7 @@ final readonly class OrderContext implements Context
             );
 
             $order->setState($isFulfilled ? BaseOrderInterface::STATE_FULFILLED : BaseOrderInterface::STATE_NEW);
+            $order->setCheckoutCompletedAt($this->clock->now());
 
             $this->objectManager->persist($order);
         }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/dashboard.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/twig/component/dashboard.xml
@@ -56,6 +56,7 @@
         >
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.provider.statistics" />
+            <argument type="service" id="clock" />
 
             <tag name="sylius.live_component.admin" key="sylius_admin:dashboard:statistics" />
         </service>

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/StatisticsComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Dashboard/StatisticsComponent.php
@@ -18,6 +18,7 @@ use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Statistics\Provider\StatisticsProviderInterface;
 use Sylius\TwigHooks\LiveComponent\HookableLiveComponentTrait;
+use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Intl\Currencies;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
@@ -57,7 +58,15 @@ class StatisticsComponent
     public function __construct(
         protected readonly ChannelRepositoryInterface $channelRepository,
         protected readonly StatisticsProviderInterface $statisticsProvider,
+        protected readonly ?ClockInterface $clock = null,
     ) {
+        if ($this->clock === null) {
+            trigger_deprecation(
+                'sylius/admin-bundle',
+                '2.1.9',
+                'Not passing $clock through constructor is deprecated and will be prohibited in Sylius 3.0.',
+            );
+        }
     }
 
     /**
@@ -73,7 +82,7 @@ class StatisticsComponent
 
         $statistics = $this->statisticsProvider->provide(
             $this->interval,
-            new \DatePeriod(new \DateTime($this->startDate), $this->resolveInterval(), new \DateTime($this->endDate)),
+            new \DatePeriod($this->createDateTime($this->startDate), $this->resolveInterval(), $this->createDateTime($this->endDate)),
             $channel,
         );
 
@@ -121,15 +130,15 @@ class StatisticsComponent
     #[LiveAction]
     public function getPreviousPeriod(): void
     {
-        $this->startDate = (new \DateTime($this->startDate))->sub(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
-        $this->endDate = (new \DateTime($this->endDate))->sub(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
+        $this->startDate = $this->createDateTime($this->startDate)->sub(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
+        $this->endDate = $this->createDateTime($this->endDate)->sub(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
     }
 
     #[LiveAction]
     public function getNextPeriod(): void
     {
-        $this->startDate = (new \DateTime($this->startDate))->add(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
-        $this->endDate = (new \DateTime($this->endDate))->add(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
+        $this->startDate = $this->createDateTime($this->startDate)->add(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
+        $this->endDate = $this->createDateTime($this->endDate)->add(new \DateInterval($this->resolveChangePeriodInterval()))->format('Y-m-d');
     }
 
     private function resolveInterval(): \DateInterval
@@ -147,16 +156,16 @@ class StatisticsComponent
     {
         [$startDate, $endDate] = match ($this->period) {
             'year' => [
-                (new \DateTime('first day of next month last year'))->format('Y-m-d'),
-                (new \DateTime('first day of next month this year'))->format('Y-m-d'),
+                $this->createDateTime('first day of next month last year')->format('Y-m-d'),
+                $this->createDateTime('first day of next month this year')->format('Y-m-d'),
             ],
             'month' => [
-                (new \DateTime('+1 day -1 month'))->format('Y-m-d'),
-                (new \DateTime('+1 day'))->format('Y-m-d'),
+                $this->createDateTime('+1 day -1 month')->format('Y-m-d'),
+                $this->createDateTime('+1 day')->format('Y-m-d'),
             ],
             '2 weeks' => [
-                (new \DateTime('+1 day -2 weeks'))->format('Y-m-d'),
-                (new \DateTime('+1 day'))->format('Y-m-d'),
+                $this->createDateTime('+1 day -2 weeks')->format('Y-m-d'),
+                $this->createDateTime('+1 day')->format('Y-m-d'),
             ],
             default => throw new \InvalidArgumentException(sprintf('Period "%s" is not supported.', $this->period)),
         };
@@ -173,5 +182,14 @@ class StatisticsComponent
             '2 weeks' => 'P2W',
             default => throw new \InvalidArgumentException(sprintf('Period "%s" is not supported.', $this->period)),
         };
+    }
+
+    private function createDateTime(string $datetime): \DateTime
+    {
+        if ($this->clock === null) {
+            return new \DateTime($datetime);
+        }
+
+        return \DateTime::createFromImmutable($this->clock->now()->modify($datetime));
     }
 }


### PR DESCRIPTION
StatisticsComponent was using native `DateTime` for calculating date ranges, ignoring the mocked clock in Behat tests. This caused the `statistics.feature:16` scenario to fail depending on the actual system date.

Changes:
- Add `ClockInterface` dependency to `StatisticsComponent` (nullable for BC, with deprecation)
- Update `OrderContext` methods to set `checkoutCompletedAt` using mocked clock
- Add upgrade note for the new constructor argument

Fixes:
<img width="1173" height="75" alt="image" src="https://github.com/user-attachments/assets/b3a57e24-b0e9-4bdd-a834-596d06f94798" />

The test started failing on December 1st because the `StatisticsComponent` doesn't have the clock service injected, so it uses real DateTime instead of the mocked clock from tests.

In December, first day of next month resolves to January, so:
- startDate = January 1, 2024
- endDate = January 1, 2025

This excludes the test data from January 1, 2025 and February 1, 2025, showing only 2 customers instead of 5.



```gherkin
    @no-api @ui
    Scenario: Seeing statistics for last 12 months and default channel when expectations are not specified
        Given it is "last day of January last year" now
        And 2 new customers have fulfilled 2 orders placed for total of "$1,000.00"
        And it is "first day of January this year" now
        And 3 new customers have fulfilled 4 orders placed for total of "$2,000.21"
        And it is "first day of February this year" now
        And 2 more new customers have paid 2 orders placed for total of "$5,000.37"
        When I view statistics
        Then I should see 5 new customers
        And I should see 6 paid orders
        And there should be total sales of "$7,000.58"
        And the average order value should be "$1,166.76"
```
