### PR TITLE
[CI] Update Full CI workflows to 1.14, 2.2 and 2.3

### DIFF
--- a/.github/workflows/ci__full_2_3.yaml
+++ b/.github/workflows/ci__full_2_3.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration 2.1 (Full)
+name: Continuous Integration 2.3 (Full)
 
 on:
     push:
@@ -6,21 +6,21 @@ on:
             - 'full-ci/**'
     schedule:
         -
-            cron: "0 2 * * *" # Run every day at 2am
+            cron: "0 3 * * *" # Run every day at 3am
     workflow_dispatch: ~
 
 concurrency:
-    group: ci-${{ github.workflow }}-${{ github.ref }}-2_1-full
+    group: ci-${{ github.workflow }}-${{ github.ref }}-2_3-full
     cancel-in-progress: true
 
-permissions: 
+permissions:
     contents: read
 
 jobs:
     static-checks:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Static checks"
         uses: ./.github/workflows/ci_static-checks.yaml
         with:
@@ -29,7 +29,7 @@ jobs:
     e2e-mariadb:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Tests (MariaDB)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mariadb.yaml
@@ -39,7 +39,7 @@ jobs:
     e2e-mysql:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Tests (MySQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-mysql.yaml
@@ -49,7 +49,7 @@ jobs:
     e2e-pgsql:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Tests (PostgreSQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_e2e-pgsql.yaml
@@ -59,7 +59,7 @@ jobs:
     e2e-js:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Javascript Tests (MySQL)"
         needs: static-checks
         uses: ./.github/workflows/ci_js.yaml
@@ -76,7 +76,7 @@ jobs:
     packages:
         strategy:
             matrix:
-                branch: ["2.1"]
+                branch: ["2.3"]
         name: "[${{ matrix.branch }}] Packages"
         needs: static-checks
         uses: ./.github/workflows/ci_packages.yaml


### PR DESCRIPTION
Removes the 2.1 workflow and adds 2.3 workflow as we released a new minor and shift testing one version up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to version 2.3 with adjusted scheduling and branch references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->