### PR TITLE
Bump phparkitect to ^0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,7 @@
         "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "nyholm/psr7": "^1.8",
-        "phparkitect/phparkitect": "^0.6",
+        "phparkitect/phparkitect": "^0.8",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -37,7 +37,7 @@
         "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.0",
         "nelmio/alice": "^3.13",
-        "phparkitect/phparkitect": "^0.6",
+        "phparkitect/phparkitect": "^0.8",
         "phpunit/phpunit": "^11.5",
         "symfony/browser-kit": "^6.4 || ^7.4",
         "symfony/debug-bundle": "^6.4 || ^7.4",


### PR DESCRIPTION
Bumps phparkitect from ^0.6 to ^0.8 for PHP 8.4 and Symfony 8 support.

phparkitect 0.8.0 adds `^8.0` to all Symfony constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to a newer compatible version to keep tooling up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Partially https://github.com/Sylius/Sylius/issues/18760