### PR TITLE
[CI] Standardize job timeouts to 15 minutes

### DIFF
--- a/.github/workflows/ci__full_1_14.yaml
+++ b/.github/workflows/ci__full_1_14.yaml
@@ -78,7 +78,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 15
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci__full_2_1.yaml
+++ b/.github/workflows/ci__full_2_1.yaml
@@ -88,7 +88,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 15
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci__full_2_2.yaml
+++ b/.github/workflows/ci__full_2_2.yaml
@@ -88,7 +88,7 @@ jobs:
         name: "Notify about build status"
         needs: [static-checks, e2e-mariadb, e2e-mysql, e2e-pgsql, e2e-js, frontend, packages]
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        timeout-minutes: 15
 
         steps:
             -   name: "Process data"

--- a/.github/workflows/ci_e2e-mariadb.yaml
+++ b/.github/workflows/ci_e2e-mariadb.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -160,7 +160,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MariaDB ${{ matrix.mariadb }}, State Machine Adapter ${{ matrix.state_machine_adapter }}${{ matrix.api_platform && format(', ApiPlatform {0}', matrix.api_platform) || '' }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-mysql.yaml
+++ b/.github/workflows/ci_e2e-mysql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -145,7 +145,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-pgsql.yaml
+++ b/.github/workflows/ci_e2e-pgsql.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHPUnit, CLI, API, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -134,7 +134,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "UI, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, PostgreSQL ${{ matrix.postgres }}"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}

--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -17,7 +17,7 @@ jobs:
     behat-no-js-unstable:
         runs-on: ubuntu-latest
         name: "Non-JS, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 15
         continue-on-error: true
         strategy:
             fail-fast: false
@@ -100,7 +100,7 @@ jobs:
     behat-ui-js-chromedriver-unstable:
         runs-on: ubuntu-latest
         name: "JS with Chromedriver, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:
@@ -183,7 +183,7 @@ jobs:
     behat-ui-js-panther-unstable:
         runs-on: ubuntu-latest
         name: "JS with Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (${{ matrix.env || 'test_cached' }}), MySQL ${{ matrix.mysql }} (Unstable Dependencies)"
-        timeout-minutes: 45
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci_js.yaml
+++ b/.github/workflows/ci_js.yaml
@@ -53,7 +53,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "[${{ matrix.group }}] [PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}]"
-        timeout-minutes: 10
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.matrix) }}
@@ -136,7 +136,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "Panther, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
-        timeout-minutes: 10
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix: ${{ fromJson(needs.get-matrix.outputs.panther-matrix) }}

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -21,7 +21,7 @@ jobs:
     test_unstable:
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} (Unstable Dependencies)"
-        timeout-minutes: 25
+        timeout-minutes: 15
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci_packages.yaml
+++ b/.github/workflows/ci_packages.yaml
@@ -45,7 +45,7 @@ jobs:
         needs: get-matrix
         runs-on: ubuntu-latest
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
-        timeout-minutes: 25
+        timeout-minutes: 15
 
         strategy:
             fail-fast: false

--- a/.github/workflows/refactor.yaml
+++ b/.github/workflows/refactor.yaml
@@ -16,7 +16,7 @@ jobs:
 
         name: "Coding standard refactor"
 
-        timeout-minutes: 5
+        timeout-minutes: 15
 
         if: github.repository == 'Sylius/Sylius'
 

--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.repository == 'Sylius/Sylius'
         name: "Upmerge PR"
-        timeout-minutes: 5
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Standardizes `timeout-minutes` across all CI workflow files to 15 minutes. Previously values ranged from 5 to 45 minutes.

Affected workflows:
- `ci__full_*.yaml` - notification jobs (5 -> 15)
- `ci_e2e-*.yaml` - e2e tests (45 -> 15)
- `ci_js.yaml` - JS tests (10 -> 15)
- `ci_packages*.yaml` - package tests (25 -> 15)
- `refactor.yaml`, `upmerge_pr.yaml` - utility jobs (5 -> 15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI/CD pipeline job timeout configurations across multiple workflows to better align with actual execution requirements, with some jobs having increased timeouts and others optimized to reduced durations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->