### PR TITLE
[Deps] Allow psr/http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "php-http/message-factory": "^1.0",
         "psr/cache": "^2.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^2.0",
         "ramsey/uuid": "^4.0",
         "sonata-project/block-bundle": "^4.2 || ^5.0",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -32,7 +32,7 @@
         "league/flysystem": "^2.4",
         "payum/core": "^1.7.3",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "sylius/addressing": "^1.13",
         "sylius/attribute": "^1.13",
         "sylius/channel": "^1.13",


### PR DESCRIPTION
Adding this to 1.14 for better flexibility when upgrading projects. This is not a BC break - it only extends the allowed versions without forcing any changes.

Many modern libraries now require `psr/http-message: ^2.0` exclusively. Sylius only uses the interfaces as type hints without implementing them, so supporting both versions is safe. Backporting to 1.14 benefits end applications that want to upgrade their dependencies.

Ref: https://github.com/Sylius/Sylius/issues/18698