### PR TITLE
Convert Behat annotations to PHP attributes in Setup contexts

### DIFF
--- a/src/Sylius/Behat/Context/Setup/AddressContext.php
+++ b/src/Sylius/Behat/Context/Setup/AddressContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -31,18 +32,14 @@ final class AddressContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^(their) default (address is "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/
-     * @Given /^(their) default (address is "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+")$/
-     */
+    #[Given('/^(their) default (address is "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/')]
+    #[Given('/^(their) default (address is "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+")$/')]
     public function theirDefaultAddressIs(CustomerInterface $customer, AddressInterface $address)
     {
         $this->setDefaultAddressOfCustomer($customer, $address);
     }
 
-    /**
-     * @Given /^(my) default address is of "([^"]+)"$/
-     */
+    #[Given('/^(my) default address is of "([^"]+)"$/')]
     public function myDefaultAddressIsOf(ShopUserInterface $user, $fullName)
     {
         [$firstName, $lastName] = explode(' ', $fullName);
@@ -57,9 +54,7 @@ final class AddressContext implements Context
         $this->setDefaultAddressOfCustomer($customer, $address);
     }
 
-    /**
-     * @Given /^(I) have an (address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) in my address book$/
-     */
+    #[Given('/^(I) have an (address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) in my address book$/')]
     public function iHaveAnAddressInAddressBook(ShopUserInterface $user, AddressInterface $address)
     {
         /** @var CustomerInterface $customer */
@@ -70,9 +65,7 @@ final class AddressContext implements Context
         $this->sharedStorage->set('address', $address);
     }
 
-    /**
-     * @Given this address has province :province
-     */
+    #[Given('this address has province :province')]
     public function thisAddressHasProvince(string $provinceName): void
     {
         $address = $this->sharedStorage->get('address');
@@ -81,10 +74,8 @@ final class AddressContext implements Context
         $this->customerManager->flush();
     }
 
-    /**
-     * @Given /^(this customer) has an (address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) in their address book$/
-     * @Given /^(this customer) has an? ("[^"]+" based address) in their address book$/
-     */
+    #[Given('/^(this customer) has an (address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) in their address book$/')]
+    #[Given('/^(this customer) has an? ("[^"]+" based address) in their address book$/')]
     public function thisCustomerHasAnAddressInAddressBook(CustomerInterface $customer, AddressInterface $address): void
     {
         $this->addAddressToCustomer($customer, $address);

--- a/src/Sylius/Behat/Context/Setup/AdminSecurityContext.php
+++ b/src/Sylius/Behat/Context/Setup/AdminSecurityContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SecurityServiceInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -30,10 +31,8 @@ final class AdminSecurityContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am logged in as an administrator
-     * @Given there is logged in the administrator
-     */
+    #[Given('I am logged in as an administrator')]
+    #[Given('there is logged in the administrator')]
     public function iAmLoggedInAsAnAdministrator()
     {
         $user = $this->userFactory->create(['email' => 'sylius@example.com', 'password' => 'sylius', 'api' => true]);
@@ -44,9 +43,7 @@ final class AdminSecurityContext implements Context
         $this->sharedStorage->set('administrator', $user);
     }
 
-    /**
-     * @Given /^I am logged in as "([^"]+)" administrator$/
-     */
+    #[Given('/^I am logged in as "([^"]+)" administrator$/')]
     public function iAmLoggedInAsAdministrator($email)
     {
         $user = $this->userRepository->findOneByEmail($email);
@@ -57,9 +54,7 @@ final class AdminSecurityContext implements Context
         $this->sharedStorage->set('administrator', $user);
     }
 
-    /**
-     * @Given I have been logged out from administration
-     */
+    #[Given('I have been logged out from administration')]
     public function iHaveBeenLoggedOutFromAdministration()
     {
         $this->securityService->logOut();

--- a/src/Sylius/Behat/Context/Setup/AdminUserContext.php
+++ b/src/Sylius/Behat/Context/Setup/AdminUserContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
@@ -44,10 +46,8 @@ final class AdminUserContext implements Context
     ) {
     }
 
-    /**
-     * @Given there is an administrator :email identified by :password
-     * @Given /^there is(?:| also) an administrator "([^"]+)"$/
-     */
+    #[Given('there is an administrator :email identified by :password')]
+    #[Given('/^there is(?:| also) an administrator "([^"]+)"$/')]
     public function thereIsAnAdministratorIdentifiedBy($email, $password = 'sylius')
     {
         /** @var AdminUserInterface $adminUser */
@@ -57,9 +57,7 @@ final class AdminUserContext implements Context
         $this->sharedStorage->set('administrator', $adminUser);
     }
 
-    /**
-     * @Given there is an administrator with name :username
-     */
+    #[Given('there is an administrator with name :username')]
     public function thereIsAnAdministratorWithName($username)
     {
         /** @var AdminUserInterface $adminUser */
@@ -70,18 +68,14 @@ final class AdminUserContext implements Context
         $this->sharedStorage->set('administrator', $adminUser);
     }
 
-    /**
-     * @Given /^(this administrator) has the "([^"]*)" image as avatar$/
-     */
+    #[Given('/^(this administrator) has the "([^"]*)" image as avatar$/')]
     public function thisAdministratorHasTheImageAsAvatar(AdminUserInterface $administrator, string $avatarPath): void
     {
         $this->iHaveTheImageAsMyAvatar($avatarPath, $administrator);
     }
 
-    /**
-     * @Given /^(this administrator) account is disabled$/
-     * @When /^(this administrator) account becomes disabled$/
-     */
+    #[Given('/^(this administrator) account is disabled$/')]
+    #[When('/^(this administrator) account becomes disabled$/')]
     public function thisAccountIsDisabled(AdminUserInterface $administrator): void
     {
         $administrator->setEnabled(false);
@@ -89,10 +83,8 @@ final class AdminUserContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this administrator) is using ("[^"]+" locale)$/
-     * @Given /^(I) am using ("[^"]+" locale) for my panel$/
-     */
+    #[Given('/^(this administrator) is using ("[^"]+" locale)$/')]
+    #[Given('/^(I) am using ("[^"]+" locale) for my panel$/')]
     public function thisAdministratorIsUsingLocale(AdminUserInterface $adminUser, $localeCode)
     {
         $adminUser->setLocaleCode($localeCode);
@@ -101,9 +93,7 @@ final class AdminUserContext implements Context
         $this->sharedStorage->set('administrator', $adminUser);
     }
 
-    /**
-     * @Given /^I have the "([^"]*)" image as (my) avatar$/
-     */
+    #[Given('/^I have the "([^"]*)" image as (my) avatar$/')]
     public function iHaveTheImageAsMyAvatar(string $avatarPath, AdminUserInterface $administrator): void
     {
         $filesPath = $this->minkParameters['files_path'];
@@ -119,9 +109,7 @@ final class AdminUserContext implements Context
         $this->sharedStorage->set($avatarPath, $avatar->getPath());
     }
 
-    /**
-     * @Given /^(I) have already received an administrator's password resetting email$/
-     */
+    #[Given('/^(I) have already received an administrator\'s password resetting email$/')]
     public function iHaveAlreadyReceivedAnAdministratorsPasswordResettingEmail(AdminUserInterface $administrator): void
     {
         $administrator->setPasswordResetToken('token');
@@ -130,9 +118,7 @@ final class AdminUserContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(my) password reset token has already expired$/
-     */
+    #[Given('/^(my) password reset token has already expired$/')]
     public function myPasswordResetTokenHasAlreadyExpired(AdminUserInterface $administrator): void
     {
         $administrator->setPasswordRequestedAt(new \DateTime('-1 year'));

--- a/src/Sylius/Behat/Context/Setup/CalendarContext.php
+++ b/src/Sylius/Behat/Context/Setup/CalendarContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 
 final class CalendarContext implements Context
@@ -21,9 +22,7 @@ final class CalendarContext implements Context
     {
     }
 
-    /**
-     * @Given it is :dateTime now
-     */
+    #[Given('it is :dateTime now')]
     public function itIsNow(string $dateTime): void
     {
         file_put_contents($this->dateFilePath, $dateTime);

--- a/src/Sylius/Behat/Context/Setup/CartContext.php
+++ b/src/Sylius/Behat/Context/Setup/CartContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Sylius\Behat\Context\Setup\Checkout\AddressContext;
@@ -57,19 +58,15 @@ final readonly class CartContext implements Context
     ) {
     }
 
-    /**
-     * @Given the customer has created empty cart
-     */
+    #[Given('the customer has created empty cart')]
     public function theCustomerHasTheCart(): void
     {
         $this->pickupCart();
     }
 
-    /**
-     * @Given /^I have(?:| added) (\d+) (product(?:|s) "[^"]+") (?:to|in) the (cart)$/
-     */
     #[Given('/^I added (\d+) (products "[^"]+") to the (cart)$/')]
     #[Given('/^I added (\d+) of (them) to (?:the|my) (cart)$/')]
+    #[Given('/^I have(?:| added) (\d+) (product(?:|s) "[^"]+") (?:to|in) the (cart)$/')]
     public function iAddedGivenQuantityOfProductsToTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue, $quantity);
@@ -84,11 +81,10 @@ final readonly class CartContext implements Context
     }
 
     /**
-     * @Given /^I added (products "([^"]+)" and "([^"]+)") to the (cart)$/
-     * @Given /^I added (products "([^"]+)", "([^"]+)" and "([^"]+)") to the (cart)$/
-     *
      * @param ProductInterface[] $products
      */
+    #[Given('/^I added (products "([^"]+)" and "([^"]+)") to the (cart)$/')]
+    #[Given('/^I added (products "([^"]+)", "([^"]+)" and "([^"]+)") to the (cart)$/')]
     public function iAddedProductsAndToTheCart(array $products, ?string $tokenValue): void
     {
         foreach ($products as $product) {
@@ -96,17 +92,15 @@ final readonly class CartContext implements Context
         }
     }
 
-    /**
-     * @Given /^I have (product "[^"]+") in the (cart)$/
-     * @Given /^I have (product "[^"]+") added to the (cart)$/
-     * @Given /^the (?:customer|visitor) has (product "[^"]+") in the (cart)$/
-     * @When /^the (?:customer|visitor) try to add (product "[^"]+") in the customer (cart)$/
-     */
     #[Given('/^I added (product "[^"]+") to the (cart)$/')]
     #[Given('/^I added (this product) to the (cart)$/')]
     #[Given('/^I added (this product) to the (cart) again$/')]
     #[Given('/^the visitor added (product "[^"]+") to the (cart)$/')]
     #[Given('/^the customer added (product "[^"]+") to the (cart)$/')]
+    #[Given('/^I have (product "[^"]+") in the (cart)$/')]
+    #[Given('/^I have (product "[^"]+") added to the (cart)$/')]
+    #[Given('/^the (?:customer|visitor) has (product "[^"]+") in the (cart)$/')]
+    #[When('/^the (?:customer|visitor) try to add (product "[^"]+") in the customer (cart)$/')]
     public function iAddedProductToTheCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->addProductToCart($product, $tokenValue);
@@ -130,11 +124,9 @@ final readonly class CartContext implements Context
         ));
     }
 
-    /**
-     * @Given /^I have ("[^"]+" variant of product "[^"]+") in the (cart)$/
-     * @Given /^I have ("[^"]+" variant of this product) in the (cart)$/
-     */
     #[Given('/^I added ("[^"]+" variant of product "[^"]+") to the (cart)$/')]
+    #[Given('/^I have ("[^"]+" variant of product "[^"]+") in the (cart)$/')]
+    #[Given('/^I have ("[^"]+" variant of this product) in the (cart)$/')]
     public function iHaveVariantOfProductInTheCart(ProductVariantInterface $productVariant, ?string $tokenValue): void
     {
         if ($tokenValue === null || !$this->doesCartWithTokenExist($tokenValue)) {
@@ -205,9 +197,7 @@ final readonly class CartContext implements Context
         ));
     }
 
-    /**
-     * @Given /^this (cart) has promotion applied with coupon "([^"]+)"$/
-     */
+    #[Given('/^this (cart) has promotion applied with coupon "([^"]+)"$/')]
     public function thisCartHasCouponAppliedWithCode(?string $tokenValue, string $couponCode): void
     {
         if ($tokenValue === null) {

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Doctrine\ORM\EntityManagerInterface;
@@ -54,10 +55,8 @@ final class CatalogPromotionContext implements Context
     ) {
     }
 
-    /**
-     * @Given there is a catalog promotion with :code code and :name name
-     * @Given there is also a catalog promotion with :code code and :name name
-     */
+    #[Given('there is a catalog promotion with :code code and :name name')]
+    #[Given('there is also a catalog promotion with :code code and :name name')]
     public function thereIsACatalogPromotionWithCodeAndName(string $code, string $name): void
     {
         $this->createCatalogPromotion($name, $code);
@@ -65,9 +64,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^(it) is enabled$/
-     */
+    #[Given('/^(it) is enabled$/')]
     public function itIsEnabled(CatalogPromotionInterface $catalogPromotion): void
     {
         $catalogPromotion->setEnabled(true);
@@ -76,9 +73,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^(this catalog promotion) is disabled$/
-     */
+    #[Given('/^(this catalog promotion) is disabled$/')]
     public function thisCatalogPromotionIsDisabled(CatalogPromotionInterface $catalogPromotion): void
     {
         $catalogPromotion->setEnabled(false);
@@ -87,10 +82,8 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given there are catalog promotions named :firstName and :secondName
-     * @Given there is a catalog promotion named :name
-     */
+    #[Given('there are catalog promotions named :firstName and :secondName')]
+    #[Given('there is a catalog promotion named :name')]
     public function thereAreCatalogPromotionsNamed(string ...$names): void
     {
         foreach ($names as $name) {
@@ -100,10 +93,8 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given the catalog promotion :catalogPromotion is available in :channel
-     * @Given /^(this catalog promotion) is(?:| also) available in the ("[^"]+" channel)$/
-     */
+    #[Given('the catalog promotion :catalogPromotion is available in :channel')]
+    #[Given('/^(this catalog promotion) is(?:| also) available in the ("[^"]+" channel)$/')]
     public function theCatalogPromotionIsAvailableIn(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -113,9 +104,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^(it) applies(?:| also) on ("[^"]+" variant)$/
-     */
+    #[Given('/^(it) applies(?:| also) on ("[^"]+" variant)$/')]
     public function itAppliesOnVariant(CatalogPromotionInterface $catalogPromotion, ProductVariantInterface $variant): void
     {
         /** @var CatalogPromotionScopeInterface $catalogPromotionScope */
@@ -128,9 +117,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^(it) applies(?:| also) on ("[^"]+" product)$/
-     */
+    #[Given('/^(it) applies(?:| also) on ("[^"]+" product)$/')]
     public function itAppliesOnProduct(CatalogPromotionInterface $catalogPromotion, ProductInterface $product): void
     {
         /** @var CatalogPromotionScopeInterface $catalogPromotionScope */
@@ -145,9 +132,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given :catalogPromotion catalog promotion is exclusive
-     */
+    #[Given(':catalogPromotion catalog promotion is exclusive')]
     public function catalogPromotionIsExclusive(CatalogPromotionInterface $catalogPromotion): void
     {
         $catalogPromotion->setExclusive(true);
@@ -155,9 +140,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^(it) reduces price by ("[^"]+")$/
-     */
+    #[Given('/^(it) reduces price by ("[^"]+")$/')]
     public function itWillReducePrice(CatalogPromotionInterface $catalogPromotion, float $discount): void
     {
         /** @var CatalogPromotionActionInterface $catalogPromotionAction */
@@ -170,9 +153,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^(it) reduces(?:| also) price by fixed ("[^"]+") in the ("[^"]+" channel)$/
-     */
+    #[Given('/^(it) reduces(?:| also) price by fixed ("[^"]+") in the ("[^"]+" channel)$/')]
     public function itReducesPriceByFixedInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         int $discount,
@@ -219,9 +200,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" variant)$/')]
     public function thereIsACatalogPromotionThatReducesPriceByFixedInTheChannelAndAppliesOnVariant(
         string $name,
         int $discount,
@@ -247,9 +226,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/')]
     public function thereIsACatalogPromotionThatReducesPriceByFixedInTheChannelAndAppliesOnProduct(
         string $name,
         int $discount,
@@ -275,9 +252,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" taxon)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]*)" that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" taxon)$/')]
     public function thereIsACatalogPromotionThatReducesPriceByFixedInTheChannelAndAppliesOnTaxon(
         string $name,
         int $discount,
@@ -303,10 +278,8 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" taxon) and ("[^"]+" taxon)$/
-     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/
-     */
+    #[Given('/^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" taxon) and ("[^"]+" taxon)$/')]
+    #[Given('/^there is (?:a|another) catalog promotion "([^"]*)" that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/')]
     public function thereIsACatalogPromotionThatReducesPriceByAndAppliesOnTaxon(
         string $name,
         float $discount,
@@ -331,9 +304,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is (?:a|another) catalog promotion "([^"]*)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsACatalogPromotionAvailableInChannelThatReducesPriceByAndAppliesOnVariant(
         string $name,
         ChannelInterface $channel,
@@ -358,9 +329,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is (?:a|another) catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsACatalogPromotionBetweenAvailableInChannelThatReducesPriceByAndAppliesOnVariant(
         string $name,
         string $startDate,
@@ -387,9 +356,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is disabled catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is disabled catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsDisabledCatalogPromotionAvailableInChannelThatReducesPriceByAndAppliesOnVariant(
         string $name,
         string $startDate,
@@ -417,9 +384,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is another catalog promotion "([^"]*)" available in ("[^"]+" channel) and ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is another catalog promotion "([^"]*)" available in ("[^"]+" channel) and ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsAnotherCatalogPromotionAvailableInChannelsThatReducesPriceByAndAppliesOnVariant(
         string $name,
         ChannelInterface $firstChannel,
@@ -447,9 +412,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is (?:a|another) catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/
-     */
+    #[Given('/^there is (?:a|another) catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/')]
     public function thereIsACatalogPromotionBetweenAvailableInChannelThatReducesPriceByAndAppliesOnTaxon(
         string $name,
         string $startDate,
@@ -476,9 +439,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is disabled catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/
-     */
+    #[Given('/^there is disabled catalog promotion "([^"]*)" between "([^"]+)" and "([^"]+)" available in ("[^"]+" channel) that reduces price by ("[^"]+") and applies on ("[^"]+" taxon)$/')]
     public function thereIsDisabledCatalogPromotionBetweenAvailableInChannelThatReducesPriceByAndAppliesOnTaxon(
         string $name,
         string $startDate,
@@ -531,9 +492,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionCreated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]+)" with priority ([^"]+)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]+)" with priority ([^"]+)$/')]
     public function thereIsACatalogPromotionWithPriority(
         string $name,
         int $priority,
@@ -545,9 +504,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsACatalogPromotionWithPriorityThatReducesPriceByAndAppliesOnVariant(
         string $name,
         int $priority,
@@ -574,9 +531,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is (?:an|another) exclusive catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/
-     */
+    #[Given('/^there is (?:an|another) exclusive catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" variant)$/')]
     public function thereIsAnExclusiveCatalogPromotionWithPriorityThatReducesPriceByAndAppliesOnVariant(
         string $name,
         int $priority,
@@ -604,9 +559,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/')]
     public function thereIsACatalogPromotionWithPriorityThatReducesPriceByFixedInTheChannelAndAppliesOnProduct(
         string $name,
         int $priority,
@@ -634,9 +587,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" taxon)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" taxon)$/')]
     public function thereIsACatalogPromotionWithPriorityThatReducesPriceByFixedInTheChannelAndAppliesOnTaxon(
         string $name,
         int $priority,
@@ -664,9 +615,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @When the :catalogPromotion catalog promotion is no longer available
-     */
+    #[When('the :catalogPromotion catalog promotion is no longer available')]
     public function theAdministratorMakesThisCatalogPromotionUnavailableInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
     ): void {
@@ -679,10 +628,8 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given the catalog promotion :catalogPromotion operates between :startDate and :endDate
-     * @Given /^(this catalog promotion) operates between "([^"]+)" and "([^"]+)"$/
-     */
+    #[Given('the catalog promotion :catalogPromotion operates between :startDate and :endDate')]
+    #[Given('/^(this catalog promotion) operates between "([^"]+)" and "([^"]+)"$/')]
     public function theCatalogPromotionOperatesBetweenDates(
         CatalogPromotionInterface $catalogPromotion,
         string $startDate,
@@ -695,9 +642,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given the catalog promotion :catalogPromotion starts at :startDate
-     */
+    #[Given('the catalog promotion :catalogPromotion starts at :startDate')]
     public function theCatalogPromotionStartsAt(CatalogPromotionInterface $catalogPromotion, string $startDate): void
     {
         $catalogPromotion->setStartDate(new \DateTime($startDate));
@@ -707,9 +652,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given the catalog promotion :catalogPromotion ended :endDate
-     */
+    #[Given('the catalog promotion :catalogPromotion ended :endDate')]
     public function theCatalogPromotionEndedAt(CatalogPromotionInterface $catalogPromotion, string $endDate): void
     {
         $catalogPromotion->setEndDate(new \DateTime($endDate));
@@ -718,9 +661,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given the end date of catalog promotion :catalogPromotion was changed to :endDate
-     */
+    #[Given('the end date of catalog promotion :catalogPromotion was changed to :endDate')]
     public function theEndDateOfCatalogPromotionWasChangedTo(
         CatalogPromotionInterface $catalogPromotion,
         string $endDate,
@@ -731,9 +672,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^(its) priority is ([^"]+)$/
-     */
+    #[Given('/^(its) priority is ([^"]+)$/')]
     public function theCatalogPromotionPriorityIs(CatalogPromotionInterface $catalogPromotion, int $priority): void
     {
         $catalogPromotion->setPriority($priority);
@@ -742,10 +681,8 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^the ("[^"]+" catalog promotion) is active$/
-     * @Given /^(this catalog promotion) is active$/
-     */
+    #[Given('/^the ("[^"]+" catalog promotion) is active$/')]
+    #[Given('/^(this catalog promotion) is active$/')]
     public function theCatalogPromotionIsActive(CatalogPromotionInterface $catalogPromotion)
     {
         if (CatalogPromotionStates::STATE_ACTIVE === $catalogPromotion->getState()) {
@@ -758,9 +695,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given the catalog promotion :catalogPromotion is currently being processed
-     */
+    #[Given('the catalog promotion :catalogPromotion is currently being processed')]
     public function theCatalogPromotionIsCurrentlyBeingProcessed(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->stateMachine->apply($catalogPromotion, CatalogPromotionTransitions::GRAPH, CatalogPromotionTransitions::TRANSITION_PROCESS);
@@ -768,9 +703,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given the :catalogPromotion catalog promotion is enabled
-     */
+    #[Given('the :catalogPromotion catalog promotion is enabled')]
     public function theCatalogPromotionIsEnabled(CatalogPromotionInterface $catalogPromotion): void
     {
         $catalogPromotion->setEnabled(true);
@@ -779,9 +712,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given there is disabled catalog promotion named :name
-     */
+    #[Given('there is disabled catalog promotion named :name')]
     public function thereIsCatalogPromotionsNamed(string $name): void
     {
         $this->createCatalogPromotion(name: $name, enabled: false);
@@ -789,9 +720,7 @@ final class CatalogPromotionContext implements Context
         $this->entityManager->flush();
     }
 
-    /**
-     * @Given /^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" product)$/
-     */
+    #[Given('/^there is a catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by ("[^"]+") and applies on ("[^"]+" product)$/')]
     public function thereIsACatalogPromotionWithPriorityThatReducesPriceByAndAppliesOnProduct(
         string $name,
         int $priority,
@@ -816,9 +745,7 @@ final class CatalogPromotionContext implements Context
         $this->eventBus->dispatch(new CatalogPromotionUpdated($catalogPromotion->getCode()));
     }
 
-    /**
-     * @Given /^there is disabled catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/
-     */
+    #[Given('/^there is disabled catalog promotion "([^"]+)" with priority ([^"]+) that reduces price by fixed ("[^"]+") in the ("[^"]+" channel) and applies on ("[^"]+" product)$/')]
     public function thereIsDisabledCatalogPromotionWithPriorityThatReducesPriceByFixedInTheChannelAndAppliesOnProduct(
         string $name,
         int $priority,

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
@@ -46,9 +47,7 @@ final readonly class ChannelContext implements Context
     ) {
     }
 
-    /**
-     * @Given :channel channel has account verification disabled
-     */
+    #[Given(':channel channel has account verification disabled')]
     public function channelHasAccountVerificationDisabled(ChannelInterface $channel): void
     {
         $channel->setAccountVerificationRequired(false);
@@ -56,9 +55,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^the (channel "[^"]+") has ("([^"]+)" and "([^"]+)" taxons) excluded from showing the lowest price of discounted products$/
-     */
+    #[Given('/^the (channel "[^"]+") has ("([^"]+)" and "([^"]+)" taxons) excluded from showing the lowest price of discounted products$/')]
     public function theTaxonAndTaxonAreExcludedFromShowingTheLowestPriceOfDiscountedProductsOnThisChannel(
         ChannelInterface $channel,
         iterable $taxons,
@@ -90,10 +87,8 @@ final readonly class ChannelContext implements Context
         $this->sharedStorage->set('channel', $defaultData['channel']);
     }
 
-    /**
-     * @Given the store operates on a single channel
-     * @Given the store operates on a single channel in :currencyCode currency
-     */
+    #[Given('the store operates on a single channel')]
+    #[Given('the store operates on a single channel in :currencyCode currency')]
     public function storeOperatesOnASingleChannel(?string $currencyCode = null): void
     {
         $defaultData = $this->defaultChannelFactory->create(null, null, $currencyCode);
@@ -102,9 +97,7 @@ final readonly class ChannelContext implements Context
         $this->sharedStorage->set('channel', $defaultData['channel']);
     }
 
-    /**
-     * @Given the store operates on a single channel in :localeCode locale
-     */
+    #[Given('the store operates on a single channel in :localeCode locale')]
     public function storeOperatesOnASingleChannelInLocale(string $localeCode): void
     {
         $defaultData = $this->defaultChannelFactory->create(localeCode: $localeCode);
@@ -133,26 +126,20 @@ final readonly class ChannelContext implements Context
         $this->sharedStorage->set('channel', $defaultData['channel']);
     }
 
-    /**
-     * @Given the channel :channel is enabled
-     */
+    #[Given('the channel :channel is enabled')]
     public function theChannelIsEnabled(ChannelInterface $channel): void
     {
         $this->changeChannelState($channel, true);
     }
 
-    /**
-     * @Given the channel :channel is disabled
-     * @Given the channel :channel has been disabled
-     */
+    #[Given('the channel :channel is disabled')]
+    #[Given('the channel :channel has been disabled')]
     public function theChannelIsDisabled(ChannelInterface $channel): void
     {
         $this->changeChannelState($channel, false);
     }
 
-    /**
-     * @Given /^the (channel "[^"]+") has showing the lowest price of discounted products (enabled|disabled)$/
-     */
+    #[Given('/^the (channel "[^"]+") has showing the lowest price of discounted products (enabled|disabled)$/')]
     public function theChannelHasShowingTheLowestPriceOfDiscountedProducts(ChannelInterface $channel, string $visible): void
     {
         $channel->getChannelPriceHistoryConfig()->setLowestPriceForDiscountedProductsVisible($visible === 'enabled');
@@ -160,36 +147,28 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given channel :channel has been deleted
-     */
+    #[Given('channel :channel has been deleted')]
     public function iChannelHasBeenDeleted(ChannelInterface $channel): void
     {
         $this->channelRepository->remove($channel);
     }
 
-    /**
-     * @Given /^(its) default tax zone is (zone "([^"]+)")$/
-     */
+    #[Given('/^(its) default tax zone is (zone "([^"]+)")$/')]
     public function itsDefaultTaxRateIs(ChannelInterface $channel, ZoneInterface $defaultTaxZone): void
     {
         $channel->setDefaultTaxZone($defaultTaxZone);
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^(this channel) has contact email set as "([^"]+)"$/
-     * @Given /^(this channel) has no contact email set$/
-     */
+    #[Given('/^(this channel) has contact email set as "([^"]+)"$/')]
+    #[Given('/^(this channel) has no contact email set$/')]
     public function thisChannelHasContactEmailSetAs(ChannelInterface $channel, ?string $contactEmail = null): void
     {
         $channel->setContactEmail($contactEmail);
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^on (this channel) shipping step is skipped if only a single shipping method is available$/
-     */
+    #[Given('/^on (this channel) shipping step is skipped if only a single shipping method is available$/')]
     public function onThisChannelShippingStepIsSkippedIfOnlyASingleShippingMethodIsAvailable(ChannelInterface $channel): void
     {
         $channel->setSkippingShippingStepAllowed(true);
@@ -197,9 +176,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^on (this channel) payment step is skipped if only a single payment method is available$/
-     */
+    #[Given('/^on (this channel) payment step is skipped if only a single payment method is available$/')]
     public function onThisChannelPaymentStepIsSkippedIfOnlyASinglePaymentMethodIsAvailable(
         ChannelInterface $channel,
     ): void {
@@ -208,9 +185,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^on (this channel) account verification is not required$/
-     */
+    #[Given('/^on (this channel) account verification is not required$/')]
     public function onThisChannelAccountVerificationIsNotRequired(ChannelInterface $channel): void
     {
         $channel->setAccountVerificationRequired(false);
@@ -218,9 +193,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^on (this channel) account verification is required$/
-     */
+    #[Given('/^on (this channel) account verification is required$/')]
     public function onThisChannelAccountVerificationIsRequired(ChannelInterface $channel): void
     {
         $channel->setAccountVerificationRequired(true);
@@ -228,9 +201,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given channel :channel billing data is :company, :street, :postcode :city, :country with :taxId tax ID
-     */
+    #[Given('channel :channel billing data is :company, :street, :postcode :city, :country with :taxId tax ID')]
     public function channelBillingDataIs(
         ChannelInterface $channel,
         string $company,
@@ -253,10 +224,8 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given channel :channel has menu taxon :taxon
-     * @Given /^(this channel) has menu (taxon "[^"]+")$/
-     */
+    #[Given('channel :channel has menu taxon :taxon')]
+    #[Given('/^(this channel) has menu (taxon "[^"]+")$/')]
     public function channelHasMenuTaxon(ChannelInterface $channel, TaxonInterface $taxon): void
     {
         $channel->setMenuTaxon($taxon);
@@ -264,9 +233,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^(this channel) operates in the ("[^"]+" country)$/
-     */
+    #[Given('/^(this channel) operates in the ("[^"]+" country)$/')]
     public function channelOperatesInCountry(ChannelInterface $channel, CountryInterface $country): void
     {
         $channel->addCountry($country);
@@ -274,9 +241,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^(this channel) does not define operating countries$/
-     */
+    #[Given('/^(this channel) does not define operating countries$/')]
     public function channelDoesNotDefineOperatingCountries(ChannelInterface $channel): void
     {
         foreach ($channel->getCountries() as $country) {
@@ -286,12 +251,10 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @When /^I change (?:|back )my current (channel to "([^"]+)")$/
-     * @When customer view shop on :channel channel
-     */
     #[Given('/^I changed my current (channel to "([^"]+)")$/')]
     #[Given('I am in the :channel channel')]
+    #[When('/^I change (?:|back )my current (channel to "([^"]+)")$/')]
+    #[When('customer view shop on :channel channel')]
     public function iChangedMyCurrentChannelTo(ChannelInterface $channel): void
     {
         $this->sharedStorage->set('channel', $channel);
@@ -299,9 +262,7 @@ final readonly class ChannelContext implements Context
         $this->channelContextSetter->setChannel($channel);
     }
 
-    /**
-     * @Given /^its required address in the checkout is (billing|shipping)$/
-     */
+    #[Given('/^its required address in the checkout is (billing|shipping)$/')]
     public function itsRequiredAddressInTheCheckoutIs(string $type): void
     {
         /** @var ChannelInterface $channel */
@@ -311,9 +272,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^(this channel) has (\d+) day(?:|s) set as the lowest price for discounted products checking period$/
-     */
+    #[Given('/^(this channel) has (\d+) day(?:|s) set as the lowest price for discounted products checking period$/')]
     public function thisChannelHasDaysSetAsTheLowestPriceForDiscountedProductsCheckingPeriod(
         ChannelInterface $channel,
         int $days,
@@ -323,9 +282,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given the :taxon taxon is excluded from showing the lowest price of discounted products in the :channel channel
-     */
+    #[Given('the :taxon taxon is excluded from showing the lowest price of discounted products in the :channel channel')]
     public function theTaxonIsExcludedFromShowingTheLowestPriceOfDiscountedProductsInTheChannel(
         TaxonInterface $taxon,
         ChannelInterface $channel,
@@ -335,17 +292,13 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^the lowest price of discounted products prior to the current discount is disabled on (this channel)$/
-     */
+    #[Given('/^the lowest price of discounted products prior to the current discount is disabled on (this channel)$/')]
     public function theLowestPriceOfDiscountedProductsPriorToTheCurrentDiscountIsDisabledOnThisChannel(ChannelInterface $channel): void
     {
         $channel->getChannelPriceHistoryConfig()->setLowestPriceForDiscountedProductsVisible(false);
     }
 
-    /**
-     * @Given the store also operates in :locale locale
-     */
+    #[Given('the store also operates in :locale locale')]
     public function theStoreAlsoOperatesInLocale(LocaleInterface $locale): void
     {
         /** @var ChannelInterface $channel */
@@ -355,9 +308,7 @@ final readonly class ChannelContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given the store uses the :taxCalculationStrategy tax calculation strategy
-     */
+    #[Given('the store uses the :taxCalculationStrategy tax calculation strategy')]
     public function theStoreUsesTheTaxCalculationStrategy(string $taxCalculationStrategy): void
     {
         /** @var ChannelInterface $channel */

--- a/src/Sylius/Behat/Context/Setup/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Setup/CheckoutContext.php
@@ -62,9 +62,7 @@ final readonly class CheckoutContext implements Context
         $this->checkoutPaymentContext->choosePaymentMethod($paymentMethod);
     }
 
-    /**
-     * @Given I have proceeded through checkout process in the :localeCode locale with email :email
-     */
+    #[Given('I have proceeded through checkout process in the :localeCode locale with email :email')]
     public function iHaveProceededThroughCheckoutProcessInTheLocaleWithEmail(string $localeCode, string $email): void
     {
         $cartToken = $this->sharedStorage->get('cart_token');
@@ -86,9 +84,7 @@ final readonly class CheckoutContext implements Context
         $this->completeCheckout($cart);
     }
 
-    /**
-     * @Given I have proceeded through checkout process
-     */
+    #[Given('I have proceeded through checkout process')]
     public function iHaveProceededThroughCheckoutProcess(): void
     {
         $cartToken = $this->sharedStorage->get('cart_token');

--- a/src/Sylius/Behat/Context/Setup/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Setup/CurrencyContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -31,9 +32,7 @@ final class CurrencyContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has currency :currencyCode
-     */
+    #[Given('the store has currency :currencyCode')]
     public function theStoreHasCurrency($currencyCode)
     {
         $currency = $this->createCurrency($currencyCode);
@@ -41,11 +40,9 @@ final class CurrencyContext implements Context
         $this->saveCurrency($currency);
     }
 
-    /**
-     * @Given the store has currency :currencyCode, :secondCurrencyCode
-     * @Given the store has currency :currencyCode and :secondCurrencyCode
-     * @Given the store has currency :currencyCode, :secondCurrencyCode and :thirdCurrencyCode
-     */
+    #[Given('the store has currency :currencyCode, :secondCurrencyCode')]
+    #[Given('the store has currency :currencyCode and :secondCurrencyCode')]
+    #[Given('the store has currency :currencyCode, :secondCurrencyCode and :thirdCurrencyCode')]
     public function theStoreHasCurrencyAnd($currencyCode, $secondCurrencyCode, $thirdCurrencyCode = null)
     {
         $this->saveCurrency($this->createCurrency($currencyCode));
@@ -56,9 +53,7 @@ final class CurrencyContext implements Context
         }
     }
 
-    /**
-     * @Given the currency :currencyCode has been disabled
-     */
+    #[Given('the currency :currencyCode has been disabled')]
     public function theStoreHasDisabledCurrency($currencyCode)
     {
         $currency = $this->provideCurrency($currencyCode);
@@ -66,11 +61,9 @@ final class CurrencyContext implements Context
         $this->saveCurrency($currency);
     }
 
-    /**
-     * @Given /^(that channel|"[^"]+" channel)(?: also|) allows to shop using the "([^"]+)" currency$/
-     * @Given /^(that channel|"[^"]+" channel)(?: also|) allows to shop using "([^"]+)" and "([^"]+)" currencies$/
-     * @Given /^(that channel)(?: also|) allows to shop using "([^"]+)", "([^"]+)" and "([^"]+)" currencies$/
-     */
+    #[Given('/^(that channel|"[^"]+" channel)(?: also|) allows to shop using the "([^"]+)" currency$/')]
+    #[Given('/^(that channel|"[^"]+" channel)(?: also|) allows to shop using "([^"]+)" and "([^"]+)" currencies$/')]
+    #[Given('/^(that channel)(?: also|) allows to shop using "([^"]+)", "([^"]+)" and "([^"]+)" currencies$/')]
     public function thatChannelAllowsToShopUsingAndCurrencies(ChannelInterface $channel, ...$currenciesCodes)
     {
         foreach ($currenciesCodes as $currencyCode) {

--- a/src/Sylius/Behat/Context/Setup/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
@@ -39,9 +40,7 @@ final class CustomerContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has customer :name with email :email
-     */
+    #[Given('the store has customer :name with email :email')]
     public function theStoreHasCustomerWithNameAndEmail($name, $email)
     {
         $partsOfName = explode(' ', $name);
@@ -51,9 +50,7 @@ final class CustomerContext implements Context
         $this->sharedStorage->set('customer', $customer);
     }
 
-    /**
-     * @Given the store (also )has customer :email
-     */
+    #[Given('the store (also )has customer :email')]
     public function theStoreHasCustomer($email)
     {
         $customer = $this->createCustomer($email);
@@ -61,9 +58,7 @@ final class CustomerContext implements Context
         $this->customerRepository->add($customer);
     }
 
-    /**
-     * @Given the store has customer :email with first name :firstName
-     */
+    #[Given('the store has customer :email with first name :firstName')]
     public function theStoreHasCustomerWithFirstName($email, $firstName)
     {
         $customer = $this->createCustomer($email, $firstName);
@@ -71,10 +66,8 @@ final class CustomerContext implements Context
         $this->customerRepository->add($customer);
     }
 
-    /**
-     * @Given the store has customer :email with name :fullName since :since
-     * @Given the store has customer :email with name :fullName and phone number :phoneNumber since :since
-     */
+    #[Given('the store has customer :email with name :fullName since :since')]
+    #[Given('the store has customer :email with name :fullName and phone number :phoneNumber since :since')]
     public function theStoreHasCustomerWithNameAndRegistrationDate($email, $fullName, $since, $phoneNumber = null)
     {
         $names = explode(' ', $fullName);
@@ -83,47 +76,37 @@ final class CustomerContext implements Context
         $this->customerRepository->add($customer);
     }
 
-    /**
-     * @Given there is disabled customer account :email with password :password
-     */
+    #[Given('there is disabled customer account :email with password :password')]
     public function thereIsDisabledCustomerAccountWithPassword($email, $password)
     {
         $customer = $this->createCustomerWithUserAccount($email, $password, false);
         $this->customerRepository->add($customer);
     }
 
-    /**
-     * @Given there is a customer account :email
-     * @Given there is a customer account :email identified by :password
-     * @Given there is enabled customer account :email with password :password
-     */
+    #[Given('there is a customer account :email')]
+    #[Given('there is a customer account :email identified by :password')]
+    #[Given('there is enabled customer account :email with password :password')]
     public function theStoreHasEnabledCustomerAccountWithPassword($email, $password = 'sylius')
     {
         $customer = $this->createCustomerWithUserAccount($email, $password, true);
         $this->customerRepository->add($customer);
     }
 
-    /**
-     * @Given there is a customer :name identified by an email :email and a password :password
-     * @Given there is a customer :name with an email :email and a password :password
-     */
+    #[Given('there is a customer :name identified by an email :email and a password :password')]
+    #[Given('there is a customer :name with an email :email and a password :password')]
     public function theStoreHasCustomerAccountWithEmailAndPassword(string $name, string $email, string $password): void
     {
         $this->createCustomerWithFullNameEmailAndPassword($name, $email, $password);
     }
 
-    /**
-     * @Given there is a customer :name with an email :email
-     * @Given there is also a customer :name with an email :email
-     */
+    #[Given('there is a customer :name with an email :email')]
+    #[Given('there is also a customer :name with an email :email')]
     public function theStoreHasCustomerAccountWithEmailAndName(string $name, string $email): void
     {
         $this->createCustomerWithFullNameEmailAndPassword($name, $email, 'sylius');
     }
 
-    /**
-     * @Given /^(the customer) subscribed to the newsletter$/
-     */
+    #[Given('/^(the customer) subscribed to the newsletter$/')]
     public function theCustomerSubscribedToTheNewsletter(CustomerInterface $customer)
     {
         $customer->setSubscribedToNewsletter(true);
@@ -131,9 +114,7 @@ final class CustomerContext implements Context
         $this->customerManager->flush();
     }
 
-    /**
-     * @Given /^(this customer) verified their email$/
-     */
+    #[Given('/^(this customer) verified their email$/')]
     public function theCustomerVerifiedTheirEmail(CustomerInterface $customer)
     {
         $customer->getUser()->setVerifiedAt(new \DateTime());
@@ -141,10 +122,8 @@ final class CustomerContext implements Context
         $this->customerManager->flush();
     }
 
-    /**
-     * @Given /^(the customer) belongs to (group "([^"]+)")$/
-     * @Given /^(this customer) belongs to (group "([^"]+)")$/
-     */
+    #[Given('/^(the customer) belongs to (group "([^"]+)")$/')]
+    #[Given('/^(this customer) belongs to (group "([^"]+)")$/')]
     public function theCustomerBelongsToGroup(CustomerInterface $customer, CustomerGroupInterface $customerGroup)
     {
         $customer->setGroup($customerGroup);
@@ -152,9 +131,7 @@ final class CustomerContext implements Context
         $this->customerManager->flush();
     }
 
-    /**
-     * @Given there is user :email with :country as shipping country
-     */
+    #[Given('there is user :email with :country as shipping country')]
     public function thereIsUserIdentifiedByWithAsShippingCountry($email, CountryInterface $country)
     {
         $customer = $this->createCustomerWithUserAccount($email, 'password123', true, 'John', 'Doe');

--- a/src/Sylius/Behat/Context/Setup/CustomerGroupContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerGroupContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -29,19 +30,15 @@ final class CustomerGroupContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has a customer group :name
-     * @Given the store has a customer group :name with :code code
-     */
+    #[Given('the store has a customer group :name')]
+    #[Given('the store has a customer group :name with :code code')]
     public function theStoreHasACustomerGroup($name, $code = null)
     {
         $this->createCustomerGroup($name, $code);
     }
 
-    /**
-     * @Given the store has customer groups :firstName and :secondName
-     * @Given the store has customer groups :firstName, :secondName and :thirdName
-     */
+    #[Given('the store has customer groups :firstName and :secondName')]
+    #[Given('the store has customer groups :firstName, :secondName and :thirdName')]
     public function theStoreHasCustomerGroups(string ...$names): void
     {
         foreach ($names as $name) {

--- a/src/Sylius/Behat/Context/Setup/ExchangeRateContext.php
+++ b/src/Sylius/Behat/Context/Setup/ExchangeRateContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
@@ -29,9 +30,7 @@ final class ExchangeRateContext implements Context
     ) {
     }
 
-    /**
-     * @Given the exchange rate of :sourceCurrency to :targetCurrency is :ratio
-     */
+    #[Given('the exchange rate of :sourceCurrency to :targetCurrency is :ratio')]
     public function thereIsAnExchangeRateWithSourceCurrencyAndTargetCurrency(
         CurrencyInterface $sourceCurrency,
         CurrencyInterface $targetCurrency,

--- a/src/Sylius/Behat/Context/Setup/GeographicalContext.php
+++ b/src/Sylius/Behat/Context/Setup/GeographicalContext.php
@@ -50,11 +50,9 @@ final readonly class GeographicalContext implements Context
         }
     }
 
-    /**
-     * @Given /^the store operates in "([^"]*)"$/
-     * @Given /^the store operates in "([^"]*)" and "([^"]*)"$/
-     * @Given /^the store(?:| also) has country "([^"]*)"$/
-     */
+    #[Given('/^the store operates in "([^"]*)"$/')]
+    #[Given('/^the store operates in "([^"]*)" and "([^"]*)"$/')]
+    #[Given('/^the store(?:| also) has country "([^"]*)"$/')]
     public function theStoreOperatesIn(string ...$countriesNames): void
     {
         foreach ($countriesNames as $countryName) {
@@ -65,9 +63,7 @@ final readonly class GeographicalContext implements Context
         }
     }
 
-    /**
-     * @Given /^the store has disabled country "([^"]*)"$/
-     */
+    #[Given('/^the store has disabled country "([^"]*)"$/')]
     public function theStoreHasDisabledCountry(string $countryName): void
     {
         $country = $this->createCountryNamed(trim($countryName));
@@ -77,10 +73,8 @@ final readonly class GeographicalContext implements Context
         $this->countryRepository->add($country);
     }
 
-    /**
-     * @Given /^(this country)(?:| also) has the "([^"]+)" province with "([^"]+)" code$/
-     * @Given /^(?:|the )(country "[^"]+") has the "([^"]+)" province with "([^"]+)" code$/
-     */
+    #[Given('/^(this country)(?:| also) has the "([^"]+)" province with "([^"]+)" code$/')]
+    #[Given('/^(?:|the )(country "[^"]+") has the "([^"]+)" province with "([^"]+)" code$/')]
     public function theCountryHasProvinceWithCode(CountryInterface $country, string $name, string $code): void
     {
         $province = $this->provinceFactory->createNew();

--- a/src/Sylius/Behat/Context/Setup/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Setup/LocaleContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -38,11 +39,9 @@ final readonly class LocaleContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has locale :localeCode
-     * @Given the store is( also) available in :localeCode
-     * @Given the locale :localeCode is enabled
-     */
+    #[Given('the store has locale :localeCode')]
+    #[Given('the store is( also) available in :localeCode')]
+    #[Given('the locale :localeCode is enabled')]
     public function theStoreHasLocale(string $localeCode): void
     {
         $locale = $this->provideLocale($localeCode);
@@ -50,9 +49,7 @@ final readonly class LocaleContext implements Context
         $this->saveLocale($locale);
     }
 
-    /**
-     * @Given the store has many locales
-     */
+    #[Given('the store has many locales')]
     public function theStoreHasManyLocales(): void
     {
         $this->theStoreHasLocale('en_US');
@@ -68,9 +65,7 @@ final readonly class LocaleContext implements Context
         $this->theStoreHasLocale('da_DK');
     }
 
-    /**
-     * @Given the locale :localeCode does not exist in the store
-     */
+    #[Given('the locale :localeCode does not exist in the store')]
     public function theStoreDoesNotHaveLocale(string $localeCode): void
     {
         /** @var LocaleInterface $locale */
@@ -80,13 +75,11 @@ final readonly class LocaleContext implements Context
         }
     }
 
-    /**
-     * @Given /^(that channel) allows to shop using the "([^"]+)" locale$/
-     * @Given /^(that channel) allows to shop using "([^"]+)" and "([^"]+)" locales$/
-     * @Given /^(that channel) allows to shop using "([^"]+)", "([^"]+)" and "([^"]+)" locales$/
-     * @Given /^(this channel) allows to shop using the "([^"]+)" locale$/
-     * @Given /^(this channel) allows to shop using "([^"]+)" and "([^"]+)" locales$/
-     */
+    #[Given('/^(that channel) allows to shop using the "([^"]+)" locale$/')]
+    #[Given('/^(that channel) allows to shop using "([^"]+)" and "([^"]+)" locales$/')]
+    #[Given('/^(that channel) allows to shop using "([^"]+)", "([^"]+)" and "([^"]+)" locales$/')]
+    #[Given('/^(this channel) allows to shop using the "([^"]+)" locale$/')]
+    #[Given('/^(this channel) allows to shop using "([^"]+)" and "([^"]+)" locales$/')]
     public function thatChannelAllowsToShopUsingAndLocales(ChannelInterface $channel, ...$localesNames): void
     {
         foreach ($channel->getLocales() as $locale) {
@@ -100,10 +93,8 @@ final readonly class LocaleContext implements Context
         $this->channelManager->flush();
     }
 
-    /**
-     * @Given /^(it) uses the "([^"]+)" locale by default$/
-     * @Given /^(this channel) uses the "([^"]+)" locale as default$/
-     */
+    #[Given('/^(it) uses the "([^"]+)" locale by default$/')]
+    #[Given('/^(this channel) uses the "([^"]+)" locale as default$/')]
     public function itUsesTheLocaleByDefault(ChannelInterface $channel, string $localeName): void
     {
         $locale = $this->provideLocale($this->localeConverter->convertNameToCode($localeName));

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
@@ -87,14 +88,12 @@ final readonly class OrderContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^there is (?:a|another) (customer "[^"]+") that placed an order$/
-     * @Given /^there is (?:a|another) (customer "[^"]+") that placed (an order "[^"]+")$/
-     * @Given a customer :customer placed an order :orderNumber
-     * @Given the customer :customer has already placed an order :orderNumber
-     * @Given there is a customer :customer that placed an order :orderNumber in channel :channel
-     * @Given /^(this customer) placed (another order "[^"]+")$/
-     */
+    #[Given('/^there is (?:a|another) (customer "[^"]+") that placed an order$/')]
+    #[Given('/^there is (?:a|another) (customer "[^"]+") that placed (an order "[^"]+")$/')]
+    #[Given('a customer :customer placed an order :orderNumber')]
+    #[Given('the customer :customer has already placed an order :orderNumber')]
+    #[Given('there is a customer :customer that placed an order :orderNumber in channel :channel')]
+    #[Given('/^(this customer) placed (another order "[^"]+")$/')]
     public function thereIsCustomerThatPlacedOrder(
         CustomerInterface $customer,
         ?string $orderNumber = null,
@@ -108,18 +107,14 @@ final readonly class OrderContext implements Context
         $this->orderRepository->add($order);
     }
 
-    /**
-     * @Given there is a customer :customer that placed an order :orderNumber later
-     */
+    #[Given('there is a customer :customer that placed an order :orderNumber later')]
     public function thereIsACustomerThatPlacedAnOrderLater(CustomerInterface $customer, string $orderNumber): void
     {
         sleep(1);
         $this->thereIsCustomerThatPlacedOrder($customer, $orderNumber);
     }
 
-    /**
-     * @Given /^there is a (customer "[^"]+") that placed order with ("[^"]+" product) to ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment) method$/
-     */
+    #[Given('/^there is a (customer "[^"]+") that placed order with ("[^"]+" product) to ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment) method$/')]
     public function thereIsACustomerThatPlacedOrderWithProductToBasedBillingAddressWithShippingMethodAndPaymentMethod(
         CustomerInterface $customer,
         ProductInterface $product,
@@ -131,9 +126,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^there is a (customer "[^"]+") that placed order with ("[^"]+" product) to ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment) method without completing it$/
-     */
+    #[Given('/^there is a (customer "[^"]+") that placed order with ("[^"]+" product) to ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment) method without completing it$/')]
     public function thereIsACustomerThatPlacedOrderWithProductToBasedBillingAddressWithShippingMethodAndPaymentMethodWithoutCompletingIt(
         CustomerInterface $customer,
         ProductInterface $product,
@@ -145,9 +138,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/
-     */
+    #[Given('/^the guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/')]
     public function theGuestCustomerPlacedOrderWithForAndBasedShippingAddress(
         ProductInterface $product,
         string $email,
@@ -163,9 +154,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the another guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/
-     */
+    #[Given('/^the another guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/')]
     public function theAnotherGuestCustomerPlacedOrderWithForAndBasedShippingAddress(
         ProductInterface $product,
         string $email,
@@ -183,9 +172,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given a customer :customer added something to cart
-     */
+    #[Given('a customer :customer added something to cart')]
     public function customerStartedCheckout(CustomerInterface $customer): void
     {
         $cart = $this->createCart($customer);
@@ -195,9 +182,7 @@ final readonly class OrderContext implements Context
         $this->orderRepository->add($cart);
     }
 
-    /**
-     * @Given the customer :customer added :product product to the cart
-     */
+    #[Given('the customer :customer added :product product to the cart')]
     public function theCustomerAddedProductToTheCart(CustomerInterface $customer, ProductInterface $product): void
     {
         $cart = $this->createCart($customer);
@@ -227,10 +212,8 @@ final readonly class OrderContext implements Context
         $this->orderRepository->add($order);
     }
 
-    /**
-     * @Given /^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/
-     * @Given /^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/
-     */
+    #[Given('/^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/')]
+    #[Given('/^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+"(?:|, "[^"]+"))$/')]
     public function theCustomerAddressedItTo(AddressInterface $address): void
     {
         /** @var OrderInterface $order */
@@ -240,9 +223,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the customer changed shipping address' street to :street
-     */
+    #[Given('the customer changed shipping address\' street to :street')]
     public function theCustomerChangedShippingAddressStreetTo(string $street): void
     {
         /** @var OrderInterface $order */
@@ -256,11 +237,9 @@ final readonly class OrderContext implements Context
         $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_ADDRESS);
     }
 
-    /**
-     * @Given /^the customer set the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
-     * @Given /^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "[^"]+", "[^"]+")$/
-     * @Given /^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "([^"]+)", "[^"]+", "[^"]+")$/
-     */
+    #[Given('/^the customer set the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/')]
+    #[Given('/^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "[^"]+", "[^"]+")$/')]
+    #[Given('/^for the billing address (of "[^"]+" in the "[^"]+", "[^"]+" "([^"]+)", "[^"]+", "[^"]+")$/')]
     public function forTheBillingAddressOf(AddressInterface $address): void
     {
         /** @var OrderInterface $order */
@@ -273,20 +252,16 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/
-     * @Given /^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/
-     */
+    #[Given('/^the customer ("[^"]+" addressed it to "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/')]
+    #[Given('/^I (addressed it to "[^"]+", "[^"]+", "[^"]+" "[^"]+" in the "[^"]+") with identical billing address$/')]
     public function theCustomerAddressedItToWithIdenticalBillingAddress(AddressInterface $address): void
     {
         $this->theCustomerAddressedItTo($address);
         $this->forTheBillingAddressOf(clone $address);
     }
 
-    /**
-     * @Given /^the customer chose ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/
-     * @Given /^I chose ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/
-     */
+    #[Given('/^the customer chose ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/')]
+    #[Given('/^I chose ("[^"]+" shipping method) (to "[^"]+") with ("[^"]+" payment)$/')]
     public function theCustomerChoseShippingToWithPayment(
         ShippingMethodInterface $shippingMethod,
         AddressInterface $address,
@@ -300,9 +275,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer chose ("[^"]+" shipping method) (to "[^"]+")$/
-     */
+    #[Given('/^the customer chose ("[^"]+" shipping method) (to "[^"]+")$/')]
     public function theCustomerChoseShippingTo(ShippingMethodInterface $shippingMethod, AddressInterface $address): void
     {
         /** @var OrderInterface $order */
@@ -321,10 +294,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer chose ("[^"]+" shipping method) with ("[^"]+" payment)$/
-     * @Given /^I chose ("[^"]+" shipping method) with ("[^"]+" payment)$/
-     */
+    #[Given('/^the customer chose ("[^"]+" shipping method) with ("[^"]+" payment)$/')]
+    #[Given('/^I chose ("[^"]+" shipping method) with ("[^"]+" payment)$/')]
     public function theCustomerChoseShippingWithPayment(
         ShippingMethodInterface $shippingMethod,
         PaymentMethodInterface $paymentMethod,
@@ -338,9 +309,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer chose ("[^"]+" payment)$/
-     */
+    #[Given('/^the customer chose ("[^"]+" payment)$/')]
     public function theCustomerChosePayment(PaymentMethodInterface $paymentMethod): void
     {
         /** @var OrderInterface $order */
@@ -356,10 +325,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the customer bought a single :product
-     * @Given I bought a single :product
-     */
+    #[Given('the customer bought a single :product')]
+    #[Given('I bought a single :product')]
     public function theCustomerBoughtSingleProduct(ProductInterface $product, ?ChannelInterface $channel = null): void
     {
         $variant = $this->getProductVariant($product);
@@ -369,9 +336,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the customer bought another :product with separate :shippingMethod shipment
-     */
+    #[Given('the customer bought another :product with separate :shippingMethod shipment')]
     public function theCustomerBoughtAnotherProductWithSeparateShipment(
         ProductInterface $product,
         ShippingMethodInterface $shippingMethod,
@@ -392,19 +357,15 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/
-     * @Given /^I bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/
-     */
+    #[Given('/^the customer bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/')]
+    #[Given('/^I bought ((?:a|an) "[^"]+") and ((?:a|an) "[^"]+")$/')]
     public function theCustomerBoughtProductAndProduct(ProductInterface $product, ProductInterface $secondProduct): void
     {
         $this->theCustomerBoughtSingleProduct($product);
         $this->theCustomerBoughtSingleProduct($secondProduct);
     }
 
-    /**
-     * @Given /^the customer bought (\d+) ("[^"]+" products)$/
-     */
+    #[Given('/^the customer bought (\d+) ("[^"]+" products)$/')]
     public function theCustomerBoughtSeveralProducts(int $quantity, ProductInterface $product): void
     {
         $variant = $this->getProductVariant($product);
@@ -414,9 +375,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer bought ([^"]+) units of ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[Given('/^the customer bought ([^"]+) units of ("[^"]+" variant of product "[^"]+")$/')]
     public function theCustomerBoughtSeveralVariantsOfProduct(int $quantity, ProductVariantInterface $variant): void
     {
         $this->addProductVariantToOrder($variant, $quantity);
@@ -424,10 +383,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer bought a single ("[^"]+" variant of product "[^"]+")$/
-     * @Given /^the customer also bought a ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[Given('/^the customer bought a single ("[^"]+" variant of product "[^"]+")$/')]
+    #[Given('/^the customer also bought a ("[^"]+" variant of product "[^"]+")$/')]
     public function theCustomerBoughtSingleProductVariant(ProductVariantInterface $productVariant): void
     {
         $this->addProductVariantToOrder($productVariant);
@@ -435,10 +392,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the customer bought a single :product using :coupon coupon
-     * @Given I bought a single :product using :coupon coupon
-     */
+    #[Given('the customer bought a single :product using :coupon coupon')]
+    #[Given('I bought a single :product using :coupon coupon')]
     public function theCustomerBoughtSingleUsing(ProductInterface $product, PromotionCouponInterface $coupon): void
     {
         $variant = $this->getProductVariant($product);
@@ -449,9 +404,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given I used :coupon coupon
-     */
+    #[Given('I used :coupon coupon')]
     public function iUsedCoupon(PromotionCouponInterface $coupon): void
     {
         $order = $this->sharedStorage->get('order');
@@ -478,12 +431,10 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given there is an :orderNumber order with :product product
-     * @Given there is an :orderNumber order with :product product in this channel
-     * @Given there is an :orderNumber order with :product product in :channel channel
-     * @Given there is a :state :orderNumber order with :product product
-     */
+    #[Given('there is an :orderNumber order with :product product')]
+    #[Given('there is an :orderNumber order with :product product in this channel')]
+    #[Given('there is an :orderNumber order with :product product in :channel channel')]
+    #[Given('there is a :state :orderNumber order with :product product')]
     public function thereIsAOrderWithProduct(
         string $orderNumber,
         ProductInterface $product,
@@ -507,9 +458,7 @@ final readonly class OrderContext implements Context
         $this->orderRepository->add($order);
     }
 
-    /**
-     * @Given there is an :orderNumber order with :product product ordered later
-     */
+    #[Given('there is an :orderNumber order with :product product ordered later')]
     public function thereIsAnOrderWithProductOrderedLater(string $orderNumber, ProductInterface $product): void
     {
         sleep(1);
@@ -517,10 +466,9 @@ final readonly class OrderContext implements Context
     }
 
     /**
-     * @Given /^(this customer) has(?:| also) placed (an order "[^"]+") at "([^"]+)"$/
-     *
      * @throws \Exception
      */
+    #[Given('/^(this customer) has(?:| also) placed (an order "[^"]+") at "([^"]+)"$/')]
     public function thisCustomerHasPlacedAnOrderAtDate(CustomerInterface $customer, string $number, string $checkoutCompletedAt): void
     {
         $order = $this->createOrder($customer, $number);
@@ -530,9 +478,7 @@ final readonly class OrderContext implements Context
         $this->orderRepository->add($order);
     }
 
-    /**
-     * @Given /^(this customer) has(?:| also) placed (an order "[^"]+") on a (channel "[^"]+")$/
-     */
+    #[Given('/^(this customer) has(?:| also) placed (an order "[^"]+") on a (channel "[^"]+")$/')]
     public function thisCustomerHasPlacedAnOrderOnAChannel(CustomerInterface $customer, string $number, ChannelInterface $channel): void
     {
         $order = $this->createOrder($customer, $number, $channel);
@@ -542,9 +488,7 @@ final readonly class OrderContext implements Context
         $this->sharedStorage->set('order', $order);
     }
 
-    /**
-     * @Given /^(this customer) has(?:| also) started checkout on a (channel "[^"]+")$/
-     */
+    #[Given('/^(this customer) has(?:| also) started checkout on a (channel "[^"]+")$/')]
     public function thisCustomerHasStartedCheckoutOnAChannel(CustomerInterface $customer, ChannelInterface $channel): void
     {
         $order = $this->createOrder($customer, null, $channel);
@@ -553,9 +497,7 @@ final readonly class OrderContext implements Context
         $this->sharedStorage->set('order', $order);
     }
 
-    /**
-     * @Given /^(customer "[^"]+"|this customer) has(?:| also) placed (\d+) orders on the ("[^"]+" channel) in each buying (\d+) ("[^"]+" products?)$/
-     */
+    #[Given('/^(customer "[^"]+"|this customer) has(?:| also) placed (\d+) orders on the ("[^"]+" channel) in each buying (\d+) ("[^"]+" products?)$/')]
     public function thisCustomerPlacedOrdersOnChannelBuyingProducts(
         CustomerInterface $customer,
         int $orderCount,
@@ -566,9 +508,7 @@ final readonly class OrderContext implements Context
         $this->createOrdersForCustomer($customer, $orderCount, $channel, $productCount, $product);
     }
 
-    /**
-     * @Given /^(customer "[^"]+"|this customer) has(?:| also) fulfilled (\d+) orders placed on the ("[^"]+" channel) in each buying (\d+) ("[^"]+" products?)$/
-     */
+    #[Given('/^(customer "[^"]+"|this customer) has(?:| also) fulfilled (\d+) orders placed on the ("[^"]+" channel) in each buying (\d+) ("[^"]+" products?)$/')]
     public function thisCustomerFulfilledOrdersPlacedOnChannelBuyingProducts(
         CustomerInterface $customer,
         int $orderCount,
@@ -579,9 +519,7 @@ final readonly class OrderContext implements Context
         $this->createOrdersForCustomer($customer, $orderCount, $channel, $productCount, $product, true);
     }
 
-    /**
-     * @Given /^(\d+) new customers have added products to the cart for total of ("[^"]+")$/
-     */
+    #[Given('/^(\d+) new customers have added products to the cart for total of ("[^"]+")$/')]
     public function customersHaveAddedProductsToTheCartForTotalOf(int $numberOfCustomers, int $total): void
     {
         $customers = $this->generateCustomers($numberOfCustomers);
@@ -602,25 +540,19 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^a single customer has placed an order for total of ("[^"]+")$/
-     */
+    #[Given('/^a single customer has placed an order for total of ("[^"]+")$/')]
     public function aSingleCustomerHasPlacedAnOrderForTotalOf(int $total): void
     {
         $this->createOrders(numberOfCustomers: 1, numberOfOrders: 1, total: $total);
     }
 
-    /**
-     * @Given /^(\d+) (?:|more )new customers have placed (\d+) orders for total of ("[^"]+")$/
-     */
+    #[Given('/^(\d+) (?:|more )new customers have placed (\d+) orders for total of ("[^"]+")$/')]
     public function customersHavePlacedOrdersForTotalOf(int $numberOfCustomers, int $numberOfOrders, int $total): void
     {
         $this->createOrders($numberOfCustomers, $numberOfOrders, $total);
     }
 
-    /**
-     * @Given /^(\d+) new customers have fulfilled (\d+) orders placed for total of ("[^"]+")$/
-     */
+    #[Given('/^(\d+) new customers have fulfilled (\d+) orders placed for total of ("[^"]+")$/')]
     public function customersHaveFulfilledOrdersPlacedForTotalOf(
         int $numberOfCustomers,
         int $numberOfOrders,
@@ -629,9 +561,7 @@ final readonly class OrderContext implements Context
         $this->createOrders($numberOfCustomers, $numberOfOrders, $total, true);
     }
 
-    /**
-     * @Given /^(\d+) (?:|more )new customers have placed (\d+) orders for total of ("[^"]+") mostly ("[^"]+" product)$/
-     */
+    #[Given('/^(\d+) (?:|more )new customers have placed (\d+) orders for total of ("[^"]+") mostly ("[^"]+" product)$/')]
     public function customersHavePlacedOrdersForTotalOfMostlyProduct(
         int $numberOfCustomers,
         int $numberOfOrders,
@@ -641,9 +571,7 @@ final readonly class OrderContext implements Context
         $this->createOrdersWithProduct($numberOfCustomers, $numberOfOrders, $total, $product);
     }
 
-    /**
-     * @Given /^(\d+) (?:|more )new customers have fulfilled (\d+) orders placed for total of ("[^"]+") mostly ("[^"]+" product)$/
-     */
+    #[Given('/^(\d+) (?:|more )new customers have fulfilled (\d+) orders placed for total of ("[^"]+") mostly ("[^"]+" product)$/')]
     public function customersHaveFulfilledOrdersPlacedForTotalOfMostlyProduct(
         int $numberOfCustomers,
         int $numberOfOrders,
@@ -653,9 +581,7 @@ final readonly class OrderContext implements Context
         $this->createOrdersWithProduct($numberOfCustomers, $numberOfOrders, $total, $product, true);
     }
 
-    /**
-     * @Given /^(\d+) (?:|more )new customers have paid (\d+) orders placed for total of ("[^"]+")$/
-     */
+    #[Given('/^(\d+) (?:|more )new customers have paid (\d+) orders placed for total of ("[^"]+")$/')]
     public function moreCustomersHavePaidOrdersPlacedForTotalOf(
         int $numberOfCustomers,
         int $numberOfOrders,
@@ -664,9 +590,7 @@ final readonly class OrderContext implements Context
         $this->createPaidOrders($numberOfCustomers, $numberOfOrders, $total);
     }
 
-    /**
-     * @Given /^(this customer) has(?:| also) placed (an order "[^"]+") buying a single ("[^"]+" product) for ("[^"]+") on the ("[^"]+" channel)$/
-     */
+    #[Given('/^(this customer) has(?:| also) placed (an order "[^"]+") buying a single ("[^"]+" product) for ("[^"]+") on the ("[^"]+" channel)$/')]
     public function customerHasPlacedAnOrderBuyingASingleProductForOnTheChannel(
         CustomerInterface $customer,
         string $orderNumber,
@@ -685,10 +609,8 @@ final readonly class OrderContext implements Context
         $this->sharedStorage->set('order', $order);
     }
 
-    /**
-     * @Given /^(this order) is already paid$/
-     * @Given the order :order is already paid
-     */
+    #[Given('/^(this order) is already paid$/')]
+    #[Given('the order :order is already paid')]
     public function thisOrderIsAlreadyPaid(OrderInterface $order): void
     {
         $this->applyPaymentTransitionOnOrder($order, PaymentTransitions::TRANSITION_COMPLETE);
@@ -696,10 +618,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this order) has been refunded$/
-     * @Given the customer has refunded the order with number :order
-     */
+    #[Given('/^(this order) has been refunded$/')]
+    #[Given('the customer has refunded the order with number :order')]
     public function thisOrderHasBeenRefunded(OrderInterface $order): void
     {
         $this->applyPaymentTransitionOnOrder($order, PaymentTransitions::TRANSITION_REFUND);
@@ -707,12 +627,10 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the customer cancelled (this order)$/
-     * @Given /^(this order) was cancelled$/
-     * @Given the order :order was cancelled
-     * @Given /^I cancelled (this order)$/
-     */
+    #[Given('/^the customer cancelled (this order)$/')]
+    #[Given('/^(this order) was cancelled$/')]
+    #[Given('the order :order was cancelled')]
+    #[Given('/^I cancelled (this order)$/')]
     public function theCustomerCancelledThisOrder(OrderInterface $order): void
     {
         $this->stateMachine->apply($order, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_CANCEL);
@@ -720,9 +638,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^I cancelled my last order$/
-     */
+    #[Given('/^I cancelled my last order$/')]
     public function theCustomerCancelledMyLastOrder(): void
     {
         $order = $this->sharedStorage->get('order');
@@ -731,10 +647,8 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this order) has already been shipped$/
-     * @Given the order :order is already shipped
-     */
+    #[Given('/^(this order) has already been shipped$/')]
+    #[Given('the order :order is already shipped')]
     public function thisOrderHasAlreadyBeenShipped(OrderInterface $order): void
     {
         $this->applyShipmentTransitionOnOrder($order, ShipmentTransitions::TRANSITION_SHIP);
@@ -742,9 +656,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @When the customer used coupon :coupon
-     */
+    #[When('the customer used coupon :coupon')]
     public function theCustomerUsedCoupon(PromotionCouponInterface $coupon): void
     {
         /** @var OrderInterface $order */
@@ -754,9 +666,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the order :order has been placed in :localeCode locale
-     */
+    #[Given('the order :order has been placed in :localeCode locale')]
     public function theOrderHasBeenPlacedInLocale(OrderInterface $order, string $localeCode): void
     {
         $order->setLocaleCode($localeCode);
@@ -764,9 +674,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the customer completed the order
-     */
+    #[Given('the customer completed the order')]
     public function theCustomerCompletedTheOrder(): void
     {
         /** @var OrderInterface $order */
@@ -776,9 +684,7 @@ final readonly class OrderContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the :product product's inventory has become tracked with :numberOfItems items
-     */
+    #[Given('the :product product\'s inventory has become tracked with :numberOfItems items')]
     public function theProductSInventoryHasBecameTrackedWithItems(ProductInterface $product, int $numberOfItems): void
     {
         /** @var ProductVariantInterface $productVariant */

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Given;
 use Doctrine\Persistence\ObjectManager;
@@ -51,9 +52,7 @@ final readonly class PaymentContext implements Context
         $this->createPaymentMethod($paymentMethodName, StringInflector::nameToCode($paymentMethodName), 'Offline', 'Payment method', true, $position);
     }
 
-    /**
-     * @Given the store has disabled all payment methods
-     */
+    #[Given('the store has disabled all payment methods')]
     public function theStoreHasDisabledAllPaymentMethods(): void
     {
         $paymentMethods = $this->paymentMethodRepository->findAll();
@@ -66,9 +65,7 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given /^the store allows paying (\w+) for (all channels)$/
-     */
+    #[Given('/^the store allows paying (\w+) for (all channels)$/')]
     public function storeAllowsPayingForAllChannels($paymentMethodName, array $channels): void
     {
         $paymentMethod = $this->createPaymentMethod($paymentMethodName, StringInflector::nameToUppercaseCode($paymentMethodName), 'Offline', 'Payment method', false);
@@ -78,17 +75,13 @@ final readonly class PaymentContext implements Context
         }
     }
 
-    /**
-     * @Given the store has (also) a payment method :paymentMethodName with a code :paymentMethodCode
-     */
+    #[Given('the store has (also) a payment method :paymentMethodName with a code :paymentMethodCode')]
     public function theStoreHasAPaymentMethodWithACode(string $paymentMethodName, string $paymentMethodCode): void
     {
         $this->createPaymentMethod($paymentMethodName, $paymentMethodCode, 'Offline');
     }
 
-    /**
-     * @Given /^(this payment method) is named "([^"]+)" in the "([^"]+)" locale$/
-     */
+    #[Given('/^(this payment method) is named "([^"]+)" in the "([^"]+)" locale$/')]
     public function thisPaymentMethodIsNamedIn(PaymentMethodInterface $paymentMethod, $name, $locale): void
     {
         /** @var PaymentMethodTranslationInterface $translation */
@@ -111,11 +104,9 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given the payment method :paymentMethod is disabled
-     * @Given /^(this payment method) (?:has been|is) disabled$/
-     * @When the payment method :paymentMethod gets disabled
-     */
+    #[Given('the payment method :paymentMethod is disabled')]
+    #[Given('/^(this payment method) (?:has been|is) disabled$/')]
+    #[When('the payment method :paymentMethod gets disabled')]
     public function theStoreHasAPaymentMethodDisabled(PaymentMethodInterface $paymentMethod): void
     {
         $paymentMethod->disable();
@@ -123,9 +114,7 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given /^(it) has instructions "([^"]+)"$/
-     */
+    #[Given('/^(it) has instructions "([^"]+)"$/')]
     public function itHasInstructions(PaymentMethodInterface $paymentMethod, $instructions): void
     {
         $paymentMethod->setInstructions($instructions);
@@ -133,17 +122,13 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given the store has :paymentMethodName payment method not assigned to any channel
-     */
+    #[Given('the store has :paymentMethodName payment method not assigned to any channel')]
     public function theStoreHasPaymentMethodNotAssignedToAnyChannel(string $paymentMethodName): void
     {
         $this->createPaymentMethod($paymentMethodName, 'PM_' . $paymentMethodName, 'Offline', 'Payment method', false);
     }
 
-    /**
-     * @Given the payment method :paymentMethod requires authorization before capturing
-     */
+    #[Given('the payment method :paymentMethod requires authorization before capturing')]
     public function thePaymentMethodRequiresAuthorizationBeforeCapturing(PaymentMethodInterface $paymentMethod): void
     {
         /** @var GatewayConfigInterface $config */
@@ -154,9 +139,7 @@ final readonly class PaymentContext implements Context
         $this->paymentMethodManager->flush();
     }
 
-    /**
-     * @Given the store allows paying with :paymentMethodName in :channel channel
-     */
+    #[Given('the store allows paying with :paymentMethodName in :channel channel')]
     public function theStoreAllowsPayingWithInChannel(string $paymentMethodName, ChannelInterface $channel): void
     {
         $paymentMethod = $this->createPaymentMethod(

--- a/src/Sylius/Behat/Context/Setup/PaymentRequestContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentRequestContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Bundle\ApiBundle\Command\Payment\AddPaymentRequest;
@@ -34,9 +35,7 @@ final readonly class PaymentRequestContext implements Context
     ) {
     }
 
-    /**
-     * @Given the payment request action :action has been executed for order :order with the payment method :paymentMethod
-     */
+    #[Given('the payment request action :action has been executed for order :order with the payment method :paymentMethod')]
     public function thePaymentRequestActionHasBeenExecutedForOrderWithThePaymentMethod(
         string $action,
         OrderInterface $order,
@@ -52,9 +51,7 @@ final readonly class PaymentRequestContext implements Context
         $this->commandBus->dispatch($addPaymentRequest);
     }
 
-    /**
-     * @Given there is (also) a :state :action payment request for order :order using the :paymentMethod payment method
-     */
+    #[Given('there is (also) a :state :action payment request for order :order using the :paymentMethod payment method')]
     public function thePaymentRequestActionHasBeenExecutedForOrderWithThePaymentMethodAndState(
         string $state,
         string $action,

--- a/src/Sylius/Behat/Context/Setup/PriceHistoryContext.php
+++ b/src/Sylius/Behat/Context/Setup/PriceHistoryContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
@@ -30,9 +31,7 @@ final class PriceHistoryContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^on "([^"]+)" (its) price changed to ("[^"]+")$/
-     */
+    #[Given('/^on "([^"]+)" (its) price changed to ("[^"]+")$/')]
     public function onDayItsPriceChangedTo(string $date, ProductInterface $product, int $price): void
     {
         $this->calendarContext->itIsNow($date);
@@ -44,9 +43,7 @@ final class PriceHistoryContext implements Context
         $this->channelPricingManager->flush();
     }
 
-    /**
-     * @Given /^on "([^"]+)" (its) original price changed to ("[^"]+")$/
-     */
+    #[Given('/^on "([^"]+)" (its) original price changed to ("[^"]+")$/')]
     public function onDayItsOriginalPriceChangedTo(string $date, ProductInterface $product, int $originalPrice): void
     {
         $this->calendarContext->itIsNow($date);
@@ -58,9 +55,7 @@ final class PriceHistoryContext implements Context
         $this->channelPricingManager->flush();
     }
 
-    /**
-     * @Given /^on "([^"]+)" (its) price changed to ("[^"]+") and original price to ("[^"]+")$/
-     */
+    #[Given('/^on "([^"]+)" (its) price changed to ("[^"]+") and original price to ("[^"]+")$/')]
     public function onDayItsOriginalPriceChangedToAndOriginalPriceTo(string $date, ProductInterface $product, int $price, int $originalPrice): void
     {
         $this->calendarContext->itIsNow($date);
@@ -73,9 +68,7 @@ final class PriceHistoryContext implements Context
         $this->channelPricingManager->flush();
     }
 
-    /**
-     * @Given /^on "([^"]+)" (its) original price has been removed$/
-     */
+    #[Given('/^on "([^"]+)" (its) original price has been removed$/')]
     public function onDayItsOriginalPriceHasBeenRemoved(string $date, ProductInterface $product): void
     {
         $this->calendarContext->itIsNow($date);

--- a/src/Sylius/Behat/Context/Setup/ProductAssociationContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAssociationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -37,18 +38,14 @@ final class ProductAssociationContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has (also) a product association type :name
-     * @Given the store has (also) a product association type :name with a code :code
-     */
+    #[Given('the store has (also) a product association type :name')]
+    #[Given('the store has (also) a product association type :name with a code :code')]
     public function theStoreHasAProductAssociationType($name, $code = null)
     {
         $this->createProductAssociationType($name, $code);
     }
 
-    /**
-     * @Given /^the store has(?:| also) a product association type named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^the store has(?:| also) a product association type named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/')]
     public function itHasVariantNamedInAndIn($firstName, $firstLocale, $secondName, $secondLocale)
     {
         $productAssociationType = $this->createProductAssociationType($firstName);
@@ -61,9 +58,7 @@ final class ProductAssociationContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the store has :firstName and :secondName product association types
-     */
+    #[Given('the store has :firstName and :secondName product association types')]
     public function theStoreHasProductAssociationTypes(...$names)
     {
         foreach ($names as $name) {
@@ -71,17 +66,13 @@ final class ProductAssociationContext implements Context
         }
     }
 
-    /**
-     * @Given the store has :firstName product association type
-     */
+    #[Given('the store has :firstName product association type')]
     public function theStoreHasProductAssociationType($name)
     {
         $this->createProductAssociationType($name);
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| also) an (association "[^"]+") with (product "[^"]+")$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| also) an (association "[^"]+") with (product "[^"]+")$/')]
     public function theProductHasAnAssociationWithProduct(
         ProductInterface $product,
         ProductAssociationTypeInterface $productAssociationType,
@@ -90,9 +81,7 @@ final class ProductAssociationContext implements Context
         $this->createProductAssociation($product, $productAssociationType, [$associatedProduct]);
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| also) an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| also) an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/')]
     public function theProductHasAnAssociationWithProducts(
         ProductInterface $product,
         ProductAssociationTypeInterface $productAssociationType,

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
@@ -43,9 +45,7 @@ final class ProductAttributeContext implements Context
         $this->faker = Factory::create();
     }
 
-    /**
-     * @Given the store has a :type product attribute :name with code :code
-     */
+    #[Given('the store has a :type product attribute :name with code :code')]
     public function theStoreHasAProductAttributeWithCode($type, $name, $code)
     {
         $productAttribute = $this->createProductAttribute($type, $name, $code);
@@ -53,9 +53,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given the store has( also) a :type product attribute :name at position :position
-     */
+    #[Given('the store has( also) a :type product attribute :name at position :position')]
     public function theStoreHasAProductAttributeWithPosition($type, $name, $position)
     {
         $productAttribute = $this->createProductAttribute($type, $name);
@@ -64,9 +62,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given /^the store has(?:| also)(?:| a| an) (text|textarea|integer|percent|float) product attribute "([^"]+)"$/
-     */
+    #[Given('/^the store has(?:| also)(?:| a| an) (text|textarea|integer|percent|float) product attribute "([^"]+)"$/')]
     public function theStoreHasAProductAttribute(string $type, string $name): void
     {
         $productAttribute = $this->createProductAttribute($type, $name);
@@ -74,9 +70,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given /^the store has(?:| also)(?:| a| an) non-translatable (text|textarea|integer|percent|float) product attribute "([^"]+)"$/
-     */
+    #[Given('/^the store has(?:| also)(?:| a| an) non-translatable (text|textarea|integer|percent|float) product attribute "([^"]+)"$/')]
     public function theStoreHasANonTranslatableProductAttribute(string $type, string $name): void
     {
         $productAttribute = $this->createProductAttribute($type, $name, null, false);
@@ -84,9 +78,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given /^(this product attribute) is not translatable$/
-     */
+    #[Given('/^(this product attribute) is not translatable$/')]
     public function thisProductAttributeIsNotTranslatable(ProductAttributeInterface $productAttribute): void
     {
         $productAttribute->setTranslatable(false);
@@ -94,9 +86,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product attribute) has(?:| also) a value "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product attribute) has(?:| also) a value "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisProductAttributeHasAValueInLocale(
         ProductAttributeInterface $productAttribute,
         string $value,
@@ -115,9 +105,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given /^(this product attribute) has(?:| also) a value "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product attribute) has(?:| also) a value "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisProductAttributeHasAValueInLocaleAndInLocale(
         ProductAttributeInterface $productAttribute,
         string $firstValue,
@@ -139,18 +127,14 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given the store has a select product attribute :name
-     */
+    #[Given('the store has a select product attribute :name')]
     public function theStoreHasASelectProductAttribute(string $name): void
     {
         $this->theStoreHasASelectProductAttributeWithValue($name);
     }
 
-    /**
-     * @Given the store has a select product attribute :name with value :value
-     * @Given the store has a select product attribute :name with values :firstValue and :secondValue
-     */
+    #[Given('the store has a select product attribute :name with value :value')]
+    #[Given('the store has a select product attribute :name with values :firstValue and :secondValue')]
     public function theStoreHasASelectProductAttributeWithValue(string $name, string ...$values): void
     {
         $choices = [];
@@ -169,9 +153,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given the store has a non-translatable select product attribute :name with value :value
-     */
+    #[Given('the store has a non-translatable select product attribute :name with value :value')]
     public function theStoreHasANonTranslatableSelectProductAttributeWithValue(string $name, string $value): void
     {
         $choices[$this->faker->uuid] = ['en_US' => $value];
@@ -188,9 +170,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given the store has a non-translatable date product attribute :name with format :format
-     */
+    #[Given('the store has a non-translatable date product attribute :name with format :format')]
     public function theStoreHasANonTranslatableDateProductAttributeWithFormat(string $name, string $format): void
     {
         $productAttribute = $this->createProductAttribute(DateAttributeType::TYPE, $name);
@@ -202,9 +182,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given the store has a non-translatable datetime product attribute :name with format :format
-     */
+    #[Given('the store has a non-translatable datetime product attribute :name with format :format')]
     public function theStoreHasANonTranslatableDatetimeProductAttributeWithFormat(string $name, string $format): void
     {
         $productAttribute = $this->createProductAttribute(DatetimeAttributeType::TYPE, $name);
@@ -216,9 +194,7 @@ final class ProductAttributeContext implements Context
         $this->saveProductAttribute($productAttribute);
     }
 
-    /**
-     * @Given /^(this product attribute)'s "([^"]+)" value is labeled "([^"]+)" in the ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product attribute)\'s "([^"]+)" value is labeled "([^"]+)" in the ("[^"]+" locale)$/')]
     public function thisProductAttributeValueIsLabeledInTheLocale(
         ProductAttributeInterface $attribute,
         string $value,
@@ -255,9 +231,7 @@ final class ProductAttributeContext implements Context
         ));
     }
 
-    /**
-     * @Given /^(this product attribute) has set min value as (\d+) and max value as (\d+)$/
-     */
+    #[Given('/^(this product attribute) has set min value as (\d+) and max value as (\d+)$/')]
     public function thisAttributeHasSetMinValueAsAndMaxValueAs(ProductAttributeInterface $attribute, $min, $max)
     {
         $attribute->setConfiguration(['min' => $min, 'max' => $max]);
@@ -265,10 +239,8 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with value "([^"]+)"$/
-     * @Given /^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with values "([^"]+)" and "([^"]+)"$/
-     */
+    #[Given('/^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with value "([^"]+)"$/')]
+    #[Given('/^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with values "([^"]+)" and "([^"]+)"$/')]
     public function thisProductHasSelectAttributeWithValues(
         ProductInterface $product,
         string $productAttributeName,
@@ -277,9 +249,7 @@ final class ProductAttributeContext implements Context
         $this->createSelectProductAttributeValue($product, $productAttributeName, $productAttributeValues);
     }
 
-    /**
-     * @Given /^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with value "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product) has(?:| also)(?:| a) select attribute "([^"]+)" with value "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisProductHasSelectAttributeWithValueInLocale(
         ProductInterface $product,
         string $productAttributeName,
@@ -289,10 +259,8 @@ final class ProductAttributeContext implements Context
         $this->createSelectProductAttributeValue($product, $productAttributeName, [$productAttributeValue], $localeCode);
     }
 
-    /**
-     * @Given /^(this product) has a (text|textarea) attribute "([^"]+)" with value "([^"]+)"$/
-     * @Given /^(this product) has a (text|textarea) attribute "([^"]+)" with value "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product) has a (text|textarea) attribute "([^"]+)" with value "([^"]+)"$/')]
+    #[Given('/^(this product) has a (text|textarea) attribute "([^"]+)" with value "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisProductHasAttributeWithValue(
         ProductInterface $product,
         string $productAttributeType,
@@ -307,9 +275,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has non-translatable (text|textarea) attribute "([^"]+)" with value "([^"]+)"$/
-     */
+    #[Given('/^(this product) has non-translatable (text|textarea) attribute "([^"]+)" with value "([^"]+)"$/')]
     public function thisProductHasNonTranslatableTextAttributeWithValue(
         ProductInterface $product,
         string $productAttributeType,
@@ -324,9 +290,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has a percent attribute "([^"]+)" with value ([^"]+)%$/
-     */
+    #[Given('/^(this product) has a percent attribute "([^"]+)" with value ([^"]+)%$/')]
     public function thisProductHasPercentAttributeWithValue(ProductInterface $product, $productAttributeName, $value)
     {
         $attribute = $this->provideProductAttribute('percent', $productAttributeName);
@@ -336,9 +300,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has non-translatable percent attribute "([^"]+)" with value ([^"]+)%$/
-     */
+    #[Given('/^(this product) has non-translatable percent attribute "([^"]+)" with value ([^"]+)%$/')]
     public function thisProductHasNonTranslatablePercentAttributeWithValue(ProductInterface $product, string $productAttributeName, int $value): void
     {
         $attribute = $this->provideProductAttribute('percent', $productAttributeName);
@@ -348,9 +310,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has a "([^"]+)" attribute "([^"]+)" set to "([^"]+)"$/
-     */
+    #[Given('/^(this product) has a "([^"]+)" attribute "([^"]+)" set to "([^"]+)"$/')]
     public function thisProductHasCheckboxAttributeWithValue(
         ProductInterface $product,
         $productAttributeType,
@@ -365,9 +325,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has non-translatable "([^"]+)" attribute "([^"]+)" set to "([^"]+)"$/
-     */
+    #[Given('/^(this product) has non-translatable "([^"]+)" attribute "([^"]+)" set to "([^"]+)"$/')]
     public function thisProductHasNonTranslatableCheckboxAttributeWithValue(
         ProductInterface $product,
         string $productAttributeType,
@@ -382,9 +340,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has percent attribute "([^"]+)" at position (\d+)$/
-     */
+    #[Given('/^(this product) has percent attribute "([^"]+)" at position (\d+)$/')]
     public function thisProductHasPercentAttributeWithValueAtPosition(
         ProductInterface $product,
         $productAttributeName,
@@ -399,9 +355,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has a ([^"]+) attribute "([^"]+)" with date "([^"]+)"$/
-     */
+    #[Given('/^(this product) has a ([^"]+) attribute "([^"]+)" with date "([^"]+)"$/')]
     public function thisProductHasDateTimeAttributeWithDate(
         ProductInterface $product,
         $productAttributeType,
@@ -416,9 +370,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has non-translatable ([^"]+) attribute "([^"]+)" with date "([^"]+)"$/
-     */
+    #[Given('/^(this product) has non-translatable ([^"]+) attribute "([^"]+)" with date "([^"]+)"$/')]
     public function thisProductHasNonTranslatableDateTimeAttributeWithDate(
         ProductInterface $product,
         string $productAttributeType,
@@ -433,9 +385,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @When /^(this product attribute)'s value changed from "([^"]+)" to "([^"]+)"$/
-     */
+    #[When('/^(this product attribute)\'s value changed from "([^"]+)" to "([^"]+)"$/')]
     public function thisAttributeValueChangedFromTo(
         ProductAttributeInterface $attribute,
         string $from,
@@ -460,9 +410,7 @@ final class ProductAttributeContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @When /^(this product attribute)'s value "([^"]+)" has been removed$/
-     */
+    #[When('/^(this product attribute)\'s value "([^"]+)" has been removed$/')]
     public function thisAttributeValueHasBeenRemoved(
         ProductAttributeInterface $attribute,
         string $value,

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -98,9 +98,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") belonging to the ("[^"]+" taxon)$/
-     */
+    #[Given('/^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") belonging to the ("[^"]+" taxon)$/')]
     public function storeHasAProductPricedAtBelongingToTheTaxon(
         string $productName,
         int $price,
@@ -112,10 +110,8 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the store(?:| also) has a product "([^"]+)" belonging to the ("[^"]+" taxon)$/
-     * @Given /^the store(?:| also) has a product "([^"]+)" belonging to (this taxon)$/
-     */
+    #[Given('/^the store(?:| also) has a product "([^"]+)" belonging to the ("[^"]+" taxon)$/')]
+    #[Given('/^the store(?:| also) has a product "([^"]+)" belonging to (this taxon)$/')]
     public function storeHasAProductBelongingToTheTaxon(
         string $productName,
         TaxonInterface $taxon,
@@ -126,9 +122,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the store(?:| also) has a product "([^"]+)" in the ("[^"]+" taxon) at (\d+)(?:st|nd|rd|th) position$/
-     */
+    #[Given('/^the store(?:| also) has a product "([^"]+)" in the ("[^"]+" taxon) at (\d+)(?:st|nd|rd|th) position$/')]
     public function theStoreHasAProductInTheTaxonAtPosition(
         string $productName,
         TaxonInterface $taxon,
@@ -142,9 +136,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given the store has :numberOfProducts products
-     */
+    #[Given('the store has :numberOfProducts products')]
     public function storeHasMoreProducts(int $numberOfProducts): void
     {
         for ($i = 0; $i < $numberOfProducts; ++$i) {
@@ -154,9 +146,7 @@ final readonly class ProductContext implements Context
         }
     }
 
-    /**
-     * @Given /^(this product) is originally priced at ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is originally priced at ("[^"]+") in ("[^"]+" channel)$/')]
     public function thisProductHasOriginallyPriceInChannel(
         ProductInterface $product,
         int $originalPrice,
@@ -172,9 +162,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) is(?:| also) priced at ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is(?:| also) priced at ("[^"]+") in ("[^"]+" channel)$/')]
     public function thisProductIsAlsoPricedAtInChannel(ProductInterface $product, int $price, ChannelInterface $channel)
     {
         $product->addChannel($channel);
@@ -188,29 +176,23 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) is(?:| also) available in ("[^"]+" channel)$/
-     * @Given /^(this product) is(?:| also) available in the ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is(?:| also) available in ("[^"]+" channel)$/')]
+    #[Given('/^(this product) is(?:| also) available in the ("[^"]+" channel)$/')]
     public function thisProductIsAlsoAvailableInChannel(ProductInterface $product, ChannelInterface $channel): void
     {
         $this->thisProductIsAlsoPricedAtInChannel($product, 0, $channel);
     }
 
-    /**
-     * @Given /^(this product) is(?:| also) unavailable in ("[^"]+" channel)$/
-     * @Given /^(this product) is disabled in ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is(?:| also) unavailable in ("[^"]+" channel)$/')]
+    #[Given('/^(this product) is disabled in ("[^"]+" channel)$/')]
     public function thisProductIsAlsoUnavailableInChannel(ProductInterface $product, ChannelInterface $channel): void
     {
         $product->removeChannel($channel);
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the store( also) has a product :productName with code :code
-     * @Given the store( also) has a product :productName with code :code, created at :date
-     */
+    #[Given('the store( also) has a product :productName with code :code')]
+    #[Given('the store( also) has a product :productName with code :code, created at :date')]
     public function storeHasProductWithCode($productName, $code, $date = 'now')
     {
         $product = $this->createProduct($productName);
@@ -220,9 +202,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") available in (channel "[^"]+") and (channel "[^"]+")$/
-     */
+    #[Given('/^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") available in (channel "[^"]+") and (channel "[^"]+")$/')]
     public function storeHasAProductPricedAtAvailableInChannels($productName, int $price = 100, ...$channels)
     {
         $product = $this->createProduct($productName, $price);
@@ -239,10 +219,8 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) is named "([^"]+)" (in the "([^"]+)" locale)$/
-     * @Given /^the (product "[^"]+") is named "([^"]+)" (in the "([^"]+)" locale)$/
-     */
+    #[Given('/^(this product) is named "([^"]+)" (in the "([^"]+)" locale)$/')]
+    #[Given('/^the (product "[^"]+") is named "([^"]+)" (in the "([^"]+)" locale)$/')]
     public function thisProductIsNamedIn(ProductInterface $product, $name, $locale)
     {
         $this->addProductTranslation($product, $name, $locale);
@@ -250,9 +228,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has no translation in the "([^"]+)" locale$/
-     */
+    #[Given('/^(this product) has no translation in the "([^"]+)" locale$/')]
     public function thisProductHasNoTranslationIn(ProductInterface $product, $locale): void
     {
         $product->removeTranslation($product->getTranslation($locale));
@@ -260,9 +236,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the store has a product named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^the store has a product named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/')]
     public function theStoreHasProductNamedInAndIn($firstName, $firstLocale, $secondName, $secondLocale)
     {
         $product = $this->createProduct($firstName);
@@ -275,10 +249,8 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the store has(?:| a| an) "([^"]+)" configurable product$/
-     * @Given /^the store has(?:| a| an) "([^"]+)" configurable product with "([^"]+)" slug$/
-     */
+    #[Given('/^the store has(?:| a| an) "([^"]+)" configurable product$/')]
+    #[Given('/^the store has(?:| a| an) "([^"]+)" configurable product with "([^"]+)" slug$/')]
     public function storeHasAConfigurableProduct($productName, $slug = null)
     {
         /** @var ChannelInterface|null $channel */
@@ -306,11 +278,9 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given the store has( also) :firstProductName and :secondProductName products
-     * @Given the store has( also) :firstProductName, :secondProductName and :thirdProductName products
-     * @Given the store has( also) :firstProductName, :secondProductName, :thirdProductName and :fourthProductName products
-     */
+    #[Given('the store has( also) :firstProductName and :secondProductName products')]
+    #[Given('the store has( also) :firstProductName, :secondProductName and :thirdProductName products')]
+    #[Given('the store has( also) :firstProductName, :secondProductName, :thirdProductName and :fourthProductName products')]
     public function theStoreHasProducts(...$productsNames)
     {
         foreach ($productsNames as $productName) {
@@ -318,12 +288,10 @@ final readonly class ProductContext implements Context
         }
     }
 
-    /**
-     * @Given /^(this channel) has "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" products$/
-     * @Given /^the ("[^"]+" channel) has a product "([^"]+)"$/
-     * @Given /^the ("[^"]+" channel) has "([^"]+)" and "([^"]+)" products$/
-     * @Given /^the ("[^"]+" channel) has "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" products$/
-     */
+    #[Given('/^(this channel) has "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" products$/')]
+    #[Given('/^the ("[^"]+" channel) has a product "([^"]+)"$/')]
+    #[Given('/^the ("[^"]+" channel) has "([^"]+)" and "([^"]+)" products$/')]
+    #[Given('/^the ("[^"]+" channel) has "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" products$/')]
     public function thisChannelHasProducts(ChannelInterface $channel, ...$productsNames)
     {
         foreach ($productsNames as $productName) {
@@ -333,11 +301,9 @@ final readonly class ProductContext implements Context
         }
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| a) "([^"]+)" variant priced at ("[^"]+")$/
-     * @Given /^(this product)(?:| also) has "([^"]+)" variant priced at ("[^"]+")$/
-     * @Given /^(this product) has "([^"]+)" variant priced at ("[^"]+") in ("([^"]+)" channel)$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| a) "([^"]+)" variant priced at ("[^"]+")$/')]
+    #[Given('/^(this product)(?:| also) has "([^"]+)" variant priced at ("[^"]+")$/')]
+    #[Given('/^(this product) has "([^"]+)" variant priced at ("[^"]+") in ("([^"]+)" channel)$/')]
     public function theProductHasVariantPricedAt(
         ProductInterface $product,
         $productVariantName,
@@ -353,10 +319,8 @@ final readonly class ProductContext implements Context
         );
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| a) "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/
-     * @Given /^(this product) has "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| a) "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/')]
+    #[Given('/^(this product) has "([^"]+)" variant priced at ("[^"]+") configured with ("[^"]+" option value)$/')]
     public function theProductHasVariantPricedAtConfiguredWithOptionValue(
         ProductInterface $product,
         string $productVariantName,
@@ -373,9 +337,7 @@ final readonly class ProductContext implements Context
         );
     }
 
-    /**
-     * @Given /^("[^"]+" variant) priced at ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[Given('/^("[^"]+" variant) priced at ("[^"]+") in ("[^"]+" channel)$/')]
     public function variantPricedAtInChannel(
         ProductVariantInterface $productVariant,
         int $price,
@@ -386,9 +348,7 @@ final readonly class ProductContext implements Context
         $this->sharedStorage->set('variant', $productVariant);
     }
 
-    /**
-     * @Given /^("[^"]+" variant) is originally priced at ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[Given('/^("[^"]+" variant) is originally priced at ("[^"]+") in ("[^"]+" channel)$/')]
     public function variantIsOriginalPricedAtInChannel(
         ProductVariantInterface $productVariant,
         int $originalPrice,
@@ -399,9 +359,7 @@ final readonly class ProductContext implements Context
         $channelPricing->setOriginalPrice($originalPrice);
     }
 
-    /**
-     * @Given /^the ("[^"]+" variant) has minimum price of ("[^"]+") in the ("[^"]+" channel)$/
-     */
+    #[Given('/^the ("[^"]+" variant) has minimum price of ("[^"]+") in the ("[^"]+" channel)$/')]
     public function variantHasMinimumPriceInChannel(
         ProductVariantInterface $productVariant,
         int $minimumPrice,
@@ -412,12 +370,10 @@ final readonly class ProductContext implements Context
         $channelPricing->setMinimumPrice($minimumPrice);
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| a| an) "([^"]+)" variant$/
-     * @Given /^(this product) has(?:| a| an) "([^"]+)" variant$/
-     * @Given /^(this product) has "([^"]+)" and "([^"]+)" variants$/
-     * @Given /^(this product) has "([^"]+)", "([^"]+)" and "([^"]+)" variants$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| a| an) "([^"]+)" variant$/')]
+    #[Given('/^(this product) has(?:| a| an) "([^"]+)" variant$/')]
+    #[Given('/^(this product) has "([^"]+)" and "([^"]+)" variants$/')]
+    #[Given('/^(this product) has "([^"]+)", "([^"]+)" and "([^"]+)" variants$/')]
     public function theProductHasVariants(ProductInterface $product, ...$variantNames)
     {
         $channel = $this->sharedStorage->get('channel');
@@ -433,11 +389,9 @@ final readonly class ProductContext implements Context
         }
     }
 
-    /**
-     * @Given /^the (product "[^"]+")(?:| also) has a nameless variant with code "([^"]+)"$/
-     * @Given /^(this product)(?:| also) has a nameless variant with code "([^"]+)"$/
-     * @Given /^(it)(?:| also) has a nameless variant with code "([^"]+)"$/
-     */
+    #[Given('/^the (product "[^"]+")(?:| also) has a nameless variant with code "([^"]+)"$/')]
+    #[Given('/^(this product)(?:| also) has a nameless variant with code "([^"]+)"$/')]
+    #[Given('/^(it)(?:| also) has a nameless variant with code "([^"]+)"$/')]
     public function theProductHasNamelessVariantWithCode(ProductInterface $product, $variantCode)
     {
         $channel = $this->sharedStorage->get('channel');
@@ -445,11 +399,9 @@ final readonly class ProductContext implements Context
         $this->createProductVariant($product, null, 0, $variantCode, $channel);
     }
 
-    /**
-     * @Given /^the (product "[^"]+")(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/
-     * @Given /^(this product)(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/
-     * @Given /^(it)(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/
-     */
+    #[Given('/^the (product "[^"]+")(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/')]
+    #[Given('/^(this product)(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/')]
+    #[Given('/^(it)(?:| also) has(?:| a| an) "([^"]+)" variant with code "([^"]+)"$/')]
     public function theProductHasVariantWithCode(ProductInterface $product, $variantName, $variantCode)
     {
         $channel = $this->sharedStorage->get('channel');
@@ -457,9 +409,7 @@ final readonly class ProductContext implements Context
         $this->createProductVariant($product, $variantName, 0, $variantCode, $channel);
     }
 
-    /**
-     * @Given /^(this product) has "([^"]+)" variant priced at ("[^"]+") which does not require shipping$/
-     */
+    #[Given('/^(this product) has "([^"]+)" variant priced at ("[^"]+") which does not require shipping$/')]
     public function theProductHasVariantWhichDoesNotRequireShipping(
         ProductInterface $product,
         $productVariantName,
@@ -476,11 +426,9 @@ final readonly class ProductContext implements Context
         );
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has(?:| also)(?:| a| an) "([^"]+)" variant$/
-     * @Given /^the (product "[^"]+") has(?:| also)(?:| a| an) "([^"]+)" variant at position ([^"]+)$/
-     * @Given /^(this product) has(?:| also)(?:| a| an) "([^"]+)" variant at position ([^"]+)$/
-     */
+    #[Given('/^the (product "[^"]+") has(?:| also)(?:| a| an) "([^"]+)" variant$/')]
+    #[Given('/^the (product "[^"]+") has(?:| also)(?:| a| an) "([^"]+)" variant at position ([^"]+)$/')]
+    #[Given('/^(this product) has(?:| also)(?:| a| an) "([^"]+)" variant at position ([^"]+)$/')]
     public function theProductHasVariantAtPosition(
         ProductInterface $product,
         $productVariantName,
@@ -496,9 +444,7 @@ final readonly class ProductContext implements Context
         );
     }
 
-    /**
-     * @Given /^(this variant) is also priced at ("[^"]+") in ("([^"]+)" channel)$/
-     */
+    #[Given('/^(this variant) is also priced at ("[^"]+") in ("([^"]+)" channel)$/')]
     public function thisVariantIsAlsoPricedAtInChannel(ProductVariantInterface $productVariant, int $price, ChannelInterface $channel)
     {
         $channelPricing = $productVariant->getChannelPricingForChannel($channel);
@@ -515,9 +461,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it|this product) has(?:| also) variant named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(it|this product) has(?:| also) variant named "([^"]+)" in ("[^"]+" locale) and "([^"]+)" in ("[^"]+" locale)$/')]
     public function itHasVariantNamedInAndIn(ProductInterface $product, $firstName, $firstLocale, $secondName, $secondLocale)
     {
         $productVariant = $this->createProductVariant(
@@ -536,9 +480,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it|this product)(?:| also) has a variant named "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Given('/^(it|this product)(?:| also) has a variant named "([^"]+)" in ("[^"]+" locale)$/')]
     public function itHasVariantNamedIn(ProductInterface $product, string $name, string $locale): void
     {
         $productVariant = $this->createProductVariant(
@@ -554,9 +496,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this variant) has no translation in ("[^"]+" locale)$/
-     */
+    #[Given('/^(this variant) has no translation in ("[^"]+" locale)$/')]
     public function thisVariantHasNoTranslationIn(ProductVariantInterface $productVariant, string $locale): void
     {
         $translation = $productVariant->getTranslation($locale);
@@ -569,9 +509,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has "([^"]+)" variant priced at ("[^"]+") identified by "([^"]+)"$/
-     */
+    #[Given('/^(this product) has "([^"]+)" variant priced at ("[^"]+") identified by "([^"]+)"$/')]
     public function theProductHasVariantPricedAtIdentifiedBy(
         ProductInterface $product,
         $productVariantName,
@@ -581,9 +519,7 @@ final readonly class ProductContext implements Context
         $this->createProductVariant($product, $productVariantName, $price, $code, $this->sharedStorage->get('channel'));
     }
 
-    /**
-     * @Given /^(this product) only variant was renamed to "([^"]+)"$/
-     */
+    #[Given('/^(this product) only variant was renamed to "([^"]+)"$/')]
     public function productOnlyVariantWasRenamed(ProductInterface $product, $variantName)
     {
         Assert::true($product->isSimple());
@@ -595,10 +531,8 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^there is product "([^"]+)" available in ((?:this|that|"[^"]+") channel)$/
-     * @Given /^the store has a product "([^"]+)" available in ("([^"]+)" channel)$/
-     */
+    #[Given('/^there is product "([^"]+)" available in ((?:this|that|"[^"]+") channel)$/')]
+    #[Given('/^the store has a product "([^"]+)" available in ("([^"]+)" channel)$/')]
     public function thereIsProductAvailableInGivenChannel($productName, ChannelInterface $channel)
     {
         $product = $this->createProduct(productName: $productName, channel: $channel);
@@ -606,10 +540,8 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^([^"]+) belongs to ("[^"]+" tax category)$/
-     * @Given the product :product belongs to :taxCategory tax category
-     */
+    #[Given('/^([^"]+) belongs to ("[^"]+" tax category)$/')]
+    #[Given('the product :product belongs to :taxCategory tax category')]
     public function productBelongsToTaxCategory(ProductInterface $product, TaxCategoryInterface $taxCategory)
     {
         /** @var ProductVariantInterface $variant */
@@ -619,9 +551,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it) comes in the following variations:$/
-     */
+    #[Given('/^(it) comes in the following variations:$/')]
     public function itComesInTheFollowingVariations(ProductInterface $product, TableNode $table)
     {
         $channel = $this->sharedStorage->get('channel');
@@ -644,9 +574,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^("[^"]+" variant of product "[^"]+") belongs to ("[^"]+" tax category)$/
-     */
+    #[Given('/^("[^"]+" variant of product "[^"]+") belongs to ("[^"]+" tax category)$/')]
     public function productVariantBelongsToTaxCategory(
         ProductVariantInterface $productVariant,
         TaxCategoryInterface $taxCategory,
@@ -657,18 +585,14 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has option "([^"]+)" with values "([^"]+)" and "([^"]+)"$/
-     * @Given /^(this product) has option "([^"]+)" with values "([^"]+)", "([^"]+)" and "([^"]+)"$/
-     */
+    #[Given('/^(this product) has option "([^"]+)" with values "([^"]+)" and "([^"]+)"$/')]
+    #[Given('/^(this product) has option "([^"]+)" with values "([^"]+)", "([^"]+)" and "([^"]+)"$/')]
     public function thisProductHasOptionWithValues(ProductInterface $product, $optionName, ...$values): void
     {
         $this->addOptionToProduct($product, $optionName, $values);
     }
 
-    /**
-     * @Given /^(this product) has an option "([^"]*)" without any values$/
-     */
+    #[Given('/^(this product) has an option "([^"]*)" without any values$/')]
     public function thisProductHasAnOptionWithoutAnyValues(ProductInterface $product, string $optionName): void
     {
         $this->addOptionToProduct($product, $optionName, []);
@@ -680,17 +604,13 @@ final readonly class ProductContext implements Context
         $this->updateOnHand($product, $quantity);
     }
 
-    /**
-     * @Given /^there (?:is|are) (\d+) unit(?:|s) of tracked (product "([^"]+)") available in the inventory$/
-     */
+    #[Given('/^there (?:is|are) (\d+) unit(?:|s) of tracked (product "([^"]+)") available in the inventory$/')]
     public function thereIsQuantityOfTrackedProductAvailableInTheInventory(int $quantity, ProductInterface $product): void
     {
         $this->updateOnHand($product, $quantity, true);
     }
 
-    /**
-     * @Given /^the (product "([^"]+)") is out of stock$/
-     */
+    #[Given('/^the (product "([^"]+)") is out of stock$/')]
     public function theProductIsOutOfStock(ProductInterface $product): void
     {
         $this->updateOnHand($product, 0, true);
@@ -717,25 +637,19 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) is available in "([^"]+)" ([^"]+) priced at ("[^"]+")$/
-     */
+    #[Given('/^(this product) is available in "([^"]+)" ([^"]+) priced at ("[^"]+")$/')]
     public function thisProductIsAvailableInSize(ProductInterface $product, string $optionValueName, string $optionName, int $price): void
     {
         $this->createProductVariantWithOption($product, $optionName, $optionValueName, $price);
     }
 
-    /**
-     * @Given /^(this product) with "([^"]+)" option "([^"]+)" is priced at ("[^"]+")$/
-     */
+    #[Given('/^(this product) with "([^"]+)" option "([^"]+)" is priced at ("[^"]+")$/')]
     public function thisProductWithOptionIsPricedAt(ProductInterface $product, string $optionName, string $optionValueName, int $price): void
     {
         $this->createProductVariantWithOption($product, $optionName, $optionValueName, $price);
     }
 
-    /**
-     * @Given the :product product's :optionValueName size belongs to :shippingCategory shipping category
-     */
+    #[Given('the :product product\'s :optionValueName size belongs to :shippingCategory shipping category')]
     public function thisProductSizeBelongsToShippingCategory(ProductInterface $product, $optionValueName, ShippingCategoryInterface $shippingCategory)
     {
         $code = sprintf('%s_%s', $product->getCode(), $optionValueName);
@@ -748,10 +662,8 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has (this product option)$/
-     * @Given /^(this product) has (?:a|an) ("[^"]+" option)$/
-     */
+    #[Given('/^(this product) has (this product option)$/')]
+    #[Given('/^(this product) has (?:a|an) ("[^"]+" option)$/')]
     public function thisProductHasThisProductOption(ProductInterface $product, ProductOptionInterface $option)
     {
         $product->addOption($option);
@@ -759,9 +671,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has all possible variants$/
-     */
+    #[Given('/^(this product) has all possible variants$/')]
     public function thisProductHasAllPossibleVariants(ProductInterface $product)
     {
         try {
@@ -792,9 +702,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^there are ([^"]+) units of ("[^"]+" variant of product "[^"]+") available in the inventory$/
-     */
+    #[Given('/^there are ([^"]+) units of ("[^"]+" variant of product "[^"]+") available in the inventory$/')]
     public function thereAreItemsOfProductInVariantAvailableInTheInventory($quantity, ProductVariantInterface $productVariant)
     {
         $productVariant->setTracked(true);
@@ -803,9 +711,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" product variant) is tracked by the inventory$/
-     */
+    #[Given('/^the ("[^"]+" product variant) is tracked by the inventory$/')]
     public function theProductVariantIsTrackedByTheInventory(ProductVariantInterface $productVariant)
     {
         $productVariant->setTracked(true);
@@ -813,11 +719,9 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product)'s price is ("[^"]+")$/
-     * @Given /^the (product "[^"]+") changed its price to ("[^"]+")$/
-     * @Given /^(this product) price has been changed to ("[^"]+")$/
-     */
+    #[Given('/^(this product)\'s price is ("[^"]+")$/')]
+    #[Given('/^the (product "[^"]+") changed its price to ("[^"]+")$/')]
+    #[Given('/^(this product) price has been changed to ("[^"]+")$/')]
     public function theProductChangedItsPriceTo(ProductInterface $product, int $price): void
     {
         /** @var false|ProductInterface $productVariant */
@@ -833,9 +737,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product)'s weight is (\d+(?:\.\d+)?)$/
-     */
+    #[Given('/^(this product)\'s weight is (\d+(?:\.\d+)?)$/')]
     public function theProductChangedItsWeightTo(ProductInterface $product, float $weight): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -845,9 +747,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product)'s price in ("[^"]+" channel) is ("[^"]+")$/
-     */
+    #[Given('/^(this product)\'s price in ("[^"]+" channel) is ("[^"]+")$/')]
     public function theProductPriceInChannelIs(ProductInterface $product, ChannelInterface $channel, int $price)
     {
         /** @var ProductVariantInterface $productVariant */
@@ -858,27 +758,21 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
-     * @Given /^the ("[^"]+" product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
-     * @Given /^(it)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/
-     */
+    #[Given('/^(this product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/')]
+    #[Given('/^the ("[^"]+" product)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/')]
+    #[Given('/^(it)(?:| also) has an image "([^"]+)" with "([^"]+)" type$/')]
     public function thisProductHasAnImageWithType(ProductInterface $product, $imagePath, $imageType)
     {
         $this->createProductImage($product, $imagePath, $imageType);
     }
 
-    /**
-     * @Given /^(this product) has an image "([^"]+)" with "([^"]+)" type at position (\d+)$/
-     */
+    #[Given('/^(this product) has an image "([^"]+)" with "([^"]+)" type at position (\d+)$/')]
     public function thisProductHasAnImageWithTypeAtPosition(ProductInterface $product, string $imagePath, string $imageType, int $position): void
     {
         $this->createProductImage($product, $imagePath, $imageType, null, $position);
     }
 
-    /**
-     * @Given /^(this product) has an image "([^"]+)" with "([^"]+)" type at position (\d+) for ("[^"]+" variant)$/
-     */
+    #[Given('/^(this product) has an image "([^"]+)" with "([^"]+)" type at position (\d+) for ("[^"]+" variant)$/')]
     public function thisProductHasAnImageWithTypeForVariant(
         ProductInterface $product,
         string $imagePath,
@@ -889,30 +783,24 @@ final readonly class ProductContext implements Context
         $this->createProductImage($product, $imagePath, $imageType, $variant, $position);
     }
 
-    /**
-     * @Given /^(this product) belongs to ("([^"]+)" shipping category)$/
-     * @Given product :product belongs to :shippingCategory shipping category
-     * @Given product :product shipping category has been changed to :shippingCategory
-     */
+    #[Given('/^(this product) belongs to ("([^"]+)" shipping category)$/')]
+    #[Given('product :product belongs to :shippingCategory shipping category')]
+    #[Given('product :product shipping category has been changed to :shippingCategory')]
     public function thisProductBelongsToShippingCategory(ProductInterface $product, ShippingCategoryInterface $shippingCategory)
     {
         $product->getVariants()->first()->setShippingCategory($shippingCategory);
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) has been disabled$/
-     * @Given the product :product has been disabled
-     */
+    #[Given('/^(this product) has been disabled$/')]
+    #[Given('the product :product has been disabled')]
     public function thisProductHasBeenDisabled(ProductInterface $product): void
     {
         $product->disable();
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product was renamed to :productName
-     */
+    #[Given('the product :product was renamed to :productName')]
     public function theProductWasRenamedTo(ProductInterface $product, string $productName): void
     {
         $product->setName($productName);
@@ -920,9 +808,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) does not require shipping$/
-     */
+    #[Given('/^(this product) does not require shipping$/')]
     public function thisProductDoesNotRequireShipping(ProductInterface $product): void
     {
         /** @var ProductVariantInterface $variant */
@@ -933,9 +819,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given product's :product code is :code
-     */
+    #[Given('product\'s :product code is :code')]
     public function productCodeIs(ProductInterface $product, string $code): void
     {
         $product->setCode($code);
@@ -943,9 +827,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has height :height, width :width, depth :depth, weight :weight
-     */
+    #[Given('the product :product has height :height, width :width, depth :depth, weight :weight')]
     public function productHasDimensions(ProductInterface $product, float $height, float $width, float $depth, float $weight): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -958,9 +840,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has the slug :slug
-     */
+    #[Given('the product :product has the slug :slug')]
     public function productHasSlug(ProductInterface $product, string $slug): void
     {
         $product->setSlug($slug);
@@ -968,9 +848,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the description of product :product is :description
-     */
+    #[Given('the description of product :product is :description')]
     public function descriptionOfProductIs(ProductInterface $product, string $description): void
     {
         $product->setDescription($description);
@@ -978,9 +856,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the meta keywords of product :product is :metaKeywords
-     */
+    #[Given('the meta keywords of product :product is :metaKeywords')]
     public function metaKeywordsOfProductIs(ProductInterface $product, string $metaKeywords): void
     {
         $product->getTranslation()->setMetaKeywords($metaKeywords);
@@ -988,9 +864,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the short description of product :product is :shortDescription
-     */
+    #[Given('the short description of product :product is :shortDescription')]
     public function shortDescriptionOfProductIs(ProductInterface $product, string $shortDescription): void
     {
         $product->getTranslation()->setShortDescription($shortDescription);
@@ -998,9 +872,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has original price :originalPrice
-     */
+    #[Given('the product :product has original price :originalPrice')]
     public function theProductHasOriginalPrice(ProductInterface $product, string $originalPrice): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -1013,9 +885,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has option :productOption named :optionValue with code :optionCode
-     */
+    #[Given('the product :product has option :productOption named :optionValue with code :optionCode')]
     public function productHasOption(
         ProductInterface $product,
         ProductOption $productOption,
@@ -1033,9 +903,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has :productVariantName variant with code :code, price :price, current stock :currentStock
-     */
+    #[Given('the product :product has :productVariantName variant with code :code, price :price, current stock :currentStock')]
     public function productHasVariant(ProductInterface $product, string $productVariantName, string $code, string $price, int $currentStock): void
     {
         /** @var ChannelInterface $channel */
@@ -1045,9 +913,7 @@ final readonly class ProductContext implements Context
         $this->createProductVariant($product, $productVariantName, $priceValue, $code, $channel, null, true, $currentStock);
     }
 
-    /**
-     * @Given /^the ("[^"]+" product variant) has original price at ("[^"]+")$/
-     */
+    #[Given('/^the ("[^"]+" product variant) has original price at ("[^"]+")$/')]
     public function productVariantHasOriginalPrice(ProductVariantInterface $productVariant, int $price): void
     {
         /** @var ChannelInterface $channel */
@@ -1057,10 +923,8 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the store has a product :productName in channel :channel
-     * @Given the store also has a product :productName in channel :channel
-     */
+    #[Given('the store has a product :productName in channel :channel')]
+    #[Given('the store also has a product :productName in channel :channel')]
     public function theStoreHasAProductWithChannel(string $productName, ChannelInterface $channel): void
     {
         $product = $this->createProduct($productName, 0, $channel);
@@ -1068,9 +932,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the ("[^"]+" product variant) is enabled$/
-     */
+    #[Given('/^the ("[^"]+" product variant) is enabled$/')]
     public function theProductVariantIsEnabled(ProductVariantInterface $productVariant): void
     {
         $productVariant->setEnabled(true);
@@ -1078,9 +940,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("([^"]*)" product variant) is disabled$/
-     */
+    #[Given('/^the ("([^"]*)" product variant) is disabled$/')]
     public function theProductVariantIsDisabled(ProductVariantInterface $productVariant): void
     {
         $productVariant->setEnabled(false);
@@ -1088,9 +948,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("([^"]*)" product) is enabled$/
-     */
+    #[Given('/^the ("([^"]*)" product) is enabled$/')]
     public function theProductIsEnabled(ProductInterface $product): void
     {
         $product->setEnabled(true);
@@ -1103,9 +961,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("([^"]*)" product) is disabled$/
-     */
+    #[Given('/^the ("([^"]*)" product) is disabled$/')]
     public function theProductIsDisabled(ProductInterface $product): void
     {
         $product->setEnabled(false);
@@ -1118,9 +974,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(products "[^"]+" and "[^"]+") are disabled$/
-     */
+    #[Given('/^(products "[^"]+" and "[^"]+") are disabled$/')]
     public function productsAreDisabled(array $products): void
     {
         foreach ($products as $product) {
@@ -1128,9 +982,7 @@ final readonly class ProductContext implements Context
         }
     }
 
-    /**
-     * @Given /^all (the product) variants with the "([^"]*)" ([^\s]+) are disabled$/
-     */
+    #[Given('/^all (the product) variants with the "([^"]*)" ([^\s]+) are disabled$/')]
     public function allTheProductVariantsWithTheColorAreDisabled(
         ProductInterface $product,
         string $optionValue,
@@ -1150,10 +1002,8 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]*" \w+ \/ "[^"]*" \w+ variant of product "[^"]*") is disabled$/
-     * @Given /^(this variant) has been disabled$/
-     */
+    #[Given('/^the ("[^"]*" \w+ \/ "[^"]*" \w+ variant of product "[^"]*") is disabled$/')]
+    #[Given('/^(this variant) has been disabled$/')]
     public function theSizeColorVariantOfThisProductIsDisabled(ProductVariantInterface $productVariant): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -1163,9 +1013,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^all variants of (this product) are disabled$/
-     */
+    #[Given('/^all variants of (this product) are disabled$/')]
     public function allVariantsOfThisProductAreDisabled(ProductInterface $product): void
     {
         foreach ($product->getVariants() as $variant) {
@@ -1175,9 +1023,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this product) is available in ("[^"]+" channel) and ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is available in ("[^"]+" channel) and ("[^"]+" channel)$/')]
     public function thisProductIsAvailableInChannels(ProductInterface $product, ChannelInterface ...$channels): void
     {
         foreach ($channels as $channel) {
@@ -1187,18 +1033,14 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) is not available in ("[^"]+" channel)$/
-     */
+    #[Given('/^(this product) is not available in ("[^"]+" channel)$/')]
     public function thisProductIsNotAvailableInChannel(ProductInterface $product, ChannelInterface $channel): void
     {
         $product->removeChannel($channel);
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) is configured with the option matching selection method$/
-     */
+    #[Given('/^(this product) is configured with the option matching selection method$/')]
     public function thisProductIsConfiguredWithTheOptionMatchingSelectionMethod(ProductInterface $product): void
     {
         $product->setVariantSelectionMethod(ProductInterface::VARIANT_SELECTION_MATCH);
@@ -1206,9 +1048,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) has all possible variants priced at ("[^"]+") with indexed names$/
-     */
+    #[Given('/^(this product) has all possible variants priced at ("[^"]+") with indexed names$/')]
     public function thisProductHasAllPossibleVariantsPricedAtWithIndexedNames(
         ProductInterface $product,
         int $price,
@@ -1242,9 +1082,7 @@ final readonly class ProductContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" product) is now priced at ("[^"]+") and originally priced at ("[^"]+")$/
-     */
+    #[Given('/^the ("[^"]+" product) is now priced at ("[^"]+") and originally priced at ("[^"]+")$/')]
     public function theProductIsPricedAtAndOriginallyPricedAt(
         ProductInterface $product,
         int $price,
@@ -1258,9 +1096,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^the (product "[^"]+") has a "([^"]+)" variant priced at ("[^"]+") and originally priced at ("[^"]+")$/
-     */
+    #[Given('/^the (product "[^"]+") has a "([^"]+)" variant priced at ("[^"]+") and originally priced at ("[^"]+")$/')]
     public function theProductHasVariantPricedAtAndOriginallyPricedAt(
         ProductInterface $product,
         string $productVariantName,
@@ -1288,9 +1124,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product)'s price changed to ("[^"]+")$/
-     */
+    #[Given('/^(this product)\'s price changed to ("[^"]+")$/')]
     public function thisProductsPriceChangedTo(ProductInterface $product, int $price): void
     {
         $channelPricing = $this->getChannelPricingFromProduct($product);
@@ -1299,9 +1133,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product)'s price changed to ("[^"]+") and original price changed to ("[^"]+")$/
-     */
+    #[Given('/^(this product)\'s price changed to ("[^"]+") and original price changed to ("[^"]+")$/')]
     public function thisProductsPriceChangedToAndOriginalPriceChangedTo(
         ProductInterface $product,
         int $price,
@@ -1315,9 +1147,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this variant)'s price changed to ("[^"]+") and original price changed to ("[^"]+")$/
-     */
+    #[Given('/^(this variant)\'s price changed to ("[^"]+") and original price changed to ("[^"]+")$/')]
     public function thisVariantsPriceChangedToAndOriginalPriceChangedTo(
         ProductVariantInterface $productVariant,
         int $price,
@@ -1334,9 +1164,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product)'s price changed to ("[^"]+") and original price was removed$/
-     */
+    #[Given('/^(this product)\'s price changed to ("[^"]+") and original price was removed$/')]
     public function thisProductsPriceChangedToAndOriginalPriceWasRemoved(ProductInterface $product, $price): void
     {
         $channelPricing = $this->getChannelPricingFromProduct($product);
@@ -1362,9 +1190,7 @@ final readonly class ProductContext implements Context
         return $channelPricing;
     }
 
-    /**
-     * @Given /^(this product) has no slug in the ("[^"]+" locale)$/
-     */
+    #[Given('/^(this product) has no slug in the ("[^"]+" locale)$/')]
     public function thisProductHasNoSlugInTheLocale(ProductInterface $product, string $localeCode): void
     {
         $productTranslation = $product->getTranslation($localeCode);
@@ -1373,9 +1199,7 @@ final readonly class ProductContext implements Context
         $this->saveProduct($product);
     }
 
-    /**
-     * @Given /^(this product) has no translations with a defined slug$/
-     */
+    #[Given('/^(this product) has no translations with a defined slug$/')]
     public function thisProductHasNoTranslationsWithADefinedSlug(ProductInterface $product): void
     {
         /** @var ProductTranslationInterface $productTranslation */

--- a/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -33,10 +34,8 @@ final class ProductOptionContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has (also) a product option :name
-     * @Given the store has a product option :name with a code :code
-     */
+    #[Given('the store has (also) a product option :name')]
+    #[Given('the store has a product option :name with a code :code')]
     public function theStoreHasAProductOptionWithACode(string $name, ?string $code = null): void
     {
         $productOption = $this->createProductOption($name, $code);
@@ -44,17 +43,13 @@ final class ProductOptionContext implements Context
         $this->sharedStorage->set('product_option', $productOption);
     }
 
-    /**
-     * @Given /^the store has(?:| also) a product option "([^"]+)" at position ([^"]+)$/
-     */
+    #[Given('/^the store has(?:| also) a product option "([^"]+)" at position ([^"]+)$/')]
     public function theStoreHasAProductOptionAtPosition($name, $position)
     {
         $this->createProductOption($name, null, $position);
     }
 
-    /**
-     * @Given /^(this product option) has(?:| also) the "([^"]+)" option value with code "([^"]+)"$/
-     */
+    #[Given('/^(this product option) has(?:| also) the "([^"]+)" option value with code "([^"]+)"$/')]
     public function thisProductOptionHasTheOptionValueWithCode(
         ProductOptionInterface $productOption,
         $productOptionValueName,

--- a/src/Sylius/Behat/Context/Setup/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductReviewContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -33,9 +34,7 @@ final class ProductReviewContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^(this product) has one review from (customer "[^"]+")$/
-     */
+    #[Given('/^(this product) has one review from (customer "[^"]+")$/')]
     public function productHasAReview(ProductInterface $product, CustomerInterface $customer): void
     {
         $review = $this->createProductReview($product, 'Title', 5, 'Comment', $customer);
@@ -43,10 +42,8 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product) has(?:| also) a review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/
-     * @Given /^(this product) has(?:| also) an accepted review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/
-     */
+    #[Given('/^(this product) has(?:| also) a review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/')]
+    #[Given('/^(this product) has(?:| also) an accepted review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/')]
     public function thisProductHasAnAcceptedReviewTitledAndRatedAddedByCustomer(
         ProductInterface $product,
         string $title,
@@ -63,9 +60,7 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product) has(?:| also) a rejected review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/
-     */
+    #[Given('/^(this product) has(?:| also) a rejected review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/')]
     public function thisProductHasARejectedReviewTitledAndRatedAddedByCustomer(
         ProductInterface $product,
         string $title,
@@ -82,9 +77,7 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product) has(?:| also) a new review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/
-     */
+    #[Given('/^(this product) has(?:| also) a new review titled "([^"]+)" and rated (\d+) added by (customer "[^"]+")(?:|, created (\d+) days ago)$/')]
     public function thisProductHasANewReviewTitledAndRatedAddedByCustomer(
         ProductInterface $product,
         string $title,
@@ -101,9 +94,7 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product) has(?:| also) a review titled "([^"]+)" and rated (\d+) with a comment "([^"]+)" added by (customer "[^"]+")$/
-     */
+    #[Given('/^(this product) has(?:| also) a review titled "([^"]+)" and rated (\d+) with a comment "([^"]+)" added by (customer "[^"]+")$/')]
     public function thisProductHasAReviewTitledAndRatedWithACommentAddedByCustomer(
         ProductInterface $product,
         string $title,
@@ -116,10 +107,8 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product)(?:| also) has accepted reviews rated (\d+), (\d+), (\d+), (\d+) and (\d+)$/
-     * @Given /^(this product)(?:| also) has accepted reviews rated (\d+), (\d+) and (\d+)$/
-     */
+    #[Given('/^(this product)(?:| also) has accepted reviews rated (\d+), (\d+), (\d+), (\d+) and (\d+)$/')]
+    #[Given('/^(this product)(?:| also) has accepted reviews rated (\d+), (\d+) and (\d+)$/')]
     public function thisProductHasAcceptedReviewsRated(ProductInterface $product, int ...$rates): void
     {
         $customer = $this->sharedStorage->get('customer');
@@ -129,9 +118,7 @@ final class ProductReviewContext implements Context
         }
     }
 
-    /**
-     * @Given /^(this product)(?:| also) has review rated (\d+) which is not accepted yet$/
-     */
+    #[Given('/^(this product)(?:| also) has review rated (\d+) which is not accepted yet$/')]
     public function itAlsoHasReviewRatedWhichIsNotAcceptedYet(ProductInterface $product, int $rate): void
     {
         $customer = $this->sharedStorage->get('customer');
@@ -139,9 +126,7 @@ final class ProductReviewContext implements Context
         $this->productReviewRepository->add($review);
     }
 
-    /**
-     * @Given /^(this product) also has review rated (\d+) which is rejected$/
-     */
+    #[Given('/^(this product) also has review rated (\d+) which is rejected$/')]
     public function itAlsoHasReviewRatedWhichIsRejected(ProductInterface $product, int $rate): void
     {
         $customer = $this->sharedStorage->get('customer');

--- a/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -28,12 +29,10 @@ final class ProductTaxonContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I assigned (this product) to ("[^"]+" taxon)$/
-     * @Given /^(it|this product) (belongs to "[^"]+")$/
-     * @Given /^(this product) is in ("[^"]+" taxon) at (\d)(?:st|nd|rd|th) position$/
-     * @Given the product :product belongs to taxon :taxon
-     */
+    #[Given('/^I assigned (this product) to ("[^"]+" taxon)$/')]
+    #[Given('/^(it|this product) (belongs to "[^"]+")$/')]
+    #[Given('/^(this product) is in ("[^"]+" taxon) at (\d)(?:st|nd|rd|th) position$/')]
+    #[Given('the product :product belongs to taxon :taxon')]
     public function itBelongsTo(ProductInterface $product, TaxonInterface $taxon, $position = null)
     {
         $productTaxon = $this->createProductTaxon($taxon, $product, (int) $position - 1);
@@ -43,9 +42,7 @@ final class ProductTaxonContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it|this product) (belongs to "[^"]+" and "[^"]+")$/
-     */
+    #[Given('/^(it|this product) (belongs to "[^"]+" and "[^"]+")$/')]
     public function itBelongsToAnd(ProductInterface $product, iterable $taxons)
     {
         foreach ($taxons as $taxon) {
@@ -57,10 +54,8 @@ final class ProductTaxonContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the product :product has a main taxon :taxon
-     * @Given /^(this product) has a main (taxon "[^"]+")$/
-     */
+    #[Given('the product :product has a main taxon :taxon')]
+    #[Given('/^(this product) has a main (taxon "[^"]+")$/')]
     public function productHasMainTaxon(ProductInterface $product, TaxonInterface $taxon): void
     {
         $product->setMainTaxon($taxon);

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -83,9 +83,7 @@ final readonly class PromotionContext implements Context
         ));
     }
 
-    /**
-     * @Given /^there is a promotion "([^"]+)" with "Has at least one from taxons" rule (configured with "[^"]+" and "[^"]+")$/
-     */
+    #[Given('/^there is a promotion "([^"]+)" with "Has at least one from taxons" rule (configured with "[^"]+" and "[^"]+")$/')]
     public function thereIsAPromotionWithHasAtLeastOneFromTaxonsRuleConfiguredWith(string $name, iterable $taxons): void
     {
         $taxonCodes = array_map(fn (TaxonInterface $taxon) => $taxon->getCode(), iterator_to_array($taxons));
@@ -103,9 +101,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^there is a promotion "([^"]+)" with "Total price of items from taxon" rule configured with ("[^"]+" taxon) and (?:€|£|\$)([^"]+) amount for ("[^"]+" channel)$/
-     */
+    #[Given('/^there is a promotion "([^"]+)" with "Total price of items from taxon" rule configured with ("[^"]+" taxon) and (?:€|£|\$)([^"]+) amount for ("[^"]+" channel)$/')]
     public function thereIsAPromotionWithTotalPriceOfItemsFromTaxonRuleConfiguredWithTaxonAndAmountForChannel(
         string $name,
         TaxonInterface $taxon,
@@ -127,9 +123,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^there is a promotion "([^"]+)" with "Contains product" rule with (products "[^"]+" and "[^"]+")$/
-     */
+    #[Given('/^there is a promotion "([^"]+)" with "Contains product" rule with (products "[^"]+" and "[^"]+")$/')]
     public function thereIsAPromotionWithContainsProductRuleConfiguredWithProducts(string $name, array $products): void
     {
         $rules = [];
@@ -148,9 +142,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^there is a promotion "([^"]+)" with "Contains product" rule with (product "[^"]+")$/
-     */
+    #[Given('/^there is a promotion "([^"]+)" with "Contains product" rule with (product "[^"]+")$/')]
     public function thereIsAPromotionWithContainsProductRuleConfiguredWithProduct(
         string $name,
         ProductInterface $product,
@@ -169,9 +161,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^there is an exclusive promotion "([^"]+)"(?:| with priority (\d+))$/
-     */
+    #[Given('/^there is an exclusive promotion "([^"]+)"(?:| with priority (\d+))$/')]
     public function thereIsAnExclusivePromotionWithPriority(string $promotionName, int $priority = 0): void
     {
         $this->createPromotion(
@@ -183,9 +173,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given there is a promotion :promotionName limited to :usageLimit usages
-     */
+    #[Given('there is a promotion :promotionName limited to :usageLimit usages')]
     public function thereIsPromotionLimitedToUsages(string $promotionName, int $usageLimit): void
     {
         $this->createPromotion(
@@ -196,10 +184,8 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given the store has a promotion :promotionName with a coupon :couponCode that is limited to :usageLimit usages
-     */
     #[Given('the store has promotion :promotionName with coupon :couponCode')]
+    #[Given('the store has a promotion :promotionName with a coupon :couponCode that is limited to :usageLimit usages')]
     public function thereIsPromotionWithCoupon(string $promotionName, string $couponCode, ?int $usageLimit = null): void
     {
         $promotion = $this->createPromotion(
@@ -229,9 +215,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^(this promotion) has "([^"]+)", "([^"]+)" and "([^"]+)" coupons/
-     */
+    #[Given('/^(this promotion) has "([^"]+)", "([^"]+)" and "([^"]+)" coupons/')]
     public function thisPromotionHasCoupons(PromotionInterface $promotion, string ...$couponCodes): void
     {
         foreach ($couponCodes as $couponCode) {
@@ -244,9 +228,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) does not apply on discounted products$/
-     */
+    #[Given('/^(this promotion) does not apply on discounted products$/')]
     public function thisPromotionDoesNotApplyOnDiscountedProducts(PromotionInterface $promotion): void
     {
         $promotion->setAppliesToDiscounted(false);
@@ -254,9 +236,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) has already expired$/
-     */
+    #[Given('/^(this promotion) has already expired$/')]
     public function thisPromotionHasExpired(PromotionInterface $promotion): void
     {
         $promotion->setEndsAt(new \DateTime('1 day ago'));
@@ -264,9 +244,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) is valid until tomorrow$/
-     */
+    #[Given('/^(this promotion) is valid until tomorrow$/')]
     public function thisPromotionIsValidUntilTomorrow(PromotionInterface $promotion): void
     {
         $promotion->setEndsAt(new \DateTime('tomorrow'));
@@ -274,9 +252,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) started yesterday$/
-     */
+    #[Given('/^(this promotion) started yesterday$/')]
     public function thisPromotionStartedYesterday(PromotionInterface $promotion): void
     {
         $promotion->setStartsAt(new \DateTime('1 day ago'));
@@ -284,9 +260,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) starts tomorrow$/
-     */
+    #[Given('/^(this promotion) starts tomorrow$/')]
     public function thisPromotionStartsTomorrow(PromotionInterface $promotion): void
     {
         $promotion->setStartsAt(new \DateTime('tomorrow'));
@@ -294,9 +268,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the promotion :promotion is archived
-     */
+    #[Given('the promotion :promotion is archived')]
     public function thisPromotionIsArchived(PromotionInterface $promotion): void
     {
         $promotion->setArchivedAt(new \DateTime());
@@ -304,9 +276,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) has already expired$/
-     */
+    #[Given('/^(this coupon) has already expired$/')]
     public function thisCouponHasExpired(PromotionCouponInterface $coupon): void
     {
         $coupon->setExpiresAt(new \DateTime('1 day ago'));
@@ -322,9 +292,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) is set as non reusable after cancelling the order in which it has been used$/
-     */
+    #[Given('/^(this coupon) is set as non reusable after cancelling the order in which it has been used$/')]
     public function thisIsSetAsNonReusableAfterCancellingTheOrderInWhichItHasBeenUsed(PromotionCouponInterface $coupon): void
     {
         $coupon->setReusableFromCancelledOrders(false);
@@ -332,9 +300,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) has already reached its usage limit$/
-     */
+    #[Given('/^(this coupon) has already reached its usage limit$/')]
     public function thisCouponHasReachedItsUsageLimit(PromotionCouponInterface $coupon): void
     {
         $coupon->setUsed(42);
@@ -343,10 +309,8 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) can be used (\d+) times?$/
-     * @Given /^(this coupon) can be used once$/
-     */
+    #[Given('/^(this coupon) can be used (\d+) times?$/')]
+    #[Given('/^(this coupon) can be used once$/')]
     public function thisCouponCanBeUsedNTimes(PromotionCouponInterface $coupon, int $usageLimit = 1): void
     {
         $coupon->setUsageLimit($usageLimit);
@@ -354,9 +318,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) can be used once per customer$/
-     */
+    #[Given('/^(this coupon) can be used once per customer$/')]
     public function thisCouponCanBeUsedOncePerCustomer(PromotionCouponInterface $coupon): void
     {
         $coupon->setPerCustomerUsageLimit(1);
@@ -372,9 +334,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) has coupon "([^"]+)"$/
-     */
+    #[Given('/^(this promotion) has coupon "([^"]+)"$/')]
     public function thisPromotionHasCoupon(PromotionInterface $promotion, string $couponCode): void
     {
         $coupon = $this->createCoupon($couponCode);
@@ -385,10 +345,8 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) can be used (\d+) times? per customer$/
-     * @Given /^(this coupon) has no per customer usage limit$/
-     */
+    #[Given('/^(this coupon) can be used (\d+) times? per customer$/')]
+    #[Given('/^(this coupon) has no per customer usage limit$/')]
     public function thisCouponCanBeUsedTimesPerCustomer(PromotionCouponInterface $coupon, ?int $usageLimit = null): void
     {
         $coupon->setPerCustomerUsageLimit($usageLimit);
@@ -396,9 +354,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) can be used (\d+) times per customer with overall usage limit of (\d+)$/
-     */
+    #[Given('/^(this coupon) can be used (\d+) times per customer with overall usage limit of (\d+)$/')]
     public function thisCouponCanBeUsedTimesPerCustomerWithOverallUsageLimitOf(
         PromotionCouponInterface $coupon,
         int $perCustomerUsageLimit,
@@ -408,9 +364,7 @@ final readonly class PromotionContext implements Context
         $this->thisCouponCanBeUsedNTimes($coupon, $overallUsageLimit);
     }
 
-    /**
-     * @Given /^(this coupon) has been used (\d+) times?$/
-     */
+    #[Given('/^(this coupon) has been used (\d+) times?$/')]
     public function thisCouponHasBeenUsedTimes(PromotionCouponInterface $coupon, int $used): void
     {
         $coupon->setUsed($used);
@@ -418,9 +372,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this coupon) expires (on "[^"]+")$/
-     */
+    #[Given('/^(this coupon) expires (on "[^"]+")$/')]
     public function thisCouponExpiresOn(PromotionCouponInterface $coupon, \DateTimeInterface $date): void
     {
         $coupon->setExpiresAt($date);
@@ -434,9 +386,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order in the ("[^"]+" channel) and ("(?:€|£|\$)[^"]+") discount to every order in the ("[^"]+" channel)$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") discount to every order in the ("[^"]+" channel) and ("(?:€|£|\$)[^"]+") discount to every order in the ("[^"]+" channel)$/')]
     public function thisPromotionGivesDiscountToEveryOrderInTheChannelAndDiscountToEveryOrderInTheChannel(
         PromotionInterface $promotion,
         int $firstChannelDiscount,
@@ -454,9 +404,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) gives ("(?:€|£|\$)[^"]+") off on every product in the ("[^"]+" channel) and ("(?:€|£|\$)[^"]+") off in the ("[^"]+" channel)$/
-     */
+    #[Given('/^(this promotion) gives ("(?:€|£|\$)[^"]+") off on every product in the ("[^"]+" channel) and ("(?:€|£|\$)[^"]+") off in the ("[^"]+" channel)$/')]
     public function thisPromotionGivesFixedDiscountOnEveryProductInTheChannelAndInTheChannel(
         PromotionInterface $promotion,
         int $firstAmount,
@@ -474,9 +422,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) gives ("[^"]+%") off on every product in the ("[^"]+" channel) and ("[^"]+%") off in the ("[^"]+" channel)$/
-     */
+    #[Given('/^(this promotion) gives ("[^"]+%") off on every product in the ("[^"]+" channel) and ("[^"]+%") off in the ("[^"]+" channel)$/')]
     public function thisPromotionGivesPercentageDiscountOnEveryProductInTheChannelAndInTheChannel(
         PromotionInterface $promotion,
         float $firstPercentage,
@@ -523,9 +469,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") discount to every order with items total at least ("[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") discount to every order with items total at least ("[^"]+")$/')]
     public function itGivesPercentageDiscountToEveryOrderWithItemsTotalAtLeast(
         PromotionInterface $promotion,
         float $discount,
@@ -558,9 +502,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^([^"]+) gives free shipping to every order$/
-     */
+    #[Given('/^([^"]+) gives free shipping to every order$/')]
     public function thePromotionGivesFreeShippingToEveryOrder(PromotionInterface $promotion): void
     {
         $this->itGivesPercentageDiscountOnShippingToEveryOrder($promotion, 1);
@@ -593,9 +535,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitFixedPromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product with maximum price at ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off on every product with maximum price at ("(?:€|£|\$)[^"]+")$/')]
     public function thisPromotionGivesOffOnEveryProductWithMaximumPriceAt(
         PromotionInterface $promotion,
         int $discount,
@@ -669,9 +609,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+" or "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off if order contains products (classified as "[^"]+" or "[^"]+")$/')]
     public function thePromotionGivesOffIfOrderContainsProductsClassifiedAsOr(
         PromotionInterface $promotion,
         int $discount,
@@ -697,9 +635,7 @@ final readonly class PromotionContext implements Context
         $this->createFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("(?:€|£|\$)[^"]+") off customer's (\d)(?:st|nd|rd|th) order$/
-     */
+    #[Given('/^([^"]+) gives ("(?:€|£|\$)[^"]+") off customer\'s (\d)(?:st|nd|rd|th) order$/')]
     public function itGivesFixedOffCustomersNthOrder(PromotionInterface $promotion, int $discount, int $nth): void
     {
         $rule = $this->ruleFactory->createNthOrder($nth);
@@ -715,9 +651,7 @@ final readonly class PromotionContext implements Context
         $this->createPercentagePromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") and ("(?:€|£|\$)[^"]+") discount on every order$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") and ("(?:€|£|\$)[^"]+") discount on every order$/')]
     public function itGivesPercentageOffOnEveryProductClassifiedAsAndAmountDiscountOnOrder(
         PromotionInterface $promotion,
         float $productDiscount,
@@ -743,9 +677,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitFixedPromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") and a ("(?:€|£|\$)[^"]+") discount to every order with items total equal at least ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") and a ("(?:€|£|\$)[^"]+") discount to every order with items total equal at least ("(?:€|£|\$)[^"]+")$/')]
     public function itGivesOffOnEveryProductClassifiedAsAndAFixedDiscountToEveryOrderWithItemsTotalEqualAtLeast(
         PromotionInterface $promotion,
         float $taxonDiscount,
@@ -768,9 +700,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+" or "[^"]+") if order contains any product (classified as "[^"]+" or "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+" or "[^"]+") if order contains any product (classified as "[^"]+" or "[^"]+")$/')]
     public function itGivesOffOnEveryProductClassifiedAsOrIfOrderContainsAnyProductClassifiedAsOr(
         PromotionInterface $promotion,
         float $discount,
@@ -790,9 +720,7 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") if order contains any product (classified as "[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off on every product (classified as "[^"]+") if order contains any product (classified as "[^"]+")$/')]
     public function itGivesOffOnEveryProductClassifiedAsIfOrderContainsAnyProductClassifiedAs(
         PromotionInterface $promotion,
         float $discount,
@@ -809,10 +737,8 @@ final readonly class PromotionContext implements Context
         );
     }
 
-    /**
-     * @Given /^(it) is coupon based promotion$/
-     * @Given /^(it) is a coupon based promotion$/
-     */
+    #[Given('/^(it) is coupon based promotion$/')]
+    #[Given('/^(it) is a coupon based promotion$/')]
     public function itIsCouponBasedPromotion(PromotionInterface $promotion): void
     {
         $promotion->setCouponBased(true);
@@ -820,9 +746,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(the promotion) was disabled for the (channel "[^"]+")$/
-     */
+    #[Given('/^(the promotion) was disabled for the (channel "[^"]+")$/')]
     public function thePromotionWasDisabledForTheChannel(PromotionInterface $promotion, ChannelInterface $channel): void
     {
         $promotion->removeChannel($channel);
@@ -830,9 +754,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the (coupon "[^"]+") was used up to its usage limit$/
-     */
+    #[Given('/^the (coupon "[^"]+") was used up to its usage limit$/')]
     public function theCouponWasUsed(PromotionCouponInterface $coupon): void
     {
         $coupon->setUsed($coupon->getUsageLimit());
@@ -860,9 +782,7 @@ final readonly class PromotionContext implements Context
         $this->createUnitPercentagePromotion($promotion, $percentage, $this->getProductsFilterConfiguration([$product->getCode()]));
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") off the order for customers from ("[^"]*" group)$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") off the order for customers from ("[^"]*" group)$/')]
     public function thePromotionGivesOffTheOrderForCustomersFromGroup(
         PromotionInterface $promotion,
         float $discount,
@@ -876,9 +796,7 @@ final readonly class PromotionContext implements Context
         $this->createPercentagePromotion($promotion, $discount, [], $rule);
     }
 
-    /**
-     * @Given /^([^"]+) gives ("[^"]+%") discount on shipping to every order over ("(?:€|£|\$)[^"]+")$/
-     */
+    #[Given('/^([^"]+) gives ("[^"]+%") discount on shipping to every order over ("(?:€|£|\$)[^"]+")$/')]
     public function itGivesDiscountOnShippingToEveryOrderOver(
         PromotionInterface $promotion,
         float $discount,
@@ -897,10 +815,8 @@ final readonly class PromotionContext implements Context
         $this->itGivesDiscountOnShippingToEveryOrderOver($promotion, 1, $itemTotal);
     }
 
-    /**
-     * @Given /^I have generated (\d+) coupons for (this promotion) with code length (\d+) and prefix "([^"]+)"$/
-     * @Given /^I have generated (\d+) coupons for (this promotion) with code length (\d+), prefix "([^"]+)" and suffix "([^"]+)"$/
-     */
+    #[Given('/^I have generated (\d+) coupons for (this promotion) with code length (\d+) and prefix "([^"]+)"$/')]
+    #[Given('/^I have generated (\d+) coupons for (this promotion) with code length (\d+), prefix "([^"]+)" and suffix "([^"]+)"$/')]
     public function iHaveGeneratedCouponsForThisPromotionWithCodeLengthPrefixAndSuffix(
         int $amount,
         PromotionInterface $promotion,
@@ -911,9 +827,7 @@ final readonly class PromotionContext implements Context
         $this->generateCoupons($amount, $promotion, $codeLength, $prefix, $suffix);
     }
 
-    /**
-     * @Given /^I have generated (\d+) coupons for (this promotion) with code length (\d+) and suffix "([^"]+)"$/
-     */
+    #[Given('/^I have generated (\d+) coupons for (this promotion) with code length (\d+) and suffix "([^"]+)"$/')]
     public function iHaveGeneratedCouponsForThisPromotionWithCodeLengthAndSuffix(
         int $amount,
         PromotionInterface $promotion,
@@ -934,9 +848,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) has usage limit equal to (\d+)$/
-     */
+    #[Given('/^(this promotion) has usage limit equal to (\d+)$/')]
     public function thisPromotionHasUsageLimitEqualTo(PromotionInterface $promotion, int $usageLimit): void
     {
         $promotion->setUsageLimit($usageLimit);
@@ -944,9 +856,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) usage limit is already reached$/
-     */
+    #[Given('/^(this promotion) usage limit is already reached$/')]
     public function thisPromotionUsageLimitIsAlreadyReached(PromotionInterface $promotion): void
     {
         $promotion->setUsed($promotion->getUsageLimit());
@@ -954,9 +864,7 @@ final readonly class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this promotion) only applies to orders with a total of at least ("[^"]+") for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[Given('/^(this promotion) only applies to orders with a total of at least ("[^"]+") for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/')]
     public function thisPromotionOnlyAppliesToOrdersWithTotalOfAtLeastForAndFor(
         PromotionInterface $promotion,
         int $firstAmount,

--- a/src/Sylius/Behat/Context/Setup/ShippingCategoryContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingCategoryContext.php
@@ -44,9 +44,7 @@ final readonly class ShippingCategoryContext implements Context
         (null === $secondShippingCategoryName) ?: $this->createShippingCategory($secondShippingCategoryName);
     }
 
-    /**
-     * @Given the store has :shippingCategoryName shipping category identified by :shippingCategoryCode
-     */
+    #[Given('the store has :shippingCategoryName shipping category identified by :shippingCategoryCode')]
     public function theStoreHasShippingCategoryIdentifiedBy($shippingCategoryName, $shippingCategoryCode)
     {
         $this->createShippingCategory($shippingCategoryName, $shippingCategoryCode);

--- a/src/Sylius/Behat/Context/Setup/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingContext.php
@@ -53,9 +53,7 @@ final readonly class ShippingContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store ships everything for Free within the :zone zone
-     */
+    #[Given('the store ships everything for Free within the :zone zone')]
     public function storeShipsEverythingForFree(ZoneInterface $zone): void
     {
         $this->saveShippingMethod($this->shippingMethodExampleFactory->create([
@@ -88,9 +86,7 @@ final readonly class ShippingContext implements Context
         }
     }
 
-    /**
-     * @Given /^the store ships everywhere for free for (all channels)$/
-     */
+    #[Given('/^the store ships everywhere for free for (all channels)$/')]
     public function theStoreShipsEverywhereForFreeForAllChannels(array $channels): void
     {
         foreach ($this->zoneRepository->findBy(['scope' => [CoreScope::SHIPPING, Scope::ALL]]) as $zone) {
@@ -116,9 +112,7 @@ final readonly class ShippingContext implements Context
         $this->saveShippingMethod($this->shippingMethodExampleFactory->create(['name' => $name, 'enabled' => true]));
     }
 
-    /**
-     * @Given the store (also )allows shipping with :name identified by :code
-     */
+    #[Given('the store (also )allows shipping with :name identified by :code')]
     public function theStoreAllowsShippingMethodWithNameAndCode(string $name, string $code): void
     {
         $this->saveShippingMethod($this->shippingMethodExampleFactory->create([
@@ -129,9 +123,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given the store (also )allows shipping with :name at position :position
-     */
+    #[Given('the store (also )allows shipping with :name at position :position')]
     public function theStoreAllowsShippingMethodWithNameAndPosition(string $name, int $position): void
     {
         $shippingMethod = $this->shippingMethodExampleFactory->create([
@@ -145,9 +137,7 @@ final readonly class ShippingContext implements Context
         $this->saveShippingMethod($shippingMethod);
     }
 
-    /**
-     * @Given /^the store(?:| also) allows shipping with "([^"]+)" at position (\d+) with ("[^"]+") fee$/
-     */
+    #[Given('/^the store(?:| also) allows shipping with "([^"]+)" at position (\d+) with ("[^"]+") fee$/')]
     public function theStoreAllowsShippingMethodWithNameAndPositionAndFee(string $name, int $position, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -169,9 +159,7 @@ final readonly class ShippingContext implements Context
         $this->saveShippingMethod($shippingMethod);
     }
 
-    /**
-     * @Given /^(this shipping method) is named "([^"]+)" in the ("[^"]+" locale)$/
-     */
+    #[Given('/^(this shipping method) is named "([^"]+)" in the ("[^"]+" locale)$/')]
     public function thisShippingMethodIsNamedInLocale(
         ShippingMethodInterface $shippingMethod,
         string $name,
@@ -188,10 +176,8 @@ final readonly class ShippingContext implements Context
         }
     }
 
-    /**
-     * @Given the store allows shipping with :firstName and :secondName
-     * @Given the store allows shipping with :firstName, :secondName and :thirdName
-     */
+    #[Given('the store allows shipping with :firstName and :secondName')]
+    #[Given('the store allows shipping with :firstName, :secondName and :thirdName')]
     public function theStoreAllowsShippingWithAnd(string ...$names): void
     {
         foreach ($names as $name) {
@@ -236,9 +222,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per shipment for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee per shipment for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/')]
     public function storeHasShippingMethodWithFeePerShipmentForChannels(
         string $shippingMethodName,
         int $firstFee,
@@ -262,9 +246,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per shipment for ("[^"]+" channel)$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee per shipment for ("[^"]+" channel)$/')]
     public function storeHasShippingMethodWithFeePerShipmentForChannel(
         string $shippingMethodName,
         int $fee,
@@ -284,10 +266,8 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel)$/
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel)$/')]
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/')]
     public function storeHasShippingMethodWithFeePerUnitForChannels(
         string $shippingMethodName,
         int $firstFee,
@@ -336,9 +316,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has an archival "([^"]+)" shipping method with ("[^"]+") fee$/
-     */
+    #[Given('/^the store has an archival "([^"]+)" shipping method with ("[^"]+") fee$/')]
     public function theStoreHasArchivalShippingMethodWithFee(string $shippingMethodName, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -357,9 +335,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit$/')]
     public function theStoreHasShippingMethodWithFeePerUnit(string $shippingMethodName, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -377,9 +353,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee not assigned to any channel$/
-     */
+    #[Given('/^the store has "([^"]+)" shipping method with ("[^"]+") fee not assigned to any channel$/')]
     public function storeHasShippingMethodWithFeeNotAssignedToAnyChannel(string $shippingMethodName, int $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -397,9 +371,7 @@ final readonly class ShippingContext implements Context
         ]));
     }
 
-    /**
-     * @Given /^(shipping method "[^"]+") belongs to ("[^"]+" tax category)$/
-     */
+    #[Given('/^(shipping method "[^"]+") belongs to ("[^"]+" tax category)$/')]
     public function shippingMethodBelongsToTaxCategory(
         ShippingMethodInterface $shippingMethod,
         TaxCategoryInterface $taxCategory,
@@ -408,27 +380,21 @@ final readonly class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given the shipping method :shippingMethod is enabled
-     */
+    #[Given('the shipping method :shippingMethod is enabled')]
     public function theShippingMethodIsEnabled(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethod->enable();
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given the shipping method :shippingMethod is disabled
-     */
+    #[Given('the shipping method :shippingMethod is disabled')]
     public function theShippingMethodIsDisabled(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethod->disable();
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this shipping method) requires at least one unit matches to ("([^"]+)" shipping category)$/
-     */
+    #[Given('/^(this shipping method) requires at least one unit matches to ("([^"]+)" shipping category)$/')]
     public function thisShippingMethodRequiresAtLeastOneUnitMatchToShippingCategory(
         ShippingMethodInterface $shippingMethod,
         ShippingCategoryInterface $shippingCategory,
@@ -448,9 +414,7 @@ final readonly class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this shipping method) requires that no units match to ("([^"]+)" shipping category)$/
-     */
+    #[Given('/^(this shipping method) requires that no units match to ("([^"]+)" shipping category)$/')]
     public function thisShippingMethodRequiresThatNoUnitsMatchToShippingCategory(
         ShippingMethodInterface $shippingMethod,
         ShippingCategoryInterface $shippingCategory,
@@ -460,18 +424,14 @@ final readonly class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^the (shipping method "[^"]+") is archival$/
-     */
+    #[Given('/^the (shipping method "[^"]+") is archival$/')]
     public function theShippingMethodIsArchival(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethod->setArchivedAt(new \DateTime());
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^the shipping fee for ("[^"]+" shipping method) has been changed to ("[^"]+")$/
-     */
+    #[Given('/^the shipping fee for ("[^"]+" shipping method) has been changed to ("[^"]+")$/')]
     public function theShippingFeeForShippingMethodHasBeenChangedTo(ShippingMethodInterface $shippingMethod, $fee): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -482,9 +442,7 @@ final readonly class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this shipping method) is only available for orders over or equal to ("[^"]+")$/
-     */
+    #[Given('/^(this shipping method) is only available for orders over or equal to ("[^"]+")$/')]
     public function thisShippingMethodIsOnlyAvailableForOrdersOverOrEqualTo(
         ShippingMethodInterface $shippingMethod,
         int $amount,
@@ -497,9 +455,7 @@ final readonly class ShippingContext implements Context
         $this->addRuleToShippingMethod($rule, $shippingMethod);
     }
 
-    /**
-     * @Given /^(this shipping method) is only available for orders under or equal to ("[^"]+")$/
-     */
+    #[Given('/^(this shipping method) is only available for orders under or equal to ("[^"]+")$/')]
     public function thisShippingMethodIsOnlyAvailableForOrdersUnderOrEqualTo(
         ShippingMethodInterface $shippingMethod,
         int $amount,
@@ -512,9 +468,7 @@ final readonly class ShippingContext implements Context
         $this->addRuleToShippingMethod($rule, $shippingMethod);
     }
 
-    /**
-     * @Given /^(this shipping method) is only available for orders with a total weight greater or equal to (\d+\.\d+)$/
-     */
+    #[Given('/^(this shipping method) is only available for orders with a total weight greater or equal to (\d+\.\d+)$/')]
     public function thisShippingMethodIsOnlyAvailableForOrdersWithATotalWeightGreaterOrEqualTo(
         ShippingMethodInterface $shippingMethod,
         float $weight,
@@ -526,9 +480,7 @@ final readonly class ShippingContext implements Context
         $this->addRuleToShippingMethod($rule, $shippingMethod);
     }
 
-    /**
-     * @Given /^(this shipping method) is only available for orders with a total weight less or equal to (\d+\.\d+)$/
-     */
+    #[Given('/^(this shipping method) is only available for orders with a total weight less or equal to (\d+\.\d+)$/')]
     public function thisShippingMethodIsOnlyAvailableForOrdersWithATotalWeightLessOrEqualTo(
         ShippingMethodInterface $shippingMethod,
         float $weight,
@@ -556,9 +508,7 @@ final readonly class ShippingContext implements Context
         $this->shippingMethodManager->flush();
     }
 
-    /**
-     * @Given /^(this shipping method) has changed zone to ("[^"]+" zone)$/
-     */
+    #[Given('/^(this shipping method) has changed zone to ("[^"]+" zone)$/')]
     public function thisShippingMethodHasChangedZone(ShippingMethodInterface $shippingMethod, ZoneInterface $zone): void
     {
         /** @var ShippingMethodInterface $shippingMethod */

--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -37,12 +38,10 @@ final class TaxationContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone
-     * @Given the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone with dates between :startDate and :endDate
-     * @Given the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone identified by the :taxRateCode code
-     * @Given /^the store has(?:| also) "([^"]+)" tax rate of ([^"]+)% for "([^"]+)" for the (rest of the world)$/
-     */
+    #[Given('the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone')]
+    #[Given('the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone with dates between :startDate and :endDate')]
+    #[Given('the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone identified by the :taxRateCode code')]
+    #[Given('/^the store has(?:| also) "([^"]+)" tax rate of ([^"]+)% for "([^"]+)" for the (rest of the world)$/')]
     public function storeHasTaxRateWithinZone(
         $taxRateName,
         $taxRateAmount,
@@ -65,9 +64,7 @@ final class TaxationContext implements Context
         );
     }
 
-    /**
-     * @Given the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone ending at :endDate
-     */
+    #[Given('the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone ending at :endDate')]
     public function storeHasTaxRateWithinZoneEndingAt(
         string $taxRateName,
         string $taxRateAmount,
@@ -78,9 +75,7 @@ final class TaxationContext implements Context
         $this->configureTaxRate($taxCategoryName, null, $taxRateName, $zone, $taxRateAmount, false, null, new \DateTime($endDate));
     }
 
-    /**
-     * @Given the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone starting at :startDate
-     */
+    #[Given('the store has :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone starting at :startDate')]
     public function storeHasTaxRateWithinZoneStartingAt(
         string $taxRateName,
         string $taxRateAmount,
@@ -91,19 +86,15 @@ final class TaxationContext implements Context
         $this->configureTaxRate($taxCategoryName, StringInflector::nameToCode($taxRateName), $taxRateName, $zone, $taxRateAmount, false, new \DateTime($startDate));
     }
 
-    /**
-     * @Given the store has included in price :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone
-     */
+    #[Given('the store has included in price :taxRateName tax rate of :taxRateAmount% for :taxCategoryName within the :zone zone')]
     public function storeHasIncludedInPriceTaxRateWithinZone($taxRateName, $taxRateAmount, $taxCategoryName, ZoneInterface $zone)
     {
         $this->storeHasTaxRateWithinZone($taxRateName, $taxRateAmount, $taxCategoryName, $zone, null, true);
     }
 
-    /**
-     * @Given the store has a tax category :name with a code :code
-     * @Given the store has a tax category :name
-     * @Given the store has a tax category :name also
-     */
+    #[Given('the store has a tax category :name with a code :code')]
+    #[Given('the store has a tax category :name')]
+    #[Given('the store has a tax category :name also')]
     public function theStoreHasTaxCategoryWithCode($name, $code = null)
     {
         $taxCategory = $this->createTaxCategory($name, $code);
@@ -111,9 +102,7 @@ final class TaxationContext implements Context
         $this->sharedStorage->set('tax_category', $taxCategory);
     }
 
-    /**
-     * @Given the store has tax categories :firstName, :secondName and :thirdName
-     */
+    #[Given('the store has tax categories :firstName, :secondName and :thirdName')]
     public function theStoreHasTaxCategories(string ...$names): void
     {
         foreach ($names as $name) {
@@ -121,9 +110,7 @@ final class TaxationContext implements Context
         }
     }
 
-    /**
-     * @Given the store does not have any categories defined
-     */
+    #[Given('the store does not have any categories defined')]
     public function theStoreDoesNotHaveAnyCategoriesDefined()
     {
         $taxCategories = $this->taxCategoryRepository->findAll();
@@ -133,9 +120,7 @@ final class TaxationContext implements Context
         }
     }
 
-    /**
-     * @Given /^the ("[^"]+" tax rate) has changed to ([^"]+)%$/
-     */
+    #[Given('/^the ("[^"]+" tax rate) has changed to ([^"]+)%$/')]
     public function theTaxRateIsOfAmount(TaxRateInterface $taxRate, $amount)
     {
         $taxRate->setAmount((float) $this->getAmountFromString($amount));
@@ -143,9 +128,7 @@ final class TaxationContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(this tax rate) operates between "([^"]+)" and "([^"]+)"$/
-     */
+    #[Given('/^(this tax rate) operates between "([^"]+)" and "([^"]+)"$/')]
     public function theTaxRateOperatesBetweenDates(
         TaxRateInterface $taxRate,
         string $startDate,
@@ -156,9 +139,7 @@ final class TaxationContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given the :taxRate tax rate has :calculator calculator configured
-     */
+    #[Given('the :taxRate tax rate has :calculator calculator configured')]
     public function theTaxRateHasCalculatorConfigured(TaxRateInterface $taxRate, string $calculator): void
     {
         $taxRate->setCalculator($calculator);

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -139,9 +139,7 @@ final class TaxonomyContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^the ("[^"]+" taxon) has an empty name in the ("[^"]+" locale)$/
-     */
+    #[Given('/^the ("[^"]+" taxon) has an empty name in the ("[^"]+" locale)$/')]
     public function theTaxonHasEmptyNameInLocale(TaxonInterface $taxon, string $localeCode): void
     {
         $taxon->getTranslation($localeCode)->setName('');

--- a/src/Sylius/Behat/Context/Setup/ThemeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ThemeContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -31,9 +32,7 @@ final readonly class ThemeContext implements Context
     ) {
     }
 
-    /**
-     * @Given the store has :themeName theme
-     */
+    #[Given('the store has :themeName theme')]
     public function storeHasTheme(string $themeName): void
     {
         $this->testThemeConfigurationManager->add([
@@ -43,9 +42,7 @@ final readonly class ThemeContext implements Context
         $this->sharedStorage->set('theme', $this->themeRepository->findOneByName($themeName));
     }
 
-    /**
-     * @Given channel :channel uses :theme theme
-     */
+    #[Given('channel :channel uses :theme theme')]
     public function channelUsesTheme(ChannelInterface $channel, ThemeInterface $theme): void
     {
         $channel->setThemeName($theme->getName());
@@ -57,9 +54,7 @@ final readonly class ThemeContext implements Context
         $this->sharedStorage->set('theme', $theme);
     }
 
-    /**
-     * @Given channel :channel does not use any theme
-     */
+    #[Given('channel :channel does not use any theme')]
     public function channelDoesNotUseAnyTheme(ChannelInterface $channel): void
     {
         $channel->setThemeName(null);
@@ -69,17 +64,13 @@ final readonly class ThemeContext implements Context
         $this->sharedStorage->set('channel', $channel);
     }
 
-    /**
-     * @Given /^(this theme) changes homepage template contents to "([^"]+)"$/
-     */
+    #[Given('/^(this theme) changes homepage template contents to "([^"]+)"$/')]
     public function themeChangesHomepageTemplateContents(ThemeInterface $theme, string $contents): void
     {
         $this->changeTemplateContents('/templates/bundles/SyliusShopBundle/homepage/index.html.twig', $theme, $contents);
     }
 
-    /**
-     * @Given /^(this theme) changes plugin main template's content to "([^"]+)"$/
-     */
+    #[Given('/^(this theme) changes plugin main template\'s content to "([^"]+)"$/')]
     public function themeChangesPluginMainTemplateContent(ThemeInterface $theme, string $content): void
     {
         $this->changeTemplateContents('/templates/bundles/SyliusTestPlugin/main.html.twig', $theme, $content);

--- a/src/Sylius/Behat/Context/Setup/UserContext.php
+++ b/src/Sylius/Behat/Context/Setup/UserContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Setup;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
@@ -38,11 +39,9 @@ final readonly class UserContext implements Context
     ) {
     }
 
-    /**
-     * @Given there is a user :email identified by :password
-     * @Given there was account of :email with password :password
-     * @Given there is a user :email
-     */
+    #[Given('there is a user :email identified by :password')]
+    #[Given('there was account of :email with password :password')]
+    #[Given('there is a user :email')]
     public function thereIsUserIdentifiedBy(string $email, string $password = 'sylius'): void
     {
         /** @var ShopUserInterface $user */
@@ -53,11 +52,9 @@ final readonly class UserContext implements Context
         $this->userRepository->add($user);
     }
 
-    /**
-     * @Given there is a disabled user :email identified by :password
-     * @Given there was disabled account of :email with password :password
-     * @Given there is a disabled user :email
-     */
+    #[Given('there is a disabled user :email identified by :password')]
+    #[Given('there was disabled account of :email with password :password')]
+    #[Given('there is a disabled user :email')]
     public function thereIsDisabledUserIdentifiedBy($email, $password = 'sylius')
     {
         $user = $this->userFactory->create(['email' => $email, 'password' => $password, 'enabled' => false]);
@@ -67,10 +64,8 @@ final readonly class UserContext implements Context
         $this->userRepository->add($user);
     }
 
-    /**
-     * @Given I registered with previously used :email email and :password password
-     * @Given I have already registered :email account
-     */
+    #[Given('I registered with previously used :email email and :password password')]
+    #[Given('I have already registered :email account')]
     public function theCustomerCreatedAccountWithPassword(string $email, string $password = 'sylius'): void
     {
         /** @var ShopUserInterface $user */
@@ -82,10 +77,8 @@ final readonly class UserContext implements Context
         $this->userRepository->add($user);
     }
 
-    /**
-     * @Given the account of :email was deleted
-     * @Given my account :email was deleted
-     */
+    #[Given('the account of :email was deleted')]
+    #[Given('my account :email was deleted')]
     public function accountWasDeleted(string $email): void
     {
         /** @var ShopUserInterface $user */
@@ -96,9 +89,7 @@ final readonly class UserContext implements Context
         $this->userRepository->remove($user);
     }
 
-    /**
-     * @Given its account was deleted
-     */
+    #[Given('its account was deleted')]
     public function hisAccountWasDeleted(): void
     {
         $user = $this->sharedStorage->get('user');
@@ -107,10 +98,8 @@ final readonly class UserContext implements Context
         $this->userManager->clear();
     }
 
-    /**
-     * @Given /^(this user) is not verified$/
-     * @Given /^(I) have not verified my account (?:yet)$/
-     */
+    #[Given('/^(this user) is not verified$/')]
+    #[Given('/^(I) have not verified my account (?:yet)$/')]
     public function accountIsNotVerified(UserInterface $user): void
     {
         $user->setVerifiedAt(null);
@@ -118,17 +107,13 @@ final readonly class UserContext implements Context
         $this->userManager->flush();
     }
 
-    /**
-     * @Given /^(?:(I) have|(this user) has) already received a verification email$/
-     */
+    #[Given('/^(?:(I) have|(this user) has) already received a verification email$/')]
     public function iHaveReceivedVerificationEmail(UserInterface $user): void
     {
         $this->prepareUserVerification($user);
     }
 
-    /**
-     * @Given a verification email has already been sent to :email
-     */
+    #[Given('a verification email has already been sent to :email')]
     public function aVerificationEmailHasBeenSentTo(string $email): void
     {
         $user = $this->userRepository->findOneByEmail($email);
@@ -136,9 +121,7 @@ final readonly class UserContext implements Context
         $this->prepareUserVerification($user);
     }
 
-    /**
-     * @Given /^(I) have already verified my account$/
-     */
+    #[Given('/^(I) have already verified my account$/')]
     public function iHaveAlreadyVerifiedMyAccount(UserInterface $user): void
     {
         $user->setVerifiedAt(new \DateTime());
@@ -146,9 +129,7 @@ final readonly class UserContext implements Context
         $this->userManager->flush();
     }
 
-    /**
-     * @Given /^(?:(I) have|(this user) has) already received a resetting password email$/
-     */
+    #[Given('/^(?:(I) have|(this user) has) already received a resetting password email$/')]
     public function iHaveReceivedResettingPasswordEmail(UserInterface $user): void
     {
         $this->prepareUserPasswordResetToken($user);
@@ -174,9 +155,7 @@ final readonly class UserContext implements Context
         $this->userManager->flush();
     }
 
-    /**
-     * @Given /^(I) waited too long, and the token expired$/
-     */
+    #[Given('/^(I) waited too long, and the token expired$/')]
     public function iWaitedTooLongAndTheTokenExpired(UserInterface $user): void
     {
         /** @var \DateTime $passwordRequestedAt */
@@ -194,9 +173,7 @@ final readonly class UserContext implements Context
         $this->userManager->flush();
     }
 
-    /**
-     * @Given /^(I)'ve changed my password from "([^"]+)" to "([^"]+)"$/
-     */
+    #[Given('/^(I)\'ve changed my password from "([^"]+)" to "([^"]+)"$/')]
     public function iveChangedMyPasswordFromTo(UserInterface $user, string $currentPassword, string $newPassword): void
     {
         $currentPassword = $this->retrieveSecurePassword($currentPassword);

--- a/src/Sylius/Behat/Context/Setup/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Setup/ZoneContext.php
@@ -80,12 +80,10 @@ final readonly class ZoneContext implements Context
         }
     }
 
-    /**
-     * @Given the store has (also) a zone :zoneName
-     * @Given the store has a zone :zoneName with code :code
-     * @Given the store also has a zone :zoneName with code :code
-     * @Given the store has a zone :zoneName with code :code and priority :priority
-     */
+    #[Given('the store has (also) a zone :zoneName')]
+    #[Given('the store has a zone :zoneName with code :code')]
+    #[Given('the store also has a zone :zoneName with code :code')]
+    #[Given('the store has a zone :zoneName with code :code and priority :priority')]
     public function theStoreHasAZoneWithCode(string $zoneName, ?string $code = null, ?int $priority = 0): void
     {
         $zone = $this->createZone($zoneName, $code, Scope::ALL);
@@ -94,9 +92,7 @@ final readonly class ZoneContext implements Context
         $this->saveZone($zone, 'zone');
     }
 
-    /**
-     * @Given the store has zones :firstName, :secondName and :thirdName
-     */
+    #[Given('the store has zones :firstName, :secondName and :thirdName')]
     public function theStoreHasZones(string ...$names): void
     {
         foreach ($names as $name) {
@@ -104,18 +100,14 @@ final readonly class ZoneContext implements Context
         }
     }
 
-    /**
-     * @Given the store has a :scope zone :zoneName with code :code
-     */
+    #[Given('the store has a :scope zone :zoneName with code :code')]
     public function theStoreHasAScopedZoneWithCode($scope, $zoneName, $code)
     {
         $this->saveZone($this->createZone($zoneName, $code, $scope), $scope . '_zone');
     }
 
-    /**
-     * @Given /^(it)(?:| also) has the ("([^"]+)" country) member$/
-     * @Given /^(this zone)(?:| also) has the ("([^"]+)" country) member$/
-     */
+    #[Given('/^(it)(?:| also) has the ("([^"]+)" country) member$/')]
+    #[Given('/^(this zone)(?:| also) has the ("([^"]+)" country) member$/')]
     public function itHasTheCountryMemberAndTheCountryMember(
         ZoneInterface $zone,
         CountryInterface $country,
@@ -126,9 +118,7 @@ final readonly class ZoneContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(the "([^"]*)" (?:country|province|zone) member) has been removed from (this zone)$/
-     */
+    #[Given('/^(the "([^"]*)" (?:country|province|zone) member) has been removed from (this zone)$/')]
     public function theZoneMemberHasBeenRemoved(
         ZoneMemberInterface $zoneMember,
         string $zoneMemberName,
@@ -139,9 +129,7 @@ final readonly class ZoneContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it)(?:| also) has the ("([^"]+)", "([^"]+)" and "([^"]+)" country) members$/
-     */
+    #[Given('/^(it)(?:| also) has the ("([^"]+)", "([^"]+)" and "([^"]+)" country) members$/')]
     public function itHasCountryMembers(ZoneInterface $zone, array $countries): void
     {
         $zone->setType(ZoneInterface::TYPE_COUNTRY);
@@ -153,10 +141,8 @@ final readonly class ZoneContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it) has the ("[^"]+" province) member$/
-     * @Given /^(it) also has the ("[^"]+" province) member$/
-     */
+    #[Given('/^(it) has the ("[^"]+" province) member$/')]
+    #[Given('/^(it) also has the ("[^"]+" province) member$/')]
     public function itHasTheProvinceMemberAndTheProvinceMember(
         ZoneInterface $zone,
         ProvinceInterface $province,
@@ -167,10 +153,8 @@ final readonly class ZoneContext implements Context
         $this->objectManager->flush();
     }
 
-    /**
-     * @Given /^(it) has the (zone named "([^"]+)")$/
-     * @Given /^(it) also has the (zone named "([^"]+)")$/
-     */
+    #[Given('/^(it) has the (zone named "([^"]+)")$/')]
+    #[Given('/^(it) also has the (zone named "([^"]+)")$/')]
     public function itHasTheZoneMemberAndTheZoneMember(
         ZoneInterface $parentZone,
         ZoneInterface $childZone,


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modernized test infrastructure by updating Behat test step declarations to use current PHP 8 syntax standards. No changes to functionality or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->