### PR TITLE
[Admin] Use specific block names in form themes

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
+++ b/src/Sylius/Bundle/AdminBundle/Form/Type/TranslatableAutocompleteType.php
@@ -35,11 +35,11 @@ final class TranslatableAutocompleteType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefault('choice_label', function (Options $options): string {
-            return $options['extra_options']['choice_label'] ?? 'name';
+        $resolver->setDefault('choice_label', function (Options $options, mixed $previousValue): mixed {
+            return $options['extra_options']['choice_label'] ?? $previousValue;
         });
 
-        $resolver->setDefault('choice_value', function (Options $options, $previousValue): mixed {
+        $resolver->setDefault('choice_value', function (Options $options, mixed $previousValue): mixed {
             return $options['extra_options']['choice_value'] ?? $previousValue;
         });
 

--- a/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/catalog_promotion/form_theme.html.twig
@@ -1,10 +1,14 @@
 {% extends '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-{%- block live_collection_widget -%}
+{%- block _sylius_admin_catalog_promotion_scopes_widget -%}
     {{ block('form_widget') }}
-{%- endblock live_collection_widget -%}
+{%- endblock -%}
 
-{%- block live_collection_entry_row -%}
+{%- block _sylius_admin_catalog_promotion_actions_widget -%}
+    {{ block('form_widget') }}
+{%- endblock -%}
+
+{%- block _sylius_admin_catalog_promotion_scopes_entry_row -%}
     <div id="{{ id }}" {{ block('attributes') }} {{ sylius_test_html_attribute('entry-row') }}>
         {{- form_errors(form) -}}
         {{- form_row(form.type) -}}
@@ -18,9 +22,42 @@
             </div>
         </div>
     </div>
-{%- endblock live_collection_entry_row -%}
+{%- endblock -%}
 
-{% block add_button_row %}
+{%- block _sylius_admin_catalog_promotion_actions_entry_row -%}
+    <div id="{{ id }}" {{ block('attributes') }} {{ sylius_test_html_attribute('entry-row') }}>
+        {{- form_errors(form) -}}
+        {{- form_row(form.type) -}}
+        <div class="alert text-body flex-column gap-0">
+            <div class="d-flex align-items-center">
+                <div class="me-auto mb-3"><strong>{{  ('sylius.ui.' ~ form.type.vars.data)|trans}}</strong></div>
+                {{- form_row(button_delete, sylius_test_form_attribute('delete-action')|sylius_merge_recursive({'attr': {'class': 'btn-close'}})) -}}
+            </div>
+            <div class="flex-grow-1">
+                {{- form_row(form.configuration, {'label': false}) -}}
+            </div>
+        </div>
+    </div>
+{%- endblock -%}
+
+{% block _sylius_admin_catalog_promotion_scopes_add_row %}
+    {% if types is not empty %}
+        <div class="dropdown">
+            <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>
+            <ul class="dropdown-menu">
+                {% for type in types %}
+                    <li>
+                        <button class="dropdown-item" type="button" {{ block('button_attributes') }} data-live-type-param="{{ type }}" {{ sylius_test_html_attribute('add-' ~ type) }}>
+                            {{  ('sylius.ui.' ~ type)|trans}}
+                        </button>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block _sylius_admin_catalog_promotion_actions_add_row %}
     {% if types is not empty %}
         <div class="dropdown">
             <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>

--- a/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/product_attribute/form_theme.html.twig
@@ -1,6 +1,6 @@
 {% extends '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-{% block sylius_select_attribute_value_translations_row %}
+{% block _sylius_admin_product_attribute_configuration_choices_entry_row %}
     {% import '@SyliusAdmin/shared/helper/translations.html.twig' as translations %}
 
     {% set parts = form.vars.full_name|split('[') %}

--- a/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/promotion/form_theme.html.twig
@@ -1,10 +1,14 @@
 {% extends '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-{%- block live_collection_widget -%}
+{%- block _sylius_admin_promotion_rules_widget -%}
     {{ block('form_widget') }}
-{%- endblock live_collection_widget -%}
+{%- endblock -%}
 
-{%- block sylius_promotion_rule_row -%}
+{%- block _sylius_admin_promotion_actions_widget -%}
+    {{ block('form_widget') }}
+{%- endblock -%}
+
+{%- block _sylius_admin_promotion_rules_entry_row -%}
     <div id="{{ id }}" {{ block('attributes') }} {{ sylius_test_html_attribute('entry-row') }}>
         {{- form_errors(form) -}}
         {{- form_row(form.type) -}}
@@ -18,9 +22,9 @@
             </div>
         </div>
     </div>
-{%- endblock sylius_promotion_rule_row -%}
+{%- endblock -%}
 
-{%- block sylius_promotion_action_row -%}
+{%- block _sylius_admin_promotion_actions_entry_row -%}
     <div id="{{ id }}" {{ block('attributes') }} {{ sylius_test_html_attribute('entry-row') }}>
         {{- form_errors(form) -}}
         {{- form_row(form.type) -}}
@@ -34,9 +38,26 @@
             </div>
         </div>
     </div>
-{%- endblock sylius_promotion_action_row -%}
+{%- endblock -%}
 
-{% block add_button_row %}
+{% block _sylius_admin_promotion_rules_add_row %}
+    {% if types is not empty %}
+        <div class="dropdown">
+            <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>
+            <ul class="dropdown-menu">
+                {% for type, label in types %}
+                    <li>
+                        <button class="dropdown-item" type="button" {{ block('button_attributes') }} data-live-type-param="{{ type }}" {{ sylius_test_html_attribute('add-' ~ type) }}>
+                            {{ (label)|trans }}
+                        </button>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block _sylius_admin_promotion_actions_add_row %}
     {% if types is not empty %}
         <div class="dropdown">
             <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>

--- a/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form_theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shipping_method/form_theme.html.twig
@@ -1,10 +1,10 @@
 {% extends '@SyliusAdmin/shared/form_theme.html.twig' %}
 
-{%- block live_collection_widget -%}
+{%- block _sylius_admin_shipping_method_rules_widget -%}
     {{ block('form_widget') }}
-{%- endblock live_collection_widget -%}
+{%- endblock -%}
 
-{%- block live_collection_entry_row -%}
+{%- block _sylius_admin_shipping_method_rules_entry_row -%}
     <div id="{{ id }}" {{ block('attributes') }} {{ sylius_test_html_attribute('entry-row') }}>
         {{- form_errors(form) -}}
         {{- form_row(form.type) -}}
@@ -19,9 +19,9 @@
             </div>
         </div>
     </div>
-{%- endblock live_collection_entry_row -%}
+{%- endblock -%}
 
-{% block add_button_row %}
+{% block _sylius_admin_shipping_method_rules_add_row %}
     {% if types is not empty %}
         <div class="dropdown">
             <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18640
| License         | MIT

  ## Summary

  - Replace generic Twig block names with entity-specific names in form themes to avoid overriding global blocks
  - Fix `choice_label` option in `TranslatableAutocompleteType` to properly respect `extra_options` override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized several admin form templates into more specific, namespaced blocks for clarity and maintainability.

* **UI Enhancement**
  * Added dropdown selectors when adding new rule/action/type entries in shipping, promotions, and catalog promotion forms.

* **Refactor**
  * Updated product attribute and form rendering entry points to use the new scoped blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->