### PR TITLE
[API] Payment Request fix default action when IRI is given

### DIFF
--- a/UPGRADE-API-2.1.md
+++ b/UPGRADE-API-2.1.md
@@ -1,3 +1,17 @@
+# UPGRADE FROM `2.1.10` TO `2.1.11`
+
+### Constructor signature changes
+
+1. `Sylius\Bundle\ApiBundle\Serializer\ContextBuilder\PaymentRequestActionAwareContextBuilder`:
+   ```diff
+   public function __construct(
+   +   private readonly IriToIdentifierConverterInterface $iriToIdentifierConverter,
+       SerializerContextBuilderInterface $decoratedContextBuilder,
+       string $attributeClass,
+       string $defaultConstructorArgumentName,
+   )
+   ```
+
 # UPGRADE FROM `2.1.4` TO `2.1.5`
 
 ## Modified responses

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
@@ -83,7 +83,7 @@ final class CheckoutOrderDetailsContext implements Context
         $payment = end($payments);
 
         $paymentId = $payment['id'];
-        $response = $this->client->requestGet(sprintf('/api/v2/shop/orders/%s/payments/%s', $this->sharedStorage->get('cart_token'), $paymentId));
+        $response = $this->client->requestGet(sprintf('orders/%s/payments/%s', $this->sharedStorage->get('cart_token'), $paymentId));
 
         return $this->responseChecker->getValue($response, 'state');
     }

--- a/src/Sylius/Behat/Context/Api/Shop/PaymentRequestContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PaymentRequestContext.php
@@ -88,7 +88,6 @@ final readonly class PaymentRequestContext implements Context
         $request->setContent([
             'paymentId' => $payment['id'],
             'paymentMethodCode' => $payment['method'],
-            'action' => PaymentRequestInterface::ACTION_CAPTURE,
             'payload' => $payload,
         ]);
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
@@ -208,6 +208,7 @@
             decorates="api_platform.serializer.context_builder"
             decoration-priority="64"
         >
+            <argument type="service" id="sylius_api.converter.iri_to_identifier" />
             <argument type="service" id=".inner" />
             <argument>Sylius\Bundle\ApiBundle\Attribute\PaymentRequestActionAware</argument>
             <argument type="constant">Sylius\Bundle\ApiBundle\Attribute\PaymentRequestActionAware::DEFAULT_ARGUMENT_NAME</argument>

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilder.php
@@ -25,7 +25,7 @@ final class PaymentRequestActionAwareContextBuilder extends AbstractInputContext
     private ?Request $request = null;
 
     public function __construct(
-        private IriToIdentifierConverterInterface $iriToIdentifierConverter,
+        private readonly IriToIdentifierConverterInterface $iriToIdentifierConverter,
         SerializerContextBuilderInterface $decoratedContextBuilder,
         string $attributeClass,
         string $defaultConstructorArgumentName,

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilder.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\Serializer\ContextBuilder;
 
 use ApiPlatform\State\SerializerContextBuilderInterface;
 use Sylius\Bundle\ApiBundle\Attribute\PaymentRequestActionAware;
+use Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface;
 use Sylius\Bundle\PaymentBundle\Provider\DefaultActionProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,6 +25,7 @@ final class PaymentRequestActionAwareContextBuilder extends AbstractInputContext
     private ?Request $request = null;
 
     public function __construct(
+        private IriToIdentifierConverterInterface $iriToIdentifierConverter,
         SerializerContextBuilderInterface $decoratedContextBuilder,
         string $attributeClass,
         string $defaultConstructorArgumentName,
@@ -50,6 +52,11 @@ final class PaymentRequestActionAwareContextBuilder extends AbstractInputContext
     {
         $data = $this->request->toArray();
 
-        return $this->defaultActionProvider->getActionFromPaymentMethodCode($data['paymentMethodCode']);
+        $paymentMethodCode = $data['paymentMethodCode'];
+        if (is_string($paymentMethodCode) && $paymentMethodCode !== '' && $this->iriToIdentifierConverter->isIdentifier($paymentMethodCode)) {
+            $paymentMethodCode = $this->iriToIdentifierConverter->getIdentifier($paymentMethodCode);
+        }
+
+        return $this->defaultActionProvider->getActionFromPaymentMethodCode($paymentMethodCode);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilderTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Serializer/ContextBuilder/PaymentRequestActionAwareContextBuilderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ApiBundle\Attribute\PaymentRequestActionAware;
 use Sylius\Bundle\ApiBundle\Command\Payment\AddPaymentRequest;
+use Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface;
 use Sylius\Bundle\ApiBundle\Serializer\ContextBuilder\PaymentRequestActionAwareContextBuilder;
 use Sylius\Bundle\PaymentBundle\Provider\DefaultActionProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
@@ -28,6 +29,8 @@ final class PaymentRequestActionAwareContextBuilderTest extends TestCase
 {
     private MockObject|SerializerContextBuilderInterface $decoratedContextBuilderMock;
 
+    private IriToIdentifierConverterInterface|MockObject $iriToIdentifierConverterMock;
+
     private DefaultActionProviderInterface|MockObject $defaultActionProviderMock;
 
     private PaymentRequestActionAwareContextBuilder $paymentRequestActionAwareContextBuilder;
@@ -35,8 +38,15 @@ final class PaymentRequestActionAwareContextBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->decoratedContextBuilderMock = $this->createMock(SerializerContextBuilderInterface::class);
+        $this->iriToIdentifierConverterMock = $this->createMock(IriToIdentifierConverterInterface::class);
         $this->defaultActionProviderMock = $this->createMock(DefaultActionProviderInterface::class);
-        $this->paymentRequestActionAwareContextBuilder = new PaymentRequestActionAwareContextBuilder($this->decoratedContextBuilderMock, PaymentRequestActionAware::class, PaymentRequestActionAware::DEFAULT_ARGUMENT_NAME, $this->defaultActionProviderMock);
+        $this->paymentRequestActionAwareContextBuilder = new PaymentRequestActionAwareContextBuilder(
+            $this->iriToIdentifierConverterMock,
+            $this->decoratedContextBuilderMock,
+            PaymentRequestActionAware::class,
+            PaymentRequestActionAware::DEFAULT_ARGUMENT_NAME,
+            $this->defaultActionProviderMock,
+        );
     }
 
     public function test_it_sets_action_as_a_constructor_argument(): void
@@ -54,6 +64,13 @@ final class PaymentRequestActionAwareContextBuilderTest extends TestCase
             ->willReturn([
                 'input' => ['class' => AddPaymentRequest::class],
             ])
+        ;
+
+        $this->iriToIdentifierConverterMock
+            ->expects($this->once())
+            ->method('isIdentifier')
+            ->with('cash_on_delivery')
+            ->willReturn(false)
         ;
 
         $this->defaultActionProviderMock
@@ -87,6 +104,59 @@ final class PaymentRequestActionAwareContextBuilderTest extends TestCase
             ->willReturn([
                 'input' => ['class' => AddPaymentRequest::class],
             ])
+        ;
+
+        $this->iriToIdentifierConverterMock
+            ->expects($this->once())
+            ->method('isIdentifier')
+            ->with('cash_on_delivery')
+            ->willReturn(false)
+        ;
+
+        $this->defaultActionProviderMock
+            ->expects($this->once())
+            ->method('getActionFromPaymentMethodCode')
+            ->with('cash_on_delivery')
+            ->willReturn(PaymentRequestInterface::ACTION_CAPTURE)
+        ;
+
+        $this->assertSame([
+            'input' => ['class' => AddPaymentRequest::class],
+            AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS => [
+                AddPaymentRequest::class => ['action' => PaymentRequestInterface::ACTION_CAPTURE],
+            ],
+        ], $this->paymentRequestActionAwareContextBuilder->createFromRequest($requestMock, true, []));
+    }
+
+    public function test_it_sets_action_as_a_constructor_argument_when_payment_method_code_is_an_iri(): void
+    {
+        /** @var Request|MockObject $requestMock */
+        $requestMock = $this->createMock(Request::class);
+        $requestMock->expects($this->exactly(2))->method('toArray')->willReturn([
+            'paymentMethodCode' => '/api/v2/shop/payment-methods/cash_on_delivery',
+        ]);
+
+        $this->decoratedContextBuilderMock
+            ->expects($this->once())
+            ->method('createFromRequest')
+            ->with($requestMock, true, [])
+            ->willReturn([
+                'input' => ['class' => AddPaymentRequest::class],
+            ])
+        ;
+
+        $this->iriToIdentifierConverterMock
+            ->expects($this->once())
+            ->method('isIdentifier')
+            ->with('/api/v2/shop/payment-methods/cash_on_delivery')
+            ->willReturn(true)
+        ;
+
+        $this->iriToIdentifierConverterMock
+            ->expects($this->once())
+            ->method('getIdentifier')
+            ->with('/api/v2/shop/payment-methods/cash_on_delivery')
+            ->willReturn('cash_on_delivery')
         ;
 
         $this->defaultActionProviderMock


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

## Description

This PR improves the handling of payment request actions by also handling IRI payment method.

## Changes

### 1. Remove explicit action parameter from Behat tests
- Removed the hardcoded `action` field from payment request context in Behat tests
- The action is already automatically determined based on the payment method configuration

### 2. Enhanced PaymentRequestActionAwareContextBuilder
- Added IRI to identifier conversion support for `paymentMethodCode` parameter
- Injected `IriToIdentifierConverterInterface` to handle IRI format payment method codes
- When `paymentMethodCode` is provided as an IRI (e.g., `/api/v2/shop/payment-methods/code`), it's automatically converted to the identifier before determining the default action
- This ensures the default action provider can correctly resolve the action based on the payment method configuration

## Benefits

- **Improved flexibility**: Supports both direct payment method codes and IRI references
- **Better consistency**: The default action is always determined from the payment method configuration, reducing potential mismatches
- **Cleaner code**: Removes redundant action specifications from tests and API calls

## Technical Details

The `PaymentRequestActionAwareContextBuilder` now:
1. Checks if the `paymentMethodCode` is an IRI
2. Converts it to an identifier if needed

This change maintains backward compatibility while adding support for IRI-based payment method references.
