### PR TITLE
[CoreBundle] [DX] [2.3] [CLI] Extend setup command with hidden notice in password setup

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Console/Command/SetupCommand.php
@@ -209,7 +209,7 @@ EOT
         $validator = $this->getPasswordQuestionValidator();
 
         do {
-            $passwordQuestion = $this->createPasswordQuestion('Choose password:', $validator);
+            $passwordQuestion = $this->createPasswordQuestion('Choose password (password is hidden while typing): ', $validator);
             $confirmPasswordQuestion = $this->createPasswordQuestion('Confirm password:', $validator);
 
             $password = $questionHelper->ask($input, $output, $passwordQuestion);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18798 
| License         | MIT

This pull request extends the password step in the `sylius:install:setup` command stating that the password for the administrator account is not displayed for security reasons.

The reason for this change is that new users may not be aware of this, and it helps to avoid potential confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the administrator password prompt text during setup to clarify that the password remains hidden while typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->