### PR TITLE
[CI] Remove pull_request trigger from full CI workflows

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -1,9 +1,6 @@
 name: Continuous Integration 1.14 (Full)
 
 on:
-    pull_request:
-        branches:
-            - '1.14'
     push:
         branches:
             - 'full-ci/**'
@@ -21,7 +18,6 @@ permissions:
 
 jobs:
     static-checks:
-        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["1.14"]

--- a/.github/workflows/ci__full_2_1.yaml
+++ b/.github/workflows/ci__full_2_1.yaml
@@ -1,9 +1,6 @@
 name: Continuous Integration 2.1 (Full)
 
 on:
-    pull_request:
-        branches:
-            - '2.1'
     push:
         branches:
             - 'full-ci/**'
@@ -21,7 +18,6 @@ permissions:
 
 jobs:
     static-checks:
-        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["2.1"]

--- a/.github/workflows/ci__full_2_2.yaml
+++ b/.github/workflows/ci__full_2_2.yaml
@@ -1,9 +1,6 @@
 name: Continuous Integration 2.2 (Full)
 
 on:
-    pull_request:
-        branches:
-            - '2.2'
     push:
         branches:
             - 'full-ci/**'
@@ -21,7 +18,6 @@ permissions:
 
 jobs:
     static-checks:
-        if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'full-ci/') }}
         strategy:
             matrix:
                 branch: ["2.2"]


### PR DESCRIPTION
Cleans up PR check lists by preventing full CI workflows from appearing as skipped jobs.

Previously, full CI workflows were triggered on every PR but jobs were skipped unless the branch started with `full-ci/`. This caused skipped jobs to appear in the PR checks list, making it cluttered.

Now full CI is only triggered by:
- Push to `full-ci/**` branches
- Daily schedule
- Manual workflow_dispatch

Ref: https://github.com/Sylius/Sylius/pull/18607
