### PR TITLE
[Behat] Temporarily disable hanging cart inventory UI test

### DIFF
--- a/features/shop/inventory/cart_inventory/e2e/verify_inventory_quantity_when_updating_cart_summary.feature
+++ b/features/shop/inventory/cart_inventory/e2e/verify_inventory_quantity_when_updating_cart_summary.feature
@@ -14,7 +14,7 @@ Feature: Verifying inventory quantity on cart summary
         And there are 10 units of product "Black Dress" available in the inventory
         And I am a logged in customer
 
-    @api @ui @mink:chromedriver
+    @api #@ui @mink:chromedriver TODO: Fix hanging CI issue with stock validation on cart update
     Scenario: Being unable to save a cart with product that is out of stock
         Given I added 3 products "Iron Maiden T-Shirt" to the cart
         When I change product "Iron Maiden T-Shirt" quantity to 6 in my cart


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Disables the UI portion of the cart inventory test that causes CI to hang during stock validation on cart update. The API test remains active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration tags and added notes for ongoing CI maintenance related to inventory validation processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->