### PR TITLE
Add config/reference.php to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 .env.*.local
 .env.local
 .env.local.php
+/config/reference.php
 ###< symfony/framework-bundle ###
 
 ###> symfony/webpack-encore-bundle ###


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | replaces #18606 
| License         | MIT

This file is automatically generated by symfony/framework-bundle in debug mode to help IDEs with autocompletion for PHP configuration. Since it's generated on the fly and may vary between environments, it makes sense to keep it out of version control.

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
