### PR TITLE
[CI] Update upmerge workflow to 2.2 -> 2.3

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -21,11 +21,8 @@ jobs:
             matrix:
                 include:
                     -
-                        base_branch: "1.14"
-                        target_branch: "2.1"
-                    -
-                        base_branch: "2.1"
-                        target_branch: "2.2"
+                        base_branch: "2.2"
+                        target_branch: "2.3"
 
         steps:
             -
@@ -59,7 +56,7 @@ jobs:
                     title: '[UPMERGE] ${{ matrix.base_branch }} -> ${{ matrix.target_branch }}'
                     body: |
                         This PR has been generated automatically.
-                        For more details see [upmerge_pr.yaml](/Sylius/Sylius/blob/2.1/.github/workflows/upmerge_pr.yaml).
+                        For more details see [upmerge_pr.yaml](/Sylius/Sylius/blob/2.3/.github/workflows/upmerge_pr.yaml).
                         
                         **Remember!** The upmerge should always be merged with using `Merge pull request` button.
                         


### PR DESCRIPTION
Removes old upmerge paths (`1.14 -> 2.1`, `2.1 -> 2.2`) and sets up upmerge from `2.2` to `2.3`. Also updates the workflow file link in PR body to point to the `2.3` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the upmerge workflow configuration to refine version merge scope and refresh reference links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->