### PR TITLE
Bump symfony/monolog-bundle to ^3.8 || ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "symfony/intl": "^6.4 || ^7.4",
         "symfony/mailer": "^6.4 || ^7.4",
         "symfony/messenger": "^6.4 || ^7.4",
-        "symfony/monolog-bundle": "^3.8.0",
+        "symfony/monolog-bundle": "^3.8 || ^4.0",
         "symfony/options-resolver": "^6.4 || ^7.4",
         "symfony/password-hasher": "^6.4 || ^7.4",
         "symfony/polyfill-iconv": "^1.31",


### PR DESCRIPTION
Bumps symfony/monolog-bundle for Symfony 8 support.

- v3.x supports SF 6.4/7.0
- v4.x supports SF 7.3+/8.0

Using `^3.8 || ^4.0` allows Composer to pick the right version based on Symfony version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging infrastructure dependencies to enable broader version compatibility. This change supports both current and upcoming releases while preserving backward compatibility with existing installations, improving system flexibility and long-term stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Partially https://github.com/Sylius/Sylius/issues/18760
