### PR TITLE
Convert Behat annotations to PHP attributes in Domain contexts

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
 return RectorConfig::configure()
     ->withImportNames(importShortClasses: false, removeUnusedImports: true)
+    ->withAttributesSets(behat: true)
     ->withSets([
         LevelSetList::UP_TO_PHP_82,
         PHPUnitSetList::PHPUNIT_110,
-        SetList::BEHAT_ANNOTATIONS_TO_ATTRIBUTES,
     ])
 ;

--- a/rector.php
+++ b/rector.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return RectorConfig::configure()
     ->withImportNames(importShortClasses: false, removeUnusedImports: true)
     ->withSets([
         LevelSetList::UP_TO_PHP_82,
         PHPUnitSetList::PHPUNIT_110,
+        SetList::BEHAT_ANNOTATIONS_TO_ATTRIBUTES,
     ])
 ;

--- a/src/Sylius/Behat/Context/Domain/CartContext.php
+++ b/src/Sylius/Behat/Context/Domain/CartContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -27,18 +29,14 @@ final class CartContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^(?:|he|she) abandoned (the cart) (\d+) (day|days|hour|hours) ago$/
-     */
+    #[Given('/^(?:|he|she) abandoned (the cart) (\d+) (day|days|hour|hours) ago$/')]
     public function theyAbandonedTheirCart(OrderInterface $cart, $amount, $time)
     {
         $cart->setUpdatedAt(new \DateTime('-' . $amount . ' ' . $time));
         $this->orderManager->flush();
     }
 
-    /**
-     * @Then /^(this cart) should be automatically deleted$/
-     */
+    #[Then('/^(this cart) should be automatically deleted$/')]
     public function thisCartShouldBeAutomaticallyDeleted(OrderInterface $cart)
     {
         $this->expiredCartsRemover->remove();
@@ -46,9 +44,7 @@ final class CartContext implements Context
         Assert::null($cart->getId());
     }
 
-    /**
-     * @Then /^(this cart) should not be deleted$/
-     */
+    #[Then('/^(this cart) should not be deleted$/')]
     public function thisCartShouldNotBeDeleted(OrderInterface $cart)
     {
         $this->expiredCartsRemover->remove();

--- a/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -39,9 +42,7 @@ final class ManagingOrdersContext implements Context
     ) {
     }
 
-    /**
-     * @When I delete the order :order
-     */
+    #[When('I delete the order :order')]
     public function iDeleteTheOrder(OrderInterface $order)
     {
         $adjustmentsId = [];
@@ -59,17 +60,13 @@ final class ManagingOrdersContext implements Context
         $this->orderRepository->remove($order);
     }
 
-    /**
-     * @When I view the summary of the order :order
-     */
+    #[When('I view the summary of the order :order')]
     public function iViewTheSummaryOfTheOrder(OrderInterface $order): void
     {
         $this->sharedStorage->set('order', $order);
     }
 
-    /**
-     * @Then this order should not exist in the registry
-     */
+    #[Then('this order should not exist in the registry')]
     public function orderShouldNotExistInTheRegistry()
     {
         $orderId = $this->sharedStorage->get('order_id');
@@ -78,9 +75,7 @@ final class ManagingOrdersContext implements Context
         Assert::null($order);
     }
 
-    /**
-     * @Then the order item with product :product should not exist
-     */
+    #[Then('the order item with product :product should not exist')]
     public function orderItemShouldNotExistInTheRegistry(ProductInterface $product)
     {
         $orderItems = $this->orderItemRepository->findBy(['variant' => $this->variantResolver->getVariant($product)]);
@@ -88,9 +83,7 @@ final class ManagingOrdersContext implements Context
         Assert::same($orderItems, []);
     }
 
-    /**
-     * @Then billing and shipping addresses of this order should not exist
-     */
+    #[Then('billing and shipping addresses of this order should not exist')]
     public function addressesShouldNotExistInTheRegistry()
     {
         $addresses = $this->sharedStorage->get('deleted_addresses');
@@ -100,9 +93,7 @@ final class ManagingOrdersContext implements Context
         Assert::same($addresses, []);
     }
 
-    /**
-     * @Then adjustments of this order should not exist
-     */
+    #[Then('adjustments of this order should not exist')]
     public function adjustmentShouldNotExistInTheRegistry()
     {
         $adjustments = $this->sharedStorage->get('deleted_adjustments');
@@ -112,9 +103,7 @@ final class ManagingOrdersContext implements Context
         Assert::same($adjustments, []);
     }
 
-    /**
-     * @Given /^(this order) has not been paid for (\d+) (day|days|hour|hours)$/
-     */
+    #[Given('/^(this order) has not been paid for (\d+) (day|days|hour|hours)$/')]
     public function thisOrderHasNotBeenPaidForDays(OrderInterface $order, $amount, $time)
     {
         $order->setCheckoutCompletedAt(new \DateTime('-' . $amount . ' ' . $time));
@@ -123,9 +112,7 @@ final class ManagingOrdersContext implements Context
         $this->unpaidOrdersStateUpdater->cancel();
     }
 
-    /**
-     * @Given /^the (order "[^"]+") has not been paid for (\d+) (day|days)$/
-     */
+    #[Given('/^the (order "[^"]+") has not been paid for (\d+) (day|days)$/')]
     public function orderWithNumberHasNotBeenPaidForDays(OrderInterface $order, int $amount, string $days): void
     {
         $order->setCheckoutCompletedAt(new \DateTime(sprintf('-%d %s', $amount, $days)));
@@ -133,33 +120,25 @@ final class ManagingOrdersContext implements Context
         $this->orderManager->flush();
     }
 
-    /**
-     * @Then /^(this order) should be automatically cancelled$/
-     */
+    #[Then('/^(this order) should be automatically cancelled$/')]
     public function thisOrderShouldBeAutomaticallyCancelled(OrderInterface $order)
     {
         Assert::same($order->getState(), OrderInterface::STATE_CANCELLED);
     }
 
-    /**
-     * @Then /^(this order) should not be cancelled$/
-     */
+    #[Then('/^(this order) should not be cancelled$/')]
     public function thisOrderShouldNotBeCancelled(OrderInterface $order)
     {
         Assert::notSame($order->getState(), OrderInterface::STATE_CANCELLED);
     }
 
-    /**
-     * @Then /^(the order)'s items total should be ("[^"]+")$/
-     */
+    #[Then('/^(the order)\'s items total should be ("[^"]+")$/')]
     public function theOrdersItemsTotalShouldBe(OrderInterface $order, int $itemsTotal): void
     {
         Assert::same($order->getItemsTotal(), $itemsTotal);
     }
 
-    /**
-     * @Then /^there should be a shipping charge ("[^"]+") for "([^"]+)" method$/
-     */
+    #[Then('/^there should be a shipping charge ("[^"]+") for "([^"]+)" method$/')]
     public function thereShouldBeAShippingChargeForMethod(int $shippingCharge, string $shippingMethodName): void
     {
         /** @var OrderInterface $order */
@@ -173,9 +152,7 @@ final class ManagingOrdersContext implements Context
         throw new \DomainException('The given order has no shipping adjustment with proper amount and method');
     }
 
-    /**
-     * @Then /^there should be a shipping tax ("[^"]+") for "([^"]+)" method$/
-     */
+    #[Then('/^there should be a shipping tax ("[^"]+") for "([^"]+)" method$/')]
     public function thereShouldBeAShippingTaxForMethod(int $shippingTax, string $shippingMethodName): void
     {
         /** @var OrderInterface $order */
@@ -189,25 +166,19 @@ final class ManagingOrdersContext implements Context
         throw new \DomainException('The given order has no shipping adjustment with proper amount and method');
     }
 
-    /**
-     * @Then /^(the order)'s shipping total should be ("[^"]+")$/
-     */
+    #[Then('/^(the order)\'s shipping total should be ("[^"]+")$/')]
     public function theOrdersShippingTotalShouldBe(OrderInterface $order, int $shippingTotal): void
     {
         Assert::same($order->getShippingTotal(), $shippingTotal);
     }
 
-    /**
-     * @Then /^(the order)'s tax total should be ("[^"]+")$/
-     */
+    #[Then('/^(the order)\'s tax total should be ("[^"]+")$/')]
     public function theOrdersTaxTotalShouldBe(OrderInterface $order, int $taxTotal): void
     {
         Assert::same($order->getTaxTotal(), $taxTotal);
     }
 
-    /**
-     * @Then /^(the order)'s total should be ("[^"]+")$/
-     */
+    #[Then('/^(the order)\'s total should be ("[^"]+")$/')]
     public function theOrdersTotalShouldBe(OrderInterface $order, int $total): void
     {
         Assert::same($order->getTotal(), $total);

--- a/src/Sylius/Behat/Context/Domain/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingPaymentsContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
@@ -24,9 +25,7 @@ final class ManagingPaymentsContext implements Context
     {
     }
 
-    /**
-     * @Then /^there should be no ("[^"]+" payments) in the registry$/
-     */
+    #[Then('/^there should be no ("[^"]+" payments) in the registry$/')]
     public function paymentShouldNotExistInTheRegistry(PaymentMethodInterface $paymentMethod)
     {
         $payments = $this->paymentRepository->findBy(['method' => $paymentMethod]);

--- a/src/Sylius/Behat/Context/Domain/ManagingPriceHistoryContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingPriceHistoryContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Bundle\CoreBundle\PriceHistory\Remover\ChannelPricingLogEntriesRemoverInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
@@ -30,17 +32,13 @@ final class ManagingPriceHistoryContext implements Context
     ) {
     }
 
-    /**
-     * @When I delete price history older than :days day(s)
-     */
+    #[When('I delete price history older than :days day(s)')]
     public function iDeletePriceHistoryOlderThanDays(int $days): void
     {
         $this->channelPricingLogEntriesRemover->remove($days);
     }
 
-    /**
-     * @Then /^there should be (\d+) price history entries for (this product)$/
-     */
+    #[Then('/^there should be (\d+) price history entries for (this product)$/')]
     public function thereShouldBeCountPriceHistoryEntriesForThisProduct(int $count, ProductInterface $product): void
     {
         $channelPricingLogEntries = $this->channelPricingLogEntryRepository->findBy([
@@ -50,9 +48,7 @@ final class ManagingPriceHistoryContext implements Context
         Assert::count($channelPricingLogEntries, $count);
     }
 
-    /**
-     * @Then /^(this product) should have no entry with original price changed to ("[^"]+")$/
-     */
+    #[Then('/^(this product) should have no entry with original price changed to ("[^"]+")$/')]
     public function thisProductShouldHaveNoEntryWithOriginalPriceChangedTo(
         ProductInterface $product,
         int $originalPrice,
@@ -63,9 +59,7 @@ final class ManagingPriceHistoryContext implements Context
         ]));
     }
 
-    /**
-     * @Then /^(this product)'s price history should be empty$/
-     */
+    #[Then('/^(this product)\'s price history should be empty$/')]
     public function thisProductsPriceHistoryShouldBeEmpty(ProductInterface $product): void
     {
         $this->thereShouldBeCountPriceHistoryEntriesForThisProduct(0, $product);

--- a/src/Sylius/Behat/Context/Domain/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingProductsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Doctrine\DBAL\DBALException;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -30,38 +33,30 @@ final class ManagingProductsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I delete the ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[When('/^I delete the ("[^"]+" variant of product "[^"]+")$/')]
     public function iDeleteTheVariantOfProduct(ProductVariantInterface $productVariant)
     {
         $this->productVariantRepository->remove($productVariant);
     }
 
-    /**
-     * @When /^I try to delete the ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[When('/^I try to delete the ("[^"]+" variant of product "[^"]+")$/')]
     public function iTryToDeleteTheVariantOfProduct(ProductVariantInterface $productVariant)
     {
         try {
             $this->productVariantRepository->remove($productVariant);
             /** @phpstan-ignore-next-line  */
-        } catch (\Doctrine\DBAL\DBALException|\Doctrine\DBAL\Exception $exception) {
+        } catch (DBALException|\Doctrine\DBAL\Exception $exception) {
             $this->sharedStorage->set('last_exception', $exception);
         }
     }
 
-    /**
-     * @When /^I delete the ("[^"]+" product)$/
-     */
+    #[When('/^I delete the ("[^"]+" product)$/')]
     public function iDeleteTheProduct(ProductInterface $product): void
     {
         $this->productRepository->remove($product);
     }
 
-    /**
-     * @When /^I try to delete the ("[^"]+" product)$/
-     */
+    #[When('/^I try to delete the ("[^"]+" product)$/')]
     public function iTryToDeleteTheProduct(ProductInterface $product)
     {
         try {
@@ -71,13 +66,11 @@ final class ManagingProductsContext implements Context
         }
     }
 
-    /**
-     * @Then /^I should be notified that this (?:variant|product) is in use and cannot be deleted$/
-     */
+    #[Then('/^I should be notified that this (?:variant|product) is in use and cannot be deleted$/')]
     public function iShouldBeNotifiedThatThisProductVariantIsInUseAndCannotBeDeleted()
     {
         if (class_exists('\Doctrine\DBAL\DBALException')) {
-            Assert::isInstanceOf($this->sharedStorage->get('last_exception'), \Doctrine\DBAL\DBALException::class);
+            Assert::isInstanceOf($this->sharedStorage->get('last_exception'), DBALException::class);
         }
 
         if (class_exists('\Doctrine\DBAL\Exception')) {
@@ -85,33 +78,25 @@ final class ManagingProductsContext implements Context
         }
     }
 
-    /**
-     * @Then /^(this variant) should not exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should not exist in the product catalog$/')]
     public function productVariantShouldNotExistInTheProductCatalog(ProductVariantInterface $productVariant)
     {
         Assert::null($this->productVariantRepository->findOneBy(['code' => $productVariant->getCode()]));
     }
 
-    /**
-     * @Then /^(this variant) should still exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should still exist in the product catalog$/')]
     public function productVariantShouldExistInTheProductCatalog(ProductVariantInterface $productVariant)
     {
         Assert::notNull($productVariant);
     }
 
-    /**
-     * @Then /^(this product) should still exist in the product catalog$/
-     */
+    #[Then('/^(this product) should still exist in the product catalog$/')]
     public function productShouldExistInTheProductCatalog(ProductInterface $product)
     {
         Assert::notNull($product);
     }
 
-    /**
-     * @Then /^there should be no reviews of (this product)$/
-     */
+    #[Then('/^there should be no reviews of (this product)$/')]
     public function thereAreNoProductReviews(ProductInterface $product)
     {
         $reviews = $this->productReviewRepository->findBy(['reviewSubject' => $product]);
@@ -119,9 +104,7 @@ final class ManagingProductsContext implements Context
         Assert::same($reviews, []);
     }
 
-    /**
-     * @Then /^there should be no variants of (this product) in the product catalog$/
-     */
+    #[Then('/^there should be no variants of (this product) in the product catalog$/')]
     public function thereAreNoVariants(ProductInterface $product)
     {
         $variants = $this->productVariantRepository->findBy(['product' => $product]);

--- a/src/Sylius/Behat/Context/Domain/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingProductsContext.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Domain;
 
 use Behat\Step\When;
-use Doctrine\DBAL\DBALException;
 use Behat\Step\Then;
 use Behat\Behat\Context\Context;
+use Doctrine\DBAL\Exception as DBALException;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -44,8 +44,7 @@ final class ManagingProductsContext implements Context
     {
         try {
             $this->productVariantRepository->remove($productVariant);
-            /** @phpstan-ignore-next-line  */
-        } catch (DBALException|\Doctrine\DBAL\Exception $exception) {
+        } catch (DBALException $exception) {
             $this->sharedStorage->set('last_exception', $exception);
         }
     }
@@ -69,13 +68,7 @@ final class ManagingProductsContext implements Context
     #[Then('/^I should be notified that this (?:variant|product) is in use and cannot be deleted$/')]
     public function iShouldBeNotifiedThatThisProductVariantIsInUseAndCannotBeDeleted()
     {
-        if (class_exists('\Doctrine\DBAL\DBALException')) {
-            Assert::isInstanceOf($this->sharedStorage->get('last_exception'), DBALException::class);
-        }
-
-        if (class_exists('\Doctrine\DBAL\Exception')) {
-            Assert::isInstanceOf($this->sharedStorage->get('last_exception'), \Doctrine\DBAL\Exception::class);
-        }
+        Assert::isInstanceOf($this->sharedStorage->get('last_exception'), DBALException::class);
     }
 
     #[Then('/^(this variant) should not exist in the product catalog$/')]

--- a/src/Sylius/Behat/Context/Domain/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingPromotionCouponsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -29,18 +31,14 @@ final class ManagingPromotionCouponsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I delete ("[^"]+" coupon) related to (this promotion)$/
-     */
+    #[When('/^I delete ("[^"]+" coupon) related to (this promotion)$/')]
     public function iDeleteCoupon(PromotionCouponInterface $coupon, PromotionInterface $promotion)
     {
         $promotion->removeCoupon($coupon);
         $this->couponRepository->remove($coupon);
     }
 
-    /**
-     * @When /^I try to delete ("[^"]+" coupon) related to (this promotion)$/
-     */
+    #[When('/^I try to delete ("[^"]+" coupon) related to (this promotion)$/')]
     public function iTryToDeleteCoupon(PromotionCouponInterface $coupon, PromotionInterface $promotion)
     {
         try {
@@ -51,25 +49,19 @@ final class ManagingPromotionCouponsContext implements Context
         }
     }
 
-    /**
-     * @Then /^(this coupon) should no longer exist in the coupon registry$/
-     */
+    #[Then('/^(this coupon) should no longer exist in the coupon registry$/')]
     public function couponShouldNotExistInTheRegistry(PromotionCouponInterface $coupon)
     {
         Assert::null($this->couponRepository->findOneBy(['code' => $coupon->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure()
     {
         Assert::isInstanceOf($this->sharedStorage->get('last_exception'), ForeignKeyConstraintViolationException::class);
     }
 
-    /**
-     * @Then /^([^"]+) should still exist in the registry$/
-     */
+    #[Then('/^([^"]+) should still exist in the registry$/')]
     public function couponShouldStillExistInTheRegistry(PromotionCouponInterface $coupon)
     {
         Assert::notNull($this->couponRepository->find($coupon->getId()));

--- a/src/Sylius/Behat/Context/Domain/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingPromotionsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\Persistence\ObjectManager;
@@ -30,17 +32,13 @@ final class ManagingPromotionsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I delete a ("([^"]+)" promotion)$/
-     */
+    #[When('/^I delete a ("([^"]+)" promotion)$/')]
     public function iDeletePromotion(PromotionInterface $promotion)
     {
         $this->promotionRepository->remove($promotion);
     }
 
-    /**
-     * @When /^I try to delete a ("([^"]+)" promotion)$/
-     */
+    #[When('/^I try to delete a ("([^"]+)" promotion)$/')]
     public function iTryToDeletePromotion(PromotionInterface $promotion)
     {
         try {
@@ -50,9 +48,7 @@ final class ManagingPromotionsContext implements Context
         }
     }
 
-    /**
-     * @When I archive the :promotion promotion
-     */
+    #[When('I archive the :promotion promotion')]
     public function iArchiveThePromotion(PromotionInterface $promotion): void
     {
         $promotion->setArchivedAt(new \DateTime());
@@ -60,33 +56,25 @@ final class ManagingPromotionsContext implements Context
         $this->promotionManager->flush();
     }
 
-    /**
-     * @Then /^(this promotion) should no longer exist in the promotion registry$/
-     */
+    #[Then('/^(this promotion) should no longer exist in the promotion registry$/')]
     public function promotionShouldNotExistInTheRegistry(PromotionInterface $promotion)
     {
         Assert::null($this->promotionRepository->findOneBy(['code' => $promotion->getCode()]));
     }
 
-    /**
-     * @Then promotion :promotion should still exist in the registry
-     */
+    #[Then('promotion :promotion should still exist in the registry')]
     public function promotionShouldStillExistInTheRegistry(PromotionInterface $promotion)
     {
         Assert::notNull($this->promotionRepository->find($promotion->getId()));
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure()
     {
         Assert::isInstanceOf($this->sharedStorage->get('last_exception'), ForeignKeyConstraintViolationException::class);
     }
 
-    /**
-     * @Then the promotion :promotion should still exist in the registry
-     */
+    #[Then('the promotion :promotion should still exist in the registry')]
     public function thePromotionShouldStillExistInTheRegistry(PromotionInterface $promotion): void
     {
         Assert::notNull($this->promotionRepository->find($promotion));

--- a/src/Sylius/Behat/Context/Domain/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingShipmentsContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
@@ -24,9 +25,7 @@ final class ManagingShipmentsContext implements Context
     {
     }
 
-    /**
-     * @Then /^there should be no shipments with ("[^"]+" shipping method) in the registry$/
-     */
+    #[Then('/^there should be no shipments with ("[^"]+" shipping method) in the registry$/')]
     public function shipmentShouldNotExistInTheRegistry(ShippingMethodInterface $shippingMethod)
     {
         $shipments = $this->shipmentRepository->findBy(['method' => $shippingMethod]);

--- a/src/Sylius/Behat/Context/Domain/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingShippingMethodsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
@@ -27,9 +29,7 @@ final class ManagingShippingMethodsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I archive the ("[^"]+" shipping method)$/
-     */
+    #[When('/^I archive the ("[^"]+" shipping method)$/')]
     public function iArchiveTheShippingMethod(ShippingMethodInterface $shippingMethod)
     {
         $shippingMethod->setArchivedAt(new \DateTime());
@@ -37,9 +37,7 @@ final class ManagingShippingMethodsContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Then the shipping method :shippingMethod should still exist in the registry
-     */
+    #[Then('the shipping method :shippingMethod should still exist in the registry')]
     public function theShippingMethodShouldStillExistInTheRegistry(ShippingMethodInterface $shippingMethod)
     {
         Assert::notNull($this->shippingMethodRepository->find($shippingMethod));

--- a/src/Sylius/Behat/Context/Domain/NotificationContext.php
+++ b/src/Sylius/Behat/Context/Domain/NotificationContext.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 
 final class NotificationContext implements Context
 {
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotified()
     {
         // Not applicable in the domain scope

--- a/src/Sylius/Behat/Context/Domain/SecurityContext.php
+++ b/src/Sylius/Behat/Context/Domain/SecurityContext.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Domain;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 
 final class SecurityContext implements Context
 {
-    /**
-     * @Given I am logged in as an administrator
-     */
+    #[Given('I am logged in as an administrator')]
     public function iAmLoggedInAsAnAdministrator()
     {
         // Not applicable in the domain scope


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

Smaller version of #18810 only applied on Domain contexts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized Behat test integration by converting step-definition annotations from docblock style to native PHP 8 attributes across test contexts.
  * Updated tooling configuration to enable Behat-style attribute handling during automated code transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->