### PR TITLE
[Admin] Fix cache TTL in `HubNotificationProvider` and refactor tests

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -4,6 +4,9 @@
    a `Symfony\Component\Clock\ClockInterface` as the third argument. Not passing it is deprecated
    and will be prohibited in Sylius 3.0.
 
+1. The `$clock` argument in `Sylius\Bundle\AdminBundle\Notification\HubNotificationProvider` constructor is deprecated
+   and will be removed in Sylius 3.0.
+
 1. The priorities of hookables in `sylius_admin.order.update.content.form.shipping_address` hook have been adjusted
    to match `sylius_admin.order.update.content.form.billing_address` and fix duplicate priority values.
    If you have customized these hooks or added custom hookables with priorities between the old values,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,6 +32,13 @@ parameters:
         - 'src/Sylius/Abstraction/StateMachine/src/WinzouStateMachineAdapter.php'
 
     ignoreErrors:
+        # Deprecated property, will be removed in Sylius 3.0
+        -
+            message: '/Property Sylius\\Bundle\\AdminBundle\\Notification\\HubNotificationProvider::\$clock is never read, only written\./'
+            identifier: property.onlyWritten
+            count: 1
+            path: src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
+
         - identifier: missingType.generics # This need to be fixed, too many classes are using generics without PHPDoc type
         # Symfony 7.4 introduced generics on NodeBuilder which phpstan-symfony does not handle correctly yet
         # See: https://github.com/phpstan/phpstan-symfony/issues/431

--- a/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
+++ b/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
@@ -44,10 +44,9 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
 
     public function getNotifications(array $context = []): array
     {
-        $metadata = $this->cache instanceof ItemInterface ? $this->cache->getMetadata() : [];
-        $metadata[ItemInterface::METADATA_EXPIRY] = $this->clock->now()->modify(sprintf('+%d minutes', $this->checkFrequency))->getTimestamp();
+        $latestVersion = $this->cache->get(self::LATEST_SYLIUS_VERSION_KEY, function (ItemInterface $item): ?string {
+            $item->expiresAfter($this->checkFrequency * 60);
 
-        $latestVersion = $this->cache->get(self::LATEST_SYLIUS_VERSION_KEY, function (): ?string {
             return $this->getLatestVersion();
         });
 
@@ -74,6 +73,10 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
     private function getLatestVersion(): ?string
     {
         $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            return null;
+        }
 
         $content = json_encode([
             'version' => SyliusCoreBundle::VERSION,

--- a/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
+++ b/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
@@ -28,6 +28,7 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
 {
     public const LATEST_SYLIUS_VERSION_KEY = 'latest_sylius_version';
 
+    /** @param ClockInterface $clock @deprecated since Sylius 2.1.9, will be removed in Sylius 3.0 */
     public function __construct(
         private ClientInterface $client,
         private RequestStack $requestStack,

--- a/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\AdminBundle\Notification;
 
-use GuzzleHttp\Exception\ConnectException;
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Clock\ClockInterface;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -34,126 +30,88 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class HubNotificationProviderTest extends TestCase
 {
-    use ProphecyTrait;
-
-    private ClientInterface|ObjectProphecy $client;
-
-    private ObjectProphecy|RequestStack $requestStack;
-
-    private ObjectProphecy|RequestFactoryInterface $requestFactory;
-
-    private ObjectProphecy|StreamFactoryInterface $streamFactory;
-
-    private CacheInterface|ObjectProphecy $cache;
-
-    private ClockInterface|ObjectProphecy $clock;
-
-    private HubNotificationProvider $hubNotificationsProvider;
-
-    private static string $hubUri = 'www.doesnotexist.test.com';
-
-    public function setUp(): void
+    public function testDoesNotReturnNotificationIfClientExceptionOccurs(): void
     {
-        parent::setUp();
+        $provider = $this->createProvider(
+            hubResponse: $this->createMock(ClientExceptionInterface::class),
+        );
 
-        $this->client = $this->prophesize(ClientInterface::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->requestFactory = $this->prophesize(RequestFactoryInterface::class);
-        $this->streamFactory = $this->prophesize(StreamFactoryInterface::class);
-        $this->cache = $this->prophesize(CacheInterface::class);
-        $this->clock = $this->prophesize(ClockInterface::class);
+        $this->assertEmpty($provider->getNotifications());
+    }
 
-        $this->hubNotificationsProvider = new HubNotificationProvider(
-            $this->client->reveal(),
-            $this->requestStack->reveal(),
-            $this->requestFactory->reveal(),
-            $this->streamFactory->reveal(),
-            $this->cache->reveal(),
-            $this->clock->reveal(),
-            self::$hubUri,
+    public function testDoesNotReturnNotificationIfCurrentVersionIsSameAsLatest(): void
+    {
+        $provider = $this->createProvider(
+            hubResponse: ['version' => SyliusCoreBundle::VERSION],
+        );
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    public function testReturnsNotificationIfVersionIsDifferent(): void
+    {
+        $provider = $this->createProvider(hubResponse: ['version' => '1.0.0']);
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '1.0.0',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testDoesNotReturnNotificationIfHubResponseHasNoVersion(): void
+    {
+        $provider = $this->createProvider(hubResponse: ['foo' => 'bar']);
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    private function createProvider(array|\Throwable $hubResponse): HubNotificationProvider
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withHeader')->willReturnSelf();
+        $request->method('withBody')->willReturnSelf();
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $stream = $this->createMock(StreamInterface::class);
+
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturn($stream);
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(new Request());
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->method('now')->willReturn(new \DateTimeImmutable());
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback());
+
+        $client = $this->createMock(ClientInterface::class);
+
+        if ($hubResponse instanceof \Throwable) {
+            $client->method('sendRequest')->willThrowException($hubResponse);
+        } else {
+            $stream->method('getContents')->willReturn(json_encode($hubResponse));
+            $response = $this->createMock(ResponseInterface::class);
+            $response->method('getBody')->willReturn($stream);
+            $client->method('sendRequest')->willReturn($response);
+        }
+
+        return new HubNotificationProvider(
+            $client,
+            $requestStack,
+            $requestFactory,
+            $streamFactory,
+            $cache,
+            $clock,
+            'https://hub.example.com',
             'prod',
             true,
             60,
         );
-    }
-
-    #[Test]
-    public function it_returns_an_empty_array_if_client_exception_occurs(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $this->client->sendRequest(Argument::cetera())->willThrow(ConnectException::class);
-
-        $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
-    }
-
-    #[Test]
-    public function it_returns_an_empty_array_if_the_current_version_is_the_same_as_latest(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $content = json_encode(['version' => SyliusCoreBundle::VERSION]);
-        $stream->getContents()->willReturn($content);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
-
-        $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
-    }
-
-    #[Test]
-    public function it_returns_a_notification_if_the_current_version_is_different_than_latest(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(fn ($args) => $args[1]());
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $content = json_encode(['version' => '1.0.0']);
-        $stream->getContents()->willReturn($content);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
-
-        $notifications = $this->hubNotificationsProvider->getNotifications();
-
-        $this->assertNotEmpty($notifications);
-        $this->assertArrayHasKey('latest_sylius_version', $notifications);
-        $this->assertSame($notifications['latest_sylius_version'], [
-            'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
-            'latest_version' => '1.0.0',
-        ]);
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/tests/Notification/HubNotificationProviderTest.php
@@ -27,14 +27,31 @@ use Sylius\Bundle\CoreBundle\SyliusCoreBundle;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 final class HubNotificationProviderTest extends TestCase
 {
     public function testDoesNotReturnNotificationIfClientExceptionOccurs(): void
     {
+        $client = $this->createMock(ClientInterface::class);
+        $client
+            ->method('sendRequest')
+            ->willThrowException($this->createMock(ClientExceptionInterface::class));
+
         $provider = $this->createProvider(
-            hubResponse: $this->createMock(ClientExceptionInterface::class),
+            hubResponse: [],
+            client: $client,
         );
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    public function testItDoesNotReturnNotificationIfThereIsNoCurrentRequest(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $provider = $this->createProvider(requestStack: $requestStack);
 
         $this->assertEmpty($provider->getNotifications());
     }
@@ -50,12 +67,12 @@ final class HubNotificationProviderTest extends TestCase
 
     public function testReturnsNotificationIfVersionIsDifferent(): void
     {
-        $provider = $this->createProvider(hubResponse: ['version' => '1.0.0']);
+        $provider = $this->createProvider(hubResponse: ['version' => 'NEW-VERSION']);
 
         $this->assertSame([
             'latest_sylius_version' => [
                 'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
-                'latest_version' => '1.0.0',
+                'latest_version' => 'NEW-VERSION',
             ],
         ], $provider->getNotifications());
     }
@@ -67,8 +84,97 @@ final class HubNotificationProviderTest extends TestCase
         $this->assertEmpty($provider->getNotifications());
     }
 
-    private function createProvider(array|\Throwable $hubResponse): HubNotificationProvider
+    public function testDoesNotCallHubWhenCacheExists(): void
     {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->method('get')
+            ->with(HubNotificationProvider::LATEST_SYLIUS_VERSION_KEY)
+            ->willReturn('2.1.7');
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->never())->method('sendRequest');
+
+        $provider = $this->createProvider(
+            hubResponse: ['version' => '2.1.7'],
+            cache: $cache,
+            client: $client,
+        );
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '2.1.7',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testCallsHubWhenCacheExpired(): void
+    {
+        $checkFrequencyInMinutes = 60;
+
+        $cacheItem = $this->createMock(ItemInterface::class);
+        $cacheItem
+            ->expects($this->once())
+            ->method('expiresAfter')
+            ->with($checkFrequencyInMinutes * 60);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->method('get')
+            ->with(HubNotificationProvider::LATEST_SYLIUS_VERSION_KEY, $this->anything())
+            ->willReturnCallback(
+                function (string $key, callable $callback) use ($cacheItem): ?string {
+                    return $callback($cacheItem);
+                },
+            );
+
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn(json_encode(['version' => '2.1.7']));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->willReturn($response);
+
+        $provider = $this->createProvider(
+            hubResponse: ['version' => '2.1.7'],
+            cache: $cache,
+            client: $client,
+            checkFrequency: $checkFrequencyInMinutes,
+        );
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '2.1.7',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testSupportsReturnsTrueWhenHubNotificationsEnabled(): void
+    {
+        $provider = $this->createProvider(areHubNotificationsEnabled: true);
+
+        $this->assertTrue($provider->supports());
+    }
+
+    public function testSupportsReturnsFalseWhenHubNotificationsDisabled(): void
+    {
+        $provider = $this->createProvider(areHubNotificationsEnabled: false);
+
+        $this->assertFalse($provider->supports());
+    }
+
+    private function createProvider(
+        array $hubResponse = [],
+        ?CacheInterface $cache = null,
+        ?ClientInterface $client = null,
+        int $checkFrequency = 60,
+        bool $areHubNotificationsEnabled = true,
+        ?RequestStack $requestStack = null,
+    ): HubNotificationProvider {
         $request = $this->createMock(RequestInterface::class);
         $request->method('withHeader')->willReturnSelf();
         $request->method('withBody')->willReturnSelf();
@@ -77,27 +183,27 @@ final class HubNotificationProviderTest extends TestCase
         $requestFactory->method('createRequest')->willReturn($request);
 
         $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn(json_encode($hubResponse));
 
         $streamFactory = $this->createMock(StreamFactoryInterface::class);
         $streamFactory->method('createStream')->willReturn($stream);
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack->method('getCurrentRequest')->willReturn(new Request());
+        if ($requestStack === null) {
+            $requestStack = $this->createMock(RequestStack::class);
+            $requestStack->method('getCurrentRequest')->willReturn(new Request());
+        }
 
-        $clock = $this->createMock(ClockInterface::class);
-        $clock->method('now')->willReturn(new \DateTimeImmutable());
+        if ($cache === null) {
+            $cacheItem = $this->createMock(ItemInterface::class);
+            $cache = $this->createMock(CacheInterface::class);
+            $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback($cacheItem));
+        }
 
-        $cache = $this->createMock(CacheInterface::class);
-        $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback());
-
-        $client = $this->createMock(ClientInterface::class);
-
-        if ($hubResponse instanceof \Throwable) {
-            $client->method('sendRequest')->willThrowException($hubResponse);
-        } else {
-            $stream->method('getContents')->willReturn(json_encode($hubResponse));
+        if ($client === null) {
             $response = $this->createMock(ResponseInterface::class);
             $response->method('getBody')->willReturn($stream);
+
+            $client = $this->createMock(ClientInterface::class);
             $client->method('sendRequest')->willReturn($response);
         }
 
@@ -107,11 +213,11 @@ final class HubNotificationProviderTest extends TestCase
             $requestFactory,
             $streamFactory,
             $cache,
-            $clock,
+            $this->createMock(ClockInterface::class),
             'https://hub.example.com',
             'prod',
-            true,
-            60,
+            $areHubNotificationsEnabled,
+            $checkFrequency,
         );
     }
 }


### PR DESCRIPTION
Fixes cache TTL bug where `expiresAfter()` was never called due to incorrect callback signature.

Changes:
- Fix cache callback to accept `ItemInterface` and set proper TTL
- Refactor tests from Prophecy to PHPUnit native mocks
- Add tests for `supports()` method and null request handling
- Deprecate unused `$clock` constructor argument (will be removed in 3.0)

