### PR TITLE
[New routing] Convert sylius_admin_customer_order_index route

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/order.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/order.php
@@ -32,6 +32,17 @@ return (new ResourceMetadata())
             routeName: '_sylius_admin_order_index',
             grid: 'sylius_admin_order',
         ),
+        new Index(
+            path: '/customers/{id}/orders',
+            routeName: '_sylius_admin_customer_order_index',
+            template: '@SyliusAdmin/shared/crud/index.html.twig',
+            shortName: 'customer_orders',
+            vars: [
+                'customer' => '@=sylius_repositories.get(\'sylius.repository.customer\').find(request.attributes.get(\'id\'))',
+                'hook_prefix' => 'sylius_admin.customer.order',
+            ],
+            grid: 'sylius_admin_customer_order',
+        ),
         new Show(
             routeName: '_sylius_admin_order_show',
             repositoryMethod: 'findOrderById',

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -15,6 +15,7 @@ sylius_admin_customer:
 sylius_admin_customer_order_index:
     path: /customers/{id}/orders
     methods: [GET]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
     defaults:
         _controller: sylius.controller.order::indexAction
         _sylius:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | new-routing
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Previous YAML routing:
```yaml
sylius_admin_customer_order_index:
    path: /customers/{id}/orders
    methods: [GET]
    condition: "context.isSyliusRoutingBcLayerEnabled('admin_order')"
    defaults:
        _controller: sylius.controller.order::indexAction
        _sylius:
            section: admin
            permission: true
            template: "@SyliusAdmin/shared/crud/index.html.twig"
            grid: sylius_admin_customer_order
            vars:
                customer: expr:service('sylius.repository.customer').find($id)
                hook_prefix: 'sylius_admin.customer.order'
```