### PR TITLE
Convert Behat annotations to PHP attributes in CLI contexts

### DIFF
--- a/src/Sylius/Behat/Context/Cli/CancelUnpaidOrdersContext.php
+++ b/src/Sylius/Behat/Context/Cli/CancelUnpaidOrdersContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Cli;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -36,9 +38,7 @@ final class CancelUnpaidOrdersContext implements Context
         $this->application = new Application($kernel);
     }
 
-    /**
-     * @When I run cancel unpaid orders command
-     */
+    #[When('I run cancel unpaid orders command')]
     public function runCancelUnpaidOrdersCommand(): void
     {
         $command = $this->application->find(self::CANCEL_UNPAID_ORDERS_COMMAND);
@@ -47,9 +47,7 @@ final class CancelUnpaidOrdersContext implements Context
         $this->commandTester->execute(['command' => self::CANCEL_UNPAID_ORDERS_COMMAND]);
     }
 
-    /**
-     * @Then only the order with number :orderNumber should be canceled
-     */
+    #[Then('only the order with number :orderNumber should be canceled')]
     public function onlyOrderWithNumberShouldBeCanceled(string $orderNumber): void
     {
         $orders = $this->orderRepository->findBy(['paymentState' => OrderPaymentStates::STATE_CANCELLED]);
@@ -58,9 +56,7 @@ final class CancelUnpaidOrdersContext implements Context
         Assert::same($orders[0]->getNumber(), $orderNumber);
     }
 
-    /**
-     * @Then I should be informed that unpaid orders have been canceled
-     */
+    #[Then('I should be informed that unpaid orders have been canceled')]
     public function shouldBeInformedThatUnpaidOrdersHaveBeenCanceled(): void
     {
         Assert::contains($this->commandTester->getDisplay(), 'Unpaid orders have been canceled');

--- a/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
+++ b/src/Sylius/Behat/Context/Cli/ChangeAdminPasswordContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Cli;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\SecurePasswordTrait;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -47,9 +49,7 @@ final class ChangeAdminPasswordContext implements Context
         $this->application = new Application($kernel);
     }
 
-    /**
-     * @When I want to change password
-     */
+    #[When('I want to change password')]
     public function iWantToChangePassword(): void
     {
         $command = $this->application->find(self::ADMIN_USER_CHANGE_PASSWORD);
@@ -57,42 +57,32 @@ final class ChangeAdminPasswordContext implements Context
         $this->commandTester = new CommandTester($command);
     }
 
-    /**
-     * @When I specify email as :email
-     */
+    #[When('I specify email as :email')]
     public function iSpecifyEmailAs(string $email = ''): void
     {
         $this->input['email'] = $email;
     }
 
-    /**
-     * @When I specify my new password as :password
-     */
+    #[When('I specify my new password as :password')]
     public function iSpecifyMyNewPassword(string $password = ''): void
     {
         $this->input['password'] = $this->replaceWithSecurePassword($password);
     }
 
-    /**
-     * @When I run command
-     */
+    #[When('I run command')]
     public function iRunCommand(): void
     {
         $this->commandTester->setInputs($this->input);
         $this->commandTester->execute(['command' => self::ADMIN_USER_CHANGE_PASSWORD]);
     }
 
-    /**
-     * @Then I should be informed that password has been changed successfully
-     */
+    #[Then('I should be informed that password has been changed successfully')]
     public function iShouldBeInformedThatPasswordHasBeenChangedSuccessfully(): void
     {
         Assert::contains($this->commandTester->getDisplay(), 'Admin user password has been changed successfully.');
     }
 
-    /**
-     * @Then I should be able to log in as :email authenticated by :password password
-     */
+    #[Then('I should be able to log in as :email authenticated by :password password')]
     public function iShouldBeAbleToLoginWithEmailAndPassword(string $email = '', string $password = ''): void
     {
         /** @var AdminUserInterface|null $adminUser */

--- a/src/Sylius/Behat/Context/Cli/InstallerContext.php
+++ b/src/Sylius/Behat/Context/Cli/InstallerContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Cli;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Console\Command\InstallSampleDataCommand;
@@ -63,9 +66,7 @@ final class InstallerContext implements Context
     ) {
     }
 
-    /**
-     * @When I run Sylius CLI installer
-     */
+    #[When('I run Sylius CLI installer')]
     public function iRunSyliusCommandLineInstaller(): void
     {
         $this->application = new Application($this->kernel);
@@ -86,9 +87,7 @@ final class InstallerContext implements Context
         $this->iExecuteCommandWithInputChoices('sylius:install:setup');
     }
 
-    /**
-     * @Given I run Sylius Install Load Sample Data command
-     */
+    #[Given('I run Sylius Install Load Sample Data command')]
     public function iRunSyliusInstallSampleDataCommand(): void
     {
         $this->application = new Application($this->kernel);
@@ -101,49 +100,37 @@ final class InstallerContext implements Context
         $this->tester = new CommandTester($this->command);
     }
 
-    /**
-     * @Given I confirm loading sample data
-     */
+    #[Given('I confirm loading sample data')]
     public function iConfirmLoadingData(): void
     {
         $this->iExecuteCommandAndConfirm('sylius:install:sample-data');
     }
 
-    /**
-     * @Then the command should finish successfully
-     */
+    #[Then('the command should finish successfully')]
     public function commandSuccess(): void
     {
         Assert::same($this->tester->getStatusCode(), 0);
     }
 
-    /**
-     * @Then I should see output :text
-     */
+    #[Then('I should see output :text')]
     public function iShouldSeeOutput(string $text): void
     {
         Assert::contains($this->tester->getDisplay(), $text);
     }
 
-    /**
-     * @Given I do not provide an email
-     */
+    #[Given('I do not provide an email')]
     public function iDoNotProvideEmail(): void
     {
         $this->inputChoices['e-mail'] = '';
     }
 
-    /**
-     * @Given I do not provide a correct email
-     */
+    #[Given('I do not provide a correct email')]
     public function iDoNotProvideCorrectEmail(): void
     {
         $this->inputChoices['e-mail'] = 'janusz';
     }
 
-    /**
-     * @Given I provide full administrator data
-     */
+    #[Given('I provide full administrator data')]
     public function iProvideFullAdministratorData(): void
     {
         $this->inputChoices['e-mail'] = 'test@admin.com';


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized test step definitions across multiple CLI testing contexts to leverage PHP 8 language features, improving code clarity and maintainability of the testing infrastructure. All existing test behavior and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->