### PR TITLE
Fix race condition in save positions Behat tests

### DIFF
--- a/features/admin/product/managing_products/sorting_products_within_a_taxon_by_position.feature
+++ b/features/admin/product/managing_products/sorting_products_within_a_taxon_by_position.feature
@@ -29,7 +29,7 @@ Feature: Sorting listed products from a taxon by position
         And the store has a product "Ultimate Pug" in the "Soft Toys" taxon at 19th position
         And I am logged in as an administrator
 
-    @no-api @ui @mink:chromedriver @failing
+    @no-api @ui @mink:chromedriver
     Scenario: Setting two products to position -1 on the non-last page
         When I am browsing the 1st page of products from "Soft Toys" taxon
         And I set the position of "Old pug" to "-1"
@@ -48,7 +48,7 @@ Feature: Sorting listed products from a taxon by position
         Then the one before last product on the list should have name "Pug XL" with position 18
         And the last product on the list should have name "Pug XS" with position 19
 
-    @no-api @ui @mink:chromedriver @failing
+    @no-api @ui @mink:chromedriver
     Scenario: Setting two products to the already occupied position on the other page
         When I am browsing the 1st page of products from "Soft Toys" taxon
         And I set the position of "Old pug" to "15"
@@ -80,7 +80,7 @@ Feature: Sorting listed products from a taxon by position
         And the 7th product on this page should be named "Pug Master"
         And this product should be at position 16
 
-    @no-api @ui @mink:chromedriver @failing
+    @no-api @ui @mink:chromedriver
     Scenario: Setting two products to the positions overflowing the max available position on the non-last page
         When I am browsing the 1st page of products from "Soft Toys" taxon
         And I set the position of "Old pug" to "25"
@@ -107,7 +107,7 @@ Feature: Sorting listed products from a taxon by position
         When I am browsing the 3rd page of products from "Soft Toys" taxon
         Then the last product on the list within this taxon should have name "Big pug"
 
-    @api @ui @mink:chromedriver @failing
+    @api @ui @mink:chromedriver
     Scenario: Product with position 0 is set as the first one
         When I am browsing products from "Soft Toys" taxon
         And I set the position of "Young pug" to 0

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
@@ -44,11 +44,21 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
 
     public function setPositionOfProduct(string $productName, string $position): void
     {
+        $this->waitForSavePositionsController();
+
         /** @var NodeElement $productsRow */
         $productsRow = $this->getElement('table')->find('css', sprintf('tbody > tr:contains("%s")', $productName));
         Assert::notNull($productsRow, 'There are no row with given product\'s name!');
 
         $productsRow->find('css', '.sylius-product-taxon-position')->setValue($position);
+    }
+
+    private function waitForSavePositionsController(): void
+    {
+        $this->getSession()->wait(
+            5000,
+            'document.querySelector("[data-test-save-configuration-button][data-ready]") !== null',
+        );
     }
 
     public function savePositions(): void

--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/SavePositionsController.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/controllers/SavePositionsController.js
@@ -22,6 +22,8 @@ export default class extends Controller {
         document.querySelectorAll(this.inputSelectorValue).forEach(input => {
             input.addEventListener('change', (event) => this.handlePositionChange(event));
         });
+
+        this.element.dataset.ready = 'true';
     }
 
     handlePositionChange(event) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

The lazy-loaded `SavePositionsController` Stimulus controller could fail to attach event listeners before Behat tests started interacting with position inputs. This caused flaky tests where changed positions weren't tracked and save did nothing.

Changes:
- Add `data-ready` attribute to controller element when `connect()` completes
- Wait for this attribute in `IndexPerTaxonPage::setPositionOfProduct()` before interacting with inputs
- Remove `@failing` tags from affected scenarios
