### PR TITLE
[Tests] Fix SelectProductAttributeChoiceRemoveListenerTest

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/tests/EventListener/SelectProductAttributeChoiceRemoveListenerTest.php
+++ b/src/Sylius/Bundle/ProductBundle/tests/EventListener/SelectProductAttributeChoiceRemoveListenerTest.php
@@ -184,7 +184,7 @@ final class SelectProductAttributeChoiceRemoveListenerTest extends TestCase
 
     public function testDoesNothingIfAnEntityIsNotAProductAttribute(): void
     {
-        $this->event->expects($this->once())->method('getObject')->willReturn('wrongObject');
+        $this->event->expects($this->once())->method('getObject')->willReturn(new \stdClass());
 
         $this->entityManager->expects($this->never())->method('getRepository')->with(ProductAttributeValue::class);
         $this->entityManager->expects($this->never())->method('flush');

--- a/src/Sylius/Bundle/ReviewBundle/tests/EventListener/ReviewChangeListenerTest.php
+++ b/src/Sylius/Bundle/ReviewBundle/tests/EventListener/ReviewChangeListenerTest.php
@@ -78,7 +78,7 @@ final class ReviewChangeListenerTest extends TestCase
 
     public function testDoesNothingIfEventSubjectIsNotReviewObject(): void
     {
-        $this->event->expects(self::once())->method('getObject')->willReturn('badObject');
+        $this->event->expects(self::once())->method('getObject')->willReturn(new \stdClass());
 
         $this->averageRatingUpdater->expects(self::never())
             ->method('update')

--- a/src/Sylius/Bundle/UserBundle/tests/EventListener/PasswordUpdaterListenerTest.php
+++ b/src/Sylius/Bundle/UserBundle/tests/EventListener/PasswordUpdaterListenerTest.php
@@ -93,7 +93,7 @@ final class PasswordUpdaterListenerTest extends TestCase
         /** @var LifecycleEventArgs&MockObject $event */
         $event = $this->createMock(LifecycleEventArgs::class);
 
-        $event->expects($this->once())->method('getObject')->willReturn('user');
+        $event->expects($this->once())->method('getObject')->willReturn(new \stdClass());
         $this->passwordUpdater->expects($this->never())->method('updatePassword');
 
         $this->passwordUpdaterListener->prePersist($event);
@@ -104,7 +104,7 @@ final class PasswordUpdaterListenerTest extends TestCase
         /** @var LifecycleEventArgs&MockObject $event */
         $event = $this->createMock(LifecycleEventArgs::class);
 
-        $event->expects($this->once())->method('getObject')->willReturn('user');
+        $event->expects($this->once())->method('getObject')->willReturn(new \stdClass());
         $this->passwordUpdater->expects($this->never())->method('updatePassword');
 
         $this->passwordUpdaterListener->preUpdate($event);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

I based it on that branch, but I think it should be fixed on the other ones when the resource 1.14 will be released as stable.

It fixes this following issue
<img width="1214" height="353" alt="image" src="https://github.com/user-attachments/assets/96aa039f-9eb6-4ff1-bf80-e597ff4e460c" />
