### PR TITLE
[Admin] Fix choice_label override via extra_options in autocomplete types

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAttributeAutocompleteType.php
@@ -32,7 +32,6 @@ final class ProductAttributeAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->productAttributeClass,
-            'choice_name' => 'name',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductAutocompleteType.php
@@ -32,7 +32,6 @@ final class ProductAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->productClass,
-            'choice_name' => 'name',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/ProductVariantAutocompleteType.php
@@ -32,7 +32,6 @@ final class ProductVariantAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->productVariantClass,
-            'choice_name' => 'descriptor',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TaxonAutocompleteType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 
@@ -32,8 +33,11 @@ final class TaxonAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->taxonClass,
-            'choice_label' => 'fullname',
         ]);
+
+        $resolver->setDefault('choice_label', function (Options $options): string {
+            return $options['extra_options']['choice_label'] ?? 'fullname';
+        });
     }
 
     public function getBlockPrefix(): string

--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
@@ -39,6 +39,10 @@ final class TranslatableAutocompleteType extends AbstractType
             return $options['extra_options']['choice_label'] ?? 'name';
         });
 
+        $resolver->setDefault('choice_value', function (Options $options, $previousValue): mixed {
+            return $options['extra_options']['choice_value'] ?? $previousValue;
+        });
+
         $resolver->setDefault('entity_fields', function (Options $options): array {
             return $options['extra_options']['entity_fields'] ?? ['code'];
         });


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

  ## Summary
  - Allow overriding `choice_label` via `extra_options` in `TaxonAutocompleteType`
  - Remove unused `choice_name` option (has no effect with Symfony UX Autocomplete)

  ## Why
  `choice_name` only affects expanded choice fields (checkboxes/radios), not select-based autocomplete. 
  The `choice_label` was set as static value, blocking `extra_options` override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored autocomplete field configuration in product, product attribute, product variant, and taxon forms for improved flexibility.
  * Enhanced default option resolution for choice display and value mapping.
  * Improved customization support in translatable autocomplete components through updated option handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->