### PR TITLE
TASK: [2.2] [UiBundle] adjust translations for admin password reset page

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
@@ -59,6 +59,7 @@ sylius:
         administration: 'Administration'
         administration_dashboard: 'Administration Dashboard'
         administration_panel_login: 'Administrations-Bereich Anmeldung'
+        administration_reset_password: 'Administrations-Passwort zurücksetzen'
         all: 'Alle'
         all_your_addresses: 'Alle Adressen'
         amount: 'Betrag'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_AT.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_AT.yml
@@ -60,7 +60,7 @@ sylius:
         administration: 'Administration'
         administration_dashboard: 'Administrations‑Dashboard'
         administration_panel_login: 'Login Administrationsbereich'
-        administration_reset_password: 'Administrations‑Passwort zurücksetzen'
+        administration_reset_password: 'Administrations-Passwort zurücksetzen'
         all: 'Alle'
         all_rights_reserved: 'Alle Rechte vorbehalten'
         all_your_addresses: 'Alle Ihre Adressen'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de_CH.yml
@@ -60,7 +60,7 @@ sylius:
         administration: 'Verwaltung'
         administration_dashboard: 'Verwaltungs-Dashboard'
         administration_panel_login: 'Anmeldung zum Verwaltungsbereich'
-        administration_reset_password: 'Passwort zurücksetzen'
+        administration_reset_password: 'Administrations-Passwort zurücksetzen'
         all: 'Alle'
         all_rights_reserved: 'Alle Rechte vorbehalten'
         all_your_addresses: 'Alle Ihre Adressen'


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

This PR adds the missing translation string for `administration_reset_password` for `de_de` langauge makes it consistent with the other DE languages.
