### PR TITLE
Bump symfonycasts/dynamic-forms to ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
         "symfony/webpack-encore-bundle": "^2.2",
         "symfony/workflow": "^6.4 || ^7.4",
         "symfony/yaml": "^6.4 || ^7.4",
-        "symfonycasts/dynamic-forms": "^0.1",
+        "symfonycasts/dynamic-forms": "^0.2",
         "twig/extra-bundle": "^3.16",
         "twig/intl-extra": "^3.16",
         "twig/string-extra": "^3.16",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -43,7 +43,7 @@
         "symfony/ux-autocomplete": "^2.25",
         "symfony/ux-live-component": "^2.25",
         "symfony/webpack-encore-bundle": "^2.2",
-        "symfonycasts/dynamic-forms": "^0.1",
+        "symfonycasts/dynamic-forms": "^0.2",
         "twig/extra-bundle": "^3.16",
         "twig/twig": "^3.16"
     },

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/ux-autocomplete": "^2.25",
         "symfony/ux-live-component": "^2.25",
         "symfony/webpack-encore-bundle": "^2.2",
-        "symfonycasts/dynamic-forms": "^0.1",
+        "symfonycasts/dynamic-forms": "^0.2",
         "twig/twig": "^3.16"
     },
     "require-dev": {


### PR DESCRIPTION
Bumps symfonycasts/dynamic-forms from ^0.1 to ^0.2 for Symfony 8 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped symfonycasts/dynamic-forms dependency from ^0.1 to ^0.2 across the project to ensure compatibility with newer form features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Partially https://github.com/Sylius/Sylius/issues/18760