### PR TITLE
[Telemetry] Fixes and improvements 1.13

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -128,5 +128,10 @@
             <argument type="service" id="doctrine.migrations.dependency_factory"/>
             <tag name="doctrine.event_listener" event="onMigrationsVersionSkipped" method="onMigrationsVersionSkipped" lazy="true" />
         </service>
+
+        <service id="sylius.listener.telemetry_index_schema" class="Sylius\Bundle\CoreBundle\Telemetry\EventListener\TelemetryIndexSchemaListener">
+            <argument type="service" id="doctrine.dbal.default_connection" />
+            <tag name="doctrine.event_listener" event="postGenerateSchema" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/telemetry/telemetry.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/telemetry/telemetry.xml
@@ -19,7 +19,6 @@
             lazy="Sylius\Component\Core\Telemetry\Generator\InstallationIdGeneratorInterface"
         >
             <argument>%sylius_core.telemetry.salt%</argument>
-            <argument type="service" id="request_stack" />
         </service>
 
         <service
@@ -126,6 +125,15 @@
         <service
             id="sylius.telemetry.data_provider.orders_business"
             class="Sylius\Bundle\CoreBundle\Telemetry\Provider\Business\OrdersBusinessDataProvider"
+            lazy="Sylius\Component\Core\Telemetry\DataProvider\DataProviderInterface"
+        >
+            <argument type="service" id="doctrine.dbal.default_connection" />
+            <tag name="sylius.telemetry.business_data_provider" />
+        </service>
+
+        <service
+            id="sylius.telemetry.data_provider.countries"
+            class="Sylius\Bundle\CoreBundle\Telemetry\Provider\Business\CountriesDataProvider"
             lazy="Sylius\Component\Core\Telemetry\DataProvider\DataProviderInterface"
         >
             <argument type="service" id="doctrine.dbal.default_connection" />

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Collector/BusinessDataCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Collector/BusinessDataCollector.php
@@ -20,9 +20,11 @@ use Sylius\Component\Core\Telemetry\DataProvider\DataProviderInterface;
 final class BusinessDataCollector implements TelemetryDataCollectorInterface
 {
     private const METRICS_KEYS = [
+        'channels_count',
         'customers_count',
         'products_count',
         'product_variants_count',
+        'virtual_product_variants_count',
         'orders_count',
         'orders_monthly_count',
         'orders_monthly_avg_items',

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/CountriesData.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/CountriesData.php
@@ -16,24 +16,19 @@ namespace Sylius\Bundle\CoreBundle\Telemetry\DTO\Business;
 use Sylius\Component\Core\Telemetry\DTO\TelemetryDataInterface;
 
 /** @internal */
-final class PaymentProviderData implements TelemetryDataInterface
+final class CountriesData implements TelemetryDataInterface
 {
+    /** @param list<string> $countries */
     public function __construct(
-        public string $name,
-        public string $gateway,
-        public string $paymentsCount,
-        public bool $enabled,
+        public array $countries,
     ) {
     }
 
-    /** @return array<string, bool|string> */
+    /** @return array<string, list<string>> */
     public function normalize(): array
     {
         return [
-            'name' => $this->name,
-            'gateway' => $this->gateway,
-            'payments_count' => $this->paymentsCount,
-            'enabled' => $this->enabled,
+            'countries' => $this->countries,
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/MetricsCountsData.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/MetricsCountsData.php
@@ -22,7 +22,9 @@ final class MetricsCountsData implements TelemetryDataInterface
         public string $customersCount,
         public string $productsCount,
         public string $productVariantsCount,
+        public string $virtualProductVariantsCount,
         public int $ordersCount,
+        public int $channelsCount,
     ) {
     }
 
@@ -32,7 +34,9 @@ final class MetricsCountsData implements TelemetryDataInterface
             'customers_count' => $this->customersCount,
             'products_count' => $this->productsCount,
             'product_variants_count' => $this->productVariantsCount,
+            'virtual_product_variants_count' => $this->virtualProductVariantsCount,
             'orders_count' => $this->ordersCount,
+            'channels_count' => $this->channelsCount,
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/ShippingProviderData.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/DTO/Business/ShippingProviderData.php
@@ -22,16 +22,18 @@ final class ShippingProviderData implements TelemetryDataInterface
         public string $name,
         public string $calculator,
         public string $shipmentsCount,
+        public bool $enabled,
     ) {
     }
 
-    /** @return array<string, string> */
+    /** @return array<string, bool|string> */
     public function normalize(): array
     {
         return [
             'name' => $this->name,
             'calculator' => $this->calculator,
             'shipments_count' => $this->shipmentsCount,
+            'enabled' => $this->enabled,
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryIndexSchemaListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryIndexSchemaListener.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Telemetry\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+/** @internal */
+final class TelemetryIndexSchemaListener
+{
+    private const TABLE_NAME = 'sylius_order';
+
+    private const INDEX_NAME = 'IDX_TELEMETRY_ORDER_STATS';
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $args): void
+    {
+        $schema = $args->getSchema();
+
+        if (!$schema->hasTable(self::TABLE_NAME)) {
+            return;
+        }
+
+        $dbIndex = $this->findIndexInDatabase();
+
+        if ($dbIndex === null) {
+            return;
+        }
+
+        $table = $schema->getTable(self::TABLE_NAME);
+
+        if ($table->hasIndex(self::INDEX_NAME)) {
+            return;
+        }
+
+        $table->addIndex(
+            $dbIndex->getColumns(),
+            $dbIndex->getName(),
+            $dbIndex->getFlags(),
+            $dbIndex->getOptions(),
+        );
+    }
+
+    private function findIndexInDatabase(): ?Index
+    {
+        try {
+            $dbIndexes = $this->connection->createSchemaManager()->listTableIndexes(self::TABLE_NAME);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $dbIndexes = array_change_key_case($dbIndexes);
+
+        return $dbIndexes[strtolower(self::INDEX_NAME)] ?? null;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/EventListener/TelemetryListener.php
@@ -34,7 +34,7 @@ class TelemetryListener
         }
 
         try {
-            $this->telemetrySendManager->sendIfNeeded();
+            $this->telemetrySendManager->sendIfNeeded($request);
         } catch (\Throwable) {
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/CountriesDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/CountriesDataProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Telemetry\Provider\Business;
+
+use Doctrine\DBAL\Connection;
+use Sylius\Bundle\CoreBundle\Telemetry\DTO\Business\CountriesData;
+use Sylius\Component\Core\Telemetry\DataProvider\DataProviderInterface;
+use Sylius\Component\Core\Telemetry\DTO\TelemetryDataInterface;
+
+/** @internal */
+final class CountriesDataProvider implements DataProviderInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function provide(): TelemetryDataInterface
+    {
+        try {
+            $channelsWithCountries = $this->connection->fetchAllAssociative(
+                'SELECT c.id as channel_id, co.code as country_code
+                 FROM sylius_channel c
+                 LEFT JOIN sylius_channel_countries cc ON cc.channel_id = c.id
+                 LEFT JOIN sylius_country co ON co.id = cc.country_id AND co.enabled = 1
+                 WHERE c.enabled = 1',
+            );
+
+            $allCountries = $this->connection->fetchFirstColumn(
+                'SELECT code FROM sylius_country WHERE enabled = 1',
+            );
+
+            $countriesByChannel = [];
+            $channelIds = [];
+
+            foreach ($channelsWithCountries as $row) {
+                $channelId = $row['channel_id'];
+                $channelIds[$channelId] = true;
+
+                if ($row['country_code'] !== null) {
+                    $countriesByChannel[$channelId][] = $row['country_code'];
+                }
+            }
+
+            $countries = [];
+            foreach (array_keys($channelIds) as $channelId) {
+                $channelCountries = $countriesByChannel[$channelId] ?? $allCountries;
+                foreach ($channelCountries as $country) {
+                    $countries[$country] = true;
+                }
+            }
+
+            return new CountriesData(array_keys($countries));
+        } catch (\Throwable) {
+            return new CountriesData([]);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/LocalesDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/LocalesDataProvider.php
@@ -33,7 +33,8 @@ final class LocalesDataProvider implements DataProviderInterface
             $locales = $this->connection->fetchFirstColumn('SELECT code FROM sylius_locale');
             $channelDefaultLocales = $this->connection->fetchFirstColumn(
                 'SELECT DISTINCT l.code FROM sylius_locale l
-                 INNER JOIN sylius_channel c ON c.default_locale_id = l.id',
+                 INNER JOIN sylius_channel c ON c.default_locale_id = l.id
+                 WHERE c.enabled = 1',
             );
 
             return new LocalesData($locales, $channelDefaultLocales, $this->defaultLocale);

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/MetricsCountsDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/MetricsCountsDataProvider.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\CoreBundle\Telemetry\Provider\Business;
 
 use Doctrine\DBAL\Connection;
 use Sylius\Bundle\CoreBundle\Telemetry\DTO\Business\MetricsCountsData;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\Telemetry\DataProvider\DataProviderInterface;
 use Sylius\Component\Core\Telemetry\DTO\TelemetryDataInterface;
 use Sylius\Component\Core\Telemetry\Mapper\ValueRangeMapper;
@@ -34,21 +35,30 @@ final class MetricsCountsDataProvider implements DataProviderInterface
                     (SELECT COUNT(id) FROM sylius_customer) as customers_count,
                     (SELECT COUNT(id) FROM sylius_product) as products_count,
                     (SELECT COUNT(id) FROM sylius_product_variant) as product_variants_count,
-                    (SELECT COUNT(id) FROM sylius_order) as orders_count',
+                    (SELECT COUNT(id) FROM sylius_product_variant WHERE shipping_required = 0) as virtual_product_variants_count,
+                    (SELECT COUNT(id) FROM sylius_order WHERE checkout_state = :completedState) as orders_count,
+                    (SELECT COUNT(id) FROM sylius_channel WHERE enabled = 1) as channels_count',
+                [
+                    'completedState' => OrderCheckoutStates::STATE_COMPLETED,
+                ],
             );
 
             return new MetricsCountsData(
                 customersCount: ValueRangeMapper::mapCustomersCount((int) $counts['customers_count']),
                 productsCount: ValueRangeMapper::mapProductsCount((int) $counts['products_count']),
                 productVariantsCount: ValueRangeMapper::mapVariantsCount((int) $counts['product_variants_count']),
+                virtualProductVariantsCount: ValueRangeMapper::mapVirtualVariantsCount((int) $counts['virtual_product_variants_count']),
                 ordersCount: (int) $counts['orders_count'],
+                channelsCount: (int) $counts['channels_count'],
             );
         } catch (\Throwable) {
             return new MetricsCountsData(
                 customersCount: ValueRangeMapper::mapCustomersCount(0),
                 productsCount: ValueRangeMapper::mapProductsCount(0),
                 productVariantsCount: ValueRangeMapper::mapVariantsCount(0),
+                virtualProductVariantsCount: ValueRangeMapper::mapVirtualVariantsCount(0),
                 ordersCount: 0,
+                channelsCount: 0,
             );
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/PaymentMethodsDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/PaymentMethodsDataProvider.php
@@ -30,21 +30,13 @@ final class PaymentMethodsDataProvider implements DataProviderInterface
     public function provide(): TelemetryDataInterface
     {
         try {
-            $oneMonthAgo = (new \DateTimeImmutable('-1 month'))->format('Y-m-d H:i:s');
-
             $results = $this->connection->fetchAllAssociative(
-                'SELECT pm.code, gc.factory_name, COUNT(p.id) as payments_count
+                'SELECT pm.code, gc.factory_name, pm.is_enabled, COUNT(p.id) as payments_count
                  FROM sylius_payment_method pm
                  JOIN sylius_gateway_config gc ON pm.gateway_config_id = gc.id
-                 LEFT JOIN (
-                    SELECT p.id, p.method_id
-                    FROM sylius_payment p
-                    INNER JOIN sylius_order o ON p.order_id = o.id
-                    WHERE o.checkout_completed_at >= :oneMonthAgo
-                 ) p ON p.method_id = pm.id
-                 WHERE pm.is_enabled = :enabled
-                 GROUP BY pm.id, pm.code, gc.factory_name',
-                ['enabled' => true, 'oneMonthAgo' => $oneMonthAgo],
+                 LEFT JOIN sylius_payment p ON p.method_id = pm.id
+                 WHERE EXISTS (SELECT 1 FROM sylius_payment_method_channels pmc WHERE pmc.payment_method_id = pm.id)
+                 GROUP BY pm.id, pm.code, gc.factory_name, pm.is_enabled',
             );
 
             $providers = [];
@@ -53,6 +45,7 @@ final class PaymentMethodsDataProvider implements DataProviderInterface
                     name: $row['code'],
                     gateway: $row['factory_name'] ?? '',
                     paymentsCount: ValueRangeMapper::mapPaymentsCount((int) $row['payments_count']),
+                    enabled: (bool) $row['is_enabled'],
                 );
             }
 

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/ShippingMethodsDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Business/ShippingMethodsDataProvider.php
@@ -30,20 +30,13 @@ final class ShippingMethodsDataProvider implements DataProviderInterface
     public function provide(): TelemetryDataInterface
     {
         try {
-            $oneMonthAgo = (new \DateTimeImmutable('-1 month'))->format('Y-m-d H:i:s');
-
             $results = $this->connection->fetchAllAssociative(
-                'SELECT sm.code, sm.calculator, COUNT(s.id) as shipments_count
+                'SELECT sm.code, sm.calculator, sm.is_enabled, COUNT(s.id) as shipments_count
                  FROM sylius_shipping_method sm
-                 LEFT JOIN (
-                    SELECT s.id, s.method_id
-                    FROM sylius_shipment s
-                    INNER JOIN sylius_order o ON s.order_id = o.id
-                    WHERE o.checkout_completed_at >= :oneMonthAgo
-                 ) s ON s.method_id = sm.id
-                 WHERE sm.is_enabled = :enabled
-                 GROUP BY sm.id, sm.code, sm.calculator',
-                ['enabled' => true, 'oneMonthAgo' => $oneMonthAgo],
+                 LEFT JOIN sylius_shipment s ON s.method_id = sm.id
+                 WHERE sm.archived_at IS NULL
+                   AND EXISTS (SELECT 1 FROM sylius_shipping_method_channels smc WHERE smc.shipping_method_id = sm.id)
+                 GROUP BY sm.id, sm.code, sm.calculator, sm.is_enabled',
             );
 
             $providers = [];
@@ -52,6 +45,7 @@ final class ShippingMethodsDataProvider implements DataProviderInterface
                     name: $row['code'],
                     calculator: $row['calculator'] ?? '',
                     shipmentsCount: ValueRangeMapper::mapShipmentsCount((int) $row['shipments_count']),
+                    enabled: (bool) $row['is_enabled'],
                 );
             }
 

--- a/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Technical/VersionDataProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Telemetry/Provider/Technical/VersionDataProvider.php
@@ -32,8 +32,18 @@ final class VersionDataProvider implements DataProviderInterface
             symfonyVersion: Kernel::VERSION,
             doctrineVersion: $this->getInstalledPackageVersion('doctrine/orm'),
             twigVersion: Environment::VERSION,
-            apiPlatformVersion: $this->getInstalledPackageVersion('api-platform/core'),
+            apiPlatformVersion: $this->getApiPlatformVersion(),
         );
+    }
+
+    private function getApiPlatformVersion(): ?string
+    {
+        $version = $this->getInstalledPackageVersion('api-platform/core');
+        if ($version !== null) {
+            return $version;
+        }
+
+        return $this->getInstalledPackageVersion('api-platform/symfony');
     }
 
     private function getInstalledPackageVersion(string $package): ?string

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Collector/BusinessDataCollectorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Collector/BusinessDataCollectorTest.php
@@ -114,7 +114,9 @@ final class BusinessDataCollectorTest extends TestCase
             customersCount: '100-1K',
             productsCount: '0-100',
             productVariantsCount: '1K-10K',
+            virtualProductVariantsCount: '0-100',
             ordersCount: 50000,
+            channelsCount: 3,
         );
         $ordersBusinessData = new OrdersBusinessData(
             gmvMonthly: ['USD' => '10K-50K'],
@@ -140,7 +142,9 @@ final class BusinessDataCollectorTest extends TestCase
         self::assertSame('100-1K', $data['metrics']['customers_count']);
         self::assertSame('0-100', $data['metrics']['products_count']);
         self::assertSame('1K-10K', $data['metrics']['product_variants_count']);
+        self::assertSame('0-100', $data['metrics']['virtual_product_variants_count']);
         self::assertSame(50000, $data['metrics']['orders_count']);
+        self::assertSame(3, $data['metrics']['channels_count']);
 
         // Metrics from OrdersBusinessData (order_metrics merged)
         self::assertSame('100-1K', $data['metrics']['orders_monthly_count']);

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/EventListener/TelemetryIndexSchemaListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/EventListener/TelemetryIndexSchemaListenerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Telemetry\EventListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Telemetry\EventListener\TelemetryIndexSchemaListener;
+
+final class TelemetryIndexSchemaListenerTest extends TestCase
+{
+    private const TABLE_NAME = 'sylius_order';
+
+    private const INDEX_NAME = 'IDX_TELEMETRY_ORDER_STATS';
+
+    private Connection $connection;
+
+    private AbstractSchemaManager $schemaManager;
+
+    private TelemetryIndexSchemaListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $this->connection->method('createSchemaManager')->willReturn($this->schemaManager);
+
+        $this->listener = new TelemetryIndexSchemaListener($this->connection);
+    }
+
+    public function test_it_does_nothing_when_table_does_not_exist_in_schema(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(false);
+
+        $this->schemaManager->expects($this->never())->method('listTableIndexes');
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_does_nothing_when_index_does_not_exist_in_database(): void
+    {
+        $table = $this->createMock(Table::class);
+        $table->expects($this->never())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_adds_index_to_schema_when_index_exists_in_database_but_not_in_schema(): void
+    {
+        $dbIndex = new Index(
+            self::INDEX_NAME,
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(false);
+        $table->expects($this->once())->method('addIndex')->with(
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+            self::INDEX_NAME,
+            [],
+            [],
+        );
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_does_nothing_when_index_already_exists_in_schema(): void
+    {
+        $dbIndex = new Index(
+            self::INDEX_NAME,
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(true);
+        $table->expects($this->never())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    public function test_it_handles_database_exceptions_silently(): void
+    {
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+
+        $this->schemaManager->method('listTableIndexes')->willThrowException(new \RuntimeException('DB error'));
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_it_handles_lowercase_index_name_from_postgresql(): void
+    {
+        $dbIndex = new Index(
+            strtolower(self::INDEX_NAME),
+            ['checkout_completed_at', 'checkout_state', 'payment_state'],
+        );
+
+        $table = $this->createMock(Table::class);
+        $table->method('hasIndex')->with(self::INDEX_NAME)->willReturn(false);
+        $table->expects($this->once())->method('addIndex');
+
+        $schema = $this->createMock(Schema::class);
+        $schema->method('hasTable')->with(self::TABLE_NAME)->willReturn(true);
+        $schema->method('getTable')->with(self::TABLE_NAME)->willReturn($table);
+
+        $this->schemaManager->method('listTableIndexes')->with(self::TABLE_NAME)->willReturn([
+            strtolower(self::INDEX_NAME) => $dbIndex,
+        ]);
+
+        $event = $this->createEvent($schema);
+
+        $this->listener->postGenerateSchema($event);
+    }
+
+    private function createEvent(Schema $schema): GenerateSchemaEventArgs
+    {
+        return new GenerateSchemaEventArgs(
+            $this->createMock(EntityManagerInterface::class),
+            $schema,
+        );
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Generator/InstallationIdGeneratorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Generator/InstallationIdGeneratorTest.php
@@ -16,51 +16,53 @@ namespace Sylius\Bundle\CoreBundle\Tests\Telemetry\Generator;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Telemetry\Generator\InstallationIdGenerator;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 final class InstallationIdGeneratorTest extends TestCase
 {
     public function test_it_generates_uuid_v5_like_string(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com'));
-
-        $generator = new InstallationIdGenerator('salt-value', $requestStack);
+        $request = Request::create('https://example.com');
+        $generator = new InstallationIdGenerator('salt-value');
 
         self::assertRegExp(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
-            $generator->generate(),
+            $generator->generate($request),
         );
     }
 
     public function test_it_generates_deterministic_identifier(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com'));
+        $request = Request::create('https://example.com');
+        $generator = new InstallationIdGenerator('salt-value');
 
-        $generator = new InstallationIdGenerator('salt-value', $requestStack);
-
-        self::assertSame($generator->generate(), $generator->generate());
+        self::assertSame($generator->generate($request), $generator->generate($request));
     }
 
     public function test_it_returns_empty_string_when_salt_is_empty(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://example.com'));
+        $request = Request::create('https://example.com');
+        $generator = new InstallationIdGenerator('   ');
 
-        $generator = new InstallationIdGenerator('   ', $requestStack);
-
-        self::assertSame('', $generator->generate());
+        self::assertSame('', $generator->generate($request));
     }
 
-    public function test_it_returns_empty_string_when_hostname_is_empty(): void
+    public function test_different_hostnames_produce_different_ids(): void
     {
-        $requestStack = new RequestStack();
+        $generator = new InstallationIdGenerator('salt-value');
 
-        $generator = new InstallationIdGenerator('salt-value', $requestStack);
+        $request1 = Request::create('https://shop1.example.com');
+        $request2 = Request::create('https://shop2.example.com');
 
-        $result = $generator->generate();
+        self::assertNotSame($generator->generate($request1), $generator->generate($request2));
+    }
 
-        self::assertIsString($result);
+    public function test_same_hostname_produces_same_id(): void
+    {
+        $generator = new InstallationIdGenerator('salt-value');
+
+        $request1 = Request::create('https://example.com/admin');
+        $request2 = Request::create('https://example.com/shop');
+
+        self::assertSame($generator->generate($request1), $generator->generate($request2));
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Mapper/ValueRangeMapperTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Mapper/ValueRangeMapperTest.php
@@ -99,6 +99,14 @@ final class ValueRangeMapperTest extends TestCase
         self::assertSame($expectedRange, ValueRangeMapper::mapVariantsCount($value));
     }
 
+    /**
+     * @dataProvider countDataProvider
+     */
+    public function test_it_maps_virtual_variants_count_to_correct_range(int $value, string $expectedRange): void
+    {
+        self::assertSame($expectedRange, ValueRangeMapper::mapVirtualVariantsCount($value));
+    }
+
     public static function countDataProvider(): array
     {
         return [

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/CountriesDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/CountriesDataProviderTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Tests\Telemetry\Provider\Business;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Telemetry\DTO\Business\CountriesData;
+use Sylius\Bundle\CoreBundle\Telemetry\Provider\Business\CountriesDataProvider;
+
+final class CountriesDataProviderTest extends TestCase
+{
+    private Connection $connection;
+    private CountriesDataProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->provider = new CountriesDataProvider($this->connection);
+    }
+
+    public function test_it_provides_countries_from_enabled_channels_with_enabled_countries(): void
+    {
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(self::logicalAnd(
+                self::stringContains('co.enabled = 1'),
+                self::stringContains('c.enabled = 1'),
+            ))
+            ->willReturn([
+                ['channel_id' => 1, 'country_code' => 'US'],
+                ['channel_id' => 1, 'country_code' => 'CA'],
+                ['channel_id' => 2, 'country_code' => 'DE'],
+                ['channel_id' => 2, 'country_code' => 'FR'],
+            ]);
+        $this->connection->expects(self::once())
+            ->method('fetchFirstColumn')
+            ->with(self::stringContains('WHERE enabled = 1'))
+            ->willReturn(['US', 'CA', 'DE', 'FR', 'PL', 'GB']);
+
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(CountriesData::class, $data);
+        self::assertCount(4, $data->countries);
+        self::assertContains('US', $data->countries);
+        self::assertContains('CA', $data->countries);
+        self::assertContains('DE', $data->countries);
+        self::assertContains('FR', $data->countries);
+    }
+
+    public function test_it_merges_countries_from_multiple_channels(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            ['channel_id' => 1, 'country_code' => 'US'],
+            ['channel_id' => 1, 'country_code' => 'CA'],
+            ['channel_id' => 2, 'country_code' => 'DE'],
+            ['channel_id' => 2, 'country_code' => 'FR'],
+            ['channel_id' => 3, 'country_code' => 'PL'],
+            ['channel_id' => 3, 'country_code' => 'GB'],
+        ]);
+        $this->connection->method('fetchFirstColumn')->willReturn(['US', 'CA', 'DE', 'FR', 'PL', 'GB']);
+
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(CountriesData::class, $data);
+        self::assertCount(6, $data->countries);
+        self::assertContains('US', $data->countries);
+        self::assertContains('CA', $data->countries);
+        self::assertContains('DE', $data->countries);
+        self::assertContains('FR', $data->countries);
+        self::assertContains('PL', $data->countries);
+        self::assertContains('GB', $data->countries);
+    }
+
+    public function test_it_uses_all_countries_as_fallback_when_channel_has_no_countries(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            ['channel_id' => 1, 'country_code' => 'US'],
+            ['channel_id' => 2, 'country_code' => null],
+        ]);
+        $this->connection->method('fetchFirstColumn')->willReturn(['US', 'CA', 'DE', 'FR', 'PL']);
+
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(CountriesData::class, $data);
+        self::assertCount(5, $data->countries);
+        self::assertContains('US', $data->countries);
+        self::assertContains('CA', $data->countries);
+        self::assertContains('DE', $data->countries);
+        self::assertContains('FR', $data->countries);
+        self::assertContains('PL', $data->countries);
+    }
+
+    public function test_it_returns_unique_countries_when_channels_share_same_countries(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            ['channel_id' => 1, 'country_code' => 'US'],
+            ['channel_id' => 1, 'country_code' => 'DE'],
+            ['channel_id' => 2, 'country_code' => 'US'],
+            ['channel_id' => 2, 'country_code' => 'FR'],
+        ]);
+        $this->connection->method('fetchFirstColumn')->willReturn(['US', 'DE', 'FR']);
+
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(CountriesData::class, $data);
+        self::assertCount(3, $data->countries);
+    }
+
+    public function test_it_returns_empty_array_on_database_error(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willThrowException(new \RuntimeException('Database error'));
+
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(CountriesData::class, $data);
+        self::assertSame([], $data->countries);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/LocalesDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/LocalesDataProviderTest.php
@@ -31,12 +31,18 @@ final class LocalesDataProviderTest extends TestCase
         $this->provider = new LocalesDataProvider($this->connection, self::DEFAULT_LOCALE);
     }
 
-    public function test_it_provides_locales_channel_defaults_and_default_locale(): void
+    public function test_it_provides_locales_channel_defaults_from_enabled_channels(): void
     {
-        $this->connection->method('fetchFirstColumn')->willReturnOnConsecutiveCalls(
-            ['en_US', 'pl_PL', 'de_DE'],
-            ['en_US', 'de_DE'],
-        );
+        $this->connection->expects(self::exactly(2))
+            ->method('fetchFirstColumn')
+            ->willReturnCallback(function (string $sql): array {
+                if (str_contains($sql, 'sylius_locale') && !str_contains($sql, 'sylius_channel')) {
+                    return ['en_US', 'pl_PL', 'de_DE'];
+                }
+                self::assertStringContainsString('c.enabled = 1', $sql);
+
+                return ['en_US', 'de_DE'];
+            });
 
         $data = $this->provider->provide();
 

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/MetricsCountsDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/MetricsCountsDataProviderTest.php
@@ -35,7 +35,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '250',
             'products_count' => '42',
             'product_variants_count' => '168',
+            'virtual_product_variants_count' => '50',
             'orders_count' => '500',
+            'channels_count' => '3',
         ]);
 
         $data = $this->provider->provide();
@@ -44,7 +46,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('100-1K', $data->customersCount);
         self::assertSame('0-100', $data->productsCount);
         self::assertSame('100-1K', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(500, $data->ordersCount);
+        self::assertSame(3, $data->channelsCount);
     }
 
     public function test_it_maps_large_values_to_correct_ranges(): void
@@ -53,7 +57,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '1000',
             'products_count' => '5000',
             'product_variants_count' => '20000',
+            'virtual_product_variants_count' => '5000',
             'orders_count' => '50000',
+            'channels_count' => '5',
         ]);
 
         $data = $this->provider->provide();
@@ -62,7 +68,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('1K-10K', $data->customersCount);
         self::assertSame('1K-10K', $data->productsCount);
         self::assertSame('10K-100K', $data->productVariantsCount);
+        self::assertSame('1K-10K', $data->virtualProductVariantsCount);
         self::assertSame(50000, $data->ordersCount);
+        self::assertSame(5, $data->channelsCount);
     }
 
     public function test_it_provides_zero_range_when_all_counts_are_zero(): void
@@ -71,7 +79,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '0',
             'products_count' => '0',
             'product_variants_count' => '0',
+            'virtual_product_variants_count' => '0',
             'orders_count' => '0',
+            'channels_count' => '0',
         ]);
 
         $data = $this->provider->provide();
@@ -80,7 +90,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('0-100', $data->customersCount);
         self::assertSame('0-100', $data->productsCount);
         self::assertSame('0-100', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(0, $data->ordersCount);
+        self::assertSame(0, $data->channelsCount);
     }
 
     public function test_it_provides_large_counts(): void
@@ -89,7 +101,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '500000',
             'products_count' => '150000',
             'product_variants_count' => '2500000',
+            'virtual_product_variants_count' => '250000',
             'orders_count' => '1500000',
+            'channels_count' => '10',
         ]);
 
         $data = $this->provider->provide();
@@ -98,7 +112,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('100K-1M', $data->customersCount);
         self::assertSame('100K-500K', $data->productsCount);
         self::assertSame('2M+', $data->productVariantsCount);
+        self::assertSame('100K-500K', $data->virtualProductVariantsCount);
         self::assertSame(1500000, $data->ordersCount);
+        self::assertSame(10, $data->channelsCount);
     }
 
     public function test_it_handles_mixed_count_values(): void
@@ -107,7 +123,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '0',
             'products_count' => '100',
             'product_variants_count' => '0',
+            'virtual_product_variants_count' => '0',
             'orders_count' => '5000',
+            'channels_count' => '2',
         ]);
 
         $data = $this->provider->provide();
@@ -116,7 +134,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('0-100', $data->customersCount);
         self::assertSame('100-1K', $data->productsCount);
         self::assertSame('0-100', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(5000, $data->ordersCount);
+        self::assertSame(2, $data->channelsCount);
     }
 
     public function test_it_returns_zero_range_for_all_counts_on_database_error(): void
@@ -130,7 +150,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('0-100', $data->customersCount);
         self::assertSame('0-100', $data->productsCount);
         self::assertSame('0-100', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(0, $data->ordersCount);
+        self::assertSame(0, $data->channelsCount);
     }
 
     public function test_it_returns_zero_range_for_all_counts_on_query_exception(): void
@@ -144,7 +166,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('0-100', $data->customersCount);
         self::assertSame('0-100', $data->productsCount);
         self::assertSame('0-100', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(0, $data->ordersCount);
+        self::assertSame(0, $data->channelsCount);
     }
 
     public function test_it_provides_consistent_data_structure(): void
@@ -153,7 +177,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '123',
             'products_count' => '456',
             'product_variants_count' => '789',
+            'virtual_product_variants_count' => '100',
             'orders_count' => '1000',
+            'channels_count' => '4',
         ]);
 
         $data = $this->provider->provide();
@@ -162,19 +188,29 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertIsString($data->customersCount);
         self::assertIsString($data->productsCount);
         self::assertIsString($data->productVariantsCount);
+        self::assertIsString($data->virtualProductVariantsCount);
         self::assertIsInt($data->ordersCount);
+        self::assertIsInt($data->channelsCount);
     }
 
     public function test_it_executes_single_query_with_subqueries(): void
     {
         $this->connection->expects(self::once())
             ->method('fetchAssociative')
-            ->with(self::stringContains('SELECT COUNT(id) FROM sylius_customer'))
+            ->with(
+                self::stringContains('SELECT COUNT(id) FROM sylius_customer'),
+                self::callback(function (array $params): bool {
+                    return isset($params['completedState'])
+                        && $params['completedState'] === 'completed';
+                }),
+            )
             ->willReturn([
                 'customers_count' => '10',
                 'products_count' => '20',
                 'product_variants_count' => '30',
+                'virtual_product_variants_count' => '5',
                 'orders_count' => '40',
+                'channels_count' => '1',
             ]);
 
         $data = $this->provider->provide();
@@ -183,7 +219,9 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertSame('0-100', $data->customersCount);
         self::assertSame('0-100', $data->productsCount);
         self::assertSame('0-100', $data->productVariantsCount);
+        self::assertSame('0-100', $data->virtualProductVariantsCount);
         self::assertSame(40, $data->ordersCount);
+        self::assertSame(1, $data->channelsCount);
     }
 
     public function test_it_provides_string_ranges_in_output(): void
@@ -192,7 +230,9 @@ final class MetricsCountsDataProviderTest extends TestCase
             'customers_count' => '100',
             'products_count' => '200',
             'product_variants_count' => '300',
+            'virtual_product_variants_count' => '50',
             'orders_count' => '400',
+            'channels_count' => '3',
         ]);
 
         $data = $this->provider->provide();
@@ -201,6 +241,8 @@ final class MetricsCountsDataProviderTest extends TestCase
         self::assertIsString($data->customersCount);
         self::assertIsString($data->productsCount);
         self::assertIsString($data->productVariantsCount);
+        self::assertIsString($data->virtualProductVariantsCount);
         self::assertIsInt($data->ordersCount);
+        self::assertIsInt($data->channelsCount);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/PaymentMethodsDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/PaymentMethodsDataProviderTest.php
@@ -29,13 +29,16 @@ final class PaymentMethodsDataProviderTest extends TestCase
         $this->provider = new PaymentMethodsDataProvider($this->connection);
     }
 
-    public function test_it_provides_active_payment_providers_with_details(): void
+    public function test_it_provides_payment_providers_assigned_to_channel(): void
     {
-        $this->connection->method('fetchAllAssociative')->willReturn([
-            ['code' => 'paypal_checkout', 'factory_name' => 'payum_paypal', 'payments_count' => 15000],
-            ['code' => 'stripe_payment', 'factory_name' => 'payum_stripe', 'payments_count' => 850],
-            ['code' => 'cash_on_delivery', 'factory_name' => 'offline', 'payments_count' => 0],
-        ]);
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(self::stringContains('EXISTS (SELECT 1 FROM sylius_payment_method_channels'))
+            ->willReturn([
+                ['code' => 'paypal_checkout', 'factory_name' => 'payum_paypal', 'is_enabled' => 1, 'payments_count' => 15000],
+                ['code' => 'stripe_payment', 'factory_name' => 'payum_stripe', 'is_enabled' => 1, 'payments_count' => 850],
+                ['code' => 'cash_on_delivery', 'factory_name' => 'offline', 'is_enabled' => 0, 'payments_count' => 0],
+            ]);
 
         $data = $this->provider->provide();
 
@@ -45,14 +48,17 @@ final class PaymentMethodsDataProviderTest extends TestCase
         self::assertSame('paypal_checkout', $data->paymentProviders[0]->name);
         self::assertSame('payum_paypal', $data->paymentProviders[0]->gateway);
         self::assertSame('10K-100K', $data->paymentProviders[0]->paymentsCount);
+        self::assertTrue($data->paymentProviders[0]->enabled);
 
         self::assertSame('stripe_payment', $data->paymentProviders[1]->name);
         self::assertSame('payum_stripe', $data->paymentProviders[1]->gateway);
         self::assertSame('100-1K', $data->paymentProviders[1]->paymentsCount);
+        self::assertTrue($data->paymentProviders[1]->enabled);
 
         self::assertSame('cash_on_delivery', $data->paymentProviders[2]->name);
         self::assertSame('offline', $data->paymentProviders[2]->gateway);
         self::assertSame('0-100', $data->paymentProviders[2]->paymentsCount);
+        self::assertFalse($data->paymentProviders[2]->enabled);
     }
 
     public function test_it_returns_empty_array_on_error(): void

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/ShippingMethodsDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Business/ShippingMethodsDataProviderTest.php
@@ -29,13 +29,19 @@ final class ShippingMethodsDataProviderTest extends TestCase
         $this->provider = new ShippingMethodsDataProvider($this->connection);
     }
 
-    public function test_it_provides_active_shipping_providers_with_details(): void
+    public function test_it_provides_non_archived_shipping_providers_assigned_to_channel(): void
     {
-        $this->connection->method('fetchAllAssociative')->willReturn([
-            ['code' => 'dhl', 'calculator' => 'dhl_express', 'shipments_count' => 150],
-            ['code' => 'flat_rate', 'calculator' => 'flat_rate', 'shipments_count' => 5000],
-            ['code' => 'per_item', 'calculator' => 'per_unit_rate', 'shipments_count' => 0],
-        ]);
+        $this->connection->expects(self::once())
+            ->method('fetchAllAssociative')
+            ->with(self::logicalAnd(
+                self::stringContains('archived_at IS NULL'),
+                self::stringContains('EXISTS (SELECT 1 FROM sylius_shipping_method_channels'),
+            ))
+            ->willReturn([
+                ['code' => 'dhl', 'calculator' => 'dhl_express', 'is_enabled' => 1, 'shipments_count' => 150],
+                ['code' => 'flat_rate', 'calculator' => 'flat_rate', 'is_enabled' => 1, 'shipments_count' => 5000],
+                ['code' => 'per_item', 'calculator' => 'per_unit_rate', 'is_enabled' => 0, 'shipments_count' => 0],
+            ]);
 
         $data = $this->provider->provide();
 
@@ -45,14 +51,17 @@ final class ShippingMethodsDataProviderTest extends TestCase
         self::assertSame('dhl', $data->shippingProviders[0]->name);
         self::assertSame('dhl_express', $data->shippingProviders[0]->calculator);
         self::assertSame('100-1K', $data->shippingProviders[0]->shipmentsCount);
+        self::assertTrue($data->shippingProviders[0]->enabled);
 
         self::assertSame('flat_rate', $data->shippingProviders[1]->name);
         self::assertSame('flat_rate', $data->shippingProviders[1]->calculator);
         self::assertSame('1K-10K', $data->shippingProviders[1]->shipmentsCount);
+        self::assertTrue($data->shippingProviders[1]->enabled);
 
         self::assertSame('per_item', $data->shippingProviders[2]->name);
         self::assertSame('per_unit_rate', $data->shippingProviders[2]->calculator);
         self::assertSame('0-100', $data->shippingProviders[2]->shipmentsCount);
+        self::assertFalse($data->shippingProviders[2]->enabled);
     }
 
     public function test_it_returns_empty_array_on_error(): void

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Technical/VersionDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Technical/VersionDataProviderTest.php
@@ -43,4 +43,12 @@ final class VersionDataProviderTest extends TestCase
         self::assertInstanceOf(VersionData::class, $data);
         self::assertSame(PHP_VERSION, $data->phpVersion);
     }
+
+    public function test_it_returns_api_platform_version(): void
+    {
+        $data = $this->provider->provide();
+
+        self::assertInstanceOf(VersionData::class, $data);
+        self::assertNotNull($data->apiPlatformVersion);
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Technical/VersionDataProviderTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/Provider/Technical/VersionDataProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Telemetry\Provider\Technical;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Telemetry\DTO\Technical\VersionData;
 use Sylius\Bundle\CoreBundle\Telemetry\Provider\Technical\VersionDataProvider;
@@ -46,6 +47,13 @@ final class VersionDataProviderTest extends TestCase
 
     public function test_it_returns_api_platform_version(): void
     {
+        if (
+            !InstalledVersions::isInstalled('api-platform/core') &&
+            !InstalledVersions::isInstalled('api-platform/symfony')
+        ) {
+            self::markTestSkipped('API Platform is not installed');
+        }
+
         $data = $this->provider->provide();
 
         self::assertInstanceOf(VersionData::class, $data);

--- a/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/TelemetryOrchestratorTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Telemetry/TelemetryOrchestratorTest.php
@@ -17,9 +17,17 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Telemetry\Collector\TelemetryDataCollectorInterface;
 use Sylius\Component\Core\Telemetry\Generator\InstallationIdGeneratorInterface;
 use Sylius\Component\Core\Telemetry\TelemetryOrchestrator;
+use Symfony\Component\HttpFoundation\Request;
 
 final class TelemetryOrchestratorTest extends TestCase
 {
+    private Request $request;
+
+    protected function setUp(): void
+    {
+        $this->request = Request::create('https://example.com');
+    }
+
     public function test_it_generates_state_with_installation_id_and_timestamp(): void
     {
         $installationIdGenerator = $this->createMock(InstallationIdGeneratorInterface::class);
@@ -35,7 +43,7 @@ final class TelemetryOrchestratorTest extends TestCase
 
         $orchestrator = new TelemetryOrchestrator($installationIdGenerator, [$collector]);
 
-        $data = $orchestrator->getData();
+        $data = $orchestrator->getData($this->request);
 
         self::assertArrayHasKey('schema_version', $data);
         self::assertArrayHasKey('installation_id', $data);
@@ -44,7 +52,7 @@ final class TelemetryOrchestratorTest extends TestCase
         self::assertArrayHasKey('start', $data['period']);
         self::assertArrayHasKey('end', $data['period']);
         self::assertArrayHasKey('technical', $data);
-        self::assertSame(1, $data['schema_version']);
+        self::assertSame(2, $data['schema_version']);
         self::assertSame('install-uuid', $data['installation_id']);
         self::assertNotEmpty($data['collected_at']);
         self::assertNotEmpty($data['period']['start']);
@@ -64,14 +72,14 @@ final class TelemetryOrchestratorTest extends TestCase
 
         $orchestrator = new TelemetryOrchestrator($installationIdGenerator, [$collector]);
 
-        $data = $orchestrator->getData();
+        $data = $orchestrator->getData($this->request);
 
         self::assertIsArray($data);
         self::assertArrayHasKey('schema_version', $data);
         self::assertArrayHasKey('installation_id', $data);
         self::assertArrayHasKey('collected_at', $data);
         self::assertArrayHasKey('period', $data);
-        self::assertSame(1, $data['schema_version']);
+        self::assertSame(2, $data['schema_version']);
         self::assertSame('', $data['installation_id']);
     }
 
@@ -96,7 +104,7 @@ final class TelemetryOrchestratorTest extends TestCase
 
         $orchestrator = new TelemetryOrchestrator($installationIdGenerator, [$technicalCollector, $businessCollector]);
 
-        $data = $orchestrator->getData();
+        $data = $orchestrator->getData($this->request);
 
         self::assertArrayHasKey('technical', $data);
         self::assertArrayHasKey('business', $data);
@@ -123,7 +131,7 @@ final class TelemetryOrchestratorTest extends TestCase
 
         $orchestrator = new TelemetryOrchestrator($installationIdGenerator, [$failingCollector, $workingCollector]);
 
-        $data = $orchestrator->getData();
+        $data = $orchestrator->getData($this->request);
 
         self::assertArrayHasKey('technical', $data);
         self::assertSame('1.12.0', $data['technical']['sylius_version']);
@@ -148,7 +156,7 @@ final class TelemetryOrchestratorTest extends TestCase
 
         $orchestrator = new TelemetryOrchestrator($installationIdGenerator, [$disabledCollector, $enabledCollector]);
 
-        $data = $orchestrator->getData();
+        $data = $orchestrator->getData($this->request);
 
         self::assertArrayHasKey('technical', $data);
         self::assertArrayNotHasKey('business', $data);

--- a/src/Sylius/Component/Core/Telemetry/Generator/InstallationIdGenerator.php
+++ b/src/Sylius/Component/Core/Telemetry/Generator/InstallationIdGenerator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Telemetry\Generator;
 
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /** @internal */
@@ -21,17 +22,16 @@ final class InstallationIdGenerator implements InstallationIdGeneratorInterface
 {
     public function __construct(
         private string $salt,
-        private RequestStack $requestStack,
     ) {
     }
 
-    public function generate(): string
+    public function generate(Request $request): string
     {
         if ('' === trim($this->salt)) {
             return '';
         }
 
-        $hostname = $this->getHostname();
+        $hostname = $this->getHostname($request);
         if ('' === $hostname) {
             return '';
         }
@@ -41,9 +41,9 @@ final class InstallationIdGenerator implements InstallationIdGeneratorInterface
         return Uuid::uuid5($saltNamespace, $hostname)->toString();
     }
 
-    private function getHostname(): string
+    private function getHostname(Request $request): string
     {
-        $host = $this->requestStack->getMainRequest()?->getHost();
+        $host = $request->getHost();
         if (null !== $host && '' !== trim($host)) {
             return mb_strtolower(trim($host));
         }

--- a/src/Sylius/Component/Core/Telemetry/Generator/InstallationIdGeneratorInterface.php
+++ b/src/Sylius/Component/Core/Telemetry/Generator/InstallationIdGeneratorInterface.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Telemetry\Generator;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /** @internal */
 interface InstallationIdGeneratorInterface
 {
-    public function generate(): string;
+    public function generate(Request $request): string;
 }

--- a/src/Sylius/Component/Core/Telemetry/Mapper/ValueRangeMapper.php
+++ b/src/Sylius/Component/Core/Telemetry/Mapper/ValueRangeMapper.php
@@ -88,6 +88,11 @@ final class ValueRangeMapper
         return self::mapToRange($value, self::COUNT_RANGES);
     }
 
+    public static function mapVirtualVariantsCount(int $value): string
+    {
+        return self::mapToRange($value, self::COUNT_RANGES);
+    }
+
     public static function mapCustomersCount(int $value): string
     {
         return self::mapToRange($value, self::CUSTOMER_ORDER_PAYMENT_SHIPMENT_RANGES);

--- a/src/Sylius/Component/Core/Telemetry/TelemetryOrchestrator.php
+++ b/src/Sylius/Component/Core/Telemetry/TelemetryOrchestrator.php
@@ -15,11 +15,12 @@ namespace Sylius\Component\Core\Telemetry;
 
 use Sylius\Component\Core\Telemetry\Collector\TelemetryDataCollectorInterface;
 use Sylius\Component\Core\Telemetry\Generator\InstallationIdGeneratorInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /** @internal */
 final class TelemetryOrchestrator implements TelemetryOrchestratorInterface
 {
-    private const SCHEMA_VERSION = 1;
+    private const SCHEMA_VERSION = 2;
 
     /**
      * @param iterable<TelemetryDataCollectorInterface> $collectors
@@ -30,7 +31,7 @@ final class TelemetryOrchestrator implements TelemetryOrchestratorInterface
     ) {
     }
 
-    public function getData(): array
+    public function getData(Request $request): array
     {
         try {
             $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
@@ -38,7 +39,7 @@ final class TelemetryOrchestrator implements TelemetryOrchestratorInterface
 
             $data = [
                 'schema_version' => self::SCHEMA_VERSION,
-                'installation_id' => $this->installationIdGenerator->generate(),
+                'installation_id' => $this->installationIdGenerator->generate($request),
                 'collected_at' => $now->format(\DATE_ATOM),
                 'period' => [
                     'start' => $oneMonthAgo->format(\DATE_ATOM),

--- a/src/Sylius/Component/Core/Telemetry/TelemetryOrchestratorInterface.php
+++ b/src/Sylius/Component/Core/Telemetry/TelemetryOrchestratorInterface.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Telemetry;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /** @internal */
 interface TelemetryOrchestratorInterface
 {
     /**
      * @return array<string, mixed>
      */
-    public function getData(): array;
+    public function getData(Request $request): array;
 }

--- a/src/Sylius/Component/Core/Telemetry/TelemetrySendManager.php
+++ b/src/Sylius/Component/Core/Telemetry/TelemetrySendManager.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Telemetry;
 
 use Sylius\Component\Core\Telemetry\Cache\TelemetryCacheInterface;
 use Sylius\Component\Core\Telemetry\Sender\TelemetrySenderInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /** @internal */
 final class TelemetrySendManager implements TelemetrySendManagerInterface
@@ -26,13 +27,13 @@ final class TelemetrySendManager implements TelemetrySendManagerInterface
     ) {
     }
 
-    public function sendIfNeeded(): void
+    public function sendIfNeeded(Request $request): void
     {
         if (!$this->telemetryCache->shouldSendTelemetry()) {
             return;
         }
 
-        $data = $this->telemetryCache->getCachedTelemetryData() ?? $this->telemetryOrchestrator->getData();
+        $data = $this->telemetryCache->getCachedTelemetryData() ?? $this->telemetryOrchestrator->getData($request);
 
         $installationId = $data['installation_id'] ?? '';
 

--- a/src/Sylius/Component/Core/Telemetry/TelemetrySendManagerInterface.php
+++ b/src/Sylius/Component/Core/Telemetry/TelemetrySendManagerInterface.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Telemetry;
 
+use Symfony\Component\HttpFoundation\Request;
+
 /** @internal */
 interface TelemetrySendManagerInterface
 {
-    public function sendIfNeeded(): void;
+    public function sendIfNeeded(Request $request): void;
 }

--- a/src/Sylius/Component/Core/Tests/Telemetry/TelemetrySendManagerTest.php
+++ b/src/Sylius/Component/Core/Tests/Telemetry/TelemetrySendManagerTest.php
@@ -19,6 +19,7 @@ use Sylius\Component\Core\Telemetry\Cache\TelemetryCacheInterface;
 use Sylius\Component\Core\Telemetry\Sender\TelemetrySenderInterface;
 use Sylius\Component\Core\Telemetry\TelemetrySendManager;
 use Sylius\Component\Core\Telemetry\TelemetryOrchestratorInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 final class TelemetrySendManagerTest extends TestCase
 {
@@ -33,12 +34,15 @@ final class TelemetrySendManagerTest extends TestCase
 
     private TelemetrySendManager $manager;
 
+    private Request $request;
+
     protected function setUp(): void
     {
         $this->orchestrator = $this->createMock(TelemetryOrchestratorInterface::class);
         $this->cache = $this->createMock(TelemetryCacheInterface::class);
         $this->sender = $this->createMock(TelemetrySenderInterface::class);
         $this->manager = new TelemetrySendManager($this->orchestrator, $this->cache, $this->sender);
+        $this->request = Request::create('https://example.com/admin');
     }
 
     public function test_it_does_nothing_when_should_not_send(): void
@@ -48,7 +52,7 @@ final class TelemetrySendManagerTest extends TestCase
         $this->orchestrator->expects($this->never())->method('getData');
         $this->sender->expects($this->never())->method('send');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_uses_cached_data_when_available(): void
@@ -66,7 +70,7 @@ final class TelemetrySendManagerTest extends TestCase
         $this->sender->expects($this->once())->method('send')->with($cachedData);
         $this->cache->expects($this->once())->method('storeSuccess')->with('cached-id');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_generates_new_data_when_no_cache(): void
@@ -78,27 +82,27 @@ final class TelemetrySendManagerTest extends TestCase
 
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn($telemetryData);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn($telemetryData);
         $this->sender->method('send')->willReturn(true);
 
         $this->orchestrator->expects($this->once())->method('getData');
         $this->sender->expects($this->once())->method('send')->with($telemetryData);
         $this->cache->expects($this->once())->method('storeSuccess')->with('test-id');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_does_nothing_when_installation_id_is_empty(): void
     {
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn(['installation_id' => '']);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn(['installation_id' => '']);
 
         $this->sender->expects($this->never())->method('send');
         $this->cache->expects($this->never())->method('storeSuccess');
         $this->cache->expects($this->never())->method('storeFailure');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_stores_success_when_send_succeeds(): void
@@ -110,13 +114,13 @@ final class TelemetrySendManagerTest extends TestCase
 
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn($telemetryData);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn($telemetryData);
         $this->sender->method('send')->willReturn(true);
 
         $this->cache->expects($this->once())->method('storeSuccess')->with('test-id');
         $this->cache->expects($this->never())->method('storeFailure');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_stores_failure_when_send_fails(): void
@@ -128,13 +132,13 @@ final class TelemetrySendManagerTest extends TestCase
 
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn($telemetryData);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn($telemetryData);
         $this->sender->method('send')->willReturn(false);
 
         $this->cache->expects($this->never())->method('storeSuccess');
         $this->cache->expects($this->once())->method('storeFailure')->with('test-id', $telemetryData);
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_stores_failure_when_send_throws_exception(): void
@@ -146,13 +150,13 @@ final class TelemetrySendManagerTest extends TestCase
 
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn($telemetryData);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn($telemetryData);
         $this->sender->method('send')->willThrowException(new \RuntimeException('Network error'));
 
         $this->cache->expects($this->never())->method('storeSuccess');
         $this->cache->expects($this->once())->method('storeFailure')->with('test-id', $telemetryData);
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 
     public function test_it_sends_only_once_per_request(): void
@@ -164,11 +168,11 @@ final class TelemetrySendManagerTest extends TestCase
 
         $this->cache->method('shouldSendTelemetry')->willReturn(true);
         $this->cache->method('getCachedTelemetryData')->willReturn(null);
-        $this->orchestrator->method('getData')->willReturn($telemetryData);
+        $this->orchestrator->method('getData')->with($this->request)->willReturn($telemetryData);
         $this->sender->method('send')->willReturn(false);
 
         $this->sender->expects($this->once())->method('send');
 
-        $this->manager->sendIfNeeded();
+        $this->manager->sendIfNeeded($this->request);
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.13 <!-- see the comment below -->
| Bug fix?        | partially
| New feature?    | no
| BC breaks?      | no
| License         | MIT

  Bug Fixes

  - Fixed hostname resolving in telemetry components
  - Fixed orders count retrieving in telemetry data collection

  New Data Collection

  - Added virtual product variants count to metrics
  - Added enabled channels count to metrics
  - Added countries data collection
  - Improved data structure for payment and shipping providers

  Technical Improvements

  - Added listener to skip optional telemetry index from schema validation
  - Added fallback check for API Platform version detection
  - Bumped telemetry schema version

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
