### PR TITLE
Set default value of auto_close to true in accordion macro

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/helper/accordion.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/helper/accordion.html.twig
@@ -1,5 +1,4 @@
-{% macro accordion(items, open = false, auto_close = null, flush = false) %}
-    {% set auto_close = auto_close|default(true) %}
+{% macro accordion(items, open = false, auto_close = true, flush = false) %}
     {% set id = id|default(random()) %}
 
     <div class="accordion{% if flush %} accordion-flush{% endif %}" id="{{ id }}">


### PR DESCRIPTION
Change to set `auto_close` default to `true`, because if you put `false`, this condition `{% set auto_close = auto_close|default(true) %}` will change it to true anyway

| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT
