### PR TITLE
Remove Gedmo sortable-position from new Zone priority field

### DIFF
--- a/features/admin/addressing/managing_zones/editing_zone.feature
+++ b/features/admin/addressing/managing_zones/editing_zone.feature
@@ -73,7 +73,7 @@ Feature: Editing a zone
         Given the store has a zone "European Union" with code "EU" and priority 0
         And it has the "France" country member
         When I want to modify the zone named "European Union"
-        And I set its priority to "2"
+        And I set its priority to "5"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And the "European Union" zone should have priority 2
+        And the "European Union" zone should have priority 5

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -11,10 +11,7 @@
 
 -->
 
-<doctrine-mapping
-    xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
-    xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
->
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
 
     <mapped-superclass name="Sylius\Component\Addressing\Model\Zone" table="sylius_zone">
         <id name="id" column="id" type="integer">
@@ -27,7 +24,6 @@
         <field name="scope" column="scope" type="string" nullable="true"/>
 
         <field name="priority" type="integer">
-            <gedmo:sortable-position/>
             <options>
                 <option name="default">0</option>
             </options>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #18662 
| License         | MIT

After reconsideration, we decided to remove Gedmo-based sorting.

Using Gedmo for Zone's priority sorting would force reordering of all existing priorities whenever a new Zone with priority 0 is added. Additionally, duplicated priorities are not an issue in our case, as zones are already separated by scope.

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated zone priority value range and adjusted related test validations.
  * Removed automatic position-based sorting behavior for zones, simplifying zone management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->