### PR TITLE
Add listener to skip optional telemetry index from schema validation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -107,5 +107,10 @@
             <argument type="service" id="Sylius\Component\Core\Promotion\Checker\ProductInPromotionRuleCheckerInterface" />
             <tag name="kernel.event_listener" event="sylius.product.pre_delete" method="protectFromRemovingProductInUseByPromotionRule" />
         </service>
+
+        <service id="sylius.listener.telemetry_index_schema" class="Sylius\Bundle\CoreBundle\Telemetry\EventListener\TelemetryIndexSchemaListener">
+            <argument type="service" id="doctrine.dbal.default_connection" />
+            <tag name="doctrine.event_listener" event="postGenerateSchema" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryIndexSchemaListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryIndexSchemaListener.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Telemetry\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+/** @internal */
+final class TelemetryIndexSchemaListener
+{
+    private const TABLE_NAME = 'sylius_order';
+
+    private const INDEX_NAME = 'IDX_TELEMETRY_ORDER_STATS';
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $args): void
+    {
+        $schema = $args->getSchema();
+
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $dbIndex = $this->findIndexInDatabase();
+
+        if ($dbIndex === null) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if ($table->hasIndex(self::INDEX_NAME)) {
+            return;
+        }
+
+        $table->addIndex(
+            $dbIndex->getColumns(),
+            $dbIndex->getName(),
+            $dbIndex->getFlags(),
+            $dbIndex->getOptions(),
+        );
+    }
+
+    private function findIndexInDatabase(): ?Index
+    {
+        try {
+            $dbIndexes = $this->connection->createSchemaManager()->listTableIndexes(self::TABLE_NAME);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $dbIndexes = array_change_key_case($dbIndexes);
+
+        return $dbIndexes[strtolower(self::INDEX_NAME)] ?? null;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/EventListener/TelemetryIndexSchemaListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/EventListener/TelemetryIndexSchemaListenerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Telemetry\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Telemetry\EventListener\TelemetryIndexSchemaListener;
+
+final class TelemetryIndexSchemaListenerTest extends TestCase
+{
+    private const TABLE_NAME = 'sylius_order';
+
+    private const INDEX_NAME = 'IDX_TELEMETRY_ORDER_STATS';
+
+    private Connection $connection;
+
+    private AbstractSchemaManager $schemaManager;
+
+    private TelemetryIndexSchemaListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $this->connection->method('createSchemaManager')->willReturn($this->schemaManager);
+
+        $this->listener = new TelemetryIndexSchemaListener($this->connection);
+    }
+
+    public function test_it_does_nothing_when_table_does_not_exist_in_schema(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(false);
+
+        $this->schemaManager->expects($this->never())->method('listTableIndexes');
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_does_nothing_when_index_does_not_exist_in_database(): void
+    {
+        $table = $this->createMock(Table::class);
+        $table->expects($this->never())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_adds_index_to_schema_when_index_exists_in_database_but_not_in_schema(): void
+    {
+        $dbIndex = new Index(
+            self::INDEX_NAME,
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(false);
+        $table->expects($this->once())->method('addIndex')->with(
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+            self::INDEX_NAME,
+            [],
+            [],
+        );
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_does_nothing_when_index_already_exists_in_schema(): void
+    {
+        $dbIndex = new Index(
+            self::INDEX_NAME,
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(true);
+        $table->expects($this->never())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_handles_database_exceptions_silently(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+
+        $this->schemaManager->method('listTableIndexes')->willThrowException(new \RuntimeException('DB error'));
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_it_handles_lowercase_index_name_from_postgresql(): void
+    {
+        $dbIndex = new Index(
+            strtolower(self::INDEX_NAME),
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(false);
+        $table->expects($this->once())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    private function createEvent(Schema $schema): GenerateSchemaEventArgs
+    {
+        return new GenerateSchemaEventArgs(
+            $this->createMock(EntityManagerInterface::class),
+            $schema,
+        );
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.12<!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
