### PR TITLE
[Shop Routing] Simple configuration changes for flexible products & taxons url

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing.yml
@@ -19,8 +19,13 @@ sylius_shop_security:
 sylius_shop_user:
     resource: "@SyliusShopBundle/Resources/config/routing/shop_user.yml"
 
+sylius_shop_taxon:
+    resource: "@SyliusShopBundle/Resources/config/routing/taxon.yml"
+    prefix: /taxons
+
 sylius_shop_product:
     resource: "@SyliusShopBundle/Resources/config/routing/product.yml"
+    prefix: /products
 
 sylius_shop_product_review:
     resource: "@SyliusShopBundle/Resources/config/routing/product_review.yml"

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product.yml
@@ -2,7 +2,7 @@
 # (c) Sylius Sp. z o.o.
 
 sylius_shop_product_show:
-    path: /products/{slug}
+    path: /{slug}
     methods: [GET]
     defaults:
         _controller: sylius.controller.product::showAction
@@ -14,14 +14,3 @@ sylius_shop_product_show:
                     - "expr:service('sylius.context.channel').getChannel()"
                     - "expr:service('sylius.context.locale').getLocaleCode()"
                     - $slug
-
-sylius_shop_product_index:
-    path: /taxons/{slug}
-    methods: [GET]
-    defaults:
-        _controller: sylius.controller.product::indexAction
-        _sylius:
-            template: "@SyliusShop/product/index.html.twig"
-            grid: sylius_shop_product
-    requirements:
-        slug: .+(?<!/)

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/taxon.yml
@@ -1,0 +1,13 @@
+# This file is part of the Sylius package.
+# (c) Sylius Sp. z o.o.
+
+sylius_shop_product_index:
+    path: /{slug}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.product::indexAction
+        _sylius:
+            template: "@SyliusShop/product/index.html.twig"
+            grid: sylius_shop_product
+    requirements:
+        slug: .+(?<!/)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I suggest a very simple change in the routing configuration so that it is easier to change the base products and taxons url.

Currently, when you want to change the url from `/en_US/taxons/t-shirts/men` to `/en_US/category/t-shirts/men` you need to completely override the route like:
```yaml
sylius_shop_product_index:
    path: /{_locale}/category/{slug}
    methods: [GET]
    defaults:
        _controller: sylius.controller.product::indexAction
        _sylius:
            template: "@SyliusShop/product/index.html.twig"
            grid: sylius_shop_product
    requirements:
        slug: .+(?<!/)
```

with the suggested changes you can simply link to the resource and change the prefix like:
```yaml
sylius_shop_product_index:
    resource: "@SyliusShopBundle/Resources/config/routing/product.yml"
    prefix: /{_locale}/category
```

A bonus, it turns out to be consistent with the other shop routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized navigation structure for product and taxon pages with updated URL paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->