### PR TITLE
Remove additional spacings in admin sidebar menu

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_navbar.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/styles/_navbar.scss
@@ -24,7 +24,6 @@
 .navbar-collapse a.nav-link,
 .navbar-collapse a.dropdown-item {
     transition: all .1s;
-    min-height: 44px;
 
     &:hover {
         color: var(--tblr-primary) !important;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Before:
<img width="1860" height="1233" alt="image" src="https://github.com/user-attachments/assets/42100cb3-c6f5-4779-bbba-394ab818ba94" />

After:
<img width="1860" height="1233" alt="image" src="https://github.com/user-attachments/assets/932f141c-51a9-4ab5-8871-a15f339999a9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical spacing and sizing of navigation menu items in the navbar for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->