### PR TITLE
[Docs] Bust GitHub camo cache for README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
     <a href="https://sylius.com/github-readme/link/" target="_blank">
-        <img src="https://sylius.com/assets/github-readme.png?3" />
+        <img src="https://sylius.com/assets/github-readme.png?4" />
     </a>
 </h1>
 


### PR DESCRIPTION
Bump cache buster query param to force GitHub camo to refetch the updated README image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README image asset reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->