### PR TITLE
[Admin] Fix cache TTL in HubNotificationProvider and refactor tests - `Sylius 2.0`

### DIFF
--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -95,7 +95,7 @@ jobs:
                     echo "{}" > public/build/app/shop/manifest.json
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -92,7 +92,7 @@ jobs:
                     echo "{}" > public/build/app/shop/manifest.json
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
@@ -181,7 +181,7 @@ jobs:
                 run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"
@@ -269,7 +269,7 @@ jobs:
                 run: composer require --no-update --no-scripts --no-interaction "twig/twig:${{ matrix.twig }}"
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}"

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -88,7 +88,7 @@ jobs:
                     echo "{}" > public/build/app/shop/manifest.json
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key: "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -57,7 +57,7 @@ jobs:
                     echo "{}" > public/build/app/shop/manifest.json
             
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     cache_key:  "${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-"

--- a/.github/workflows/ci_frontend.yaml
+++ b/.github/workflows/ci_frontend.yaml
@@ -73,7 +73,7 @@ jobs:
                 uses: actions/checkout@v4
 
             -   name: Build application
-                uses: SyliusLabs/BuildTestAppAction@v2.4
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
                     build_type: "sylius"
                     e2e_js: "yes"

--- a/AUDIT-IGNORE.md
+++ b/AUDIT-IGNORE.md
@@ -1,0 +1,8 @@
+# AUDIT-IGNORE
+
+This document explains why specific advisories are added to `composer.json` → `config.audit.ignore`.
+
+**PKSA-gs8r-6kz6-pp56** — CVE-2025-64500; Symfony versions <5.4.50, >=6, <6.4.29, >=7, <7.3.7 of the Symfony HTTP Foundation component are affected by this security issue.
+
+https://www.cve.org/CVERecord?id=CVE-2025-64500
+https://symfony.com/blog/cve-2025-64500-incorrect-parsing-of-path-info-can-lead-to-limited-authorization-bypass

--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -16,3 +16,19 @@ This document explains why certain conflicts were added to `composer.json` and r
 
   The versions 2.28.0 and 2.28.1 throws a MethodNotAllowedException during using live components.
   Since the version 2.29 the behavior of UrlFactory::createFromPreviousAndProps method has been changed that unmatches the previous one.
+
+- `api-platform/metadata:>=4.1.0 <4.2.0` and `api-platform/serializer:>=4.1.0 <4.2.0`:
+
+  In API Platform 4.1.24+, the `api-platform/serializer` package calls `getNativeType()` method on
+  `ApiPlatform\Metadata\ApiProperty` which doesn't exist in the `api-platform/metadata` package of the
+  same 4.1.x branch, causing an "undefined method" error when custom serializers are used with API Platform's
+  `ObjectNormalizer`.
+
+  Error: `Attempted to call an undefined method named "getNativeType" of class "ApiPlatform\Metadata\ApiProperty".`
+
+  This is a version mismatch issue between API Platform 4.1.x packages. The conflict excludes the entire 4.1.x
+  series, allowing only 4.0.x (stable, without this bug) or 4.2.x+ (where all packages are consistent).
+
+  Related issues:
+    - https://github.com/api-platform/core/issues/7404
+    - https://github.com/api-platform/api-platform/issues/2934

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -24,7 +24,7 @@ default:
 
         Behat\MinkExtension:
             files_path: "%paths.base%/src/Sylius/Behat/Resources/fixtures/"
-            base_url: "https://127.0.0.1:8080/"
+            base_url: "http://127.0.0.1:8080/"
             default_session: symfony
             javascript_session: panther
             sessions:

--- a/composer.json
+++ b/composer.json
@@ -243,6 +243,8 @@
     },
     "conflict": {
         "api-platform/jsonld": "^4.1.1",
+        "api-platform/metadata": ">=4.1.0 <4.2.0",
+        "api-platform/serializer": ">=4.1.0 <4.2.0",
         "behat/gherkin": "^4.13.0",
         "symfony/ux-live-component": "2.28.0 || 2.28.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -256,6 +256,11 @@
             "php-http/discovery": false,
             "symfony/flex": true,
             "symfony/runtime": true
+        },
+        "audit": {
+            "ignore": [
+                "PKSA-365x-2zjk-pt47"
+            ]
         }
     },
     "extra": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -47,3 +47,8 @@ parameters:
         - '/Method Symfony\\Component\\HttpKernel\\CacheWarmer\\WarmableInterface\:\:warmUp\(\) invoked with 2 parameters\, 1 required\./' # Symfony compatibility
         - '/Method Sylius\\Component\\(\w+)\\Model\\(\w+)\:\:getId\(\) has no return type specified./'
         - '/Method Sylius\\Bundle\\(Admin|Shop)Bundle\\Twig\\Component\\[a-zA-Z\\]+\:\:getDataModelValue\(\) is unused./'
+        -
+            message: '/Property Sylius\\Bundle\\AdminBundle\\Notification\\HubNotificationProvider::\$clock is never read, only written\./'
+            identifier: property.onlyWritten
+            count: 1
+            path: src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php

--- a/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
+++ b/src/Sylius/Bundle/AdminBundle/Notification/HubNotificationProvider.php
@@ -44,10 +44,9 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
 
     public function getNotifications(array $context = []): array
     {
-        $metadata = $this->cache instanceof ItemInterface ? $this->cache->getMetadata() : [];
-        $metadata[ItemInterface::METADATA_EXPIRY] = $this->clock->now()->modify(sprintf('+%d minutes', $this->checkFrequency))->getTimestamp();
+        $latestVersion = $this->cache->get(self::LATEST_SYLIUS_VERSION_KEY, function (ItemInterface $item): ?string {
+            $item->expiresAfter($this->checkFrequency * 60);
 
-        $latestVersion = $this->cache->get(self::LATEST_SYLIUS_VERSION_KEY, function (): ?string {
             return $this->getLatestVersion();
         });
 
@@ -74,6 +73,10 @@ final readonly class HubNotificationProvider implements NotificationProviderInte
     private function getLatestVersion(): ?string
     {
         $request = $this->requestStack->getCurrentRequest();
+
+        if ($request === null) {
+            return null;
+        }
 
         $content = json_encode([
             'version' => SyliusCoreBundle::VERSION,

--- a/src/Sylius/Bundle/AdminBundle/Tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Notification/HubNotificationProviderTest.php
@@ -27,14 +27,31 @@ use Sylius\Bundle\CoreBundle\SyliusCoreBundle;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 final class HubNotificationProviderTest extends TestCase
 {
     public function testDoesNotReturnNotificationIfClientExceptionOccurs(): void
     {
+        $client = $this->createMock(ClientInterface::class);
+        $client
+            ->method('sendRequest')
+            ->willThrowException($this->createMock(ClientExceptionInterface::class));
+
         $provider = $this->createProvider(
-            hubResponse: $this->createMock(ClientExceptionInterface::class),
+            hubResponse: [],
+            client: $client,
         );
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    public function testItDoesNotReturnNotificationIfThereIsNoCurrentRequest(): void
+    {
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $provider = $this->createProvider(requestStack: $requestStack);
 
         $this->assertEmpty($provider->getNotifications());
     }
@@ -50,12 +67,12 @@ final class HubNotificationProviderTest extends TestCase
 
     public function testReturnsNotificationIfVersionIsDifferent(): void
     {
-        $provider = $this->createProvider(hubResponse: ['version' => '1.0.0']);
+        $provider = $this->createProvider(hubResponse: ['version' => 'NEW-VERSION']);
 
         $this->assertSame([
             'latest_sylius_version' => [
                 'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
-                'latest_version' => '1.0.0',
+                'latest_version' => 'NEW-VERSION',
             ],
         ], $provider->getNotifications());
     }
@@ -67,8 +84,97 @@ final class HubNotificationProviderTest extends TestCase
         $this->assertEmpty($provider->getNotifications());
     }
 
-    private function createProvider(array|\Throwable $hubResponse): HubNotificationProvider
+    public function testDoesNotCallHubWhenCacheExists(): void
     {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->method('get')
+            ->with(HubNotificationProvider::LATEST_SYLIUS_VERSION_KEY)
+            ->willReturn('2.1.7');
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->never())->method('sendRequest');
+
+        $provider = $this->createProvider(
+            hubResponse: ['version' => '2.1.7'],
+            cache: $cache,
+            client: $client,
+        );
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '2.1.7',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testCallsHubWhenCacheExpired(): void
+    {
+        $checkFrequencyInMinutes = 60;
+
+        $cacheItem = $this->createMock(ItemInterface::class);
+        $cacheItem
+            ->expects($this->once())
+            ->method('expiresAfter')
+            ->with($checkFrequencyInMinutes * 60);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->method('get')
+            ->with(HubNotificationProvider::LATEST_SYLIUS_VERSION_KEY, $this->anything())
+            ->willReturnCallback(
+                function (string $key, callable $callback) use ($cacheItem): ?string {
+                    return $callback($cacheItem);
+                },
+            );
+
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn(json_encode(['version' => '2.1.7']));
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($stream);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->willReturn($response);
+
+        $provider = $this->createProvider(
+            hubResponse: ['version' => '2.1.7'],
+            cache: $cache,
+            client: $client,
+            checkFrequency: $checkFrequencyInMinutes,
+        );
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '2.1.7',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testSupportsReturnsTrueWhenHubNotificationsEnabled(): void
+    {
+        $provider = $this->createProvider(areHubNotificationsEnabled: true);
+
+        $this->assertTrue($provider->supports());
+    }
+
+    public function testSupportsReturnsFalseWhenHubNotificationsDisabled(): void
+    {
+        $provider = $this->createProvider(areHubNotificationsEnabled: false);
+
+        $this->assertFalse($provider->supports());
+    }
+
+    private function createProvider(
+        array $hubResponse = [],
+        ?CacheInterface $cache = null,
+        ?ClientInterface $client = null,
+        int $checkFrequency = 60,
+        bool $areHubNotificationsEnabled = true,
+        ?RequestStack $requestStack = null,
+    ): HubNotificationProvider {
         $request = $this->createMock(RequestInterface::class);
         $request->method('withHeader')->willReturnSelf();
         $request->method('withBody')->willReturnSelf();
@@ -77,27 +183,27 @@ final class HubNotificationProviderTest extends TestCase
         $requestFactory->method('createRequest')->willReturn($request);
 
         $stream = $this->createMock(StreamInterface::class);
+        $stream->method('getContents')->willReturn(json_encode($hubResponse));
 
         $streamFactory = $this->createMock(StreamFactoryInterface::class);
         $streamFactory->method('createStream')->willReturn($stream);
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack->method('getCurrentRequest')->willReturn(new Request());
+        if ($requestStack === null) {
+            $requestStack = $this->createMock(RequestStack::class);
+            $requestStack->method('getCurrentRequest')->willReturn(new Request());
+        }
 
-        $clock = $this->createMock(ClockInterface::class);
-        $clock->method('now')->willReturn(new \DateTimeImmutable());
+        if ($cache === null) {
+            $cacheItem = $this->createMock(ItemInterface::class);
+            $cache = $this->createMock(CacheInterface::class);
+            $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback($cacheItem));
+        }
 
-        $cache = $this->createMock(CacheInterface::class);
-        $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback());
-
-        $client = $this->createMock(ClientInterface::class);
-
-        if ($hubResponse instanceof \Throwable) {
-            $client->method('sendRequest')->willThrowException($hubResponse);
-        } else {
-            $stream->method('getContents')->willReturn(json_encode($hubResponse));
+        if ($client === null) {
             $response = $this->createMock(ResponseInterface::class);
             $response->method('getBody')->willReturn($stream);
+
+            $client = $this->createMock(ClientInterface::class);
             $client->method('sendRequest')->willReturn($response);
         }
 
@@ -107,11 +213,11 @@ final class HubNotificationProviderTest extends TestCase
             $requestFactory,
             $streamFactory,
             $cache,
-            $clock,
+            $this->createMock(ClockInterface::class),
             'https://hub.example.com',
             'prod',
-            true,
-            60,
+            $areHubNotificationsEnabled,
+            $checkFrequency,
         );
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Tests/Notification/HubNotificationProviderTest.php
+++ b/src/Sylius/Bundle/AdminBundle/Tests/Notification/HubNotificationProviderTest.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Tests\Notification;
 
-use GuzzleHttp\Exception\ConnectException;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Clock\ClockInterface;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -33,132 +30,88 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 final class HubNotificationProviderTest extends TestCase
 {
-    use ProphecyTrait;
-
-    private ClientInterface|ObjectProphecy $client;
-
-    private ObjectProphecy|RequestStack $requestStack;
-
-    private ObjectProphecy|RequestFactoryInterface $requestFactory;
-
-    private ObjectProphecy|StreamFactoryInterface $streamFactory;
-
-    private CacheInterface|ObjectProphecy $cache;
-
-    private ClockInterface|ObjectProphecy $clock;
-
-    private HubNotificationProvider $hubNotificationsProvider;
-
-    private static string $hubUri = 'www.doesnotexist.test.com';
-
-    public function setUp(): void
+    public function testDoesNotReturnNotificationIfClientExceptionOccurs(): void
     {
-        parent::setUp();
+        $provider = $this->createProvider(
+            hubResponse: $this->createMock(ClientExceptionInterface::class),
+        );
 
-        $this->client = $this->prophesize(ClientInterface::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->requestFactory = $this->prophesize(RequestFactoryInterface::class);
-        $this->streamFactory = $this->prophesize(StreamFactoryInterface::class);
-        $this->cache = $this->prophesize(CacheInterface::class);
-        $this->clock = $this->prophesize(ClockInterface::class);
+        $this->assertEmpty($provider->getNotifications());
+    }
 
-        $this->hubNotificationsProvider = new HubNotificationProvider(
-            $this->client->reveal(),
-            $this->requestStack->reveal(),
-            $this->requestFactory->reveal(),
-            $this->streamFactory->reveal(),
-            $this->cache->reveal(),
-            $this->clock->reveal(),
-            self::$hubUri,
+    public function testDoesNotReturnNotificationIfCurrentVersionIsSameAsLatest(): void
+    {
+        $provider = $this->createProvider(
+            hubResponse: ['version' => SyliusCoreBundle::VERSION],
+        );
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    public function testReturnsNotificationIfVersionIsDifferent(): void
+    {
+        $provider = $this->createProvider(hubResponse: ['version' => '1.0.0']);
+
+        $this->assertSame([
+            'latest_sylius_version' => [
+                'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
+                'latest_version' => '1.0.0',
+            ],
+        ], $provider->getNotifications());
+    }
+
+    public function testDoesNotReturnNotificationIfHubResponseHasNoVersion(): void
+    {
+        $provider = $this->createProvider(hubResponse: ['foo' => 'bar']);
+
+        $this->assertEmpty($provider->getNotifications());
+    }
+
+    private function createProvider(array|\Throwable $hubResponse): HubNotificationProvider
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('withHeader')->willReturnSelf();
+        $request->method('withBody')->willReturnSelf();
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $stream = $this->createMock(StreamInterface::class);
+
+        $streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $streamFactory->method('createStream')->willReturn($stream);
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(new Request());
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->method('now')->willReturn(new \DateTimeImmutable());
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturnCallback(fn ($key, $callback) => $callback());
+
+        $client = $this->createMock(ClientInterface::class);
+
+        if ($hubResponse instanceof \Throwable) {
+            $client->method('sendRequest')->willThrowException($hubResponse);
+        } else {
+            $stream->method('getContents')->willReturn(json_encode($hubResponse));
+            $response = $this->createMock(ResponseInterface::class);
+            $response->method('getBody')->willReturn($stream);
+            $client->method('sendRequest')->willReturn($response);
+        }
+
+        return new HubNotificationProvider(
+            $client,
+            $requestStack,
+            $requestFactory,
+            $streamFactory,
+            $cache,
+            $clock,
+            'https://hub.example.com',
             'prod',
             true,
             60,
         );
-    }
-
-    /** @test */
-    public function it_returns_an_empty_array_if_client_exception_occurs(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(function ($args) {
-            return $args[1]();
-        });
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $this->client->sendRequest(Argument::cetera())->willThrow(ConnectException::class);
-
-        $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
-    }
-
-    /** @test */
-    public function it_returns_an_empty_array_if_the_current_version_is_the_same_as_latest(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(function ($args) {
-            return $args[1]();
-        });
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $content = json_encode(['version' => SyliusCoreBundle::VERSION]);
-        $stream->getContents()->willReturn($content);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
-
-        $this->assertEmpty($this->hubNotificationsProvider->getNotifications());
-    }
-
-    /** @test */
-    public function it_returns_a_notification_if_the_current_version_is_different_than_latest(): void
-    {
-        $request = $this->prophesize(RequestInterface::class);
-        $stream = $this->prophesize(StreamInterface::class);
-        $externalResponse = $this->prophesize(ResponseInterface::class);
-
-        $this->cache->get('latest_sylius_version', Argument::type('callable'))->will(function ($args) {
-            return $args[1]();
-        });
-
-        $this->requestStack->getCurrentRequest()->willReturn(new Request());
-        $this->clock->now()->willReturn(new \DateTimeImmutable());
-        $this->streamFactory->createStream(Argument::cetera())->willReturn($stream);
-
-        $content = json_encode(['version' => '1.0.0']);
-        $stream->getContents()->willReturn($content);
-
-        $this->requestFactory->createRequest(Argument::cetera())->willReturn($request);
-        $request->withHeader('Content-Type', 'application/json')->willReturn($request);
-        $request->withBody($stream)->willReturn($request);
-
-        $externalResponse->getBody()->willReturn($stream->reveal());
-        $this->client->sendRequest(Argument::cetera())->willReturn($externalResponse->reveal());
-
-        $notifications = $this->hubNotificationsProvider->getNotifications();
-
-        $this->assertNotEmpty($notifications);
-        $this->assertArrayHasKey('latest_sylius_version', $notifications);
-        $this->assertSame($notifications['latest_sylius_version'], [
-            'message' => 'sylius.ui.notifications.new_version_of_sylius_available',
-            'latest_version' => '1.0.0',
-        ]);
     }
 }


### PR DESCRIPTION
Fixes cache TTL bug where `expiresAfter()` was never called due to incorrect callback signature.

Changes:
- Fix cache callback to accept `ItemInterface` and set proper TTL
- Refactor tests from Prophecy to PHPUnit native mocks
- Add tests for `supports()` method and null request handling

<img width="1359" height="468" alt="image" src="https://github.com/user-attachments/assets/2e28a5fb-18c9-456c-b44d-b3914015ddf0" />

