### PR TITLE
[Channel] Resolve localhost equivalents when matching channel by hostname

### DIFF
--- a/src/Sylius/Component/Channel/Context/RequestBased/HostnameBasedRequestResolver.php
+++ b/src/Sylius/Component/Channel/Context/RequestBased/HostnameBasedRequestResolver.php
@@ -19,12 +19,33 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class HostnameBasedRequestResolver implements RequestResolverInterface
 {
+    private const LOCALHOST_EQUIVALENTS = ['localhost', '127.0.0.1', '::1'];
+
     public function __construct(private ChannelRepositoryInterface $channelRepository)
     {
     }
 
     public function findChannel(Request $request): ?ChannelInterface
     {
-        return $this->channelRepository->findOneEnabledByHostname($request->getHost());
+        $hostname = $request->getHost();
+
+        $channel = $this->channelRepository->findOneEnabledByHostname($hostname);
+
+        if (null !== $channel || !in_array($hostname, self::LOCALHOST_EQUIVALENTS, true)) {
+            return $channel;
+        }
+
+        foreach (self::LOCALHOST_EQUIVALENTS as $localhostEquivalent) {
+            if ($localhostEquivalent === $hostname) {
+                continue;
+            }
+
+            $channel = $this->channelRepository->findOneEnabledByHostname($localhostEquivalent);
+            if (null !== $channel) {
+                return $channel;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Sylius/Component/Channel/tests/Context/RequestBased/HostnameBasedRequestResolverTest.php
+++ b/src/Sylius/Component/Channel/tests/Context/RequestBased/HostnameBasedRequestResolverTest.php
@@ -72,4 +72,103 @@ final class HostnameBasedRequestResolverTest extends TestCase
 
         self::assertNull($this->resolver->findChannel($request));
     }
+
+    public function testFindsChannelByLocalhostWhenRequestIs127001(): void
+    {
+        $request = $this->createMock(Request::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $request->expects(self::once())
+            ->method('getHost')
+            ->willReturn('127.0.0.1');
+
+        $this->channelRepository->expects(self::exactly(2))
+            ->method('findOneEnabledByHostname')
+            ->willReturnCallback(function (string $hostname) use ($channel) {
+                return match ($hostname) {
+                    '127.0.0.1' => null,
+                    'localhost' => $channel,
+                    default => null,
+                };
+            });
+
+        self::assertSame($channel, $this->resolver->findChannel($request));
+    }
+
+    public function testFindsChannelBy127001WhenRequestIsLocalhost(): void
+    {
+        $request = $this->createMock(Request::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $request->expects(self::once())
+            ->method('getHost')
+            ->willReturn('localhost');
+
+        $this->channelRepository->expects(self::exactly(2))
+            ->method('findOneEnabledByHostname')
+            ->willReturnCallback(function (string $hostname) use ($channel) {
+                return match ($hostname) {
+                    'localhost' => null,
+                    '127.0.0.1' => $channel,
+                    default => null,
+                };
+            });
+
+        self::assertSame($channel, $this->resolver->findChannel($request));
+    }
+
+    public function testFindsChannelByIpv6LocalhostWhenRequestIsLocalhost(): void
+    {
+        $request = $this->createMock(Request::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $request->expects(self::once())
+            ->method('getHost')
+            ->willReturn('localhost');
+
+        $this->channelRepository->expects(self::exactly(3))
+            ->method('findOneEnabledByHostname')
+            ->willReturnCallback(function (string $hostname) use ($channel) {
+                return match ($hostname) {
+                    'localhost' => null,
+                    '127.0.0.1' => null,
+                    '::1' => $channel,
+                    default => null,
+                };
+            });
+
+        self::assertSame($channel, $this->resolver->findChannel($request));
+    }
+
+    public function testReturnsNullWhenNoLocalhostEquivalentFound(): void
+    {
+        $request = $this->createMock(Request::class);
+
+        $request->expects(self::once())
+            ->method('getHost')
+            ->willReturn('localhost');
+
+        $this->channelRepository->expects(self::exactly(3))
+            ->method('findOneEnabledByHostname')
+            ->willReturn(null);
+
+        self::assertNull($this->resolver->findChannel($request));
+    }
+
+    public function testPrefersExactMatchOverLocalhostEquivalent(): void
+    {
+        $request = $this->createMock(Request::class);
+        $exactChannel = $this->createMock(ChannelInterface::class);
+
+        $request->expects(self::once())
+            ->method('getHost')
+            ->willReturn('127.0.0.1');
+
+        $this->channelRepository->expects(self::once())
+            ->method('findOneEnabledByHostname')
+            ->with('127.0.0.1')
+            ->willReturn($exactChannel);
+
+        self::assertSame($exactChannel, $this->resolver->findChannel($request));
+    }
 }


### PR DESCRIPTION
When resolving channels by hostname, localhost, 127.0.0.1 and ::1 are now treated as equivalents. If no channel is found for the exact hostname but the hostname is one of these localhost variants, the resolver will try the other variants.

Previously, Sylius did exact string comparison when matching channels by hostname. This meant that a channel configured with `localhost` would not be matched when accessing via `127.0.0.1`, and vice versa. This caused friction in local development when browser URL and fixtures used different hostname formats.

The fix adds fallback logic in `HostnameBasedRequestResolver` that checks other localhost equivalents when:
1. No channel is found for the exact hostname
2. The hostname is one of the localhost equivalents (localhost, 127.0.0.1, ::1)