### PR TITLE
[New routing] Convert sylius_admin_catalog_promotion_product_variant_…

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/product_variant.php
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/resources/product_variant.php
@@ -36,6 +36,17 @@ return (new ResourceMetadata())
             ],
             grid: 'sylius_admin_product_variant',
         ),
+        new Index(
+            path: 'catalog-promotions/{id}/variants',
+            routeName: '_sylius_admin_catalog_promotion_product_variant_index',
+            routePrefix: '/%sylius_admin.path_name%',
+            template: '@SyliusAdmin/catalog_promotion/product_variant/index.html.twig',
+            shortName: 'catalog_promotion_product_variants',
+            vars: [
+                'catalogPromotion' => '@=sylius_repositories.get(\'sylius.repository.catalog_promotion\').find(request.attributes.get(\'id\'))',
+            ],
+            grid: 'sylius_admin_product_variant_with_catalog_promotion',
+        ),
         new Create(
             path: 'variants/new',
             routeName: '_sylius_admin_product_variant_create',

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/catalog_promotion.yaml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/catalog_promotion.yaml
@@ -15,6 +15,7 @@ sylius_admin_catalog_promotion:
 sylius_admin_catalog_promotion_product_variant_index:
     path: /catalog-promotions/{id}/variants
     methods: [GET]
+    condition: "context.isSyliusRoutingBcLayerEnabled('admin_product_variant')"
     defaults:
         _controller: sylius.controller.product_variant::indexAction
         _sylius:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | new-routing
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Previous YAML routing:
```yaml
sylius_admin_catalog_promotion_product_variant_index:
    path: /catalog-promotions/{id}/variants
    methods: [GET]
    condition: "context.isSyliusRoutingBcLayerEnabled('admin_product_variant')"
    defaults:
        _controller: sylius.controller.product_variant::indexAction
        _sylius:
            section: admin
            grid: sylius_admin_product_variant_with_catalog_promotion
            template: "@SyliusAdmin/catalog_promotion/product_variant/index.html.twig"
            permission: true
            vars:
                catalogPromotion: expr:service('sylius.repository.catalog_promotion').find($id)
```
