### PR TITLE
Refactoring order thank you controller

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -13,38 +13,3 @@ A few route paths have been updated:
 | sylius_admin_promotion_coupon_delete    | `/admin/promotions/{promotionId}/coupons/{id}` | `/admin/promotions/{promotionId}/coupons/{id}/delete` |
 | sylius_admin_shop_user_delete           | `/admin/shop-user/{id}`                        | `/admin/shop-users/{id}/delete`                       |
 | sylius_shop_account_address_book_delete | `/{_locale}/account/address-book/{id}`         | `/{_locale}/account/address-book/{id}/delete`         |
-
-The `sylius_shop_order_thank_you` route has been updated.
-
-**Before**
-```yaml
-sylius_shop_order_thank_you:
-    path: /thank-you
-    methods: [GET]
-    defaults:
-        _controller: sylius.controller.order::thankYouAction
-        _sylius:
-            template: "@SyliusShop/order/thank_you.html.twig"
-```
-
-**After**
-```yaml
-sylius_shop_order_thank_you:
-    path: /thank-you
-    methods: [GET]
-    controller: sylius_shop.controller.order_thank_you
-```
-
-If you have already overridden the route to change the template, update it as follows:
-```diff
-sylius_shop_order_thank_you:
-    path: /thank-you
-    methods: [GET]
--    defaults:
--        _controller: sylius.controller.order::thankYouAction
--        _sylius:
--            template: "shop/order/thank_you.html.twig"
-+    controller: sylius_shop.controller.order_thank_you
-+    defaults:
-+        template: "shop/order/thank_you.html.twig"
-```

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -13,3 +13,38 @@ A few route paths have been updated:
 | sylius_admin_promotion_coupon_delete    | `/admin/promotions/{promotionId}/coupons/{id}` | `/admin/promotions/{promotionId}/coupons/{id}/delete` |
 | sylius_admin_shop_user_delete           | `/admin/shop-user/{id}`                        | `/admin/shop-users/{id}/delete`                       |
 | sylius_shop_account_address_book_delete | `/{_locale}/account/address-book/{id}`         | `/{_locale}/account/address-book/{id}/delete`         |
+
+The `sylius_shop_order_thank_you` route has been updated.
+
+**Before**
+```yaml
+sylius_shop_order_thank_you:
+    path: /thank-you
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.order::thankYouAction
+        _sylius:
+            template: "@SyliusShop/order/thank_you.html.twig"
+```
+
+**After**
+```yaml
+sylius_shop_order_thank_you:
+    path: /thank-you
+    methods: [GET]
+    controller: sylius_shop.controller.order_thank_you
+```
+
+If you have already overridden the route to change the template, update it as follows:
+```diff
+sylius_shop_order_thank_you:
+    path: /thank-you
+    methods: [GET]
+-    defaults:
+-        _controller: sylius.controller.order::thankYouAction
+-        _sylius:
+-            template: "shop/order/thank_you.html.twig"
++    controller: sylius_shop.controller.order_thank_you
++    defaults:
++        template: "shop/order/thank_you.html.twig"
+```

--- a/config/packages/_sylius.yaml
+++ b/config/packages/_sylius.yaml
@@ -52,6 +52,7 @@ sylius_core:
                 shop_account_address_book: false
                 shop_account_order: false
                 shop_checkout: false
+                shop_order_thank_you: false
                 shop_product: false
                 shop_product_review: false
                 shop_register: false

--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -59,6 +59,7 @@ class OrderController extends BaseOrderController
         );
     }
 
+    /** @deprecated This method is deprecated and will be removed in Sylius 3.0 */
     public function thankYouAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);

--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -62,6 +62,8 @@ class OrderController extends BaseOrderController
     /** @deprecated This method is deprecated and will be removed in Sylius 3.0 */
     public function thankYouAction(Request $request): Response
     {
+        trigger_deprecation('sylius/shop-bundle', '2.3', '"%s" method is deprecated and will be removed in Sylius 3.0', __METHOD__);
+
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
         $orderId = $request->getSession()->get('sylius_order_id', null);

--- a/src/Sylius/Bundle/ShopBundle/Controller/OrderThankYouAction.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/OrderThankYouAction.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Controller;
+
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+
+final readonly class OrderThankYouAction
+{
+    private const ORDER_ID_PARAM = 'sylius_order_id';
+
+    public function __construct(
+        private Environment $twig,
+        private OrderRepositoryInterface $orderRepository,
+        private RouterInterface $router,
+    ) {
+    }
+
+    public function __invoke(Request $request, ?string $template = null): Response
+    {
+        $orderId = $request->getSession()->get(self::ORDER_ID_PARAM, null);
+
+        if (null === $orderId) {
+            return new RedirectResponse($this->router->generate('sylius_shop_homepage'));
+        }
+
+        $request->getSession()->remove(self::ORDER_ID_PARAM);
+        $order = $this->orderRepository->findOrderById($orderId);
+
+        if (null === $order) {
+            return new RedirectResponse($this->router->generate('sylius_shop_homepage'));
+        }
+
+        return new Response($this->twig->render($template ?? '@SyliusShop/order/thank_you.html.twig', [
+            'order' => $order,
+        ]));
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Controller/OrderThankYouAction.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/OrderThankYouAction.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
+/**
+ * @experimental
+ */
 final readonly class OrderThankYouAction
 {
     private const ORDER_ID_PARAM = 'sylius_order_id';
@@ -33,6 +36,8 @@ final readonly class OrderThankYouAction
 
     public function __invoke(Request $request, ?string $template = null): Response
     {
+        $template ??= '@SyliusShop/order/thank_you.html.twig';
+
         $orderId = $request->getSession()->get(self::ORDER_ID_PARAM, null);
 
         if (null === $orderId) {
@@ -46,7 +51,7 @@ final readonly class OrderThankYouAction
             return new RedirectResponse($this->router->generate('sylius_shop_homepage'));
         }
 
-        return new Response($this->twig->render($template ?? '@SyliusShop/order/thank_you.html.twig', [
+        return new Response($this->twig->render($template, [
             'order' => $order,
         ]));
     }

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
@@ -4,10 +4,8 @@
 sylius_shop_order_thank_you:
     path: /thank-you
     methods: [GET]
+    controller: sylius_shop.controller.order_thank_you
     defaults:
-        _controller: sylius.controller.order::thankYouAction
-        _sylius:
-            template: "@SyliusShop/order/thank_you.html.twig"
 
 sylius_shop_order_pay:
     path: /{tokenValue}/pay

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
@@ -4,8 +4,17 @@
 sylius_shop_order_thank_you:
     path: /thank-you
     methods: [GET]
-    controller: sylius_shop.controller.order_thank_you
+    condition: "context.isSyliusRoutingBcLayerEnabled('shop_order_thank_you')"
     defaults:
+        _controller: sylius.controller.order::thankYouAction
+        _sylius:
+            template: "@SyliusShop/order/thank_you.html.twig"
+            
+_sylius_shop_order_thank_you:
+    path: /thank-you
+    methods: [GET]
+    controller: sylius_shop.controller.order_thank_you
+    condition: "not context.isSyliusRoutingBcLayerEnabled('shop_order_thank_you')"
 
 sylius_shop_order_pay:
     path: /{tokenValue}/pay

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.php
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Sylius\Bundle\ShopBundle\Controller\ContactController;
 use Sylius\Bundle\ShopBundle\Controller\CurrencySwitchController;
 use Sylius\Bundle\ShopBundle\Controller\LocaleSwitchController;
+use Sylius\Bundle\ShopBundle\Controller\OrderThankYouAction;
 use Sylius\Bundle\ShopBundle\Controller\RegistrationThankYouController;
 
 return static function (ContainerConfigurator $container) {
@@ -50,6 +51,15 @@ return static function (ContainerConfigurator $container) {
             service('sylius.provider.locale'),
             service('sylius_shop.locale_switcher'),
         ])
+    ;
+    $services
+        ->set('sylius_shop.controller.order_thank_you', OrderThankYouAction::class)
+        ->args([
+            service('twig'),
+            service('sylius.repository.order'),
+            service('router.default'),
+        ])
+        ->tag('controller.service_arguments')
     ;
 
     $services


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes (but an easy one)
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The idea is to remove the ResourceController usage.
Indead, we will deprecate the ResourceController after closing this issue https://github.com/Sylius/Sylius/issues/18212.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guide with before/after examples and step‑by‑step migration instructions for the order thank-you route.

* **Deprecations**
  * Legacy thank-you action marked deprecated with guidance for updating integrations.

* **Refactor**
  * Thank-you page moved to a new service-backed controller; route definition simplified and behavior preserved (redirects when no order in session, renders the thank-you template when present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->