### PR TITLE
Remove `choice_value` from autocomplete types to fix performance issue

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1,5 +1,14 @@
 # UPGRADE FROM `2.1.8` TO `2.1.9`
 
+## Autocomplete Form Types
+
+1. The `choice_value => 'code'` option has been removed from autocomplete form types (`ProductAutocompleteType`,
+   `ProductVariantAutocompleteType`, `ProductAttributeAutocompleteType`, `TaxonAutocompleteType`,
+   `ProductOptionAutocompleteType`) to fix performance issue with large datasets (#17953).
+   Autocomplete fields now use entity IDs instead of codes as their internal values.
+
+## Dashboard
+
 1. The `Sylius\Bundle\AdminBundle\Twig\Component\Dashboard\StatisticsComponent` constructor now requires
    a `Symfony\Component\Clock\ClockInterface` as the third argument. Not passing it is deprecated
    and will be prohibited in Sylius 3.0.

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -224,10 +224,10 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iAddScopeThatAppliesOnVariants(ProductVariantInterface ...$variants): void
     {
-        $variantCodes = array_map(fn (ProductVariantInterface $variant) => $variant->getCode(), $variants);
+        $variantNames = array_map(fn (ProductVariantInterface $variant) => $variant->getName(), $variants);
 
         $this->formElement->addScope(InForVariantsScopeVariantChecker::TYPE);
-        $this->formElement->selectScopeOption($variantCodes);
+        $this->formElement->selectScopeOption($variantNames);
     }
 
     /**
@@ -235,10 +235,10 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iAddScopeThatAppliesOnTaxons(TaxonInterface ...$taxons): void
     {
-        $taxonsCodes = array_map(fn (TaxonInterface $taxon) => $taxon->getCode(), $taxons);
+        $taxonNames = array_map(fn (TaxonInterface $taxon) => $taxon->getName(), $taxons);
 
         $this->formElement->addScope(InForTaxonsScopeVariantChecker::TYPE);
-        $this->formElement->selectScopeOption($taxonsCodes);
+        $this->formElement->selectScopeOption($taxonNames);
     }
 
     /**
@@ -247,7 +247,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function iAddScopeThatAppliesOnProduct(ProductInterface $product): void
     {
         $this->formElement->addScope(InForProductScopeVariantChecker::TYPE);
-        $this->formElement->selectScopeOption([$product->getCode()]);
+        $this->formElement->selectScopeOption([$product->getName()]);
     }
 
     /**
@@ -255,7 +255,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iAddVariantToItsScope(ProductVariantInterface $productVariant): void
     {
-        $this->formElement->selectScopeOption([$productVariant->getCode()]);
+        $this->formElement->selectScopeOption([$productVariant->getName()]);
     }
 
     /**
@@ -263,7 +263,7 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function iRemoveVariantFromItsScope(ProductVariantInterface $productVariant): void
     {
-        $this->formElement->removeScopeOption([$productVariant->getCode()]);
+        $this->formElement->removeScopeOption([$productVariant->getName()]);
     }
 
     /**
@@ -754,10 +754,10 @@ final class ManagingCatalogPromotionsContext implements Context
     ): void {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
 
-        $selectedVariants = $this->formElement->getLastScopeCodes();
+        $selectedVariants = $this->formElement->getLastScopeNames();
 
         foreach ($variants as $productVariant) {
-            Assert::inArray($productVariant->getCode(), $selectedVariants);
+            Assert::inArray($productVariant->getName(), $selectedVariants);
         }
 
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
@@ -772,10 +772,10 @@ final class ManagingCatalogPromotionsContext implements Context
     ): void {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
 
-        $selectedTaxons = $this->formElement->getLastScopeCodes();
+        $selectedTaxons = $this->formElement->getLastScopeNames();
 
         foreach ($taxons as $taxon) {
-            Assert::inArray($taxon->getCode(), $selectedTaxons);
+            Assert::inArray($taxon->getName(), $selectedTaxons);
         }
     }
 
@@ -784,9 +784,9 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thisCatalogPromotionShouldBeAppliedOnTaxon(TaxonInterface $taxon): void
     {
-        $selectedTaxons = $this->formElement->getLastScopeCodes();
+        $selectedTaxons = $this->formElement->getLastScopeNames();
 
-        Assert::inArray($taxon->getCode(), $selectedTaxons);
+        Assert::inArray($taxon->getName(), $selectedTaxons);
     }
 
     /**
@@ -806,8 +806,8 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function thisCatalogPromotionShouldBeAppliedOnProduct(ProductInterface $product): void
     {
-        $selectedProducts = $this->formElement->getLastScopeCodes();
-        Assert::inArray($product->getCode(), $selectedProducts);
+        $selectedProducts = $this->formElement->getLastScopeNames();
+        Assert::inArray($product->getName(), $selectedProducts);
     }
 
     /**
@@ -816,10 +816,10 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function itShouldApplyToVariants(ProductVariantInterface ...$variants): void
     {
-        $selectedVariants = $this->formElement->getLastScopeCodes();
+        $selectedVariants = $this->formElement->getLastScopeNames();
 
         foreach ($variants as $productVariant) {
-            Assert::inArray($productVariant->getCode(), $selectedVariants);
+            Assert::inArray($productVariant->getName(), $selectedVariants);
         }
     }
 
@@ -828,10 +828,10 @@ final class ManagingCatalogPromotionsContext implements Context
      */
     public function itShouldNotApplyToVariants(ProductVariantInterface ...$variants): void
     {
-        $selectedVariants = $this->formElement->getLastScopeCodes();
+        $selectedVariants = $this->formElement->getLastScopeNames();
 
         foreach ($variants as $productVariant) {
-            Assert::false(in_array($productVariant->getCode(), $selectedVariants));
+            Assert::false(in_array($productVariant->getName(), $selectedVariants, true));
         }
     }
 
@@ -1191,7 +1191,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->formElement->setExclusiveness($exclusive);
         $this->formElement->checkChannel($channel);
         $this->formElement->addScope(InForProductScopeVariantChecker::TYPE);
-        $this->formElement->selectScopeOption([$product->getCode()]);
+        $this->formElement->selectScopeOption([$product->getName()]);
         $this->formElement->addAction(PercentageDiscountPriceCalculator::TYPE);
         $this->formElement->fillActionOption('Amount', $discount);
         $this->createPage->create();

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -964,7 +964,14 @@ final readonly class ManagingProductsContext implements Context
      */
     public function itsImageShouldHaveVariantSelected(ProductVariantInterface $productVariant): void
     {
-        Assert::true($this->mediaFormElement->hasImageWithVariant($productVariant));
+        Assert::true(
+            $this->mediaFormElement->hasImageWithVariant($productVariant),
+            sprintf(
+                'Expected variant "%s" to be selected, but got "%s".',
+                $productVariant->getName(),
+                $this->mediaFormElement->getFirstImageSelectedVariantName() ?? 'none',
+            ),
+        );
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -271,7 +271,7 @@ final readonly class ManagingTaxonsContext implements Context
      */
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon): void
     {
-        Assert::same($this->formElement->getParent(), $taxon->getCode());
+        Assert::same($this->formElement->getParent(), $taxon->getName());
     }
 
     /**

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElement.php
@@ -98,14 +98,14 @@ class FormElement extends BaseFormElement implements FormElementInterface
         $this->waitForFormUpdate();
     }
 
-    public function selectScopeOption(array $values): void
+    public function selectScopeOption(array $names): void
     {
         $lastScope = $this->getElement('last_scope');
-        foreach ($values as $value) {
-            $this->autocompleteHelper->selectByValue(
+        foreach ($names as $name) {
+            $this->autocompleteHelper->selectByName(
                 $this->getDriver(),
                 $lastScope->find('css', 'select')->getXpath(),
-                $value,
+                $name,
             );
         }
 
@@ -128,12 +128,12 @@ class FormElement extends BaseFormElement implements FormElementInterface
         $lastAction->find('css', sprintf('[id$="_configuration_%s"]', $channelCode))->fillField($option, $value);
     }
 
-    public function getLastScopeCodes(): array
+    public function getLastScopeNames(): array
     {
         $lastScope = $this->getElement('last_scope');
 
         return array_map(
-            fn (NodeElement $element) => $element->getValue(),
+            fn (NodeElement $element) => $element->getText(),
             $lastScope->findAll('css', 'option[selected="selected"]'),
         );
     }
@@ -176,14 +176,14 @@ class FormElement extends BaseFormElement implements FormElementInterface
         return array_map(fn (NodeElement $element) => $element->getText(), $errors);
     }
 
-    public function removeScopeOption(array $values): void
+    public function removeScopeOption(array $names): void
     {
         $lastScope = $this->getElement('last_scope');
-        foreach ($values as $value) {
-            $this->autocompleteHelper->removeByValue(
+        foreach ($names as $name) {
+            $this->autocompleteHelper->removeByName(
                 $this->getDriver(),
                 $lastScope->find('css', 'select')->getXpath(),
-                $value,
+                $name,
             );
         }
 

--- a/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/CatalogPromotion/FormElementInterface.php
@@ -41,13 +41,13 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function addAction(string $type): void;
 
-    public function selectScopeOption(array $values): void;
+    public function selectScopeOption(array $names): void;
 
     public function fillActionOption(string $option, string $value): void;
 
     public function fillActionOptionForChannel(string $channelCode, string $option, string $value): void;
 
-    public function getLastScopeCodes(): array;
+    public function getLastScopeNames(): array;
 
     public function getLastActionOption(string $option): string;
 
@@ -61,7 +61,7 @@ interface FormElementInterface extends BaseFormElementInterface
 
     public function getValidationMessages(): array;
 
-    public function removeScopeOption(array $values): void;
+    public function removeScopeOption(array $names): void;
 
     public function removeLastAction(): void;
 

--- a/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ExcludeTaxonsFromShowingLowestPriceInputElement.php
@@ -33,10 +33,10 @@ class ExcludeTaxonsFromShowingLowestPriceInputElement extends BaseFormElement im
     {
         $excludeTaxonElement = $this->getElement('taxons_excluded_from_showing_lowest_price');
 
-        $this->autocompleteHelper->selectByValue(
+        $this->autocompleteHelper->selectByName(
             $this->getDriver(),
             $excludeTaxonElement->getXpath(),
-            $taxon->getCode(),
+            $taxon->getName(),
         );
         $this->waitForFormUpdate();
     }
@@ -45,10 +45,10 @@ class ExcludeTaxonsFromShowingLowestPriceInputElement extends BaseFormElement im
     {
         $excludeTaxonElement = $this->getElement('taxons_excluded_from_showing_lowest_price');
 
-        $this->autocompleteHelper->removeByValue(
+        $this->autocompleteHelper->removeByName(
             $this->getDriver(),
             $excludeTaxonElement->getXpath(),
-            $taxon->getCode(),
+            $taxon->getName(),
         );
         $this->waitForFormUpdate();
     }

--- a/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/AssociationsFormElement.php
@@ -50,10 +50,10 @@ class AssociationsFormElement extends BaseFormElement implements AssociationsFor
         $this->changeTab();
         $associationField = $this->getElement('associations', ['%association%' => $productAssociationType->getCode()]);
 
-        $this->autocompleteHelper->removeByValue(
+        $this->autocompleteHelper->removeByName(
             $this->getDriver(),
             $associationField->getXpath(),
-            $product->getCode(),
+            $product->getName(),
         );
     }
 
@@ -62,7 +62,12 @@ class AssociationsFormElement extends BaseFormElement implements AssociationsFor
         $this->changeTab();
         $associationField = $this->getElement('associations', ['%association%' => $productAssociationType->getCode()]);
 
-        return in_array($product->getCode(), $associationField->getValue(), true);
+        $selectedItems = $this->autocompleteHelper->getSelectedItems(
+            $this->getDriver(),
+            $associationField->getXpath(),
+        );
+
+        return in_array($product->getName(), $selectedItems, true);
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Product/MediaFormElement.php
@@ -48,10 +48,10 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
         }
 
         if (null !== $productVariant) {
-            $this->autocompleteHelper->selectByValue(
+            $this->autocompleteHelper->selectByName(
                 $this->getDriver(),
                 $imageSubform->find('css', '[data-test-product-variant]')->getXpath(),
-                $productVariant->getCode(),
+                $productVariant->getName(),
             );
         }
 
@@ -107,11 +107,29 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
 
     public function hasImageWithVariant(ProductVariantInterface $productVariant): bool
     {
+        $selectedVariantName = $this->getFirstImageSelectedVariantName();
+
+        if (null === $selectedVariantName) {
+            return false;
+        }
+
+        return str_contains($selectedVariantName, $productVariant->getName());
+    }
+
+    public function getFirstImageSelectedVariantName(): ?string
+    {
         $this->changeTab();
 
-        $images = $this->getElement('images');
+        $imageSubform = $this->getFirstImageSubform();
+        $variantField = $imageSubform->find('css', '[data-test-product-variant]');
 
-        return $images->has('css', sprintf('[data-test-product-variant*="%s"]', $productVariant->getCode()));
+        $selectedOption = $variantField->find('css', 'option[selected]');
+
+        if (null === $selectedOption) {
+            return null;
+        }
+
+        return $selectedOption->getText();
     }
 
     public function countImages(): int
@@ -189,10 +207,10 @@ class MediaFormElement extends BaseFormElement implements MediaFormElementInterf
         $this->changeTab();
 
         $imageSubform = $this->getFirstImageSubform();
-        $this->autocompleteHelper->selectByValue(
+        $this->autocompleteHelper->selectByName(
             $this->getDriver(),
             $imageSubform->find('css', '[data-test-product-variant]')->getXpath(),
-            $productVariant->getCode(),
+            $productVariant->getName(),
         );
     }
 

--- a/src/Sylius/Behat/Element/Admin/Product/MediaFormElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Product/MediaFormElementInterface.php
@@ -29,6 +29,8 @@ interface MediaFormElementInterface
 
     public function hasImageWithVariant(ProductVariantInterface $productVariant): bool;
 
+    public function getFirstImageSelectedVariantName(): ?string;
+
     public function countImages(): int;
 
     public function getImages(): array;

--- a/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
+++ b/src/Sylius/Behat/Element/Admin/Taxon/FormElement.php
@@ -66,7 +66,20 @@ class FormElement extends BaseFormElement implements FormElementInterface
 
     public function getParent(): string
     {
-        return $this->getElement('parent')->getValue();
+        $parentElement = $this->getElement('parent');
+
+        if (DriverHelper::isJavascript($this->getDriver())) {
+            $items = $this->autocompleteHelper->getSelectedItems(
+                $this->getDriver(),
+                $parentElement->getXpath(),
+            );
+
+            return count($items) > 0 ? reset($items) : '';
+        }
+
+        $selectedOption = $parentElement->find('css', 'option[selected]');
+
+        return $selectedOption?->getText() ?? '';
     }
 
     public function chooseParent(TaxonInterface $taxon): void

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ChannelPriceHistoryConfigType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ChannelPriceHistoryConfigType.php
@@ -44,7 +44,6 @@ final class ChannelPriceHistoryConfigType extends AbstractType implements DataMa
                 'required' => false,
                 'multiple' => true,
                 'expanded' => false,
-                'choice_value' => 'code',
             ])
         ;
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeAutocompleteType.php
@@ -33,7 +33,6 @@ final class ProductAttributeAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'class' => $this->productAttributeClass,
             'choice_name' => 'name',
-            'choice_value' => 'code',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAutocompleteType.php
@@ -33,7 +33,6 @@ final class ProductAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'class' => $this->productClass,
             'choice_name' => 'name',
-            'choice_value' => 'code',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductImageType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductImageType.php
@@ -37,7 +37,6 @@ final class ProductImageType extends AbstractType
                     'multiple' => true,
                     'required' => false,
                     'choice_label' => 'descriptor',
-                    'choice_value' => 'code',
                     'query_builder' => function (EntityRepository $er) use ($options): QueryBuilder {
                         return $er->createQueryBuilder('o')
                             ->where('o.product = :product')

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantAutocompleteType.php
@@ -33,7 +33,6 @@ final class ProductVariantAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'class' => $this->productVariantClass,
             'choice_name' => 'descriptor',
-            'choice_value' => 'code',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -33,7 +33,6 @@ final class TaxonAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'class' => $this->taxonClass,
             'choice_label' => 'fullname',
-            'choice_value' => 'code',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
@@ -35,14 +35,23 @@ final class TranslatableAutocompleteType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefault('entity_fields', ['code']);
+        $resolver->setDefault('choice_label', function (Options $options): string {
+            return $options['extra_options']['choice_label'] ?? 'name';
+        });
+
+        $resolver->setDefault('entity_fields', function (Options $options): array {
+            return $options['extra_options']['entity_fields'] ?? ['code'];
+        });
+
         $resolver->setAllowedTypes('entity_fields', ['array', 'null']);
         $resolver->setNormalizer('entity_fields', fn (Options $options, ?array $entityFields) => array_map(
             fn (string $field) => self::ENTITY_ALIAS . '.' . $field,
             $entityFields ?? [],
         ));
 
-        $resolver->setDefault('translation_fields', ['name']);
+        $resolver->setDefault('translation_fields', function (Options $options): array {
+            return $options['extra_options']['translation_fields'] ?? ['name'];
+        });
         $resolver->setAllowedTypes('translation_fields', 'array');
         $resolver->setNormalizer('translation_fields', fn (Options $options, array $translationFields) => array_map(
             fn (string $field) => self::TRANSLATION_ALIAS . '.' . $field,

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Product/FormComponent.php
@@ -123,11 +123,11 @@ class FormComponent
     public function addAttributes(): void
     {
         foreach ($this->attributesToBeAdded as $attributeCode) {
-            $productAttribute = $this->productAttributeRepository->findOneBy(['code' => $attributeCode]);
+            $productAttribute = $this->productAttributeRepository->find($attributeCode);
 
             if (!$productAttribute->isTranslatable()) {
                 $this->formValues['attributes'][] = [
-                    'attribute' => $attributeCode,
+                    'attribute' => $productAttribute->getCode(),
                     'localeCode' => null,
                     'value' => '',
                 ];
@@ -137,7 +137,7 @@ class FormComponent
 
             foreach ($this->formValues['translations'] as $localesCode => $translation) {
                 $this->formValues['attributes'][] = [
-                    'attribute' => $attributeCode,
+                    'attribute' => $productAttribute->getCode(),
                     'localeCode' => $localesCode,
                     'value' => '',
                 ];

--- a/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/FormComponent.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/Component/Taxon/FormComponent.php
@@ -53,7 +53,7 @@ class FormComponent
     public function generateTaxonSlug(#[LiveArg] string $localeCode): void
     {
         $name = $this->formValues['translations'][$localeCode]['name'];
-        $parent = $this->repository->findOneBy(['code' => $this->formValues['parent']]);
+        $parent = $this->repository->find($this->formValues['parent']);
 
         $this->formValues['translations'][$localeCode]['slug'] = $this->slugGenerator->generate($name, $localeCode, $parent);
     }

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionAutocompleteType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionAutocompleteType.php
@@ -24,7 +24,6 @@ final class ProductOptionAutocompleteType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choice_value' => 'code',
             'choice_name' => 'name',
             'resource' => 'sylius.product_option',
         ]);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Fixed tickets   | fixes #17953
| License         | MIT

## Summary

Removes explicit `choice_value => 'code'` from autocomplete form types to fix a **critical performance issue**.

### The Problem

When `choice_value` is explicitly set (even to a property like `code`), Symfony's `DoctrineChoiceLoader` cannot use the optimized `getEntitiesByIds()` query. Instead, it falls back to loading **ALL entities** via `getEntities()` without any WHERE clause.

With 4000+ products, this causes severe performance degradation.

### The Solution

- Remove `choice_value` option, letting Symfony use the default (entity ID)
- This enables the optimized `WHERE id IN (...)` query
- Update all Behat contexts/elements to use `getId()` instead of `getCode()`

### References

- [Symfony UX Issue #2736](https://github.com/symfony/ux/issues/2736) - Extra query without WHERE when choice_value is defined
- [Symfony Issue #57724](https://github.com/symfony/symfony/issues/57724) - EntityType performance with large datasets
- [Lazy Choice Loader (Symfony 7.2)](https://symfony.com/blog/new-in-symfony-7-2-lazy-choice-loader)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Autocomplete fields across products, variants, options and taxons now display and select by human-readable names while using stable internal identifiers for form submissions.
  * Catalog promotion scope controls updated for clearer name-based selection and feedback when adding/removing scopes.
  * Product image and variant selection flows enhanced to show and verify selected variant names more reliably.
  * Taxon parent selection improved for richer behavior in JavaScript-enabled admin pages.

* **Documentation**
  * Added upgrade notes explaining autocomplete behavior and migration considerations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->