### PR TITLE
[API] Add error codes to all constraint validators

### DIFF
--- a/UPGRADE-API-2.3.md
+++ b/UPGRADE-API-2.3.md
@@ -16,6 +16,27 @@ Request body:
 
 Returns `202 Accepted` on success (regardless of whether the email was sent).
 
+## Validation
+
+1. Violations raised by the API constraint validators now expose a `code`, which was previously always `null`:
+
+   ```diff
+    {
+        "violations": [
+            {
+                "propertyPath": "",
+                "message": "An empty order cannot be processed.",
+   -            "code": null
+   +            "code": "ORDER_EMPTY"
+            }
+        ]
+    }
+   ```
+
+   The codes are defined as constants on the constraint classes in
+   `Sylius\Bundle\ApiBundle\Validator\Constraints`, e.g. `OrderNotEmpty::ORDER_EMPTY_ERROR`.
+   If your tests compare full validation error payloads, update the expected responses accordingly.
+
 ## Admin API
 
 1. The `Administrator` resource exposes two new boolean properties, `administrationAccess` and `apiAccess`, which

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -19,6 +19,10 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AddingEligibleProductVariantToCart extends Constraint
 {
+    public const PRODUCT_NOT_EXIST_ERROR = 'PRODUCT_NOT_FOUND';
+    public const PRODUCT_VARIANT_NOT_EXIST_ERROR = 'PRODUCT_VARIANT_NOT_FOUND';
+    public const PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR = 'INSUFFICIENT_STOCK';
+
     /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotSufficient = 'sylius.product_variant.not_sufficient';
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCart.php
@@ -20,7 +20,9 @@ use Symfony\Component\Validator\Constraint;
 final class AddingEligibleProductVariantToCart extends Constraint
 {
     public const PRODUCT_NOT_EXIST_ERROR = 'PRODUCT_NOT_FOUND';
+
     public const PRODUCT_VARIANT_NOT_EXIST_ERROR = 'PRODUCT_VARIANT_NOT_FOUND';
+
     public const PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR = 'INSUFFICIENT_STOCK';
 
     /** @deprecated since Sylius 2.3, use $productVariantNotSufficientMessage instead. It will be removed in Sylius 3.0. */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
@@ -74,7 +74,7 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         if (!$product->isEnabled()) {
             $this->context
                 ->buildViolation($constraint->productNotExistMessage)
-                ->setParameter('%productName%', $product->getName())
+                ->setParameter('%productName%', (string) $product->getName())
                 ->setCode(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)
                 ->addViolation()
             ;
@@ -85,7 +85,7 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         if (!$productVariant->isEnabled()) {
             $this->context
                 ->buildViolation($constraint->productVariantNotExistMessage)
-                ->setParameter('%productVariantCode%', $productVariant->getCode())
+                ->setParameter('%productVariantCode%', (string) $productVariant->getCode())
                 ->setCode(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_EXIST_ERROR)
                 ->addViolation()
             ;
@@ -113,7 +113,7 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         if (!$product->hasChannel($channel)) {
             $this->context
                 ->buildViolation($constraint->productNotExistMessage)
-                ->setParameter('%productName%', $product->getName())
+                ->setParameter('%productName%', (string) $product->getName())
                 ->setCode(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)
                 ->addViolation()
             ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AddingEligibleProductVariantToCartValidator.php
@@ -59,10 +59,12 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         $productVariant = $this->productVariantRepository->findOneBy(['code' => $value->productVariantCode]);
 
         if ($productVariant === null) {
-            $this->context->addViolation(
-                $constraint->productVariantNotExistMessage,
-                ['%productVariantCode%' => $value->productVariantCode],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotExistMessage)
+                ->setParameter('%productVariantCode%', $value->productVariantCode)
+                ->setCode(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -70,19 +72,23 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         /** @var ProductInterface $product */
         $product = $productVariant->getProduct();
         if (!$product->isEnabled()) {
-            $this->context->addViolation(
-                $constraint->productNotExistMessage,
-                ['%productName%' => $product->getName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productNotExistMessage)
+                ->setParameter('%productName%', $product->getName())
+                ->setCode(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
 
         if (!$productVariant->isEnabled()) {
-            $this->context->addViolation(
-                $constraint->productVariantNotExistMessage,
-                ['%productVariantCode%' => $productVariant->getCode()],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotExistMessage)
+                ->setParameter('%productVariantCode%', $productVariant->getCode())
+                ->setCode(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -91,10 +97,12 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
             $productVariant,
             $value->quantity + $this->getExistingCartItemQuantityFromCart($cart, $productVariant),
         )) {
-            $this->context->addViolation(
-                $constraint->productVariantNotSufficientMessage,
-                ['%productVariantCode%' => $productVariant->getCode()],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotSufficientMessage)
+                ->setParameter('%productVariantCode%', (string) $productVariant->getCode())
+                ->setCode(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -103,10 +111,12 @@ final class AddingEligibleProductVariantToCartValidator extends ConstraintValida
         Assert::notNull($channel);
 
         if (!$product->hasChannel($channel)) {
-            $this->context->addViolation(
-                $constraint->productNotExistMessage,
-                ['%productName%' => $product->getName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productNotExistMessage)
+                ->setParameter('%productName%', $product->getName())
+                ->setCode(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
         }
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpired.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class AdminResetPasswordTokenNonExpired extends Constraint
 {
+    public const TOKEN_EXPIRED_ERROR = 'PASSWORD_RESET_TOKEN_EXPIRED';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpiredValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/AdminResetPasswordTokenNonExpiredValidator.php
@@ -44,7 +44,11 @@ final class AdminResetPasswordTokenNonExpiredValidator extends ConstraintValidat
         $lifetime = new \DateInterval($this->tokenTtl);
 
         if (!$user->isPasswordRequestNonExpired($lifetime)) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(AdminResetPasswordTokenNonExpired::TOKEN_EXPIRED_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChanged.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChanged.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CanPaymentMethodBeChanged extends Constraint
 {
+    public const ORDER_CANCELLED_ERROR = 'ORDER_CANCELLED';
+
     public const CANNOT_CHANGE_PAYMENT_METHOD_FOR_CANCELLED_ORDER = 'sylius.payment_method.cannot_change_payment_method_for_cancelled_order';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChangedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CanPaymentMethodBeChangedValidator.php
@@ -38,7 +38,11 @@ final class CanPaymentMethodBeChangedValidator extends ConstraintValidator
         Assert::notNull($order);
 
         if ($order->getState() === OrderInterface::STATE_CANCELLED) {
-            $this->context->addViolation($constraint::CANNOT_CHANGE_PAYMENT_METHOD_FOR_CANCELLED_ORDER);
+            $this->context
+                ->buildViolation($constraint::CANNOT_CHANGE_PAYMENT_METHOD_FOR_CANCELLED_ORDER)
+                ->setCode(CanPaymentMethodBeChanged::ORDER_CANCELLED_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -20,7 +20,9 @@ use Symfony\Component\Validator\Constraint;
 final class ChangedItemQuantityInCart extends Constraint
 {
     public const PRODUCT_NOT_EXIST_ERROR = 'PRODUCT_NOT_FOUND';
+
     public const PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR = 'PRODUCT_VARIANT_NOT_AVAILABLE';
+
     public const PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR = 'INSUFFICIENT_STOCK';
 
     /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCart.php
@@ -19,6 +19,10 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChangedItemQuantityInCart extends Constraint
 {
+    public const PRODUCT_NOT_EXIST_ERROR = 'PRODUCT_NOT_FOUND';
+    public const PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR = 'PRODUCT_VARIANT_NOT_AVAILABLE';
+    public const PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR = 'INSUFFICIENT_STOCK';
+
     /** @deprecated since Sylius 2.3, use $productVariantNotLongerAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $productVariantNotLongerAvailable = 'sylius.product_variant.not_longer_available';
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
@@ -75,7 +75,7 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
         if (!$product->isEnabled()) {
             $this->context
                 ->buildViolation($constraint->productNotExistMessage)
-                ->setParameter('%productName%', $product->getName())
+                ->setParameter('%productName%', (string) $product->getName())
                 ->setCode(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)
                 ->addViolation()
             ;
@@ -114,7 +114,7 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
         if (!$product->hasChannel($channel)) {
             $this->context
                 ->buildViolation($constraint->productNotExistMessage)
-                ->setParameter('%productName%', $product->getName())
+                ->setParameter('%productName%', (string) $product->getName())
                 ->setCode(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)
                 ->addViolation()
             ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChangedItemQuantityInCartValidator.php
@@ -58,10 +58,12 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
         $productVariant = $orderItem->getVariant();
 
         if ($productVariant === null) {
-            $this->context->addViolation(
-                $constraint->productVariantNotLongerAvailableMessage,
-                ['%productVariantName%' => $orderItem->getVariantName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotLongerAvailableMessage)
+                ->setParameter('%productVariantName%', (string) $orderItem->getVariantName())
+                ->setCode(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -71,28 +73,34 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
         /** @var ProductInterface $product */
         $product = $productVariant->getProduct();
         if (!$product->isEnabled()) {
-            $this->context->addViolation(
-                $constraint->productNotExistMessage,
-                ['%productName%' => $product->getName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productNotExistMessage)
+                ->setParameter('%productName%', $product->getName())
+                ->setCode(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
 
         if (!$productVariant->isEnabled()) {
-            $this->context->addViolation(
-                $constraint->productVariantNotLongerAvailableMessage,
-                ['%productVariantName%' => $orderItem->getVariantName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotLongerAvailableMessage)
+                ->setParameter('%productVariantName%', (string) $orderItem->getVariantName())
+                ->setCode(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
 
         if (!$this->availabilityChecker->isStockSufficient($productVariant, $value->quantity)) {
-            $this->context->addViolation(
-                $constraint->productVariantNotSufficientMessage,
-                ['%productVariantCode%' => $productVariantCode],
-            );
+            $this->context
+                ->buildViolation($constraint->productVariantNotSufficientMessage)
+                ->setParameter('%productVariantCode%', (string) $productVariantCode)
+                ->setCode(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -104,10 +112,12 @@ final class ChangedItemQuantityInCartValidator extends ConstraintValidator
         Assert::notNull($channel);
 
         if (!$product->hasChannel($channel)) {
-            $this->context->addViolation(
-                $constraint->productNotExistMessage,
-                ['%productName%' => $product->getName()],
-            );
+            $this->context
+                ->buildViolation($constraint->productNotExistMessage)
+                ->setParameter('%productName%', $product->getName())
+                ->setCode(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletion.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 class CheckoutCompletion extends Constraint
 {
+    public const INVALID_STATE_TRANSITION_ERROR = 'INVALID_STATE_TRANSITION';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletionValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletionValidator.php
@@ -50,7 +50,7 @@ class CheckoutCompletionValidator extends ConstraintValidator
 
         $this->context
             ->buildViolation($constraint->message)
-            ->setParameter('%currentState%', $order->getCheckoutState())
+            ->setParameter('%currentState%', (string) $order->getCheckoutState())
             ->setParameter('%possibleTransitions%', implode(
                 ', ',
                 array_map(

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletionValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CheckoutCompletionValidator.php
@@ -48,15 +48,18 @@ class CheckoutCompletionValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolation($constraint->message, [
-            '%currentState%' => $order->getCheckoutState(),
-            '%possibleTransitions%' => implode(
+        $this->context
+            ->buildViolation($constraint->message)
+            ->setParameter('%currentState%', $order->getCheckoutState())
+            ->setParameter('%possibleTransitions%', implode(
                 ', ',
                 array_map(
                     fn (TransitionInterface $transition) => $transition->getName(),
                     $this->stateMachine->getEnabledTransitions($order, OrderCheckoutTransitions::GRAPH),
                 ),
-            ),
-        ]);
+            ))
+            ->setCode(CheckoutCompletion::INVALID_STATE_TRANSITION_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -19,6 +19,10 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentMethodEligibility extends Constraint
 {
+    public const PAYMENT_METHOD_NOT_AVAILABLE_ERROR = 'PAYMENT_METHOD_NOT_AVAILABLE';
+    public const PAYMENT_METHOD_NOT_EXIST_ERROR = 'PAYMENT_METHOD_NOT_FOUND';
+    public const PAYMENT_NOT_FOUND_ERROR = 'PAYMENT_NOT_FOUND';
+
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_method.not_available';
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibility.php
@@ -20,7 +20,9 @@ use Symfony\Component\Validator\Constraint;
 final class ChosenPaymentMethodEligibility extends Constraint
 {
     public const PAYMENT_METHOD_NOT_AVAILABLE_ERROR = 'PAYMENT_METHOD_NOT_AVAILABLE';
+
     public const PAYMENT_METHOD_NOT_EXIST_ERROR = 'PAYMENT_METHOD_NOT_FOUND';
+
     public const PAYMENT_NOT_FOUND_ERROR = 'PAYMENT_NOT_FOUND';
 
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentMethodEligibilityValidator.php
@@ -48,7 +48,12 @@ final class ChosenPaymentMethodEligibilityValidator extends ConstraintValidator
         $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $value->paymentMethodCode]);
 
         if ($paymentMethod === null) {
-            $this->context->addViolation($constraint->notExistMessage, ['%code%' => $value->paymentMethodCode]);
+            $this->context
+                ->buildViolation($constraint->notExistMessage)
+                ->setParameter('%code%', (string) $value->paymentMethodCode)
+                ->setCode(ChosenPaymentMethodEligibility::PAYMENT_METHOD_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -57,13 +62,22 @@ final class ChosenPaymentMethodEligibilityValidator extends ConstraintValidator
         $payment = $this->paymentRepository->find($value->paymentId);
 
         if (null === $payment) {
-            $this->context->addViolation($constraint->paymentNotFoundMessage);
+            $this->context
+                ->buildViolation($constraint->paymentNotFoundMessage)
+                ->setCode(ChosenPaymentMethodEligibility::PAYMENT_NOT_FOUND_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
 
         if (!in_array($paymentMethod, $this->paymentMethodsResolver->getSupportedMethods($payment), true)) {
-            $this->context->addViolation($constraint->notAvailableMessage, ['%name%' => $paymentMethod->getName()]);
+            $this->context
+                ->buildViolation($constraint->notAvailableMessage)
+                ->setParameter('%name%', (string) $paymentMethod->getName())
+                ->setCode(ChosenPaymentMethodEligibility::PAYMENT_METHOD_NOT_AVAILABLE_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraint;
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
     public const ACTION_NOT_AVAILABLE_ERROR = 'PAYMENT_REQUEST_ACTION_NOT_AVAILABLE';
+
     public const PAYMENT_METHOD_NOT_EXIST_ERROR = 'PAYMENT_METHOD_NOT_FOUND';
 
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibility.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenPaymentRequestActionEligibility extends Constraint
 {
+    public const ACTION_NOT_AVAILABLE_ERROR = 'PAYMENT_REQUEST_ACTION_NOT_AVAILABLE';
+    public const PAYMENT_METHOD_NOT_EXIST_ERROR = 'PAYMENT_METHOD_NOT_FOUND';
+
     /** @deprecated since Sylius 2.3, use $notAvailableMessage instead. It will be removed in Sylius 3.0. */
     public string $notAvailable = 'sylius.payment_request.action_not_available';
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidator.php
@@ -48,7 +48,12 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
         /** @var PaymentMethodInterface|null $paymentMethod */
         $paymentMethod = $this->paymentMethodRepository->findOneBy(['code' => $value->paymentMethodCode]);
         if ($paymentMethod?->getGatewayConfig() === null) {
-            $this->context->addViolation($constraint->notExistMessage, ['%code%' => $value->paymentMethodCode]);
+            $this->context
+                ->buildViolation($constraint->notExistMessage)
+                ->setParameter('%code%', (string) $value->paymentMethodCode)
+                ->setCode(ChosenPaymentRequestActionEligibility::PAYMENT_METHOD_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -56,10 +61,13 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
         $factoryName = $this->gatewayFactoryNameProvider->provide($paymentMethod);
         $gatewayFactoryCommandProvider = $this->gatewayFactoryCommandProvider->getCommandProvider($factoryName);
         if (null === $gatewayFactoryCommandProvider) {
-            $this->context->addViolation($constraint->notAvailableMessage, [
-                '%code%' => $value->paymentMethodCode,
-                '%id%' => $value->paymentId,
-            ]);
+            $this->context
+                ->buildViolation($constraint->notAvailableMessage)
+                ->setParameter('%code%', (string) $value->paymentMethodCode)
+                ->setParameter('%id%', (string) $value->paymentId)
+                ->setCode(ChosenPaymentRequestActionEligibility::ACTION_NOT_AVAILABLE_ERROR)
+                ->addViolation()
+            ;
         }
 
         if (false === $gatewayFactoryCommandProvider instanceof ServiceProviderAwareCommandProviderInterface) {
@@ -71,9 +79,12 @@ final class ChosenPaymentRequestActionEligibilityValidator extends ConstraintVal
             return;
         }
 
-        $this->context->addViolation($constraint->notAvailableMessage, [
-            '%code%' => $value->paymentMethodCode,
-            '%id%' => $value->paymentId,
-        ]);
+        $this->context
+            ->buildViolation($constraint->notAvailableMessage)
+            ->setParameter('%code%', (string) $value->paymentMethodCode)
+            ->setParameter('%id%', (string) $value->paymentId)
+            ->setCode(ChosenPaymentRequestActionEligibility::ACTION_NOT_AVAILABLE_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -20,8 +20,11 @@ use Symfony\Component\Validator\Constraint;
 final class ChosenShippingMethodEligibility extends Constraint
 {
     public const SHIPPING_METHOD_NOT_AVAILABLE_ERROR = 'SHIPPING_METHOD_NOT_AVAILABLE';
+
     public const SHIPPING_METHOD_NOT_FOUND_ERROR = 'SHIPPING_METHOD_NOT_FOUND';
+
     public const SHIPMENT_NOT_FOUND_ERROR = 'SHIPMENT_NOT_FOUND';
+
     public const SHIPPING_ADDRESS_NOT_FOUND_ERROR = 'SHIPPING_ADDRESS_NOT_FOUND';
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibility.php
@@ -19,6 +19,11 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ChosenShippingMethodEligibility extends Constraint
 {
+    public const SHIPPING_METHOD_NOT_AVAILABLE_ERROR = 'SHIPPING_METHOD_NOT_AVAILABLE';
+    public const SHIPPING_METHOD_NOT_FOUND_ERROR = 'SHIPPING_METHOD_NOT_FOUND';
+    public const SHIPMENT_NOT_FOUND_ERROR = 'SHIPMENT_NOT_FOUND';
+    public const SHIPPING_ADDRESS_NOT_FOUND_ERROR = 'SHIPPING_ADDRESS_NOT_FOUND';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibilityValidator.php
@@ -83,7 +83,7 @@ final class ChosenShippingMethodEligibilityValidator extends ConstraintValidator
         if (!in_array($shippingMethod, $this->shippingMethodsResolver->getSupportedMethods($shipment), true)) {
             $this->context
                 ->buildViolation($constraint->message)
-                ->setParameter('%name%', $shippingMethod->getName())
+                ->setParameter('%name%', (string) $shippingMethod->getName())
                 ->setCode(ChosenShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)
                 ->addViolation()
             ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ChosenShippingMethodEligibilityValidator.php
@@ -47,7 +47,12 @@ final class ChosenShippingMethodEligibilityValidator extends ConstraintValidator
         /** @var ShippingMethodInterface|null $shippingMethod */
         $shippingMethod = $this->shippingMethodRepository->findOneBy(['code' => $value->shippingMethodCode]);
         if (null === $shippingMethod) {
-            $this->context->addViolation($constraint->notFoundMessage, ['%code%' => $value->shippingMethodCode]);
+            $this->context
+                ->buildViolation($constraint->notFoundMessage)
+                ->setParameter('%code%', $value->shippingMethodCode)
+                ->setCode(ChosenShippingMethodEligibility::SHIPPING_METHOD_NOT_FOUND_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -56,7 +61,11 @@ final class ChosenShippingMethodEligibilityValidator extends ConstraintValidator
         $shipment = $this->shipmentRepository->find($value->shipmentId);
 
         if (null === $shipment) {
-            $this->context->addViolation($constraint->shipmentNotFoundMessage);
+            $this->context
+                ->buildViolation($constraint->shipmentNotFoundMessage)
+                ->setCode(ChosenShippingMethodEligibility::SHIPMENT_NOT_FOUND_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -64,11 +73,20 @@ final class ChosenShippingMethodEligibilityValidator extends ConstraintValidator
         $order = $shipment->getOrder();
 
         if ($order->getShippingAddress() === null) {
-            $this->context->addViolation($constraint->shippingAddressNotFoundMessage);
+            $this->context
+                ->buildViolation($constraint->shippingAddressNotFoundMessage)
+                ->setCode(ChosenShippingMethodEligibility::SHIPPING_ADDRESS_NOT_FOUND_ERROR)
+                ->addViolation()
+            ;
         }
 
         if (!in_array($shippingMethod, $this->shippingMethodsResolver->getSupportedMethods($shipment), true)) {
-            $this->context->addViolation($constraint->message, ['%name%' => $shippingMethod->getName()]);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('%name%', $shippingMethod->getName())
+                ->setCode(ChosenShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPassword.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ConfirmResetPassword extends Constraint
 {
+    public const PASSWORD_MISMATCH_ERROR = 'PASSWORD_MISMATCH';
+
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPasswordValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ConfirmResetPasswordValidator.php
@@ -30,6 +30,7 @@ final class ConfirmResetPasswordValidator extends ConstraintValidator
         if ($value->confirmNewPassword !== $value->newPassword) {
             $this->context->buildViolation($constraint->message)
                 ->atPath('newPassword')
+                ->setCode(ConfirmResetPassword::PASSWORD_MISMATCH_ERROR)
                 ->addViolation()
             ;
         }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPassword.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CorrectChangeShopUserConfirmPassword extends Constraint
 {
+    public const PASSWORD_MISMATCH_ERROR = 'PASSWORD_MISMATCH';
+
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidator.php
@@ -30,6 +30,7 @@ final class CorrectChangeShopUserConfirmPasswordValidator extends ConstraintVali
         if ($value->confirmNewPassword !== $value->newPassword) {
             $this->context->buildViolation($constraint->message)
                 ->atPath('newPassword')
+                ->setCode(CorrectChangeShopUserConfirmPassword::PASSWORD_MISMATCH_ERROR)
                 ->addViolation()
             ;
         }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraint;
 final class CorrectOrderAddress extends Constraint
 {
     public const COUNTRY_NOT_EXIST_ERROR = 'COUNTRY_NOT_FOUND';
+
     public const ADDRESS_WITHOUT_COUNTRY_ERROR = 'ADDRESS_WITHOUT_COUNTRY';
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddress.php
@@ -19,6 +19,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class CorrectOrderAddress extends Constraint
 {
+    public const COUNTRY_NOT_EXIST_ERROR = 'COUNTRY_NOT_FOUND';
+    public const ADDRESS_WITHOUT_COUNTRY_ERROR = 'ADDRESS_WITHOUT_COUNTRY';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddressValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectOrderAddressValidator.php
@@ -54,9 +54,11 @@ final class CorrectOrderAddressValidator extends ConstraintValidator
         $countryCode = $address->getCountryCode();
 
         if ($countryCode === null) {
-            $this->context->addViolation(
-                $constraint->addressWithoutCountryCodeCanNotExistMessage,
-            );
+            $this->context
+                ->buildViolation($constraint->addressWithoutCountryCodeCanNotExistMessage)
+                ->setCode(CorrectOrderAddress::ADDRESS_WITHOUT_COUNTRY_ERROR)
+                ->addViolation()
+            ;
 
             return;
         }
@@ -65,10 +67,12 @@ final class CorrectOrderAddressValidator extends ConstraintValidator
         $country = $this->countryRepository->findOneBy(['code' => $countryCode]);
 
         if ($country === null) {
-            $this->context->addViolation(
-                $constraint->countryCodeNotExistMessage,
-                ['%countryCode%' => $countryCode],
-            );
+            $this->context
+                ->buildViolation($constraint->countryCodeNotExistMessage)
+                ->setParameter('%countryCode%', $countryCode)
+                ->setCode(CorrectOrderAddress::COUNTRY_NOT_EXIST_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirement.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderAddressRequirement extends Constraint
 {
+    public const ADDRESS_REQUIRED_ERROR = 'ADDRESS_REQUIRED';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirementValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderAddressRequirementValidator.php
@@ -53,7 +53,12 @@ final class OrderAddressRequirementValidator extends ConstraintValidator
         [$property, $addressName] = $channel->isShippingAddressInCheckoutRequired() ? ['shippingAddress', 'shipping address'] : ['billingAddress', 'billing address'];
 
         if (null === $value->$property) {
-            $this->context->addViolation($constraint->message, ['%addressName%' => $addressName]);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('%addressName%', $addressName)
+                ->setCode(OrderAddressRequirement::ADDRESS_REQUIRED_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailability.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderItemAvailability extends Constraint
 {
+    public const INSUFFICIENT_STOCK_ERROR = 'INSUFFICIENT_STOCK';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailabilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailabilityValidator.php
@@ -49,7 +49,7 @@ final class OrderItemAvailabilityValidator extends ConstraintValidator
             if (!$this->availabilityChecker->isStockSufficient($variant, $orderItem->getQuantity())) {
                 $this->context
                     ->buildViolation($constraint->message)
-                    ->setParameter('%productVariantName%', $variant->getName())
+                    ->setParameter('%productVariantName%', (string) $variant->getName())
                     ->setCode(OrderItemAvailability::INSUFFICIENT_STOCK_ERROR)
                     ->addViolation()
                 ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailabilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderItemAvailabilityValidator.php
@@ -47,10 +47,12 @@ final class OrderItemAvailabilityValidator extends ConstraintValidator
         foreach ($order->getItems() as $orderItem) {
             $variant = $orderItem->getVariant();
             if (!$this->availabilityChecker->isStockSufficient($variant, $orderItem->getQuantity())) {
-                $this->context->addViolation(
-                    $constraint->message,
-                    ['%productVariantName%' => $variant->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('%productVariantName%', $variant->getName())
+                    ->setCode(OrderItemAvailability::INSUFFICIENT_STOCK_ERROR)
+                    ->addViolation()
+                ;
             }
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmpty.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderNotEmpty extends Constraint
 {
+    public const ORDER_EMPTY_ERROR = 'ORDER_EMPTY';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmptyValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmptyValidator.php
@@ -46,7 +46,11 @@ final class OrderNotEmptyValidator extends ConstraintValidator
         Assert::isInstanceOf($order, OrderInterface::class);
 
         if ($order->getItems()->isEmpty()) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(OrderNotEmpty::ORDER_EMPTY_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibility.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderPaymentMethodEligibility extends Constraint
 {
+    public const PAYMENT_METHOD_NOT_ELIGIBLE_ERROR = 'PAYMENT_METHOD_NOT_ELIGIBLE';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibilityValidator.php
@@ -49,10 +49,12 @@ final class OrderPaymentMethodEligibilityValidator extends ConstraintValidator
             $paymentMethod = $payment->getMethod();
 
             if (!$paymentMethod->isEnabled() || !$paymentMethod->hasChannel($channel)) {
-                $this->context->addViolation(
-                    $constraint->message,
-                    ['%paymentMethodName%' => $paymentMethod->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('%paymentMethodName%', (string) $paymentMethod->getName())
+                    ->setCode(OrderPaymentMethodEligibility::PAYMENT_METHOD_NOT_ELIGIBLE_ERROR)
+                    ->addViolation()
+                ;
             }
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentRequestEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentRequestEligibility.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderPaymentRequestEligibility extends Constraint
 {
+    public const INVALID_ORDER_CHECKOUT_STATE_ERROR = 'INVALID_ORDER_CHECKOUT_STATE';
+
     public string $message = 'sylius.payment_request.invalid_order_checkout_state';
 
     public function validatedBy(): string

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentRequestEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentRequestEligibilityValidator.php
@@ -91,7 +91,11 @@ final class OrderPaymentRequestEligibilityValidator extends ConstraintValidator
     private function validateOrderEligibility(OrderInterface $order, OrderPaymentRequestEligibility $constraint): void
     {
         if (!$this->orderPaymentRequestEligibilityChecker->isEligible($order)) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(OrderPaymentRequestEligibility::INVALID_ORDER_CHECKOUT_STATE_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibility.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderProductEligibility extends Constraint
 {
+    public const PRODUCT_NOT_ELIGIBLE_ERROR = 'PRODUCT_NOT_ELIGIBLE';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -51,21 +51,21 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
             if (!$orderItem->getVariant()->isEnabled()) {
                 $this->context
                     ->buildViolation($constraint->message)
-                    ->setParameter('%productName%', $orderItem->getVariant()->getName())
+                    ->setParameter('%productName%', (string) $orderItem->getVariant()->getName())
                     ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
                     ->addViolation()
                 ;
             } elseif (!$orderItem->getProduct()->isEnabled()) {
                 $this->context
                     ->buildViolation($constraint->message)
-                    ->setParameter('%productName%', $orderItem->getProduct()->getName())
+                    ->setParameter('%productName%', (string) $orderItem->getProduct()->getName())
                     ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
                     ->addViolation()
                 ;
             } elseif (null !== $channel && !$orderItem->getProduct()->hasChannel($channel)) {
                 $this->context
                     ->buildViolation($constraint->message)
-                    ->setParameter('%productName%', $orderItem->getProduct()->getName())
+                    ->setParameter('%productName%', (string) $orderItem->getProduct()->getName())
                     ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
                     ->addViolation()
                 ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -49,20 +49,26 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
 
         foreach ($orderItems as $orderItem) {
             if (!$orderItem->getVariant()->isEnabled()) {
-                $this->context->addViolation(
-                    $constraint->message,
-                    ['%productName%' => $orderItem->getVariant()->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('%productName%', $orderItem->getVariant()->getName())
+                    ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
+                    ->addViolation()
+                ;
             } elseif (!$orderItem->getProduct()->isEnabled()) {
-                $this->context->addViolation(
-                    $constraint->message,
-                    ['%productName%' => $orderItem->getProduct()->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('%productName%', $orderItem->getProduct()->getName())
+                    ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
+                    ->addViolation()
+                ;
             } elseif (null !== $channel && !$orderItem->getProduct()->hasChannel($channel)) {
-                $this->context->addViolation(
-                    $constraint->message,
-                    ['%productName%' => $orderItem->getProduct()->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->message)
+                    ->setParameter('%productName%', $orderItem->getProduct()->getName())
+                    ->setCode(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)
+                    ->addViolation()
+                ;
             }
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibility.php
@@ -19,6 +19,10 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class OrderShippingMethodEligibility extends Constraint
 {
+    public const SHIPPING_METHOD_NOT_ELIGIBLE_ERROR = 'SHIPPING_METHOD_NOT_ELIGIBLE';
+
+    public const SHIPPING_METHOD_NOT_AVAILABLE_ERROR = 'SHIPPING_METHOD_NOT_AVAILABLE';
+
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -52,7 +52,7 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
             if (!$shippingMethod->isEnabled() || !$shippingMethod->getChannels()->contains($order->getChannel())) {
                 $this->context
                     ->buildViolation($constraint->getMethodNotAvailableMessage())
-                    ->setParameter('%shippingMethodName%', $shippingMethod->getName())
+                    ->setParameter('%shippingMethodName%', (string) $shippingMethod->getName())
                     ->setCode(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)
                     ->addViolation()
                 ;
@@ -63,7 +63,7 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
             if (!$this->eligibilityChecker->isEligible($shipment, $shippingMethod)) {
                 $this->context
                     ->buildViolation($constraint->getMessage())
-                    ->setParameter('%shippingMethodName%', $shippingMethod->getName())
+                    ->setParameter('%shippingMethodName%', (string) $shippingMethod->getName())
                     ->setCode(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_ELIGIBLE_ERROR)
                     ->addViolation()
                 ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -50,19 +50,23 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
             $shippingMethod = $shipment->getMethod();
 
             if (!$shippingMethod->isEnabled() || !$shippingMethod->getChannels()->contains($order->getChannel())) {
-                $this->context->addViolation(
-                    $constraint->getMethodNotAvailableMessage(),
-                    ['%shippingMethodName%' => $shippingMethod->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->getMethodNotAvailableMessage())
+                    ->setParameter('%shippingMethodName%', $shippingMethod->getName())
+                    ->setCode(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)
+                    ->addViolation()
+                ;
 
                 continue;
             }
 
             if (!$this->eligibilityChecker->isEligible($shipment, $shippingMethod)) {
-                $this->context->addViolation(
-                    $constraint->getMessage(),
-                    ['%shippingMethodName%' => $shippingMethod->getName()],
-                );
+                $this->context
+                    ->buildViolation($constraint->getMessage())
+                    ->setParameter('%shippingMethodName%', $shippingMethod->getName())
+                    ->setCode(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_ELIGIBLE_ERROR)
+                    ->addViolation()
+                ;
             }
         }
     }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutable.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PlacedOrderCartItemsImmutable extends Constraint
 {
+    public const CART_ITEMS_IMMUTABLE_ERROR = 'CART_ITEMS_IMMUTABLE';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutableValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PlacedOrderCartItemsImmutableValidator.php
@@ -51,7 +51,11 @@ final class PlacedOrderCartItemsImmutableValidator extends ConstraintValidator
         }
 
         if ($order->getState() === BaseOrderInterface::STATE_NEW) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(PlacedOrderCartItemsImmutable::CART_ITEMS_IMMUTABLE_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibility.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class PromotionCouponEligibility extends Constraint
 {
+    public const COUPON_INVALID_ERROR = 'COUPON_INVALID';
+
     /**
      * @param array<string, mixed>|null $options
      * @param array<string>|null $groups

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -49,6 +49,7 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
             $this->context
                 ->buildViolation($constraint->message)
                 ->atPath('couponCode')
+                ->setCode(PromotionCouponEligibility::COUPON_INVALID_ERROR)
                 ->addViolation()
             ;
 
@@ -64,6 +65,7 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
             $this->context
                 ->buildViolation($constraint->message)
                 ->atPath('couponCode')
+                ->setCode(PromotionCouponEligibility::COUPON_INVALID_ERROR)
                 ->addViolation()
             ;
         }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShipped.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShipmentAlreadyShipped extends Constraint
 {
+    public const SHIPMENT_ALREADY_SHIPPED_ERROR = 'SHIPMENT_ALREADY_SHIPPED';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShippedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShipmentAlreadyShippedValidator.php
@@ -36,7 +36,11 @@ final class ShipmentAlreadyShippedValidator extends ConstraintValidator
         $shipment = $this->shipmentRepository->find($value->shipmentId);
 
         if ($shipment->getState() === OrderShippingStates::STATE_SHIPPED) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(ShipmentAlreadyShipped::SHIPMENT_ALREADY_SHIPPED_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerified.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserNotVerified extends Constraint
 {
+    public const USER_ALREADY_VERIFIED_ERROR = 'USER_ALREADY_VERIFIED';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerifiedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerifiedValidator.php
@@ -44,7 +44,7 @@ final class ShopUserNotVerifiedValidator extends ConstraintValidator
 
         $this->context
             ->buildViolation($constraint->message)
-            ->setParameter('%email%', $shopUser->getEmail())
+            ->setParameter('%email%', (string) $shopUser->getEmail())
             ->setCode(ShopUserNotVerified::USER_ALREADY_VERIFIED_ERROR)
             ->addViolation()
         ;

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerifiedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserNotVerifiedValidator.php
@@ -42,6 +42,11 @@ final class ShopUserNotVerifiedValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolation($constraint->message, ['%email%' => $shopUser->getEmail()]);
+        $this->context
+            ->buildViolation($constraint->message)
+            ->setParameter('%email%', $shopUser->getEmail())
+            ->setCode(ShopUserNotVerified::USER_ALREADY_VERIFIED_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExists.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserResetPasswordTokenExists extends Constraint
 {
+    public const TOKEN_INVALID_ERROR = 'PASSWORD_RESET_TOKEN_INVALID';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExistsValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenExistsValidator.php
@@ -42,6 +42,11 @@ final class ShopUserResetPasswordTokenExistsValidator extends ConstraintValidato
             return;
         }
 
-        $this->context->addViolation($constraint->message, ['%token%' => $value]);
+        $this->context
+            ->buildViolation($constraint->message)
+            ->setParameter('%token%', $value)
+            ->setCode(ShopUserResetPasswordTokenExists::TOKEN_INVALID_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpired.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserResetPasswordTokenNotExpired extends Constraint
 {
+    public const TOKEN_EXPIRED_ERROR = 'PASSWORD_RESET_TOKEN_EXPIRED';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpiredValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserResetPasswordTokenNotExpiredValidator.php
@@ -50,6 +50,10 @@ final class ShopUserResetPasswordTokenNotExpiredValidator extends ConstraintVali
             return;
         }
 
-        $this->context->addViolation($constraint->message);
+        $this->context
+            ->buildViolation($constraint->message)
+            ->setCode(ShopUserResetPasswordTokenNotExpired::TOKEN_EXPIRED_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibility.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class ShopUserVerificationTokenEligibility extends Constraint
 {
+    public const VERIFICATION_TOKEN_INVALID_ERROR = 'VERIFICATION_TOKEN_INVALID';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/ShopUserVerificationTokenEligibilityValidator.php
@@ -39,10 +39,12 @@ final class ShopUserVerificationTokenEligibilityValidator extends ConstraintVali
         $user = $this->shopUserRepository->findOneBy(['emailVerificationToken' => $value->token]);
 
         if (null === $user) {
-            $this->context->addViolation(
-                $constraint->message,
-                ['%verificationToken%' => $value->token],
-            );
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setParameter('%verificationToken%', $value->token)
+                ->setCode(ShopUserVerificationTokenEligibility::VERIFICATION_TOKEN_INVALID_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOption.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class SingleValueForProductVariantOption extends Constraint
 {
+    public const MULTIPLE_VALUES_FOR_OPTION_ERROR = 'MULTIPLE_VALUES_FOR_OPTION';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOptionValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/SingleValueForProductVariantOptionValidator.php
@@ -33,7 +33,11 @@ final class SingleValueForProductVariantOptionValidator extends ConstraintValida
         /** @var array<string, int> $flippedMap */
         $flippedMap = array_flip($map);
         if (count($map) !== count($flippedMap)) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(SingleValueForProductVariantOption::MULTIPLE_VALUES_FOR_OPTION_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmail.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueReviewerEmail extends Constraint
 {
+    public const REVIEWER_ALREADY_EXISTS_ERROR = 'REVIEWER_ALREADY_EXISTS';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmailValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueReviewerEmailValidator.php
@@ -43,7 +43,11 @@ final class UniqueReviewerEmailValidator extends ConstraintValidator
         }
 
         if ($this->shopUserRepository->findOneByEmail($value) !== null) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(UniqueReviewerEmail::REVIEWER_ALREADY_EXISTS_ERROR)
+                ->addViolation()
+            ;
         }
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmail.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UniqueShopUserEmail extends Constraint
 {
+    public const EMAIL_NOT_UNIQUE_ERROR = 'EMAIL_ALREADY_EXISTS';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmailValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UniqueShopUserEmailValidator.php
@@ -43,6 +43,10 @@ final class UniqueShopUserEmailValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolation($constraint->message);
+        $this->context
+            ->buildViolation($constraint->message)
+            ->setCode(UniqueShopUserEmail::EMAIL_NOT_UNIQUE_ERROR)
+            ->addViolation()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowed.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute]
 final class UpdateCartEmailNotAllowed extends Constraint
 {
+    public const EMAIL_NOT_CHANGEABLE_ERROR = 'EMAIL_NOT_CHANGEABLE';
+
     /**
      * @param array<string, mixed>|null $options
      */

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowedValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/UpdateCartEmailNotAllowedValidator.php
@@ -53,7 +53,11 @@ final class UpdateCartEmailNotAllowedValidator extends ConstraintValidator
         }
 
         if ($this->userContext->getUser() !== null) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(UpdateCartEmailNotAllowed::EMAIL_NOT_CHANGEABLE_ERROR)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/AddingEligibleProductVariantToCartValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/AddingEligibleProductVariantToCartValidatorTest.php
@@ -33,6 +33,7 @@ use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
@@ -119,7 +120,7 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
         $this->productVariantRepository->expects(self::never())
             ->method('findOneBy')
             ->with(['code' => 'productVariantCode']);
-        $this->executionContext->expects(self::never())->method('addViolation')->with($this->anything());
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             new AddItemToCart(orderTokenValue: 'TOKEN', productVariantCode: 'productVariantCode', quantity: 1),
             new AddingEligibleProductVariantToCart(),
@@ -136,9 +137,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
             ->method('findOneBy')
             ->with(['code' => 'productVariantCode'])
             ->willReturn(null);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_exist', ['%productVariantCode%' => 'productVariantCode']);
+            ->method('buildViolation')
+            ->with('sylius.product_variant.not_exist')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantCode%', 'productVariantCode')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             new AddItemToCart(orderTokenValue: 'TOKEN', productVariantCode: 'productVariantCode', quantity: 1),
             new AddingEligibleProductVariantToCart(),
@@ -158,9 +164,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
         $this->productVariant->expects(self::once())->method('getProduct')->willReturn($this->product);
         $this->product->expects(self::once())->method('isEnabled')->willReturn(false);
         $this->product->expects(self::once())->method('getName')->willReturn('PRODUCT NAME');
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME']);
+            ->method('buildViolation')
+            ->with('sylius.product.not_exist')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productName%', 'PRODUCT NAME')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             new AddItemToCart(orderTokenValue: 'TOKEN', productVariantCode: 'productVariantCode', quantity: 1),
             new AddingEligibleProductVariantToCart(),
@@ -182,9 +193,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
         $this->productVariant->expects(self::once())->method('isEnabled')->willReturn(false);
         $this->productVariant->expects(self::once())->method('getProduct')->willReturn($this->product);
         $this->product->expects(self::once())->method('isEnabled')->willReturn(true);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_exist', ['%productVariantCode%' => 'productVariantCode']);
+            ->method('buildViolation')
+            ->with('sylius.product_variant.not_exist')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantCode%', 'productVariantCode')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             new AddItemToCart(orderTokenValue: 'TOKEN', productVariantCode: 'productVariantCode', quantity: 1),
             new AddingEligibleProductVariantToCart(),
@@ -221,9 +237,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
             ->method('isStockSufficient')
             ->with($this->productVariant, 2)
             ->willReturn(false);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_sufficient', ['%productVariantCode%' => 'productVariantCode']);
+            ->method('buildViolation')
+            ->with('sylius.product_variant.not_sufficient')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantCode%', 'productVariantCode')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             $command,
             new AddingEligibleProductVariantToCart(),
@@ -259,9 +280,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
             ->method('isStockSufficient')
             ->with($this->productVariant, 1)
             ->willReturn(false);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_sufficient', ['%productVariantCode%' => 'productVariantCode']);
+            ->method('buildViolation')
+            ->with('sylius.product_variant.not_sufficient')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantCode%', 'productVariantCode')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate(
             $command,
             new AddingEligibleProductVariantToCart(),
@@ -302,9 +328,14 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
         $this->product->expects(self::once())->method('hasChannel')->with($this->channel)->willReturn(false);
         $this->product->expects(self::once())->method('getName')->willReturn('PRODUCT NAME');
         $this->cart->expects(self::once())->method('getChannel')->willReturn($this->channel);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME']);
+            ->method('buildViolation')
+            ->with('sylius.product.not_exist')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productName%', 'PRODUCT NAME')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(AddingEligibleProductVariantToCart::PRODUCT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->addingEligibleProductVariantToCartValidator->validate($command, new AddingEligibleProductVariantToCart());
     }
 
@@ -344,19 +375,7 @@ final class AddingEligibleProductVariantToCartValidatorTest extends TestCase
             ->method('findCartByTokenValue')
             ->with('TOKEN')->willReturn($this->cart);
         $this->cart->expects(self::once())->method('getChannel')->willReturn($this->channel);
-        $this->executionContext->expects(self::never())
-            ->method('addViolation')
-            ->willReturnMap([
-                [
-                    'sylius.product_variant.not_exist', ['%productVariantCode%' => 'productVariantCode'],
-                ],
-                [
-                    'sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME'],
-                ],
-                [
-                    'sylius.product_variant.not_sufficient', ['%productVariantCode%' => 'productVariantCode'],
-                ],
-            ]);
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->addingEligibleProductVariantToCartValidator->validate($command, new AddingEligibleProductVariantToCart());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/AdminResetPasswordTokenNonExpiredValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/AdminResetPasswordTokenNonExpiredValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class AdminResetPasswordTokenNonExpiredValidatorTest extends TestCase
@@ -108,7 +109,22 @@ final class AdminResetPasswordTokenNonExpiredValidatorTest extends TestCase
             ->method('findOneBy')
             ->with(['passwordResetToken' => 'token'])
             ->willReturn($this->adminUser);
-        $this->executionContext->expects(self::once())->method('addViolation')->with($constraint->message);
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(AdminResetPasswordTokenNonExpired::TOKEN_EXPIRED_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
+
         $this->adminResetPasswordTokenNonExpiredValidator->validate($value, $constraint);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CanPaymentMethodBeChangedValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CanPaymentMethodBeChangedValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class CanPaymentMethodBeChangedValidatorTest extends TestCase
@@ -85,6 +86,8 @@ final class CanPaymentMethodBeChangedValidatorTest extends TestCase
 
     public function testAddsViolationIfOrderIsCancelled(): void
     {
+        /** @var ConstraintViolationBuilderInterface|MockObject $violationBuilderMock */
+        $violationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $command = new ChangePaymentMethod(
             orderTokenValue: 'ORDER_TOKEN',
             paymentMethodCode: 'PAYMENT_METHOD_CODE',
@@ -96,8 +99,15 @@ final class CanPaymentMethodBeChangedValidatorTest extends TestCase
             ->willReturn($this->order);
         $this->order->expects(self::once())->method('getState')->willReturn(OrderInterface::STATE_CANCELLED);
         $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.payment_method.cannot_change_payment_method_for_cancelled_order');
+            ->method('buildViolation')
+            ->with('sylius.payment_method.cannot_change_payment_method_for_cancelled_order')
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('setCode')
+            ->with(CanPaymentMethodBeChanged::ORDER_CANCELLED_ERROR)
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('addViolation');
         $this->canPaymentMethodBeChangedValidator->validate($command, new CanPaymentMethodBeChanged());
     }
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChangedItemQuantityInCartValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChangedItemQuantityInCartValidatorTest.php
@@ -33,6 +33,7 @@ use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ChangedItemQuantityInCartValidatorTest extends TestCase
@@ -121,9 +122,11 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
             ->willReturn($this->orderItem);
         $this->orderItem->expects(self::once())->method('getVariant')->willReturn(null);
         $this->orderItem->expects(self::once())->method('getVariantName')->willReturn('MacPro');
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_longer_available', ['%productVariantName%' => 'MacPro']);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product_variant.not_longer_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantName%', 'MacPro')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->changedItemQuantityInCartValidator->validate(
             new ChangeItemQuantityInCart(orderTokenValue: 'token', orderItemId: 11, quantity: 2),
             new ChangedItemQuantityInCart(),
@@ -143,9 +146,11 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
         $this->productVariant->expects(self::once())->method('getCode')->willReturn('VARIANT_CODE');
         $this->product->expects(self::once())->method('isEnabled')->willReturn(false);
         $this->product->expects(self::once())->method('getName')->willReturn('PRODUCT NAME');
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME']);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product.not_exist')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productName%', 'PRODUCT NAME')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->changedItemQuantityInCartValidator->validate(
             new ChangeItemQuantityInCart(orderTokenValue: 'token', orderItemId: 11, quantity: 2),
             new ChangedItemQuantityInCart(),
@@ -166,9 +171,11 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
         $this->product->expects(self::once())->method('isEnabled')->willReturn(true);
         $this->product->method('getName')->willReturn('PRODUCT NAME');
         $this->productVariant->expects(self::once())->method('isEnabled')->willReturn(false);
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_longer_available', ['%productVariantName%' => 'Variant Name']);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product_variant.not_longer_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantName%', 'Variant Name')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_LONGER_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->changedItemQuantityInCartValidator->validate(
             new ChangeItemQuantityInCart(orderTokenValue: 'token', orderItemId: 11, quantity: 2),
             new ChangedItemQuantityInCart(),
@@ -193,9 +200,11 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
             ->method('isStockSufficient')
             ->with($this->productVariant, 2)
             ->willReturn(false);
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_sufficient', ['%productVariantCode%' => 'VARIANT_CODE']);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product_variant.not_sufficient')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantCode%', 'VARIANT_CODE')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChangedItemQuantityInCart::PRODUCT_VARIANT_NOT_SUFFICIENT_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->changedItemQuantityInCartValidator->validate(
             new ChangeItemQuantityInCart(orderTokenValue: 'token', orderItemId: 11, quantity: 2),
             new ChangedItemQuantityInCart(),
@@ -229,9 +238,11 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
             ->method('hasChannel')
             ->with($this->channel)
             ->willReturn(false);
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME'], );
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product.not_exist')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productName%', 'PRODUCT NAME')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChangedItemQuantityInCart::PRODUCT_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
         $this->changedItemQuantityInCartValidator->validate(
             new ChangeItemQuantityInCart(
                 orderTokenValue: 'token',
@@ -262,15 +273,6 @@ final class ChangedItemQuantityInCartValidatorTest extends TestCase
             ->willReturn($this->cart);
         $this->cart->method('getChannel')->willReturn($this->channel);
         $this->product->method('hasChannel')->with($this->channel)->willReturn(true);
-        $this->executionContext->expects(self::never())
-            ->method('addViolation')
-            ->with('sylius.product_variant.not_exist', ['%productVariantCode%' => 'productVariantCode']);
-        $this->executionContext->expects(self::never())
-            ->method('addViolation')
-            ->willReturnMap([
-                ['sylius.product_variant.not_exist', ['%productVariantCode%' => 'productVariantCode']],
-                ['sylius.product.not_exist', ['%productName%' => 'PRODUCT NAME']],
-                ['sylius.product_variant.not_sufficient', ['%productVariantCode%' => 'productVariantCode']],
-            ]);
+        $this->executionContext->expects(self::never())->method('buildViolation');
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CheckoutCompletionValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CheckoutCompletionValidatorTest.php
@@ -27,6 +27,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class CheckoutCompletionValidatorTest extends TestCase
@@ -95,6 +96,8 @@ final class CheckoutCompletionValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $violationBuilderMock */
+        $violationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var OrderInterface|MockObject $orderMock */
         $orderMock = $this->createMock(OrderInterface::class);
         $this->checkoutCompletionValidator->initialize($executionContextMock);
@@ -106,11 +109,24 @@ final class CheckoutCompletionValidatorTest extends TestCase
             new Transition('another_possible_transition', [], []),
         ]);
         $orderMock->expects(self::once())->method('getCheckoutState')->willReturn('some_state_that_does_not_allow_to_complete_order');
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.order.invalid_state_transition', [
-            '%currentState%' => 'some_state_that_does_not_allow_to_complete_order',
-            '%possibleTransitions%' => 'some_possible_transition, another_possible_transition',
-        ])
-        ;
+        $executionContextMock->expects(self::once())
+            ->method('buildViolation')
+            ->with('sylius.order.invalid_state_transition')
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(function (string $key, string $value) use ($violationBuilderMock): ConstraintViolationBuilderInterface {
+                self::assertContains($key, ['%currentState%', '%possibleTransitions%']);
+                self::assertContains($value, ['some_state_that_does_not_allow_to_complete_order', 'some_possible_transition, another_possible_transition']);
+
+                return $violationBuilderMock;
+            });
+        $violationBuilderMock->expects(self::once())
+            ->method('setCode')
+            ->with(CheckoutCompletion::INVALID_STATE_TRANSITION_ERROR)
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('addViolation');
         $this->checkoutCompletionValidator->validate($completeOrder, new CheckoutCompletion());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
@@ -126,8 +126,13 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
         $outOfChannelPaymentMethodMock->expects(self::once())->method('getName')->willReturn('offline');
         $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn($paymentMock);
         $this->paymentMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($paymentMock)->willReturn([$supportedPaymentMethodMock]);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment_method.not_available', ['%name%' => 'offline'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.payment_method.not_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%name%', 'offline')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenPaymentMethodEligibility::PAYMENT_METHOD_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());
     }
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentMethodEligibilityValidatorTest.php
@@ -28,6 +28,7 @@ use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
@@ -98,8 +99,13 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
         $firstPaymentMethodMock->expects(self::once())->method('getName')->willReturn('offline');
         $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn($paymentMock);
         $this->paymentMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($paymentMock)->willReturn([$secondPaymentMethodMock, $thirdPaymentMethodMock]);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment_method.not_available', ['%name%' => 'offline'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.payment_method.not_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%name%', 'offline')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenPaymentMethodEligibility::PAYMENT_METHOD_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());
     }
 
@@ -136,8 +142,12 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
         );
         $this->paymentMethodRepository->expects(self::once())->method('findOneBy')->with(['code' => 'PAYMENT_METHOD_CODE'])->willReturn($paymentMethodMock);
         $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn(null);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment.not_found')
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.payment.not_found')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenPaymentMethodEligibility::PAYMENT_NOT_FOUND_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());
     }
 
@@ -149,8 +159,13 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
             paymentId: 123,
         );
         $this->paymentMethodRepository->expects(self::once())->method('findOneBy')->with(['code' => 'PAYMENT_METHOD_CODE'])->willReturn(null);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.payment_method.not_exist', ['%code%' => 'PAYMENT_METHOD_CODE'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.payment_method.not_exist')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%code%', 'PAYMENT_METHOD_CODE')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenPaymentMethodEligibility::PAYMENT_METHOD_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenPaymentMethodEligibilityValidator->validate($command, new ChosenPaymentMethodEligibility());
     }
 
@@ -171,8 +186,8 @@ final class ChosenPaymentMethodEligibilityValidatorTest extends TestCase
         $firstPaymentMethodMock->method('getName')->willReturn('offline');
         $this->paymentRepository->expects(self::once())->method('find')->with('123')->willReturn($paymentMock);
         $this->paymentMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($paymentMock)->willReturn([$firstPaymentMethodMock, $secondPaymentMethodMock]);
-        $this->executionContext->expects(self::never())->method('addViolation')->with('sylius.payment_method.not_exist', ['%code%' => 'PAYMENT_METHOD_CODE'])
-        ;
+        $this->executionContext->expects(self::never())->method('buildViolation');
+
         $this->chosenPaymentMethodEligibilityValidator->validate(
             $command,
             new ChosenPaymentMethodEligibility(),

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenPaymentRequestActionEligibilityValidatorTest.php
@@ -28,6 +28,7 @@ use Sylius\Component\Payment\Model\GatewayConfigInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
@@ -93,8 +94,11 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
             action: 'capture',
         );
         $this->paymentMethodRepositoryMock->expects($this->once())->method('findOneBy')->with(['code' => 'PAYMENT_METHOD_CODE'])->willReturn(null);
-        $this->executionContextMock->expects($this->once())->method('addViolation')->with('sylius.payment_method.not_exist', ['%code%' => 'PAYMENT_METHOD_CODE'])
-        ;
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContextMock->expects($this->once())->method('buildViolation')->with('sylius.payment_method.not_exist')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setParameter')->with('%code%', 'PAYMENT_METHOD_CODE')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(ChosenPaymentRequestActionEligibility::PAYMENT_METHOD_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate($command, new ChosenPaymentRequestActionEligibility());
     }
 
@@ -110,8 +114,11 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
         );
         $this->paymentMethodRepositoryMock->expects($this->once())->method('findOneBy')->with(['code' => 'PAYMENT_METHOD_CODE'])->willReturn($paymentMethodMock);
         $paymentMethodMock->expects($this->once())->method('getGatewayConfig')->willReturn(null);
-        $this->executionContextMock->expects($this->once())->method('addViolation')->with('sylius.payment_method.not_exist', ['%code%' => 'PAYMENT_METHOD_CODE'])
-        ;
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContextMock->expects($this->once())->method('buildViolation')->with('sylius.payment_method.not_exist')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setParameter')->with('%code%', 'PAYMENT_METHOD_CODE')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(ChosenPaymentRequestActionEligibility::PAYMENT_METHOD_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate($command, new ChosenPaymentRequestActionEligibility());
     }
 
@@ -132,11 +139,11 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
         $factoryName = 'offline';
         $this->gatewayFactoryNameProviderMock->expects($this->once())->method('provide')->with($paymentMethodMock)->willReturn($factoryName);
         $this->gatewayFactoryCommandProviderMock->expects($this->once())->method('getCommandProvider')->with($factoryName)->willReturn(null);
-        $this->executionContextMock->expects($this->once())->method('addViolation')->with('sylius.payment_request.action_not_available', [
-            '%code%' => 'PAYMENT_METHOD_CODE',
-            '%id%' => 123,
-        ])
-        ;
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContextMock->expects($this->once())->method('buildViolation')->with('sylius.payment_request.action_not_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->method('setParameter')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(ChosenPaymentRequestActionEligibility::ACTION_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate($command, new ChosenPaymentRequestActionEligibility());
     }
 
@@ -159,11 +166,7 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
         $factoryName = 'offline';
         $this->gatewayFactoryNameProviderMock->expects($this->once())->method('provide')->with($paymentMethodMock)->willReturn($factoryName);
         $this->gatewayFactoryCommandProviderMock->expects($this->once())->method('getCommandProvider')->with($factoryName)->willReturn($commandProviderMock);
-        $this->executionContextMock->expects($this->never())->method('addViolation')->with('sylius.payment_request.action_not_available', [
-            '%code%' => 'PAYMENT_METHOD_CODE',
-            '%id%' => 123,
-        ])
-        ;
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate($command, new ChosenPaymentRequestActionEligibility());
     }
 
@@ -189,11 +192,7 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
         $this->gatewayFactoryNameProviderMock->expects($this->once())->method('provide')->with($paymentMethodMock)->willReturn($factoryName);
         $this->gatewayFactoryCommandProviderMock->expects($this->once())->method('getCommandProvider')->with($factoryName)->willReturn($actionsCommandProviderMock);
         $actionsCommandProviderMock->expects($this->once())->method('getCommandProvider')->with('capture')->willReturn($commandProviderMock);
-        $this->executionContextMock->expects($this->never())->method('addViolation')->with('sylius.payment_request.action_not_available', [
-            '%code%' => 'PAYMENT_METHOD_CODE',
-            '%id%' => 123,
-        ])
-        ;
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate(
             $command,
             new ChosenPaymentRequestActionEligibility(),
@@ -220,11 +219,11 @@ final class ChosenPaymentRequestActionEligibilityValidatorTest extends TestCase
         $this->gatewayFactoryNameProviderMock->expects($this->once())->method('provide')->with($paymentMethodMock)->willReturn($factoryName);
         $this->gatewayFactoryCommandProviderMock->expects($this->once())->method('getCommandProvider')->with($factoryName)->willReturn($commandProviderMock);
         $commandProviderMock->expects($this->once())->method('getCommandProvider')->with('capture')->willReturn(null);
-        $this->executionContextMock->expects($this->once())->method('addViolation')->with('sylius.payment_request.action_not_available', [
-            '%code%' => 'PAYMENT_METHOD_CODE',
-            '%id%' => 123,
-        ])
-        ;
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContextMock->expects($this->once())->method('buildViolation')->with('sylius.payment_request.action_not_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->method('setParameter')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(ChosenPaymentRequestActionEligibility::ACTION_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
         $this->chosenPaymentRequestActionEligibilityValidator->validate($command, new ChosenPaymentRequestActionEligibility());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenShippingMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ChosenShippingMethodEligibilityValidatorTest.php
@@ -30,6 +30,7 @@ use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
@@ -104,8 +105,13 @@ final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
         $shipmentMock->expects(self::once())->method('getOrder')->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getShippingAddress')->willReturn($shippingAddressMock);
         $this->shippingMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($shipmentMock)->willReturn([$differentShippingMethodMock]);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.shipping_method.not_available', ['%name%' => 'DHL'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.shipping_method.not_available')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%name%', 'DHL')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenShippingMethodEligibilityValidator->validate($command, new ChosenShippingMethodEligibility());
     }
 
@@ -129,8 +135,8 @@ final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
         $shipmentMock->expects(self::once())->method('getOrder')->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getShippingAddress')->willReturn($shippingAddressMock);
         $this->shippingMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($shipmentMock)->willReturn([$shippingMethodMock]);
-        $this->executionContext->expects(self::never())->method('addViolation')
-        ;
+        $this->executionContext->expects(self::never())->method('buildViolation');
+
         $this->chosenShippingMethodEligibilityValidator->validate($command, new ChosenShippingMethodEligibility());
     }
 
@@ -152,10 +158,11 @@ final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
             ->expects(self::never())
             ->method('find');
 
-        $this->executionContext
-            ->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.shipping_method.not_found', ['%code%' => 'SHIPPING_METHOD_CODE']);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.shipping_method.not_found')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%code%', 'SHIPPING_METHOD_CODE')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenShippingMethodEligibility::SHIPPING_METHOD_NOT_FOUND_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->chosenShippingMethodEligibilityValidator->validate(
             $command,
@@ -183,8 +190,12 @@ final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
         $shipmentMock->expects(self::once())->method('getOrder')->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getShippingAddress')->willReturn(null);
         $this->shippingMethodsResolver->expects(self::once())->method('getSupportedMethods')->with($shipmentMock)->willReturn([$shippingMethodMock]);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.shipping_method.shipping_address_not_found')
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.shipping_method.shipping_address_not_found')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenShippingMethodEligibility::SHIPPING_ADDRESS_NOT_FOUND_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->chosenShippingMethodEligibilityValidator->validate($command, new ChosenShippingMethodEligibility());
     }
 
@@ -211,10 +222,10 @@ final class ChosenShippingMethodEligibilityValidatorTest extends TestCase
             ->with('123')
             ->willReturn(null);
 
-        $this->executionContext
-            ->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.shipment.not_found');
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.shipment.not_found')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(ChosenShippingMethodEligibility::SHIPMENT_NOT_FOUND_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->chosenShippingMethodEligibilityValidator->validate(
             $command,

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ConfirmResetPasswordValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ConfirmResetPasswordValidatorTest.php
@@ -62,6 +62,7 @@ final class ConfirmResetPasswordValidatorTest extends TestCase
         $value = new ResetPassword('token', 'password', 'differentPassword');
         $executionContextMock->expects(self::once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('atPath')->with('newPassword')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(ConfirmResetPassword::PASSWORD_MISMATCH_ERROR)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->confirmResetPasswordValidator->validate($value, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidatorTest.php
@@ -72,6 +72,7 @@ final class CorrectChangeShopUserConfirmPasswordValidatorTest extends TestCase
         );
         $executionContextMock->expects(self::once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('atPath')->with('newPassword')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(CorrectChangeShopUserConfirmPassword::PASSWORD_MISMATCH_ERROR)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->correctChangeShopUserConfirmPasswordValidator->validate($value, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CorrectOrderAddressValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/CorrectOrderAddressValidatorTest.php
@@ -26,6 +26,7 @@ use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class CorrectOrderAddressValidatorTest extends TestCase
@@ -71,12 +72,16 @@ final class CorrectOrderAddressValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var AddressInterface|MockObject $billingAddressMock */
         $billingAddressMock = $this->createMock(AddressInterface::class);
         $this->correctOrderAddressValidator->initialize($executionContextMock);
         $billingAddressMock->expects(self::once())->method('getCountryCode')->willReturn('united_russia');
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.country.not_exist', ['%countryCode%' => 'united_russia'])
-        ;
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.country.not_exist')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setParameter')->with('%countryCode%', 'united_russia')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(CorrectOrderAddress::COUNTRY_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->correctOrderAddressValidator->validate(
             new UpdateCart(
                 orderTokenValue: 'TOKEN',
@@ -91,12 +96,15 @@ final class CorrectOrderAddressValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var AddressInterface|MockObject $billingAddressMock */
         $billingAddressMock = $this->createMock(AddressInterface::class);
         $this->correctOrderAddressValidator->initialize($executionContextMock);
         $billingAddressMock->expects(self::once())->method('getCountryCode')->willReturn(null);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.address.without_country')
-        ;
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.address.without_country')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(CorrectOrderAddress::ADDRESS_WITHOUT_COUNTRY_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->correctOrderAddressValidator->validate(
             new UpdateCart(
                 orderTokenValue: 'TOKEN',
@@ -111,6 +119,8 @@ final class CorrectOrderAddressValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var AddressInterface|MockObject $billingAddressMock */
         $billingAddressMock = $this->createMock(AddressInterface::class);
         /** @var AddressInterface|MockObject $shippingAddressMock */
@@ -137,8 +147,12 @@ final class CorrectOrderAddressValidatorTest extends TestCase
             ]);
 
         $executionContextMock->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.country.not_exist', ['%countryCode%' => 'united_russia']);
+            ->method('buildViolation')
+            ->with('sylius.country.not_exist')
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setParameter')->with('%countryCode%', 'united_russia')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(CorrectOrderAddress::COUNTRY_NOT_EXIST_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
 
         $this->correctOrderAddressValidator->validate(
             new UpdateCart(
@@ -155,6 +169,8 @@ final class CorrectOrderAddressValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var AddressInterface|MockObject $billingAddressMock */
         $billingAddressMock = $this->createMock(AddressInterface::class);
         /** @var AddressInterface|MockObject $shippingAddressMock */
@@ -178,13 +194,25 @@ final class CorrectOrderAddressValidatorTest extends TestCase
                 [['code' => 'united_russia'], null],
             ]);
 
-        $violations = [];
         $executionContextMock
             ->expects($this->exactly(2))
-            ->method('addViolation')
-            ->willReturnCallback(function ($message, $params) use (&$violations) {
-                $violations[] = ['message' => $message, 'params' => $params];
+            ->method('buildViolation')
+            ->with('sylius.country.not_exist')
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock
+            ->expects($this->exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(function ($key, $value) use ($constraintViolationBuilderMock) {
+                return $constraintViolationBuilderMock;
             });
+        $constraintViolationBuilderMock
+            ->expects($this->exactly(2))
+            ->method('setCode')
+            ->with(CorrectOrderAddress::COUNTRY_NOT_EXIST_ERROR)
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock
+            ->expects($this->exactly(2))
+            ->method('addViolation');
 
         $this->correctOrderAddressValidator->validate(
             new UpdateCart(
@@ -195,16 +223,5 @@ final class CorrectOrderAddressValidatorTest extends TestCase
             ),
             new CorrectOrderAddress(),
         );
-
-        $this->assertEquals([
-            [
-                'message' => 'sylius.country.not_exist',
-                'params' => ['%countryCode%' => 'euroland'],
-            ],
-            [
-                'message' => 'sylius.country.not_exist',
-                'params' => ['%countryCode%' => 'united_russia'],
-            ],
-        ], $violations);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderAddressRequirementValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderAddressRequirementValidatorTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class OrderAddressRequirementValidatorTest extends TestCase
@@ -73,8 +74,7 @@ final class OrderAddressRequirementValidatorTest extends TestCase
         $channelMock = $this->createMock(ChannelInterface::class);
         $updateCart = new UpdateCart('token');
         $this->orderAddressRequirementValidator->validate($updateCart, new OrderAddressRequirement());
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'billingAddress']);
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'shippingAddress']);
+        $this->context->expects(self::never())->method('buildViolation');
     }
 
     public function testThrowsAnExceptionIfOrderIsNotFound(): void
@@ -113,7 +113,7 @@ final class OrderAddressRequirementValidatorTest extends TestCase
         $channelMock->expects(self::once())->method('isShippingAddressInCheckoutRequired')->willReturn(true);
         $updateCart = new UpdateCart(shippingAddress: $shippingAddressMock, orderTokenValue: 'TOKEN');
         $this->orderAddressRequirementValidator->validate($updateCart, new OrderAddressRequirement());
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'shippingAddress']);
+        $this->context->expects(self::never())->method('buildViolation');
     }
 
     public function testDoesNothingIfBillingAddressIsRequiredAndProvided(): void
@@ -129,7 +129,7 @@ final class OrderAddressRequirementValidatorTest extends TestCase
         $channelMock->expects(self::once())->method('isShippingAddressInCheckoutRequired')->willReturn(false);
         $updateCart = new UpdateCart(billingAddress: $billingAddressMock, orderTokenValue: 'TOKEN');
         $this->orderAddressRequirementValidator->validate($updateCart, new OrderAddressRequirement());
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'billingAddress']);
+        $this->context->expects(self::never())->method('buildViolation');
     }
 
     public function testAddsViolationIfShippingAddressIsRequiredButNotProvided(): void
@@ -140,12 +140,17 @@ final class OrderAddressRequirementValidatorTest extends TestCase
         $billingAddressMock = $this->createMock(AddressInterface::class);
         /** @var ChannelInterface|MockObject $channelMock */
         $channelMock = $this->createMock(ChannelInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->orderRepository->expects(self::once())->method('findCartByTokenValue')->with('TOKEN')->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getChannel')->willReturn($channelMock);
         $channelMock->expects(self::once())->method('isShippingAddressInCheckoutRequired')->willReturn(true);
         $updateCart = new UpdateCart(billingAddress: $billingAddressMock, orderTokenValue: 'TOKEN');
+        $this->context->expects(self::once())->method('buildViolation')->with(self::MESSAGE)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setParameter')->with('%addressName%', 'shipping address')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(OrderAddressRequirement::ADDRESS_REQUIRED_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->orderAddressRequirementValidator->validate($updateCart, new OrderAddressRequirement());
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'shipping address']);
     }
 
     public function testAddsViolationIfBillingAddressIsRequiredButNotProvided(): void
@@ -156,11 +161,16 @@ final class OrderAddressRequirementValidatorTest extends TestCase
         $shippingAddressMock = $this->createMock(AddressInterface::class);
         /** @var ChannelInterface|MockObject $channelMock */
         $channelMock = $this->createMock(ChannelInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->orderRepository->expects(self::once())->method('findCartByTokenValue')->with('TOKEN')->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getChannel')->willReturn($channelMock);
         $channelMock->expects(self::once())->method('isShippingAddressInCheckoutRequired')->willReturn(false);
         $updateCart = new UpdateCart(shippingAddress: $shippingAddressMock, orderTokenValue: 'TOKEN');
+        $this->context->expects(self::once())->method('buildViolation')->with(self::MESSAGE)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setParameter')->with('%addressName%', 'billing address')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(OrderAddressRequirement::ADDRESS_REQUIRED_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->orderAddressRequirementValidator->validate($updateCart, new OrderAddressRequirement());
-        $this->context->expects(self::never())->method('addViolation')->with(self::MESSAGE, ['%addressName%' => 'billing address']);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderItemAvailabilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderItemAvailabilityValidatorTest.php
@@ -29,6 +29,7 @@ use Sylius\Component\Inventory\Checker\AvailabilityCheckerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class OrderItemAvailabilityValidatorTest extends TestCase
@@ -86,8 +87,13 @@ final class OrderItemAvailabilityValidatorTest extends TestCase
         $orderItemMock->expects(self::once())->method('getQuantity')->willReturn(1);
         $this->availabilityChecker->expects(self::once())->method('isStockSufficient')->with($productVariantMock, 1)->willReturn(false);
         $productVariantMock->expects(self::once())->method('getName')->willReturn('variant name');
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.product_variant.product_variant_with_name_not_sufficient', ['%productVariantName%' => 'variant name'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product_variant.product_variant_with_name_not_sufficient')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%productVariantName%', 'variant name')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(OrderItemAvailability::INSUFFICIENT_STOCK_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->orderItemAvailabilityValidator->validate($command, new OrderItemAvailability());
     }
 
@@ -109,8 +115,7 @@ final class OrderItemAvailabilityValidatorTest extends TestCase
         $orderItemMock->expects(self::once())->method('getQuantity')->willReturn(1);
         $this->availabilityChecker->expects(self::once())->method('isStockSufficient')->with($productVariantMock, 1)->willReturn(true);
         $productVariantMock->expects(self::never())->method('getName');
-        $this->executionContext->expects(self::never())->method('addViolation')->with('sylius.product_variant.product_variant_with_name_not_sufficient', ['%productVariantName%' => 'variant name'])
-        ;
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->orderItemAvailabilityValidator->validate($command, new OrderItemAvailability());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderNotEmptyValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderNotEmptyValidatorTest.php
@@ -28,6 +28,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class OrderNotEmptyValidatorTest extends TestCase
@@ -84,7 +85,12 @@ final class OrderNotEmptyValidatorTest extends TestCase
         $value = new CompleteOrder(orderTokenValue: 'token');
         $this->orderRepository->expects(self::once())->method('findOneBy')->with(['tokenValue' => 'token'])->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getItems')->willReturn(new ArrayCollection());
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.order.not_empty');
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.order.not_empty')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(OrderNotEmpty::ORDER_EMPTY_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->orderNotEmptyValidator->validate($value, new OrderNotEmpty());
     }
 
@@ -100,7 +106,7 @@ final class OrderNotEmptyValidatorTest extends TestCase
         $value = new UpdateCart(orderTokenValue: 'token');
         $this->orderRepository->expects(self::once())->method('findOneBy')->with(['tokenValue' => 'token'])->willReturn($orderMock);
         $orderMock->expects(self::once())->method('getItems')->willReturn(new ArrayCollection([$orderItemMock]));
-        $executionContextMock->expects(self::never())->method('addViolation')->with('sylius.order.not_empty');
+        $executionContextMock->expects(self::never())->method('buildViolation');
         $this->orderNotEmptyValidator->validate($value, new OrderNotEmpty());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentMethodEligibilityValidatorTest.php
@@ -166,13 +166,11 @@ final class OrderPaymentMethodEligibilityValidatorTest extends TestCase
         $paymentMethodMock->method('hasChannel')->with($channelMock)->willReturn(false);
         $paymentMethodMock->method('getName')->willReturn('bank transfer');
 
-        $executionContextMock
-            ->expects(self::once())
-            ->method('addViolation')
-            ->with(
-                'sylius.order.payment_method_eligibility',
-                ['%paymentMethodName%' => 'bank transfer'],
-            );
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.order.payment_method_eligibility')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%paymentMethodName%', 'bank transfer')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(OrderPaymentMethodEligibility::PAYMENT_METHOD_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->orderPaymentMethodEligibilityValidator->validate($value, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentMethodEligibilityValidatorTest.php
@@ -29,6 +29,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class OrderPaymentMethodEligibilityValidatorTest extends TestCase
@@ -117,13 +118,11 @@ final class OrderPaymentMethodEligibilityValidatorTest extends TestCase
             ->method('getName')
             ->willReturn('bank transfer');
 
-        $executionContextMock
-            ->expects(self::once())
-            ->method('addViolation')
-            ->with(
-                'sylius.order.payment_method_eligibility',
-                ['%paymentMethodName%' => 'bank transfer'],
-            );
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.order.payment_method_eligibility')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%paymentMethodName%', 'bank transfer')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(OrderPaymentMethodEligibility::PAYMENT_METHOD_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
 
         $this->orderPaymentMethodEligibilityValidator->validate($value, $constraint);
     }
@@ -218,7 +217,7 @@ final class OrderPaymentMethodEligibilityValidatorTest extends TestCase
 
         $executionContextMock
             ->expects(self::never())
-            ->method('addViolation');
+            ->method('buildViolation');
 
         $this->orderPaymentMethodEligibilityValidator->validate($value, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentRequestEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderPaymentRequestEligibilityValidatorTest.php
@@ -27,6 +27,7 @@ use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Sylius\Component\Payment\Repository\PaymentRequestRepositoryInterface;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
 {
@@ -79,7 +80,7 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
 
         $this->orderPaymentRequestEligibilityCheckerMock->expects($this->never())->method('isEligible');
 
-        $this->executionContextMock->expects($this->never())->method('addViolation');
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -103,7 +104,7 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
             ->with($orderMock)
             ->willReturn(true);
 
-        $this->executionContextMock->expects($this->never())->method('addViolation');
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -127,10 +128,18 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
             ->with($orderMock)
             ->willReturn(false);
 
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContextMock
             ->expects($this->once())
-            ->method('addViolation')
-            ->with('sylius.payment_request.invalid_order_checkout_state');
+            ->method('buildViolation')
+            ->with('sylius.payment_request.invalid_order_checkout_state')
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock
+            ->expects($this->once())
+            ->method('setCode')
+            ->with(OrderPaymentRequestEligibility::INVALID_ORDER_CHECKOUT_STATE_ERROR)
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects($this->once())->method('addViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -147,7 +156,7 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
 
         $this->orderPaymentRequestEligibilityCheckerMock->expects($this->never())->method('isEligible');
 
-        $this->executionContextMock->expects($this->never())->method('addViolation');
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -172,7 +181,7 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
 
         $this->orderPaymentRequestEligibilityCheckerMock->expects($this->never())->method('isEligible');
 
-        $this->executionContextMock->expects($this->never())->method('addViolation');
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -204,7 +213,7 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
             ->with($orderMock)
             ->willReturn(true);
 
-        $this->executionContextMock->expects($this->never())->method('addViolation');
+        $this->executionContextMock->expects($this->never())->method('buildViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }
@@ -236,10 +245,18 @@ final class OrderPaymentRequestEligibilityValidatorTest extends TestCase
             ->with($orderMock)
             ->willReturn(false);
 
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContextMock
             ->expects($this->once())
-            ->method('addViolation')
-            ->with('sylius.payment_request.invalid_order_checkout_state');
+            ->method('buildViolation')
+            ->with('sylius.payment_request.invalid_order_checkout_state')
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock
+            ->expects($this->once())
+            ->method('setCode')
+            ->with(OrderPaymentRequestEligibility::INVALID_ORDER_CHECKOUT_STATE_ERROR)
+            ->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects($this->once())->method('addViolation');
 
         $this->validator->validate($command, new OrderPaymentRequestEligibility());
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderProductEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderProductEligibilityValidatorTest.php
@@ -26,6 +26,7 @@ use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 final class OrderProductEligibilityValidatorTest extends TestCase
 {
@@ -72,10 +73,11 @@ final class OrderProductEligibilityValidatorTest extends TestCase
 
         $constraint = new OrderProductEligibility();
 
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message, ['%productName%' => $variantName]);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->context->expects($this->once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setParameter')->with('%productName%', $variantName)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
 
         $this->validator->validate($command, $constraint);
     }
@@ -109,10 +111,11 @@ final class OrderProductEligibilityValidatorTest extends TestCase
 
         $constraint = new OrderProductEligibility();
 
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message, ['%productName%' => $productName]);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->context->expects($this->once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setParameter')->with('%productName%', $productName)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
 
         $this->validator->validate($command, $constraint);
     }
@@ -146,10 +149,11 @@ final class OrderProductEligibilityValidatorTest extends TestCase
 
         $constraint = new OrderProductEligibility();
 
-        $this->context
-            ->expects($this->once())
-            ->method('addViolation')
-            ->with($constraint->message, ['%productName%' => $productName]);
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->context->expects($this->once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setParameter')->with('%productName%', $productName)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('setCode')->with(OrderProductEligibility::PRODUCT_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->once())->method('addViolation');
 
         $this->validator->validate($command, $constraint);
     }
@@ -183,7 +187,7 @@ final class OrderProductEligibilityValidatorTest extends TestCase
 
         $this->context
             ->expects($this->never())
-            ->method('addViolation');
+            ->method('buildViolation');
 
         $this->validator->validate($command, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderShippingMethodEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/OrderShippingMethodEligibilityValidatorTest.php
@@ -30,6 +30,7 @@ use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheck
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class OrderShippingMethodEligibilityValidatorTest extends TestCase
@@ -154,21 +155,31 @@ final class OrderShippingMethodEligibilityValidatorTest extends TestCase
             ->method('getName')
             ->willReturn('Shipping method two');
 
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $contextMock
             ->expects($this->exactly(2))
-            ->method('addViolation')
-            ->willReturnCallback(function (string $message, array $params) {
+            ->method('buildViolation')
+            ->with('sylius.order.shipping_method_not_available')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->exactly(2))
+            ->method('setParameter')
+            ->willReturnCallback(function (string $key, string $value) use ($constraintViolationBuilder) {
                 static $calls = 0;
                 ++$calls;
 
                 if ($calls === 1) {
-                    $this->assertSame('sylius.order.shipping_method_not_available', $message);
-                    $this->assertSame(['%shippingMethodName%' => 'Shipping method one'], $params);
+                    $this->assertSame('%shippingMethodName%', $key);
+                    $this->assertSame('Shipping method one', $value);
                 } elseif ($calls === 2) {
-                    $this->assertSame('sylius.order.shipping_method_not_available', $message);
-                    $this->assertSame(['%shippingMethodName%' => 'Shipping method two'], $params);
+                    $this->assertSame('%shippingMethodName%', $key);
+                    $this->assertSame('Shipping method two', $value);
                 }
+
+                return $constraintViolationBuilder;
             });
+        $constraintViolationBuilder->expects($this->exactly(2))->method('setCode')->with(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_AVAILABLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects($this->exactly(2))->method('addViolation');
 
         $this->orderShippingMethodEligibilityValidator->validate(
             new CompleteOrder('ORDERTOKENVALUE'),
@@ -262,7 +273,7 @@ final class OrderShippingMethodEligibilityValidatorTest extends TestCase
             ->method('isEligible')
             ->willReturn(true);
 
-        $contextMock->expects(self::never())->method('addViolation');
+        $contextMock->expects(self::never())->method('buildViolation');
 
         $this->orderShippingMethodEligibilityValidator->validate(
             new CompleteOrder('ORDERTOKENVALUE'),
@@ -296,8 +307,13 @@ final class OrderShippingMethodEligibilityValidatorTest extends TestCase
         $shippingMethodMock->expects(self::once())->method('isEnabled')->willReturn(true);
         $shippingMethodMock->expects(self::once())->method('getChannels')->willReturn($channelsCollectionMock);
         $channelsCollectionMock->expects(self::once())->method('contains')->with($channelMock)->willReturn(true);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.order.shipping_method_eligibility', ['%shippingMethodName%' => 'InPost'])
-        ;
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock->expects(self::once())->method('buildViolation')->with('sylius.order.shipping_method_eligibility')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setParameter')->with('%shippingMethodName%', 'InPost')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('setCode')->with(OrderShippingMethodEligibility::SHIPPING_METHOD_NOT_ELIGIBLE_ERROR)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->expects(self::once())->method('addViolation');
+
         $this->orderShippingMethodEligibilityValidator->validate($value, $constraint);
     }
 
@@ -366,7 +382,7 @@ final class OrderShippingMethodEligibilityValidatorTest extends TestCase
 
         $executionContextMock
             ->expects(self::never())
-            ->method('addViolation');
+            ->method('buildViolation');
 
         $this->orderShippingMethodEligibilityValidator->validate($value, $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/PlacedOrderCartItemsImmutableValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/PlacedOrderCartItemsImmutableValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class PlacedOrderCartItemsImmutableValidatorTest extends TestCase
@@ -62,11 +63,21 @@ final class PlacedOrderCartItemsImmutableValidatorTest extends TestCase
         $orderMock = $this->createMock(OrderInterface::class);
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $violationBuilderMock */
+        $violationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->placedOrderCartItemsImmutableValidator->initialize($executionContextMock);
         $orderMock->expects(self::once())->method('getState')->willReturn(OrderInterface::STATE_NEW);
         $this->orderRepository->expects(self::once())->method('findOneWithCompletedCheckout')->with('orderTokenValue')->willReturn($orderMock);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.order.cart_items_immutable')
-        ;
+        $executionContextMock->expects(self::once())
+            ->method('buildViolation')
+            ->with('sylius.order.cart_items_immutable')
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('setCode')
+            ->with(PlacedOrderCartItemsImmutable::CART_ITEMS_IMMUTABLE_ERROR)
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('addViolation');
         $this->placedOrderCartItemsImmutableValidator->validate(
             new AddItemToCart(orderTokenValue: 'orderTokenValue', productVariantCode: 'productVariantCode', quantity: 1),
             new PlacedOrderCartItemsImmutable(),

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/PromotionCouponEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/PromotionCouponEligibilityValidatorTest.php
@@ -99,6 +99,7 @@ final class PromotionCouponEligibilityValidatorTest extends TestCase
         $this->appliedCouponEligibilityChecker->expects(self::once())->method('isEligible')->with($promotionCouponMock, $cartMock)->willReturn(false);
         $executionContextMock->expects(self::once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('atPath')->with('couponCode')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(PromotionCouponEligibility::COUPON_INVALID_ERROR)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->promotionCouponEligibilityValidator->validate($value, $constraint);
     }
@@ -116,6 +117,7 @@ final class PromotionCouponEligibilityValidatorTest extends TestCase
         $this->promotionCouponRepository->expects(self::once())->method('findOneBy')->with(['code' => 'couponCode'])->willReturn(null);
         $executionContextMock->expects(self::once())->method('buildViolation')->with($constraint->message)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('atPath')->with('couponCode')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(PromotionCouponEligibility::COUPON_INVALID_ERROR)->willReturn($constraintViolationBuilderMock);
         $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->orderRepository->expects(self::never())->method('findCartByTokenValue')->with('token');
         $this->promotionCouponEligibilityValidator->validate($value, $constraint);

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShipmentAlreadyShippedValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShipmentAlreadyShippedValidatorTest.php
@@ -23,6 +23,7 @@ use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderShippingStates;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ShipmentAlreadyShippedValidatorTest extends TestCase
@@ -46,11 +47,22 @@ final class ShipmentAlreadyShippedValidatorTest extends TestCase
     {
         /** @var ShipmentInterface|MockObject $shipmentMock */
         $shipmentMock = $this->createMock(ShipmentInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $violationBuilderMock */
+        $violationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraint = new ShipmentAlreadyShipped();
         $shipShipment = new ShipShipment(shipmentId: 123);
         $this->shipmentRepository->expects(self::once())->method('find')->with(123)->willReturn($shipmentMock);
         $shipmentMock->expects(self::once())->method('getState')->willReturn(OrderShippingStates::STATE_SHIPPED);
-        $this->executionContext->expects(self::once())->method('addViolation')->with($constraint->message);
+        $this->executionContext->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('setCode')
+            ->with(ShipmentAlreadyShipped::SHIPMENT_ALREADY_SHIPPED_ERROR)
+            ->willReturn($violationBuilderMock);
+        $violationBuilderMock->expects(self::once())
+            ->method('addViolation');
         $this->shipmentAlreadyShippedValidator->validate($shipShipment, $constraint);
     }
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserNotVerifiedValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserNotVerifiedValidatorTest.php
@@ -25,6 +25,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ShopUserNotVerifiedValidatorTest extends TestCase
@@ -75,13 +76,33 @@ final class ShopUserNotVerifiedValidatorTest extends TestCase
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
         /** @var ShopUserInterface|MockObject $shopUserMock */
         $shopUserMock = $this->createMock(ShopUserInterface::class);
+        $constraint = new ShopUserNotVerified();
         $this->shopUserNotVerifiedValidator->initialize($executionContextMock);
         $this->shopUserRepository->expects(self::once())->method('find')->with(42)->willReturn($shopUserMock);
         $shopUserMock->expects(self::once())->method('isVerified')->willReturn(true);
         $shopUserMock->expects(self::once())->method('getEmail')->willReturn('test@sylius.com');
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.account.is_verified', ['%email%' => 'test@sylius.com'])
-        ;
-        $this->shopUserNotVerifiedValidator->validate(new RequestShopUserVerification(42, '', ''), new ShopUserNotVerified());
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setParameter')
+            ->with('%email%', 'test@sylius.com')
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(ShopUserNotVerified::USER_ALREADY_VERIFIED_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
+
+        $this->shopUserNotVerifiedValidator->validate(new RequestShopUserVerification(42, '', ''), $constraint);
     }
 
     public function testDoesNotAddViolationIfShopUserExists(): void

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserResetPasswordTokenExistsValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserResetPasswordTokenExistsValidatorTest.php
@@ -23,6 +23,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ShopUserResetPasswordTokenExistsValidatorTest extends TestCase
@@ -74,9 +75,30 @@ final class ShopUserResetPasswordTokenExistsValidatorTest extends TestCase
     {
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        $constraint = new ShopUserResetPasswordTokenExists();
         $this->shopUserResetPasswordTokenExistsValidator->initialize($executionContextMock);
         $this->userRepository->expects(self::once())->method('findOneBy')->with(['passwordResetToken' => 'token'])->willReturn(null);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.reset_password.invalid_token', ['%token%' => 'token']);
-        $this->shopUserResetPasswordTokenExistsValidator->validate('token', new ShopUserResetPasswordTokenExists());
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setParameter')
+            ->with('%token%', 'token')
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(ShopUserResetPasswordTokenExists::TOKEN_INVALID_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
+
+        $this->shopUserResetPasswordTokenExistsValidator->validate('token', $constraint);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserResetPasswordTokenNotExpiredValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserResetPasswordTokenNotExpiredValidatorTest.php
@@ -23,6 +23,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ShopUserResetPasswordTokenNotExpiredValidatorTest extends TestCase
@@ -91,6 +92,7 @@ final class ShopUserResetPasswordTokenNotExpiredValidatorTest extends TestCase
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
         /** @var UserInterface|MockObject $userMock */
         $userMock = $this->createMock(UserInterface::class);
+        $constraint = new ShopUserResetPasswordTokenNotExpired();
         $this->shopUserResetPasswordTokenNotExpiredValidator->initialize($executionContextMock);
         $userMock->expects(self::once())->method('isPasswordRequestNonExpired')->with($this->callback(function (\DateInterval $dateInterval) {
             $this->assertSame('1', $dateInterval->format('%d'));
@@ -98,7 +100,22 @@ final class ShopUserResetPasswordTokenNotExpiredValidatorTest extends TestCase
             return true;
         }))->willReturn(false);
         $this->userRepository->expects(self::once())->method('findOneBy')->with(['passwordResetToken' => 'token'])->willReturn($userMock);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.reset_password.token_expired');
-        $this->shopUserResetPasswordTokenNotExpiredValidator->validate('token', new ShopUserResetPasswordTokenNotExpired());
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(ShopUserResetPasswordTokenNotExpired::TOKEN_EXPIRED_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
+
+        $this->shopUserResetPasswordTokenNotExpiredValidator->validate('token', $constraint);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserVerificationTokenEligibilityValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/ShopUserVerificationTokenEligibilityValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class ShopUserVerificationTokenEligibilityValidatorTest extends TestCase
@@ -71,8 +72,27 @@ final class ShopUserVerificationTokenEligibilityValidatorTest extends TestCase
         );
         $this->shopUserVerificationTokenEligibilityValidator->initialize($executionContextMock);
         $this->shopUserRepository->expects(self::once())->method('findOneBy')->with(['emailVerificationToken' => 'TOKEN'])->willReturn(null);
-        $executionContextMock->expects(self::once())->method('addViolation')->with('sylius.account.invalid_verification_token', ['%verificationToken%' => 'TOKEN'])
-        ;
+
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $executionContextMock
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setParameter')
+            ->with('%verificationToken%', 'TOKEN')
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(ShopUserVerificationTokenEligibility::VERIFICATION_TOKEN_INVALID_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
+
         $this->shopUserVerificationTokenEligibilityValidator->validate($value, $constraint);
     }
 

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/SingleValueForProductVariantOptionValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/SingleValueForProductVariantOptionValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class SingleValueForProductVariantOptionValidatorTest extends TestCase
@@ -75,6 +76,8 @@ final class SingleValueForProductVariantOptionValidatorTest extends TestCase
         $firstProductOptionValueMock = $this->createMock(ProductOptionValueInterface::class);
         /** @var ProductOptionValueInterface|MockObject $secondProductOptionValueMock */
         $secondProductOptionValueMock = $this->createMock(ProductOptionValueInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $constraint = new SingleValueForProductVariantOption();
         $firstProductOptionValueMock->expects(self::once())->method('getOptionCode')->willReturn('OPTION');
         $secondProductOptionValueMock->expects(self::once())->method('getOptionCode')->willReturn('OPTION');
@@ -82,7 +85,9 @@ final class SingleValueForProductVariantOptionValidatorTest extends TestCase
             $firstProductOptionValueMock,
             $secondProductOptionValueMock,
         ]));
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.product_variant.option_values.single_value');
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.product_variant.option_values.single_value')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(SingleValueForProductVariantOption::MULTIPLE_VALUES_FOR_OPTION_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->singleValueForProductVariantOptionValidator->validate($variantMock, $constraint);
     }
 
@@ -101,7 +106,7 @@ final class SingleValueForProductVariantOptionValidatorTest extends TestCase
             $firstProductOptionValueMock,
             $secondProductOptionValueMock,
         ]));
-        $this->executionContext->expects(self::never())->method('addViolation')->with($constraint->message);
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->singleValueForProductVariantOptionValidator->validate($variantMock, $constraint);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UniqueReviewerEmailValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UniqueReviewerEmailValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class UniqueReviewerEmailValidatorTest extends TestCase
@@ -55,15 +56,19 @@ final class UniqueReviewerEmailValidatorTest extends TestCase
     {
         /** @var ShopUserInterface|MockObject $shopUserMock */
         $shopUserMock = $this->createMock(ShopUserInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $constraintViolationBuilderMock */
+        $constraintViolationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->userContext->expects(self::once())->method('getUser')->willReturn(null);
         $this->shopUserRepository->expects(self::once())->method('findOneByEmail')->with('email@example.com')->willReturn($shopUserMock);
-        $this->executionContext->expects(self::once())->method('addViolation')->with('sylius.review.author.already_exists');
+        $this->executionContext->expects(self::once())->method('buildViolation')->with('sylius.review.author.already_exists')->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('setCode')->with(UniqueReviewerEmail::REVIEWER_ALREADY_EXISTS_ERROR)->willReturn($constraintViolationBuilderMock);
+        $constraintViolationBuilderMock->expects(self::once())->method('addViolation');
         $this->uniqueReviewerEmailValidator->validate('email@example.com', new UniqueReviewerEmail());
     }
 
     public function testDoesNothingIfValueIsNull(): void
     {
-        $this->executionContext->expects(self::never())->method('addViolation');
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->uniqueReviewerEmailValidator->validate(null, new UniqueReviewerEmail());
     }
 
@@ -82,7 +87,7 @@ final class UniqueReviewerEmailValidatorTest extends TestCase
         $shopUserMock = $this->createMock(ShopUserInterface::class);
         $this->userContext->expects(self::once())->method('getUser')->willReturn($shopUserMock);
         $shopUserMock->expects(self::once())->method('getEmail')->willReturn('email@example.com');
-        $this->executionContext->expects(self::never())->method('addViolation');
+        $this->executionContext->expects(self::never())->method('buildViolation');
         $this->uniqueReviewerEmailValidator->validate('email@example.com', new UniqueReviewerEmail());
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UniqueShopUserEmailValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UniqueShopUserEmailValidatorTest.php
@@ -24,6 +24,7 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class UniqueShopUserEmailValidatorTest extends TestCase
@@ -90,9 +91,20 @@ final class UniqueShopUserEmailValidatorTest extends TestCase
             ->with('email@example.com')
             ->willReturn($shopUserMock);
 
-        $this->executionContext->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.user.email.unique');
+        $violationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+        $this->executionContext
+            ->expects(self::once())
+            ->method('buildViolation')
+            ->with($constraint->message)
+            ->willReturn($violationBuilder);
+        $violationBuilder
+            ->expects(self::once())
+            ->method('setCode')
+            ->with(UniqueShopUserEmail::EMAIL_NOT_UNIQUE_ERROR)
+            ->willReturnSelf();
+        $violationBuilder
+            ->expects(self::once())
+            ->method('addViolation');
 
         $this->uniqueShopUserEmailValidator->validate('eMaIl@example.com', $constraint);
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UpdateCartEmailNotAllowedValidatorTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Validator/Constraints/UpdateCartEmailNotAllowedValidatorTest.php
@@ -28,6 +28,7 @@ use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 #[AllowMockObjectsWithoutExpectations]
 final class UpdateCartEmailNotAllowedValidatorTest extends TestCase
@@ -144,6 +145,8 @@ final class UpdateCartEmailNotAllowedValidatorTest extends TestCase
         $customerMock = $this->createMock(CustomerInterface::class);
         /** @var ExecutionContextInterface|MockObject $executionContextMock */
         $executionContextMock = $this->createMock(ExecutionContextInterface::class);
+        /** @var ConstraintViolationBuilderInterface|MockObject $violationBuilderMock */
+        $violationBuilderMock = $this->createMock(ConstraintViolationBuilderInterface::class);
         /** @var OrderInterface|MockObject $orderMock */
         $orderMock = $this->createMock(OrderInterface::class);
         /** @var ShopUserInterface|MockObject $shopUserMock */
@@ -170,8 +173,17 @@ final class UpdateCartEmailNotAllowedValidatorTest extends TestCase
             ->willReturn($shopUserMock);
 
         $executionContextMock->expects(self::once())
-            ->method('addViolation')
-            ->with('sylius.checkout.email.not_changeable');
+            ->method('buildViolation')
+            ->with('sylius.checkout.email.not_changeable')
+            ->willReturn($violationBuilderMock);
+
+        $violationBuilderMock->expects(self::once())
+            ->method('setCode')
+            ->with(UpdateCartEmailNotAllowed::EMAIL_NOT_CHANGEABLE_ERROR)
+            ->willReturn($violationBuilderMock);
+
+        $violationBuilderMock->expects(self::once())
+            ->method('addViolation');
 
         $this->updateCartEmailNotAllowedValidator->validate($command, new UpdateCartEmailNotAllowed());
     }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Adds specific error codes to all API constraint validators. Previously, API validation errors returned `"code": null` in violation responses, making it impossible for BFF (Backend For Frontend) applications to programmatically differentiate between error types.

Now each violation includes a readable code like `PRODUCT_NOT_FOUND`, `INSUFFICIENT_STOCK`, `PAYMENT_METHOD_NOT_ELIGIBLE`, etc.

Changes:
- Added error code constants to all `Constraint` classes in `ApiBundle/Validator/Constraints/`
- Updated validators to use `buildViolation()->setCode()->addViolation()` pattern
- Updated unit tests to mock `ConstraintViolationBuilderInterface` properly
- Documented the response change in `UPGRADE-API-2.3.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit error code constants to all API validators, enabling more granular error handling and categorization.

* **Tests**
  * Updated validator tests to support the new violation builder pattern for better error code tracking and structured error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
