### PR TITLE
[Admin] Fix order history address fields not displaying empty values

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/city.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/city.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.city|default(false) %}
+{% if log.data.city is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.city' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.city }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/company.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/company.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.company|default(false) %}
+{% if log.data.company is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.company' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.company }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/country_code.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/country_code.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.countryCode|default(false) %}
+{% if log.data.countryCode is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.country_code' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.countryCode }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/first_name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/first_name.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.firstName|default(false) %}
+{% if log.data.firstName is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.first_name' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.firstName }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/last_name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/last_name.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.lastName|default(false) %}
+{% if log.data.lastName is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.last_name' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.lastName }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/phone_number.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/phone_number.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.phoneNumber|default(false) %}
+{% if log.data.phoneNumber is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.phone_number' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.phoneNumber }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/postcode.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/postcode.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.postcode|default(false) %}
+{% if log.data.postcode is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.postcode' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.postcode }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/province_code.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/province_code.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.provinceCode|default(false) %}
+{% if log.data.provinceCode is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.province_code' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.provinceCode }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/province_name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/province_name.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.provinceName|default(false) %}
+{% if log.data.provinceName is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.province_name' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.provinceName }}</span></td>

--- a/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/street.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/order/history/common/sections/addresses/address/details/data/street.html.twig
@@ -1,6 +1,6 @@
 {% set log = hookable_metadata.context.log %}
 
-{% if log.data.street|default(false) %}
+{% if log.data.street is defined %}
     <tr>
         <td class="col-4 border-0"><strong>{{ 'sylius.ui.street' |trans }}</strong></td>
         <td class="col-8 border-0 text-body w-full"><span>{{ log.data.street }}</span></td>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | na
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

 ## Summary                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
  Fix address fields in order history not being displayed when they contain falsy values (empty string, null, 0).
                                                                                                                                                                                                                                 
  Changed condition from `|default(false)` to `is defined` in all address detail templates to properly show fields that exist in the log data, regardless of their value.
                                                                                                                                                                                                                                 
  ## Affected templates                                                                                                                                                                                                          
  - city, company, country_code, first_name, last_name                                                                                                                                                                           
  - phone_number, postcode, province_code, province_name, street 
