### PR TITLE
Add missing index to Order XML mapping

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -92,6 +92,10 @@
 
         <field type="string" name="tokenValue" column="token_value" nullable="true" unique="true" />
         <field type="string" name="customerIp" column="customer_ip" nullable="true" />
+
+        <indexes>
+            <index name="IDX_TELEMETRY_ORDER_STATS" columns="checkout_completed_at,checkout_state,payment_state"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database query performance by adding a new index to the Order table, improving lookup speeds for order processing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->