### PR TITLE
[Core] Fix NotNull validation for ChannelPriceHistoryConfig checking period

### DIFF
--- a/src/Sylius/Component/Core/Model/ChannelPriceHistoryConfig.php
+++ b/src/Sylius/Component/Core/Model/ChannelPriceHistoryConfig.php
@@ -22,7 +22,7 @@ class ChannelPriceHistoryConfig implements ChannelPriceHistoryConfigInterface
     /** @var mixed */
     protected $id;
 
-    protected int $lowestPriceForDiscountedProductsCheckingPeriod = 30;
+    protected ?int $lowestPriceForDiscountedProductsCheckingPeriod = 30;
 
     protected bool $lowestPriceForDiscountedProductsVisible = true;
 
@@ -44,7 +44,7 @@ class ChannelPriceHistoryConfig implements ChannelPriceHistoryConfigInterface
         return $this->lowestPriceForDiscountedProductsCheckingPeriod;
     }
 
-    public function setLowestPriceForDiscountedProductsCheckingPeriod(int $periodInDays): void
+    public function setLowestPriceForDiscountedProductsCheckingPeriod(?int $periodInDays): void
     {
         $this->lowestPriceForDiscountedProductsCheckingPeriod = $periodInDays;
     }

--- a/src/Sylius/Component/Core/Model/ChannelPriceHistoryConfigInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelPriceHistoryConfigInterface.php
@@ -25,7 +25,7 @@ interface ChannelPriceHistoryConfigInterface extends ResourceInterface
 
     public function getLowestPriceForDiscountedProductsCheckingPeriod(): int;
 
-    public function setLowestPriceForDiscountedProductsCheckingPeriod(int $periodInDays): void;
+    public function setLowestPriceForDiscountedProductsCheckingPeriod(?int $periodInDays): void;
 
     public function getTaxonsExcludedFromShowingLowestPrice(): Collection;
 


### PR DESCRIPTION
  | Q               | A                                                                                                                                                                                                    
  | --------------- | -----                                 
  | Branch?         | 1.14
  | Bug fix?        | yes
  | New feature?    | no
  | BC breaks?      | no
  | Deprecations?   | no
  | Related tickets |
  | License         | MIT

  ## Description

  The `NotNull` validation constraint on `lowestPriceForDiscountedProductsCheckingPeriod` never triggers because the setter has a strict `int` type hint.

  When submitting an empty value:
  1. `IntegerType` transforms `''` to `null`
  2. The setter rejects `null` (TypeError) since it expects `int`
  3. The property keeps its default value (30)
  4. `NotNull` validation passes because the value is `30`, not `null`

  This fix allows `null` to be set so the validation can properly reject empty submissions.