### PR TITLE
[Admin] Fix shipping address form hooks priorities

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -4,6 +4,20 @@
    a `Symfony\Component\Clock\ClockInterface` as the third argument. Not passing it is deprecated
    and will be prohibited in Sylius 3.0.
 
+1. The priorities of hookables in `sylius_admin.order.update.content.form.shipping_address` hook have been adjusted
+   to match `sylius_admin.order.update.content.form.billing_address` and fix duplicate priority values.
+   If you have customized these hooks or added custom hookables with priorities between the old values,
+   please review your priority configuration:
+
+   | Hookable       | Old Priority | New Priority |
+   |----------------|--------------|--------------|
+   | company        | 700          | 800          |
+   | first_name     | 600          | 700          |
+   | last_name      | 500          | 600          |
+   | country        | 400          | 500          |
+   | phone_number   | 300          | 400          |
+   | street_address | 200          | 300          |
+
 # UPGRADE FROM `2.1.7` TO `2.1.8`
 
 ## State Machine

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/order/update.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/twig_hooks/order/update.yaml
@@ -61,22 +61,22 @@ sylius_twig_hooks:
         'sylius_admin.order.update.content.form.shipping_address':
             company:
                 template: '@SyliusAdmin/order/form/common/company.html.twig'
-                priority: 700
+                priority: 800
             first_name:
                 template: '@SyliusAdmin/order/form/common/first_name.html.twig'
-                priority: 600
+                priority: 700
             last_name:
                 template: '@SyliusAdmin/order/form/common/last_name.html.twig'
-                priority: 500
+                priority: 600
             country:
                 template: '@SyliusAdmin/order/form/common/country.html.twig'
-                priority: 400
+                priority: 500
             phone_number:
                 template: '@SyliusAdmin/order/form/common/phone_number.html.twig'
-                priority: 300
+                priority: 400
             street_address:
                 template: '@SyliusAdmin/order/form/common/street_address.html.twig'
-                priority: 200
+                priority: 300
             city:
                 template: '@SyliusAdmin/order/form/common/city.html.twig'
                 priority: 200


### PR DESCRIPTION
Fixes duplicate priority values in `sylius_admin.order.update.content.form.shipping_address` hook - `street_address` and `city` both had priority 200. Adjusted all priorities to match `billing_address` hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guide detailing shipping address hook priority changes and migration guidance for users with custom configurations.

* **Chores**
  * Adjusted shipping address field priorities in the admin order update form to align with billing address structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->