### PR TITLE
[Composer] Remove outdated twig/twig conflicts from bundles

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -74,6 +74,10 @@ class RoboFile extends Tasks
             $task->exec('composer config prefer-stable false');
         }
 
+        if (str_starts_with($symfonyVersion, '^5.4')) {
+            $task->exec('composer require --no-progress --no-update --no-scripts --no-plugins "sylius/resource-bundle:~1.11.0"');
+        }
+
         $task
             ->exec('composer update --no-scripts --no-interaction')
             ->exec('composer validate --ansi --strict')

--- a/UPGRADE-1.14.md
+++ b/UPGRADE-1.14.md
@@ -1,3 +1,13 @@
+# UPGRADING FROM `v1.14.14` TO `v1.14.15`
+
+## Symfony 5.4 Compatibility
+
+If you are using Sylius 1.14 with Symfony 5.4, it is recommended to use `sylius/resource-bundle:~1.11.0`:
+
+```bash
+composer require "sylius/resource-bundle:~1.11.0"
+```
+
 # UPGRADING FROM `v1.14.13` TO `v1.14.14`
 
 ## Telemetry

--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,7 @@
         "behat/gherkin": "^4.13.0",
         "doctrine/orm": "2.20.7",
         "lexik/jwt-authentication-bundle": "^2.18",
+        "liip/imagine-bundle": "2.17.0",
         "stof/doctrine-extensions-bundle": "1.8.0",
         "symfony/serializer": "6.4.23",
         "symfony/validator": "5.4.25",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -34,8 +34,7 @@
         "symfony/intl": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^1.0 || ^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.4",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -38,7 +38,10 @@
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.4",
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
@@ -46,6 +49,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4",
         "theofidry/alice-data-fixtures": "^1.4"
     },

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -41,13 +41,19 @@
         "twig/twig": "^2.12 || ^3.3"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "php-http/message-factory": "^1.0",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/dotenv": "^5.4.21 || ^6.4"
+        "symfony/dotenv": "^5.4.21 || ^6.4",
+        "symfony/security-bundle": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
+        "willdurand/hateoas-bundle": "^2.0"
     },
     "conflict": {
         "twig/twig": "3.9.0"

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -31,7 +31,10 @@
         "symfony/messenger": "^5.4.21 || ^6.4"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "ext-sqlite3": "*",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "nelmio/alice": "^3.8",
@@ -42,8 +45,11 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/debug-bundle": "^5.4.21 || ^6.4",
         "symfony/dotenv": "^5.4.21 || ^6.4",
+        "symfony/security-bundle": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/webpack-encore-bundle": "^1.15",
-        "theofidry/alice-data-fixtures": "^1.4"
+        "theofidry/alice-data-fixtures": "^1.4",
+        "willdurand/hateoas-bundle": "^2.0"
     },
     "conflict": {
         "api-platform/core": "2.7.17",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -38,13 +38,16 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/form": "^5.4.21 || ^6.4"
+        "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "conflict": {
         "stof/doctrine-extensions-bundle": "1.8.0"

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -38,8 +38,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -35,6 +35,8 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
@@ -42,6 +44,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "twig/twig": "^2.12 || ^3.3"
     },
     "conflict": {

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -35,8 +35,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -77,6 +77,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
+        "friendsofsymfony/rest-bundle": "^3.0",
         "hwi/oauth-bundle": "^1.1 || ^2.0@beta",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
@@ -84,7 +85,10 @@
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/dotenv": "^5.4.21 || ^6.4"
+        "symfony/dotenv": "^5.4.21 || ^6.4",
+        "symfony/security-bundle": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
+        "willdurand/hateoas-bundle": "^2.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -35,7 +35,7 @@
         "symfony/templating": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "twig/twig": "^1.0 || 3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -40,6 +40,8 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
@@ -47,6 +49,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "twig/twig": "^2.12 || ^3.3"
     },
     "config": {

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -40,8 +40,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -44,12 +44,16 @@
         "webmozart/assert": "^1.9"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/form": "^5.4.21 || ^6.4"
+        "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -43,9 +43,6 @@
         "symfony/framework-bundle": "^5.4.21 || ^6.4",
         "webmozart/assert": "^1.9"
     },
-    "conflict": {
-        "twig/twig": "^3.0"
-    },
     "require-dev": {
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -41,11 +41,14 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "twig/twig": "^2.12 || ^3.3"
     },
     "config": {

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -41,8 +41,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -36,7 +36,7 @@
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "twig/twig": "^1.0 || 3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -41,13 +41,16 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "twig/twig": "^2.12 || ^3.3"
     },
     "config": {

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -42,8 +42,6 @@
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
         "friendsofphp/proxy-manager-lts": "^1.0.7",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -36,7 +36,7 @@
         "symfony/templating": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "twig/twig": "^1.0 || 3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -35,7 +35,7 @@
         "webmozart/assert": "^1.9"
     },
     "conflict": {
-        "twig/twig": "^1.0 || 3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -40,8 +40,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -40,6 +40,8 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
@@ -47,6 +49,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "twig/twig": "^2.12 || ^3.3"
     },
     "config": {

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -38,8 +38,7 @@
         "symfony/templating": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^1.0 || ^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -41,12 +41,16 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "config": {

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -32,8 +32,7 @@
         "symfony/framework-bundle": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
-        "twig/twig": "^3.0"
+        "doctrine/orm": "2.15.2"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -35,14 +35,18 @@
         "doctrine/orm": "2.15.2"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sylius/locale-bundle": "^1.13",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
-        "symfony/dependency-injection": "^5.4.21 || ^6.4"
+        "symfony/dependency-injection": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -39,8 +39,6 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
-        "friendsofsymfony/rest-bundle": "^3.0",
-        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "mockery/mockery": "^1.4",
         "phpspec/phpspec": "^7.2",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -39,6 +39,8 @@
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "mockery/mockery": "^1.4",
         "phpspec/phpspec": "^7.2",
@@ -46,6 +48,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "conflict": {

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -38,8 +38,7 @@
     },
     "conflict": {
         "doctrine/orm": "2.15.2",
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -41,7 +41,10 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
@@ -50,6 +53,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "config": {

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -47,8 +47,7 @@
         "symfony/framework-bundle": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^7.2",

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -50,6 +50,9 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
@@ -58,6 +61,7 @@
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
         "symfony/security-bundle": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "config": {

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -38,8 +38,7 @@
     },
     "conflict": {
         "doctrine/orm": "2.15.2",
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -41,7 +41,10 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
@@ -49,6 +52,7 @@
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
         "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4",
         "symfony/validator": "^5.4.21 || ^6.4"
     },
     "config": {

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -39,14 +39,18 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
-        "symfony/form": "^5.4.21 || ^6.4"
+        "symfony/form": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -36,8 +36,7 @@
         "symfony/framework-bundle": "^5.4.21 || ^6.4"
     },
     "conflict": {
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -36,8 +36,7 @@
     },
     "conflict": {
         "doctrine/orm": "2.15.2",
-        "stof/doctrine-extensions-bundle": "1.8.0",
-        "twig/twig": "^3.0"
+        "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.13",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -39,10 +39,14 @@
         "stof/doctrine-extensions-bundle": "1.8.0"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
         "doctrine/orm": "^2.13",
+        "friendsofsymfony/rest-bundle": "^3.0",
+        "jms/serializer-bundle": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
-        "symfony/dependency-injection": "^5.4.21 || ^6.4"
+        "symfony/dependency-injection": "^5.4.21 || ^6.4",
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "config": {
         "allow-plugins": {

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -44,7 +44,7 @@
         "laminas/laminas-stdlib": "^3.3.1"
     },
     "conflict": {
-        "twig/twig": "^1.0 || 3.9.0"
+        "twig/twig": "3.9.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.2",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -50,8 +50,7 @@
         "webmozart/assert": "^1.9"
     },
     "conflict": {
-        "doctrine/orm": "2.15.2",
-        "twig/twig": "^3.0"
+        "doctrine/orm": "2.15.2"
     },
     "require-dev": {
         "hwi/oauth-bundle": "^1.1 || ^2.0@beta",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -53,13 +53,17 @@
         "doctrine/orm": "2.15.2"
     },
     "require-dev": {
+        "doctrine/doctrine-bundle": "^1.12 || ^2.3.1",
+        "friendsofsymfony/rest-bundle": "^3.0",
         "hwi/oauth-bundle": "^1.1 || ^2.0@beta",
+        "jms/serializer-bundle": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpspec/phpspec": "^7.2",
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
+        "symfony/mailer": "^5.4.21 || ^6.4",
         "symfony/security-bundle": "^5.4.21 || ^6.4",
-        "symfony/mailer": "^5.4.21 || ^6.4"
+        "symfony/twig-bundle": "^5.4.21 || ^6.4"
     },
     "suggest": {
         "hwi/oauth-bundle": "For OAuth integration"


### PR DESCRIPTION
Remove legacy `twig/twig` version conflicts that blocked users of standalone bundles from upgrading to Twig 3.x:

- Remove `^3.0` conflict added in 2019, already removed in Sylius 2.0+
- Remove `^1.0` conflict (Twig 1.x reached EOL years ago)
- Keep `3.9.0` conflict as it's a specific buggy version documented in `CONFLICTS.md`

Since Twig 2.x reached EOL in December 2023, these conflicts were blocking users who use Sylius bundles standalone from upgrading.

Also adds `friendsofsymfony/rest-bundle` and `jms/serializer-bundle` to UserBundle `require-dev` - they're used in functional tests but were previously installed as transitive dependencies of `sylius/resource-bundle` (moved from `require` to `require-dev` in ResourceBundle 1.13).

Additionally adds conflict for `liip/imagine-bundle: 2.17.0` - this version was released on 2026-01-05 and breaks container compilation when AssetMapper is not used (unrelated to twig changes).

Affected bundles: AddressingBundle, CustomerBundle, CurrencyBundle, InventoryBundle, LocaleBundle, MoneyBundle, OrderBundle, PaymentBundle, PromotionBundle, ReviewBundle, ShippingBundle, TaxationBundle, TaxonomyBundle, UiBundle, UserBundle

Closes #18700