### PR TITLE
[CI][Robo] Fix packages workflow for PHP 8.4

### DIFF
--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -64,11 +64,9 @@ jobs:
                     restore-keys: |
                         "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-"
 
-            -   name: Install Robo
-                run: |
-                    wget https://github.com/consolidation/Robo/releases/latest/download/robo.phar
-                    chmod +x robo.phar && sudo mv robo.phar /tmp/robo
+            -   name: Install dependencies
+                run: composer install --no-interaction --no-scripts
 
             -   name: "Run pipeline"
                 continue-on-error: ${{ inputs.ignore-failure }}
-                run: find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c . | xargs -0 /tmp/robo ci:packages
+                run: find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq  --raw-input . | jq --slurp . | jq -c . | xargs -0 vendor/bin/robo ci:packages

--- a/.github/workflows/ci_packages.yaml
+++ b/.github/workflows/ci_packages.yaml
@@ -92,12 +92,10 @@ jobs:
                     restore-keys: |
                         "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}-"
 
-            -   name: Install Robo
-                run: |
-                    wget https://github.com/consolidation/Robo/releases/latest/download/robo.phar
-                    chmod +x robo.phar && sudo mv robo.phar /tmp/robo
+            -   name: Install dependencies
+                run: composer install --no-interaction --no-scripts
 
             -   name: "Run pipeline"
                 run: |
                     PACKAGES=$(find src/Sylius -mindepth 3 -maxdepth 3 -type f -name composer.json -exec dirname '{}' \; | sed -e 's/src\/Sylius\///g' | sort | jq --raw-input . | jq --slurp . | jq -c .)
-                    /tmp/robo ci:packages "$PACKAGES"
+                    vendor/bin/robo ci:packages "$PACKAGES"

--- a/src/Sylius/Bundle/ApiBundle/tests/Application/config/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/tests/Application/config/config.yaml
@@ -13,9 +13,6 @@ parameters:
     sylius_core.public_dir: '%kernel.project_dir%/public'
 
 api_platform:
-    enable_swagger_ui: false
-    enable_re_doc: false
-    enable_swagger: false
     enable_entrypoint: false
     enable_docs: false
     mapping:


### PR DESCRIPTION
Fixes two issues breaking the packages CI workflow on PHP 8.4/8.5:

- **Robo**: The `robo.phar` from GitHub releases (v4.0.4) uses implicit nullable parameters causing deprecation errors. Switch to `vendor/bin/robo` from project dependencies (v5.1.1) via `composer install`.

Ref: https://github.com/Sylius/Sylius/actions/runs/19828133347/job/56807101604

<img width="1678" height="859" alt="image" src="https://github.com/user-attachments/assets/5ece7bae-c70c-44d3-adf5-4c3ad6f92cd6" />

- **API Platform**: Remove deprecated `enable_swagger_ui`, `enable_re_doc`, `enable_swagger` options from ApiBundle test app config (no longer exist in API Platform 4.x).

Ref:

<img width="1683" height="933" alt="image" src="https://github.com/user-attachments/assets/52cf70fa-e053-4129-8f4e-6d7b2f70c740" />
