### PR TITLE
Update unstable build to Symfony 8

### DIFF
--- a/.github/workflows/ci_e2e-unstable.yaml
+++ b/.github/workflows/ci_e2e-unstable.yaml
@@ -24,8 +24,8 @@ jobs:
             matrix:
                 include:
                     -
-                        php: "8.3"
-                        symfony: "^7.4@beta"
+                        php: "8.4"
+                        symfony: "~8.0.0"
                         mysql: "8.4"
 
         env:

--- a/.github/workflows/ci_packages-unstable.yaml
+++ b/.github/workflows/ci_packages-unstable.yaml
@@ -28,8 +28,8 @@ jobs:
             matrix:
                 include:
                     -
-                        php: "8.3"
-                        symfony: "^7.4@beta"
+                        php: "8.4"
+                        symfony: "~8.0.0"
 
         env:
             COMPOSER_ROOT_VERSION: "dev-main"


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | SF-8 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end and unstable dependency testing workflows to use PHP 8.4 and Symfony 8.0.0, replacing PHP 8.3 and Symfony 7.4 beta versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->