### PR TITLE
Convert Behat annotations to PHP attributes in Api Admin contexts

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/BrowsingCatalogPromotionProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/BrowsingCatalogPromotionProductVariantsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -33,10 +36,8 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing variants affected by catalog promotion :catalogPromotion
-     * @When I browse variants affected by catalog promotion :catalogPromotion
-     */
+    #[Given('I am browsing variants affected by catalog promotion :catalogPromotion')]
+    #[When('I browse variants affected by catalog promotion :catalogPromotion')]
     public function iBrowseVariantsAffectedByCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -44,10 +45,8 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When /^I want to view all variants of (this product)$/
-     * @When /^I view(?:| all) variants of the (product "[^"]+")$/
-     */
+    #[When('/^I want to view all variants of (this product)$/')]
+    #[When('/^I view(?:| all) variants of the (product "[^"]+")$/')]
     public function iWantToViewAllVariantsOfThisProduct(ProductInterface $product): void
     {
         $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -55,27 +54,21 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->client->addFilter('code', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by name containing :phrase
-     */
+    #[When('I filter by name containing :phrase')]
     public function iFilterByNameContaining(string $phrase): void
     {
         $this->client->addFilter('translations.name', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @Then /^there should be (\d+) product variants? on the list$/
-     */
+    #[Then('/^there should be (\d+) product variants? on the list$/')]
     public function thereShouldBeProductVariantsOnTheList(int $count): void
     {
         Assert::same(
@@ -84,10 +77,8 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then it should be the :variantName product variant
-     * @Then it should be :firstVariant and :secondVariant product variants
-     */
+    #[Then('it should be the :variantName product variant')]
+    #[Then('it should be :firstVariant and :secondVariant product variants')]
     public function theProductVariantShouldBeInTheRegistry(string ...$variantsNames): void
     {
         foreach ($variantsNames as $variantName) {
@@ -100,9 +91,7 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
         }
     }
 
-    /**
-     * @Then :variant variant price should be decreased by catalog promotion :catalogPromotion in :channel channel
-     */
+    #[Then(':variant variant price should be decreased by catalog promotion :catalogPromotion in :channel channel')]
     public function variantPriceShouldBeDecreasedByCatalogPromotion(
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,
@@ -119,9 +108,7 @@ final class BrowsingCatalogPromotionProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then :variant variant price should not be decreased by catalog promotion :catalogPromotion in :channel channel
-     */
+    #[Then(':variant variant price should not be decreased by catalog promotion :catalogPromotion in :channel channel')]
     public function variantPriceShouldNotBeDecreasedByCatalogPromotion(
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,

--- a/src/Sylius/Behat/Context/Api/Admin/BrowsingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/BrowsingProductVariantsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -28,9 +30,7 @@ final class BrowsingProductVariantsContext implements Context
     ) {
     }
 
-    /**
-     * @When I start sorting variants by position
-     */
+    #[When('I start sorting variants by position')]
     public function iSortProductsByPosition(): void
     {
         $this->client->index(
@@ -41,26 +41,20 @@ final class BrowsingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @When I set the position of :productVariant to :position
-     */
+    #[When('I set the position of :productVariant to :position')]
     public function iSetThePositionOfTo(ProductVariantInterface $productVariant, int $position): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCT_VARIANTS, $productVariant->getCode());
         $this->client->updateRequestData(['position' => $position]);
     }
 
-    /**
-     * @When I save my new elements order
-     */
+    #[When('I save my new elements order')]
     public function iSaveMyNewElementsOrder(): void
     {
         $this->client->update();
     }
 
-    /**
-     * @Then the first variant in the list should have name :variantName
-     */
+    #[Then('the first variant in the list should have name :variantName')]
     public function theFirstVariantInTheListShouldHaveName(string $variantName): void
     {
         $variants = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -70,9 +64,7 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertProductVariantName($firstVariant['translations']['en_US']['name'], $variantName);
     }
 
-    /**
-     * @Then the last variant in the list should have name :variantName
-     */
+    #[Then('the last variant in the list should have name :variantName')]
     public function theLastVariantInTheListShouldHaveName(string $variantName): void
     {
         $variants = $this->responseChecker->getCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Admin/ChannelPricingLogEntryContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ChannelPricingLogEntryContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -30,9 +32,7 @@ final class ChannelPricingLogEntryContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I go to the price history of a (variant with code "[^"]+")$/
-     */
+    #[When('/^I go to the price history of a (variant with code "[^"]+")$/')]
     public function iGoToThePriceHistoryOfAVariant(ProductVariantInterface $productVariant): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -46,18 +46,14 @@ final class ChannelPricingLogEntryContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see :count log entries in the catalog price history
-     * @Then I should see a single log entry in the catalog price history
-     */
+    #[Then('I should see :count log entries in the catalog price history')]
+    #[Then('I should see a single log entry in the catalog price history')]
     public function iShouldSeeLogEntriesInTheCatalogPriceHistoryForTheVariant(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then /^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the ("[^"]+") selling price, (no|"[^"]+") original price and datetime of the price change$/
-     */
+    #[Then('/^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the ("[^"]+") selling price, (no|"[^"]+") original price and datetime of the price change$/')]
     public function thereShouldBeALogEntryOnThePositionWithTheSellingPriceOriginalPriceAndDatetimeOfThePriceChange(
         int $position,
         int $price,
@@ -74,9 +70,7 @@ final class ChannelPricingLogEntryContext implements Context
         Assert::keyExists($logEntry, 'loggedAt');
     }
 
-    /**
-     * @Then /^there should be a log entry with the ("[^"]+") selling price, (no|"[^"]+") original price and datetime of the price change$/
-     */
+    #[Then('/^there should be a log entry with the ("[^"]+") selling price, (no|"[^"]+") original price and datetime of the price change$/')]
     public function thereShouldBeALogEntryWithTheSellingPriceOriginalPriceAndDatetimeOfThePriceChange(
         int $price,
         int|string $originalPrice,

--- a/src/Sylius/Behat/Context/Api/Admin/CreatingProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/CreatingProductVariantContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -27,9 +28,7 @@ final class CreatingProductVariantContext implements Context
     {
     }
 
-    /**
-     * @When /^I create a new "([^"]+)" variant priced at ("[^"]+") for ("[^"]+" product) in the ("[^"]+" channel)$/
-     */
+    #[When('/^I create a new "([^"]+)" variant priced at ("[^"]+") for ("[^"]+" product) in the ("[^"]+" channel)$/')]
     public function iCreateANewVariantPricedAtForProductInTheChannel(
         string $name,
         int $price,

--- a/src/Sylius/Behat/Context/Api/Admin/DashboardContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/DashboardContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -29,19 +31,15 @@ final class DashboardContext implements Context
     ) {
     }
 
-    /**
-     * @When I view statistics
-     */
+    #[When('I view statistics')]
     public function iBrowseStatistics(): void
     {
         $this->client->index('statistics');
     }
 
-    /**
-     * @When I view statistics for :channel channel and current year split by month
-     * @When I choose :channel channel
-     * @When I view statistics for :channel channel
-     */
+    #[When('I view statistics for :channel channel and current year split by month')]
+    #[When('I choose :channel channel')]
+    #[When('I view statistics for :channel channel')]
     public function iViewStatisticsForChannelAndYear(ChannelInterface $channel): void
     {
         $this->client->index(
@@ -55,9 +53,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @When I view statistics for :channel channel and previous year split by month
-     */
+    #[When('I view statistics for :channel channel and previous year split by month')]
     public function iViewStatisticsForChannelAndPreviousYear(ChannelInterface $channel): void
     {
         $currentYear = (int) $this->clock->now()->format('Y');
@@ -73,9 +69,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @When I view statistics for :channel channel and next year split by month
-     */
+    #[When('I view statistics for :channel channel and next year split by month')]
     public function iViewStatisticsForChannelAndNextYear(ChannelInterface $channel): void
     {
         $currentYear = (int) $this->clock->now()->format('Y');
@@ -91,9 +85,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count paid orders
-     */
+    #[Then('I should see :count paid orders')]
     public function iShouldSeePaidOrders(int $count): void
     {
         Assert::true(
@@ -105,9 +97,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :number new customers( in the list)
-     */
+    #[Then('I should see :number new customers( in the list)')]
     public function iShouldSeeNewCustomers(int $count): void
     {
         Assert::true(
@@ -126,9 +116,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @Then /^there should be total sales of ("[^"]+")$/
-     */
+    #[Then('/^there should be total sales of ("[^"]+")$/')]
     public function thereShouldBeTotalSalesOf(int $totalSales): void
     {
         Assert::true(
@@ -140,9 +128,7 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @Then /^the average order value should be ("[^"]+")$/
-     */
+    #[Then('/^the average order value should be ("[^"]+")$/')]
     public function myAverageOrderValueShouldBe(int $averageTotalValue): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/Helper/ValidationTrait.php
+++ b/src/Sylius/Behat/Context/Api/Admin/Helper/ValidationTrait.php
@@ -13,23 +13,21 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin\Helper;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Webmozart\Assert\Assert;
 
 trait ValidationTrait
 {
-    /**
-     * @When I specify a too long :field
-     */
+    #[When('I specify a too long :field')]
     public function iSpecifyATooLong(string $field): void
     {
         $this->client->addRequestData($field, str_repeat('a', $this->getMaxCodeLength() + 1));
     }
 
-    /**
-     * @Then I should be notified that :field is too long
-     * @Then I should be notified that :field should be no longer than :maxLength characters
-     */
+    #[Then('I should be notified that :field is too long')]
+    #[Then('I should be notified that :field should be no longer than :maxLength characters')]
     public function iShouldBeNotifiedThatFieldIsTooLong(string $field, int $maxLength = 255): void
     {
         Assert::regex(

--- a/src/Sylius/Behat/Context/Api/Admin/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/LoginContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiSecurityClientInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -27,49 +29,37 @@ final class LoginContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to log in
-     */
+    #[When('I want to log in')]
     public function iWantToLogIn(): void
     {
         $this->apiSecurityClient->prepareLoginRequest();
     }
 
-    /**
-     * @When I specify the username as :username
-     */
+    #[When('I specify the username as :username')]
     public function iSpecifyTheUsername(string $username): void
     {
         $this->apiSecurityClient->setEmail($username);
     }
 
-    /**
-     * @When I specify the password as :password
-     */
+    #[When('I specify the password as :password')]
     public function iSpecifyThePasswordAs(string $password): void
     {
         $this->apiSecurityClient->setPassword($password);
     }
 
-    /**
-     * @When I log in
-     */
+    #[When('I log in')]
     public function iLogIn(): void
     {
         $this->apiSecurityClient->call();
     }
 
-    /**
-     * @Then I should be logged in
-     */
+    #[Then('I should be logged in')]
     public function iShouldBeLoggedIn(): void
     {
         Assert::true($this->apiSecurityClient->isLoggedIn(), 'Admin should be logged in, but they are not.');
     }
 
-    /**
-     * @Then I should not be logged in
-     */
+    #[Then('I should not be logged in')]
     public function iShouldNotBeLoggedIn(): void
     {
         try {
@@ -79,26 +69,20 @@ final class LoginContext implements Context
         }
     }
 
-    /**
-     * @Then I should be notified about bad credentials
-     */
+    #[Then('I should be notified about bad credentials')]
     public function iShouldBeNotifiedAboutBadCredentials(): void
     {
         Assert::same($this->apiSecurityClient->getErrorMessage(), 'Invalid credentials.');
     }
 
-    /**
-     * @Then I should be able to log in as :username authenticated by :password password
-     */
+    #[Then('I should be able to log in as :username authenticated by :password password')]
     public function iShouldBeAbleToLogInAsAuthenticatedByPassword(string $username, string $password): void
     {
         $this->logIn($username, $password);
         $this->iShouldBeLoggedIn();
     }
 
-    /**
-     * @Then I should not be able to log in as :username authenticated by :password password
-     */
+    #[Then('I should not be able to log in as :username authenticated by :password password')]
     public function iShouldNotBeAbleToLogInAsAuthenticatedByPassword(string $username, string $password): void
     {
         $this->logIn($username, $password);

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingAdministratorsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestBuilder;
@@ -41,39 +44,31 @@ final class ManagingAdministratorsContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am editing (my) details$/
-     * @When /^I want to edit (this administrator)$/
-     */
+    #[Given('/^I am editing (my) details$/')]
+    #[When('/^I want to edit (this administrator)$/')]
     public function iWantToEditThisAdministrator(AdminUserInterface $adminUser): void
     {
         $this->client->buildUpdateRequest(Resources::ADMINISTRATORS, (string) $adminUser->getId());
     }
 
-    /**
-     * @When I browse administrators
-     * @When I want to browse administrators
-     * @When I try to browse administrators
-     */
+    #[When('I browse administrators')]
+    #[When('I want to browse administrators')]
+    #[When('I try to browse administrators')]
     public function iBrowseAdministrators(): void
     {
         $this->client->index(Resources::ADMINISTRATORS);
         $this->sharedStorage->set('last_response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I want to create a new administrator
-     */
+    #[When('I want to create a new administrator')]
     public function iWantToCreateANewAdministrator(): void
     {
         $this->client->buildCreateRequest(Resources::ADMINISTRATORS);
     }
 
-    /**
-     * @When I specify its email as :email
-     * @When I do not specify its email
-     * @When I change its email to :email
-     */
+    #[When('I specify its email as :email')]
+    #[When('I do not specify its email')]
+    #[When('I change its email to :email')]
     public function iSpecifyItsEmailAs(?string $email = null): void
     {
         if ($email !== null) {
@@ -81,11 +76,9 @@ final class ManagingAdministratorsContext implements Context
         }
     }
 
-    /**
-     * @When I specify its name as :username
-     * @When I do not specify its name
-     * @When I change its name to :username
-     */
+    #[When('I specify its name as :username')]
+    #[When('I do not specify its name')]
+    #[When('I change its name to :username')]
     public function iSpecifyItsNameAs(?string $username = null): void
     {
         if ($username !== null) {
@@ -93,19 +86,15 @@ final class ManagingAdministratorsContext implements Context
         }
     }
 
-    /**
-     * @When I specify its :field as too long string
-     */
+    #[When('I specify its :field as too long string')]
     public function iSpecifyItsFieldAsTooLongString(string $field): void
     {
         $this->client->addRequestData(StringInflector::nameToCamelCase(lcfirst(trim(ucwords($field)))), str_repeat('a', 256));
     }
 
-    /**
-     * @When I specify its password as :password
-     * @When I do not specify its password
-     * @When I change its password to :password
-     */
+    #[When('I specify its password as :password')]
+    #[When('I do not specify its password')]
+    #[When('I change its password to :password')]
     public function iSpecifyItsPasswordAs(?string $password = null): void
     {
         if ($password !== null) {
@@ -113,49 +102,37 @@ final class ManagingAdministratorsContext implements Context
         }
     }
 
-    /**
-     * @When I specify its locale as :localeCode
-     */
+    #[When('I specify its locale as :localeCode')]
     public function iSpecifyItsLocaleAs(string $localeCode): void
     {
         $this->client->addRequestData('localeCode', $localeCode);
     }
 
-    /**
-     * @When I specify its locale as a wrong code
-     */
+    #[When('I specify its locale as a wrong code')]
     public function iSpecifyItsLocaleAsWrongCode(): void
     {
         $this->client->addRequestData('localeCode', 'wr_ONG');
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->addRequestData('enabled', true);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I delete administrator with email :adminUser
-     */
+    #[When('I delete administrator with email :adminUser')]
     public function iDeleteAdministratorWithEmail(AdminUserInterface $adminUser): void
     {
         $this->client->delete(Resources::ADMINISTRATORS, (string) $adminUser->getId());
     }
 
-    /**
-     * @When /^I (?:upload|update) the "([^"]+)" image as (my) avatar$/
-     */
+    #[When('/^I (?:upload|update) the "([^"]+)" image as (my) avatar$/')]
     public function iUploadTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
         $builder = RequestBuilder::createPost(
@@ -171,9 +148,7 @@ final class ManagingAdministratorsContext implements Context
         $this->sharedStorage->set(StringInflector::nameToCode($avatar), $this->responseChecker->getValue($response, '@id'));
     }
 
-    /**
-     * @When I remove the avatar
-     */
+    #[When('I remove the avatar')]
     public function iRemoveTheAvatarImage(): void
     {
         /** @var AdminUserInterface $administrator */
@@ -187,19 +162,15 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single administrator in the list
-     * @Then there should be :count administrators in the list
-     */
+    #[Then('I should see a single administrator in the list')]
+    #[Then('there should be :count administrators in the list')]
     public function iShouldSeeAdministratorsInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the administrator :email should appear in the store
-     * @Then I should see the administrator :email in the list
-     */
+    #[Then('the administrator :email should appear in the store')]
+    #[Then('I should see the administrator :email in the list')]
     public function theAdministratorShouldAppearInTheStore(string $email): void
     {
         Assert::true(
@@ -208,9 +179,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then there should not be :email administrator anymore
-     */
+    #[Then('there should not be :email administrator anymore')]
     public function thereShouldNotBeAdministratorAnymore(string $email): void
     {
         Assert::false(
@@ -219,9 +188,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one administrator with an email :email
-     */
+    #[Then('there should still be only one administrator with an email :email')]
     public function thereShouldStillBeOnlyOneAdministratorWithAnEmail(string $email): void
     {
         Assert::count(
@@ -231,10 +198,8 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one administrator with name :username
-     * @Then this administrator with name :username should appear in the store
-     */
+    #[Then('there should still be only one administrator with name :username')]
+    #[Then('this administrator with name :username should appear in the store')]
     public function thisAdministratorWithNameShouldAppearInTheStore(string $username): void
     {
         Assert::count(
@@ -244,9 +209,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -255,9 +218,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -266,9 +227,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that email must be unique
-     */
+    #[Then('I should be notified that email must be unique')]
     public function iShouldBeNotifiedThatEmailMustBeUnique(): void
     {
         Assert::contains(
@@ -277,9 +236,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that name must be unique
-     */
+    #[Then('I should be notified that name must be unique')]
     public function iShouldBeNotifiedThatNameMustBeUnique(): void
     {
         Assert::contains(
@@ -288,9 +245,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the :elementName is required
-     */
+    #[Then('I should be notified that the :elementName is required')]
     public function iShouldBeNotifiedThatFirstNameIsRequired(string $elementName): void
     {
         Assert::contains(
@@ -299,9 +254,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this email is not valid
-     */
+    #[Then('I should be notified that this email is not valid')]
     public function iShouldBeNotifiedThatEmailIsNotValid(): void
     {
         Assert::contains(
@@ -310,9 +263,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this :field is too long
-     */
+    #[Then('I should be notified that this :field is too long')]
     public function iShouldBeNotifiedThatThisFieldIsTooLong(string $field): void
     {
         Assert::contains(
@@ -321,9 +272,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this value is not valid locale
-     */
+    #[Then('I should be notified that this value is not valid locale')]
     public function iShouldBeNotifiedThatThisValueIsNotValidLocale(): void
     {
         Assert::contains(
@@ -332,9 +281,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it cannot be deleted
-     */
+    #[Then('I should be notified that it cannot be deleted')]
     public function iShouldBeNotifiedThatItCannotBeDeleted(): void
     {
         Assert::false(
@@ -347,9 +294,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see the "([^"]*)" image as (my) avatar$/
-     */
+    #[Then('/^I should see the "([^"]*)" image as (my) avatar$/')]
     public function iShouldSeeTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
         Assert::true($this->responseChecker->hasValue(
@@ -359,9 +304,7 @@ final class ManagingAdministratorsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not see the :avatar avatar image in the additional information section of my account
-     */
+    #[Then('I should not see the :avatar avatar image in the additional information section of my account')]
     public function iShouldNotSeeTheAvatarImage(string $avatar): void
     {
         /** @var AdminUserInterface $administrator */
@@ -374,9 +317,7 @@ final class ManagingAdministratorsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that this email is not valid in :locale locale
-     */
+    #[Then('I should be notified that this email is not valid in :locale locale')]
     public function iShouldBeNotifiedThatEmailIsNotValidInLocale(LocaleInterface $locale): void
     {
         Assert::contains(
@@ -386,10 +327,8 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the :avatar avatar image in the top bar next to my name
-     * @Then I should not see the :avatar avatar image in the top bar next to my name
-     */
+    #[Then('I should see the :avatar avatar image in the top bar next to my name')]
+    #[Then('I should not see the :avatar avatar image in the top bar next to my name')]
     public function iShouldSeeTheAvatarImageInTheTopBarNextToMyName(string $avatar): void
     {
         // intentionally left blank, as it is ui step

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -45,18 +48,14 @@ final readonly class ManagingCatalogPromotionsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing catalog promotions
-     * @When I browse catalog promotions
-     */
+    #[Given('I am browsing catalog promotions')]
+    #[When('I browse catalog promotions')]
     public function iBrowseCatalogPromotions(): void
     {
         $this->client->index(Resources::CATALOG_PROMOTIONS);
     }
 
-    /**
-     * @When I create a new catalog promotion with :code code and :name name
-     */
+    #[When('I create a new catalog promotion with :code code and :name name')]
     public function iCreateANewCatalogPromotionWithCodeAndName(string $code, string $name): void
     {
         $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
@@ -65,9 +64,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When I create a new catalog promotion with :code code and :name name and :priority priority
-     */
+    #[When('I create a new catalog promotion with :code code and :name name and :priority priority')]
     public function iCreateANewCatalogPromotionWithCodeAndNameAndPriority(string $code, string $name, int $priority): void
     {
         $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
@@ -77,43 +74,33 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When I create a new catalog promotion without specifying its code and name
-     */
+    #[When('I create a new catalog promotion without specifying its code and name')]
     public function iCreateANewCatalogPromotionWithoutSpecifyingItsCodeAndName(): void
     {
         $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
         $this->client->create();
     }
 
-    /**
-     * @When I want to create a new catalog promotion
-     */
+    #[When('I want to create a new catalog promotion')]
     public function iWantToCreateNewCatalogPromotion(): void
     {
         $this->client->buildCreateRequest(Resources::CATALOG_PROMOTIONS);
     }
 
-    /**
-     * @When I specify its :field as :value
-     * @When I :field it :value
-     */
+    #[When('I specify its :field as :value')]
+    #[When('I :field it :value')]
     public function iSpecifyItsAs(string $field, string $value): void
     {
         $this->client->addRequestData($field, $value);
     }
 
-    /**
-     * @When I set its priority to :priority
-     */
+    #[When('I set its priority to :priority')]
     public function iSetsItsPriorityTo(int $priority): void
     {
         $this->client->addRequestData('priority', $priority);
     }
 
-    /**
-     * @When I specify its :field as :value in :localeCode
-     */
+    #[When('I specify its :field as :value in :localeCode')]
     public function iSpecifyItsAsIn(string $field, string $value, string $localeCode): void
     {
         $data['translations'][$localeCode][$field] = $value;
@@ -121,25 +108,19 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->client->updateRequestData(['enabled' => false]);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->updateRequestData(['enabled' => true]);
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $data = ['translations' => [$localeCode => []]];
@@ -148,17 +129,13 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I make it available in channel :channel
-     */
+    #[When('I make it available in channel :channel')]
     public function iMakeItAvailableInChannel(ChannelInterface $channel): void
     {
         $this->client->addRequestData('channels', [$this->iriConverter->getIriFromResourceInSection($channel, 'admin')]);
     }
 
-    /**
-     * @When /^I make (it) unavailable in (channel "[^"]+")$/
-     */
+    #[When('/^I make (it) unavailable in (channel "[^"]+")$/')]
     public function iMakeItUnavailableInChannel(CatalogPromotionInterface $catalogPromotion, ChannelInterface $channel): void
     {
         $channels = $this->responseChecker->getValue($this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode()), 'channels');
@@ -170,18 +147,14 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('channels', $channels);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I rename the :catalogPromotion catalog promotion to :name
-     * @When I try to rename the :catalogPromotion catalog promotion to :name
-     */
+    #[When('I rename the :catalogPromotion catalog promotion to :name')]
+    #[When('I try to rename the :catalogPromotion catalog promotion to :name')]
     public function iRenameTheCatalogPromotionTo(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
         $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
@@ -189,10 +162,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When I want to modify a catalog promotion :catalogPromotion
-     * @When I modify a catalog promotion :catalogPromotion
-     */
+    #[When('I want to modify a catalog promotion :catalogPromotion')]
+    #[When('I modify a catalog promotion :catalogPromotion')]
     public function iWantToModifyACatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->client->buildUpdateRequest(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
@@ -200,9 +171,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @When /^I add action that gives ("[^"]+") percentage discount$/
-     */
+    #[When('/^I add action that gives ("[^"]+") percentage discount$/')]
     public function iAddActionThatGivesPercentageDiscount(float $amount): void
     {
         $actions = [[
@@ -215,9 +184,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I add action that gives ("[^"]+") of fixed discount in the ("[^"]+" channel)$/
-     */
+    #[When('/^I add action that gives ("[^"]+") of fixed discount in the ("[^"]+" channel)$/')]
     public function iAddActionThatGivesFixedDiscount(int $amount, ChannelInterface $channel): void
     {
         $actions = [[
@@ -232,9 +199,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I add another action that gives ("[^"]+") percentage discount$/
-     */
+    #[When('/^I add another action that gives ("[^"]+") percentage discount$/')]
     public function iAddAnotherActionThatGivesPercentageDiscount(float $amount): void
     {
         $actions = $this->client->getContent()['actions'];
@@ -251,9 +216,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I add another scope that applies on ("[^"]+" variant)$/
-     */
+    #[When('/^I add another scope that applies on ("[^"]+" variant)$/')]
     public function iAddAnotherScopeThatGivesPercentageDiscount(ProductVariantInterface $productVariant): void
     {
         $scopes = $this->client->getContent()['scopes'];
@@ -270,9 +233,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When /^I edit its action so that it reduces price by ("[^"]+")$/
-     */
+    #[When('/^I edit its action so that it reduces price by ("[^"]+")$/')]
     public function iEditItsActionSoThatItReducesPriceBy(float $amount): void
     {
         $content = $this->client->getContent();
@@ -280,9 +241,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->updateRequestData($content);
     }
 
-    /**
-     * @When I remove its last action
-     */
+    #[When('I remove its last action')]
     public function iRemoveItsLastAction(): void
     {
         $content = $this->client->getContent();
@@ -293,9 +252,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @When I add invalid percentage discount action with non number in amount
-     */
+    #[When('I add invalid percentage discount action with non number in amount')]
     public function iAddInvalidPercentageDiscountActionWithNonNumberInAmount(): void
     {
         $actions = [[
@@ -308,17 +265,13 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I make it start at :startDate and ends at :endDate
-     */
+    #[When('I make it start at :startDate and ends at :endDate')]
     public function iMakeCatalogPromotionOperateBetweenDates(string $startDate, string $endDate): void
     {
         $this->client->updateRequestData(['startDate' => $startDate, 'endDate' => $endDate]);
     }
 
-    /**
-     * @When I make it start yesterday and ends tomorrow
-     */
+    #[When('I make it start yesterday and ends tomorrow')]
     public function iMakeCatalogPromotionOperateBetweenYesterdayAndTomorrow(): void
     {
         $this->client->updateRequestData([
@@ -327,18 +280,14 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         ]);
     }
 
-    /**
-     * @When I make it start at :startDate
-     */
+    #[When('I make it start at :startDate')]
     public function iMakeCatalogPromotionOperateFrom(string $startDate): void
     {
         $this->client->updateRequestData(['startDate' => $startDate]);
     }
 
-    /**
-     * @When /^I add scope that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
-     * @When /^I add scope that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
-     */
+    #[When('/^I add scope that applies on ("[^"]+" variant) and ("[^"]+" variant)$/')]
+    #[When('/^I add scope that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/')]
     public function iAddScopeThatAppliesOnVariants(ProductVariantInterface $firstVariant, ProductVariantInterface $secondVariant): void
     {
         $scopes = [[
@@ -354,9 +303,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add catalog promotion scope for taxon without taxons
-     */
+    #[When('I add catalog promotion scope for taxon without taxons')]
     public function iAddCatalogPromotionScopeForTaxonWithoutTaxons(): void
     {
         $scopes = [[
@@ -367,9 +314,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add catalog promotion scope for taxon with nonexistent taxons
-     */
+    #[When('I add catalog promotion scope for taxon with nonexistent taxons')]
     public function iAddCatalogPromotionScopeForTaxonWithNonexistentTaxons(): void
     {
         $scopes = [[
@@ -385,9 +330,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add catalog promotion scope for product without products
-     */
+    #[When('I add catalog promotion scope for product without products')]
     public function iAddCatalogPromotionScopeForProductWithoutProducts(): void
     {
         $scopes = [[
@@ -398,9 +341,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add catalog promotion scope for product with nonexistent products
-     */
+    #[When('I add catalog promotion scope for product with nonexistent products')]
     public function iAddCatalogPromotionScopeForProductsWithNonexistentProducts(): void
     {
         $scopes = [[
@@ -416,9 +357,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add scope that applies on :taxon taxon
-     */
+    #[When('I add scope that applies on :taxon taxon')]
     public function iAddScopeThatAppliesOnTaxon(TaxonInterface $taxon): void
     {
         $scopes = [[
@@ -431,9 +370,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add scope that applies on :product product
-     */
+    #[When('I add scope that applies on :product product')]
     public function iAddScopeThatAppliesOnProduct(ProductInterface $product): void
     {
         $scopes = [[
@@ -446,9 +383,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When /^I create an exclusive "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[When('/^I create an exclusive "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by ("[^"]+") in ("[^"]+" channel)$/')]
     public function iCreateAnExclusiveCatalogPromotionWithCodeAndNameAndPriorityThatAppliesOnProductAndReducesPriceByInChannel(
         string $name,
         int $priority,
@@ -459,9 +394,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->createCatalogPromotion($name, $priority, true, $product, $discount, $channel);
     }
 
-    /**
-     * @When /^I create a "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[When('/^I create a "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by ("[^"]+") in ("[^"]+" channel)$/')]
     public function iCreateACatalogPromotionWithCodeAndNameAndPriorityThatAppliesOnProductAndReducesPriceByInChannel(
         string $name,
         int $priority,
@@ -472,9 +405,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->createCatalogPromotion($name, $priority, false, $product, $discount, $channel);
     }
 
-    /**
-     * @When I remove its last scope
-     */
+    #[When('I remove its last scope')]
     public function iRemoveItsLastScope(): void
     {
         $content = $this->client->getContent();
@@ -485,9 +416,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @When I add :productVariant variant to its scope
-     */
+    #[When('I add :productVariant variant to its scope')]
     public function iAddVariantToItsScope(ProductVariantInterface $productVariant): void
     {
         $content = $this->client->getContent();
@@ -495,9 +424,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I remove :productVariant variant from its scope
-     */
+    #[When('I remove :productVariant variant from its scope')]
     public function iRemoveVariantFromItsScope(ProductVariantInterface $productVariant): void
     {
         $content = $this->client->getContent();
@@ -508,9 +435,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @When /^I edit ("[^"]+" catalog promotion) to be applied on ("[^"]+" variant)$/
-     */
+    #[When('/^I edit ("[^"]+" catalog promotion) to be applied on ("[^"]+" variant)$/')]
     public function iEditCatalogPromotionToBeAppliedOnVariant(
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant,
@@ -532,25 +457,19 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I disable :catalogPromotion catalog promotion
-     */
+    #[When('I disable :catalogPromotion catalog promotion')]
     public function iDisableThisCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->toggleCatalogPromotion($catalogPromotion, false);
     }
 
-    /**
-     * @When I enable :catalogPromotion catalog promotion
-     */
+    #[When('I enable :catalogPromotion catalog promotion')]
     public function iEnableCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->toggleCatalogPromotion($catalogPromotion, true);
     }
 
-    /**
-     * @When /^I edit it to have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/
-     */
+    #[When('/^I edit it to have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/')]
     public function iEditItToHaveFixedDiscountInTheChannel(
         int $amount,
         ChannelInterface $channel,
@@ -565,9 +484,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I edit it to have empty amount of percentage discount
-     */
+    #[When('I edit it to have empty amount of percentage discount')]
     public function iEditItToHaveEmptyPercentageDiscount(): void
     {
         $content = $this->client->getContent();
@@ -580,9 +497,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I edit it to have empty amount of fixed discount in the :channel channel
-     */
+    #[When('I edit it to have empty amount of fixed discount in the :channel channel')]
     public function iEditItToHaveEmptyFixedDiscountInTheChannel(ChannelInterface $channel): void
     {
         $content = $this->client->getContent();
@@ -595,9 +510,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I add catalog promotion scope with nonexistent type
-     */
+    #[When('I add catalog promotion scope with nonexistent type')]
     public function iAddCatalogPromotionScopeWithNonexistentType(): void
     {
         $scopes = [[
@@ -610,9 +523,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add for variants scope with the wrong configuration
-     */
+    #[When('I add for variants scope with the wrong configuration')]
     public function iAddForVariantsScopeWithTheWrongConfiguration(): void
     {
         $scopes = [[
@@ -625,9 +536,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add for variants scope without variants configured
-     */
+    #[When('I add for variants scope without variants configured')]
     public function iAddForVariantsScopeWithoutVariantsConfigured(): void
     {
         $scopes = [[
@@ -640,9 +549,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('scopes', $scopes);
     }
 
-    /**
-     * @When I add percentage discount action without amount configured
-     */
+    #[When('I add percentage discount action without amount configured')]
     public function iAddPercentageDiscountActionWithoutAmountConfigured(): void
     {
         $actions = [[
@@ -655,9 +562,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I add fixed discount action without amount configured for the :channel channel
-     */
+    #[When('I add fixed discount action without amount configured for the :channel channel')]
     public function iAddFixedDiscountActionWithoutAmountConfigured(ChannelInterface $channel): void
     {
         $actions = [[
@@ -668,9 +573,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I add invalid fixed discount action with non number in amount for the :channel channel
-     */
+    #[When('I add invalid fixed discount action with non number in amount for the :channel channel')]
     public function iAddInvalidFixedDiscountActionWithNonNumberInAmountForTheChannel(
         ChannelInterface $channel,
     ): void {
@@ -682,9 +585,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I add invalid fixed discount action configured for nonexistent channel
-     */
+    #[When('I add invalid fixed discount action configured for nonexistent channel')]
     public function iAddInvalidFixedDiscountActionConfiguredForNonexistentChannel(): void
     {
         $actions = [[
@@ -695,9 +596,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I add catalog promotion action with nonexistent type
-     */
+    #[When('I add catalog promotion action with nonexistent type')]
     public function iAddCatalogPromotionActionWithNonexistentType(): void
     {
         $actions = [[
@@ -708,10 +607,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I make (this catalog promotion) unavailable in the ("[^"]+" channel)$/
-     * @When /^I make the ("[^"]+" catalog promotion) unavailable in the ("[^"]+" channel)$/
-     */
+    #[When('/^I make (this catalog promotion) unavailable in the ("[^"]+" channel)$/')]
+    #[When('/^I make the ("[^"]+" catalog promotion) unavailable in the ("[^"]+" channel)$/')]
     public function iMakeThisCatalogPromotionUnavailableInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -729,10 +626,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When /^I make (this catalog promotion) available in the ("[^"]+" channel)$/
-     * @When /^I make ("[^"]+" catalog promotion) available in the ("[^"]+" channel)$/
-     */
+    #[When('/^I make (this catalog promotion) available in the ("[^"]+" channel)$/')]
+    #[When('/^I make ("[^"]+" catalog promotion) available in the ("[^"]+" channel)$/')]
     public function iMakeThisCatalogPromotionAvailableInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -744,10 +639,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When /^I switch (this catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/
-     * @When /^I switch ("[^"]+" catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/
-     */
+    #[When('/^I switch (this catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/')]
+    #[When('/^I switch ("[^"]+" catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/')]
     public function iSwitchThisCatalogPromotionAvailabilityFromTheChannelToTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $removedChannel,
@@ -767,9 +660,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When I view details of the catalog promotion :catalogPromotion
-     */
+    #[When('I view details of the catalog promotion :catalogPromotion')]
     public function iViewDetailsOfTheCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
@@ -777,71 +668,55 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @When I( try to) change its end date to :endDate
-     */
+    #[When('I( try to) change its end date to :endDate')]
     public function iChangeItsEndDateTo(string $endDate): void
     {
         $this->client->updateRequestData(['endDate' => $endDate]);
     }
 
-    /**
-     * @When /^I search by "([^"]+)" (code|name)$/
-     */
+    #[When('/^I search by "([^"]+)" (code|name)$/')]
     public function iSearchByName(string $phrase, string $field): void
     {
         $this->client->addFilter($field, $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by :channel channel
-     */
+    #[When('I filter by :channel channel')]
     public function iFilterByChannel(ChannelInterface $channel): void
     {
         $this->client->addFilter('channel', $this->iriConverter->getIriFromResource($channel));
         $this->client->filter();
     }
 
-    /**
-     * @When I filter enabled catalog promotions
-     */
+    #[When('I filter enabled catalog promotions')]
     public function iFilterEnabledCatalogPromotions(): void
     {
         $this->client->addFilter('enabled', true);
         $this->client->filter();
     }
 
-    /**
-     * @When /^I filter by (active|failed|inactive|processing) state$/
-     */
+    #[When('/^I filter by (active|failed|inactive|processing) state$/')]
     public function iFilterByState(string $state): void
     {
         $this->client->addFilter('state', $state);
         $this->client->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterDateUpTo(string $dateType, string $date): void
     {
         $this->client->addFilter(sprintf('%sDate[before]', $dateType), $date);
         $this->client->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterByDateFrom(string $dateType, string $date): void
     {
         $this->client->addFilter(sprintf('%sDate[after]', $dateType), $date);
         $this->client->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterByDateFromDateToDate(string $dateType, string $fromDate, string $toDate): void
     {
         $this->client->addFilter(sprintf('%sDate[after]', $dateType), $fromDate);
@@ -849,9 +724,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I sort catalog promotions by :order :field
-     */
+    #[When('I sort catalog promotions by :order :field')]
     public function iSortCatalogPromotionByOrderField(string $order, string $field): void
     {
         $this->client->addFilter(
@@ -861,17 +734,13 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I request the removal of :catalogPromotion catalog promotion
-     */
+    #[When('I request the removal of :catalogPromotion catalog promotion')]
     public function iRequestTheRemovalOfCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->client->delete(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
     }
 
-    /**
-     * @Then I should be notified that the removal operation has started successfully
-     */
+    #[Then('I should be notified that the removal operation has started successfully')]
     public function iShouldBeNotifiedThatTheRemovalOperationHasStartedSuccessfully(): void
     {
         Assert::true(
@@ -880,19 +749,15 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then there should be :amount new catalog promotion on the list
-     * @Then there should be :amount catalog promotions on the list
-     * @Then there should be an empty list of catalog promotions
-     */
+    #[Then('there should be :amount new catalog promotion on the list')]
+    #[Then('there should be :amount catalog promotions on the list')]
+    #[Then('there should be an empty list of catalog promotions')]
     public function thereShouldBeNewCatalogPromotionOnTheList(int $amount = 0): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->index(Resources::CATALOG_PROMOTIONS)), $amount);
     }
 
-    /**
-     * @Then /^it should have ("[^"]+") discount$/
-     */
+    #[Then('/^it should have ("[^"]+") discount$/')]
     public function itShouldHaveDiscount(float $amount): void
     {
         $catalogPromotion = $this->responseChecker->getCollection($this->client->getLastResponse())[0];
@@ -900,9 +765,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::same($catalogPromotion['actions'][0]['configuration']['amount'], $amount);
     }
 
-    /**
-     * @Then /^the ("[^"]+" catalog promotion) should have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/
-     */
+    #[Then('/^the ("[^"]+" catalog promotion) should have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/')]
     public function theCatalogPromotionShouldHaveFixedDiscountInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         int $amount,
@@ -913,10 +776,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::same($catalogPromotion['actions'][0]['configuration'][$channel->getCode()]['amount'], $amount);
     }
 
-    /**
-     * @Then /^this catalog promotion should have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/
-     * @Then /^it should reduce price by ("[^"]+") in the ("[^"]+" channel)$/
-     */
+    #[Then('/^this catalog promotion should have ("[^"]+") of fixed discount in the ("[^"]+" channel)$/')]
+    #[Then('/^it should reduce price by ("[^"]+") in the ("[^"]+" channel)$/')]
     public function thisCatalogPromotionShouldHaveFixedDiscountInTheChannel(int $amount, ChannelInterface $channel): void
     {
         $catalogPromotionActions = $this->responseChecker->getValue($this->client->getLastResponse(), 'actions');
@@ -938,10 +799,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^this catalog promotion should have ("[^"]+") percentage discount$/
-     * @Then /^it should reduce price by ("[^"]+")$/
-     */
+    #[Then('/^this catalog promotion should have ("[^"]+") percentage discount$/')]
+    #[Then('/^it should reduce price by ("[^"]+")$/')]
     public function thisCatalogPromotionShouldHavePercentageDiscount(float $amount): void
     {
         $catalogPromotionActions = $this->responseChecker->getResponseContent($this->client->getLastResponse())['actions'];
@@ -957,9 +816,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         throw new \Exception(sprintf('There is no "%s" action with %f', PercentageDiscountPriceCalculator::TYPE, $amount));
     }
 
-    /**
-     * @Then it should have :code code and :name name
-     */
+    #[Then('it should have :code code and :name name')]
     public function itShouldHaveCodeAndName(string $code, string $name): void
     {
         Assert::true(
@@ -968,9 +825,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then it should have priority equal to :priority
-     */
+    #[Then('it should have priority equal to :priority')]
     public function itShouldHavePriorityEqualTo(int $priority): void
     {
         Assert::true(
@@ -979,10 +834,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the catalog promotions named :firstName and :secondName should be in the registry
-     * @Then the catalog promotion named :firstName should be in the registry
-     */
+    #[Then('the catalog promotions named :firstName and :secondName should be in the registry')]
+    #[Then('the catalog promotion named :firstName should be in the registry')]
     public function theCatalogPromotionsNamedShouldBeInTheRegistry(string ...$names): void
     {
         foreach ($names as $name) {
@@ -993,12 +846,10 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then the catalog promotion named :catalogPromotion should operate between :startDate and :endDate
-     * @Then /^(it) should operate between "([^"]+)" and "([^"]+)"$/
-     * @Then /^(it) should start at "([^"]+)" and end at "([^"]+)"$/
-     * @Then /^(this catalog promotion) should operate between "([^"]+)" and "([^"]+)"$/
-     */
+    #[Then('the catalog promotion named :catalogPromotion should operate between :startDate and :endDate')]
+    #[Then('/^(it) should operate between "([^"]+)" and "([^"]+)"$/')]
+    #[Then('/^(it) should start at "([^"]+)" and end at "([^"]+)"$/')]
+    #[Then('/^(this catalog promotion) should operate between "([^"]+)" and "([^"]+)"$/')]
     public function theCatalogPromotionNamedShouldOperateBetweenDates(
         CatalogPromotionInterface $catalogPromotion,
         string $startDate,
@@ -1020,9 +871,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the catalog promotion named :catalogPromotion should have priority :priority
-     */
+    #[Then('the catalog promotion named :catalogPromotion should have priority :priority')]
     public function theCatalogPromotionNamedShouldHavePriority(
         CatalogPromotionInterface $catalogPromotion,
         int $priority,
@@ -1042,9 +891,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(it) should operate between yesterday and tomorrow$/
-     */
+    #[Then('/^(it) should operate between yesterday and tomorrow$/')]
     public function theCatalogPromotionsNamedShouldOperateBetweenYesterdayAndTomorrow(
         CatalogPromotionInterface $catalogPromotion,
     ): void {
@@ -1068,9 +915,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(it) should be (inactive|active)$/
-     */
+    #[Then('/^(it) should be (inactive|active)$/')]
     public function itShouldBe(CatalogPromotionInterface $catalogPromotion, string $state): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -1079,9 +924,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(its) priority should be ([^"]+)$/
-     */
+    #[Then('/^(its) priority should be ([^"]+)$/')]
     public function itPriorityShouldBe(CatalogPromotionInterface $catalogPromotion, int $priority): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -1090,9 +933,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should(?:| still) be (inactive|active)$/
-     */
+    #[Then('/^(this catalog promotion) should(?:| still) be (inactive|active)$/')]
     public function thisCatalogPromotionShouldBe(CatalogPromotionInterface $catalogPromotion, string $state): void
     {
         $response = $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
@@ -1100,9 +941,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'state', $state));
     }
 
-    /**
-     * @Then /^("[^"]+" catalog promotion) should apply to ("[^"]+" variant) and ("[^"]+" variant)$/
-     */
+    #[Then('/^("[^"]+" catalog promotion) should apply to ("[^"]+" variant) and ("[^"]+" variant)$/')]
     public function catalogPromotionShouldApplyToVariants(
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $firstVariant,
@@ -1116,9 +955,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @Then :catalogPromotionName catalog promotion should apply to all products from :taxon taxon
-     */
+    #[Then(':catalogPromotionName catalog promotion should apply to all products from :taxon taxon')]
     public function catalogPromotionShouldApplyToAllProductsFromTaxons(string $catalogPromotionName, TaxonInterface $taxon): void
     {
         Assert::same(
@@ -1127,9 +964,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :catalogPromotionName catalog promotion should apply to all variants of :product product
-     */
+    #[Then('the :catalogPromotionName catalog promotion should apply to all variants of :product product')]
     public function theCatalogPromotionShouldApplyToAllVariantsOfProduct(string $catalogPromotionName, ProductInterface $product): void
     {
         Assert::same(
@@ -1138,10 +973,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the catalog promotion :catalogPromotion should be available in channel :channel
-     * @Then /^(this catalog promotion) should be available in (channel "[^"]+")$/
-     */
+    #[Then('the catalog promotion :catalogPromotion should be available in channel :channel')]
+    #[Then('/^(this catalog promotion) should be available in (channel "[^"]+")$/')]
     public function itShouldBeAvailableInChannel(CatalogPromotionInterface $catalogPromotion, ChannelInterface $channel): void
     {
         Assert::true(
@@ -1156,9 +989,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @Then /^(this catalog promotion) should not be available in (channel "[^"]+")$/
-     */
+    #[Then('/^(this catalog promotion) should not be available in (channel "[^"]+")$/')]
     public function itShouldNotBeAvailableInChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -1173,9 +1004,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that catalog promotion has been successfully created
-     */
+    #[Then('I should be notified that catalog promotion has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -1184,9 +1013,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that not all channels are filled
-     */
+    #[Then('I should be notified that not all channels are filled')]
     public function iShouldBeNotifiedThatNotAllChannelsAreFilled(): void
     {
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -1194,9 +1021,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::same($response['violations'][0]['message'], 'This field is missing.');
     }
 
-    /**
-     * @Then /^(this catalog promotion) name should(?:| still) be "([^"]+)"$/
-     */
+    #[Then('/^(this catalog promotion) name should(?:| still) be "([^"]+)"$/')]
     public function thisCatalogPromotionNameShouldBe(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
         $response = $this->client->show(Resources::CATALOG_PROMOTIONS, $catalogPromotion->getCode());
@@ -1207,9 +1032,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be (labelled|described) as "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Then('/^(this catalog promotion) should be (labelled|described) as "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisCatalogPromotionLabelInLocaleShouldBe(
         CatalogPromotionInterface $catalogPromotion,
         string $field,
@@ -1226,9 +1049,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->responseChecker->hasTranslation($response, $localeCode, $fieldsMapping[$field], $value));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be applied on ("[^"]+" variant)$/
-     */
+    #[Then('/^(this catalog promotion) should be applied on ("[^"]+" variant)$/')]
     public function thisCatalogPromotionShouldBeAppliedOnVariant(
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant,
@@ -1238,25 +1059,19 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->catalogPromotionHasValuesInScopeConfiguration('variants', $productVariant->getCode()));
     }
 
-    /**
-     * @Then it should apply on :variant variant
-     */
+    #[Then('it should apply on :variant variant')]
     public function itShouldApplyOnVariant(ProductVariantInterface $variant): void
     {
         Assert::true($this->catalogPromotionHasValuesInScopeConfiguration('variants', $variant->getCode()));
     }
 
-    /**
-     * @Then it should apply on :product product
-     */
+    #[Then('it should apply on :product product')]
     public function itShouldApplyOnProduct(ProductInterface $product): void
     {
         Assert::true($this->catalogPromotionHasValuesInScopeConfiguration('products', $product->getCode()));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be applied on ("[^"]+" taxon)$/
-     */
+    #[Then('/^(this catalog promotion) should be applied on ("[^"]+" taxon)$/')]
     public function thisCatalogPromotionShouldBeAppliedOnTaxon(
         CatalogPromotionInterface $catalogPromotion,
         TaxonInterface $taxon,
@@ -1266,9 +1081,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->catalogPromotionHasValuesInScopeConfiguration('taxons', $taxon->getCode()));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should not be applied on ("[^"]+" variant)$/
-     */
+    #[Then('/^(this catalog promotion) should not be applied on ("[^"]+" variant)$/')]
     public function thisCatalogPromotionShouldNotBeAppliedOn(
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $productVariant,
@@ -1278,9 +1091,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::false($this->catalogPromotionHasValuesInScopeConfiguration('variants', $productVariant->getCode()));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be applied on ("[^"]+" product)$/
-     */
+    #[Then('/^(this catalog promotion) should be applied on ("[^"]+" product)$/')]
     public function thisCatalogPromotionShouldBeAppliedOnProduct(
         CatalogPromotionInterface $catalogPromotion,
         ProductInterface $product,
@@ -1290,9 +1101,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->catalogPromotionHasValuesInScopeConfiguration('products', $product->getCode()));
     }
 
-    /**
-     * @Then I should be notified that code and name are required
-     */
+    #[Then('I should be notified that code and name are required')]
     public function iShouldBeNotifiedThatCodeAndNameAreRequired(): void
     {
         $validationError = $this->responseChecker->getError($this->client->getLastResponse());
@@ -1301,9 +1110,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         Assert::contains($validationError, 'name: Please enter catalog promotion name.');
     }
 
-    /**
-     * @Then I should be notified that catalog promotion with this code already exists
-     */
+    #[Then('I should be notified that catalog promotion with this code already exists')]
     public function iShouldBeNotifiedThatCatalogPromotionWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -1317,17 +1124,13 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one catalog promotion with code :code
-     */
+    #[Then('there should still be only one catalog promotion with code :code')]
     public function thereShouldStillBeOnlyOneCatalogPromotionWithCode(string $code): void
     {
         Assert::count($this->responseChecker->getCollectionItemsWithValue($this->client->index(Resources::CATALOG_PROMOTIONS), 'code', $code), 1);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -1339,9 +1142,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a discount amount is required
-     */
+    #[Then('I should be notified that a discount amount is required')]
     public function iShouldBeNotifiedThatADiscountAmountIsRequired(): void
     {
         $response = $this->client->getLastResponse();
@@ -1355,9 +1156,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that type of action is invalid$/
-     */
+    #[Then('/^I should be notified that type of action is invalid$/')]
     public function iShouldBeNotifiedThatTypeOfActionIsInvalid(): void
     {
         Assert::contains(
@@ -1366,9 +1165,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that type of scope is invalid$/
-     */
+    #[Then('/^I should be notified that type of scope is invalid$/')]
     public function iShouldBeNotifiedThatTypeOfScopeIsInvalid(): void
     {
         Assert::contains(
@@ -1377,9 +1174,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a discount amount should be between 0% and 100%
-     */
+    #[Then('I should be notified that a discount amount should be between 0% and 100%')]
     public function iShouldBeNotifiedThatADiscountAmountShouldBeBetween0And100(): void
     {
         Assert::contains(
@@ -1388,9 +1183,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the percentage amount should be a number and cannot be empty
-     */
+    #[Then('I should be notified that the percentage amount should be a number and cannot be empty')]
     public function iShouldBeNotifiedThatDiscountAmountShouldBeANumberAndCannotBeEmpty(): void
     {
         Assert::contains(
@@ -1399,10 +1192,8 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the fixed amount should be a number
-     * @Then I should be notified that the fixed amount cannot be empty
-     */
+    #[Then('I should be notified that the fixed amount should be a number')]
+    #[Then('I should be notified that the fixed amount cannot be empty')]
     public function iShouldBeNotifiedThatTheFixedAmountShouldBeANumber(): void
     {
         Assert::contains(
@@ -1411,9 +1202,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that at least one of the provided channel codes does not exist
-     */
+    #[Then('I should be notified that at least one of the provided channel codes does not exist')]
     public function iShouldBeNotifiedThatAtLeastOneOfTheProvidedChannelCodesDoesNotExist(): void
     {
         Assert::regex(
@@ -1422,9 +1211,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that scope configuration is invalid
-     */
+    #[Then('I should be notified that scope configuration is invalid')]
     public function iShouldBeNotifiedThatScopeConfigurationIsInvalid(): void
     {
         Assert::contains(
@@ -1433,9 +1220,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that I must add at least one (product|taxon)$/
-     */
+    #[Then('/^I should be notified that I must add at least one (product|taxon)$/')]
     public function iShouldBeNotifiedThatIMustAddAtLeastOne(string $entity): void
     {
         Assert::contains(
@@ -1444,9 +1229,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that I can add only existing (product|taxon)$/
-     */
+    #[Then('/^I should be notified that I can add only existing (product|taxon)$/')]
     public function iShouldBeNotifiedThatICanAddOnlyExisting(string $entity): void
     {
         Assert::regex(
@@ -1455,9 +1238,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that at least 1 variant is required
-     */
+    #[Then('I should be notified that at least 1 variant is required')]
     public function iShouldBeNotifiedThatAtLeast1VariantIsRequired(): void
     {
         Assert::contains(
@@ -1466,9 +1247,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit it due to wrong state
-     */
+    #[Then('I should not be able to edit it due to wrong state')]
     public function iShouldNotBeAbleToEditItDueToWrongState(): void
     {
         Assert::contains(
@@ -1477,33 +1256,25 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then its name should be :name
-     */
+    #[Then('its name should be :name')]
     public function itsNameShouldBe(string $name): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'name', $name));
     }
 
-    /**
-     * @Given it should be exclusive
-     */
+    #[Given('it should be exclusive')]
     public function itShouldBeExclusive(): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'exclusive', true));
     }
 
-    /**
-     * @Given it should not be exclusive
-     */
+    #[Given('it should not be exclusive')]
     public function itShouldNotBeExclusive(): void
     {
         Assert::false($this->responseChecker->hasValue($this->client->getLastResponse(), 'exclusive', true));
     }
 
-    /**
-     * @Then I should get information that the end date cannot be set before start date
-     */
+    #[Then('I should get information that the end date cannot be set before start date')]
     public function iShouldGetInformationThatTheEndDateCannotBeSetBeforeStartDate(): void
     {
         Assert::contains(
@@ -1512,9 +1283,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a catalog promotion with name :name
-     */
+    #[Then('I should see a catalog promotion with name :name')]
     public function iShouldSeeACatalogPromotionWithName(string $name): void
     {
         $response = $this->client->getLastResponse();
@@ -1525,9 +1294,7 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see a catalog promotion with name :name
-     */
+    #[Then('I should not see a catalog promotion with name :name')]
     public function iShouldNotSeeACatalogPromotionWithName(string $name): void
     {
         $response = $this->client->getLastResponse();
@@ -1538,17 +1305,13 @@ final readonly class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count catalog promotions on the list
-     */
+    #[Then('I should see :count catalog promotions on the list')]
     public function iShouldSeeCountCatalogPromotionsOnTheList(int $count): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the first catalog promotion should have code :code
-     */
+    #[Then('the first catalog promotion should have code :code')]
     public function theFirstCatalogPromotionShouldHaveCode(string $code): void
     {
         $catalogPromotions = $this->responseChecker->getCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelPriceHistoryConfigContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelPriceHistoryConfigContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -33,9 +35,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I (enable|disable) showing the lowest price of discounted products$/
-     */
+    #[When('/^I (enable|disable) showing the lowest price of discounted products$/')]
     public function iEnableShowingTheLowestPriceOfDiscountedProducts(string $visible): void
     {
         $this->client->addRequestData(
@@ -44,9 +44,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         );
     }
 
-    /**
-     * @When /^I specify (-?\d+) days as the lowest price for discounted products checking period$/
-     */
+    #[When('/^I specify (-?\d+) days as the lowest price for discounted products checking period$/')]
     public function iSpecifyDaysAsTheLowestPriceForDiscountedProductsCheckingPeriod(int $days): void
     {
         $this->client->addRequestData(
@@ -55,17 +53,13 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         );
     }
 
-    /**
-     * @When I exclude the :taxon taxon from showing the lowest price of discounted products
-     */
+    #[When('I exclude the :taxon taxon from showing the lowest price of discounted products')]
     public function iExcludeTheTaxonFromShowingTheLowestPriceOfDiscountedProducts(TaxonInterface $taxon): void
     {
         $this->iExcludeTheTaxonsFromShowingTheLowestPriceOfDiscountedProducts([$taxon]);
     }
 
-    /**
-     * @When I remove the :taxon taxon from excluded taxons from showing the lowest price of discounted products
-     */
+    #[When('I remove the :taxon taxon from excluded taxons from showing the lowest price of discounted products')]
     public function iRemoveTheTaxonFromExcludedTaxonsFromShowingTheLowestPriceOfDiscountedProducts(TaxonInterface $taxon): void
     {
         /** @var ChannelInterface $channel */
@@ -81,9 +75,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         $this->iExcludeTheTaxonsFromShowingTheLowestPriceOfDiscountedProducts($leftTaxons);
     }
 
-    /**
-     * @When /^I exclude the ("[^"]+" and "[^"]+" taxons) from showing the lowest price of discounted products$/
-     */
+    #[When('/^I exclude the ("[^"]+" and "[^"]+" taxons) from showing the lowest price of discounted products$/')]
     public function iExcludeTheTaxonsFromShowingTheLowestPriceOfDiscountedProducts(iterable $taxons): void
     {
         $taxonsIris = [];
@@ -97,9 +89,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         );
     }
 
-    /**
-     * @Then /^the "[^"]+" channel should have the lowest price of discounted products prior to the current discount (enabled|disabled)$/
-     */
+    #[Then('/^the "[^"]+" channel should have the lowest price of discounted products prior to the current discount (enabled|disabled)$/')]
     public function theChannelShouldHaveTheLowestPriceOfDiscountedProductsPriorToTheCurrentDiscountEnabledOrDisabled(
         string $visible,
     ): void {
@@ -109,10 +99,8 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         );
     }
 
-    /**
-     * @Then /^the "[^"]+" channel should have the lowest price for discounted products checking period set to (\d+) days$/
-     * @Then its lowest price for discounted products checking period should be set to :days days
-     */
+    #[Then('/^the "[^"]+" channel should have the lowest price for discounted products checking period set to (\d+) days$/')]
+    #[Then('its lowest price for discounted products checking period should be set to :days days')]
     public function theChannelShouldHaveTheLowestPriceForDiscountedProductsCheckingPeriodSetToDays(int $days): void
     {
         Assert::same(
@@ -121,9 +109,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the lowest price for discounted products checking period must be greater than 0
-     */
+    #[Then('I should be notified that the lowest price for discounted products checking period must be greater than 0')]
     public function iShouldBeNotifiedThatTheLowestPriceForDiscountedProductsCheckingPeriodMustBeGreaterThanZero(): void
     {
         Assert::true($this->responseChecker->hasViolationWithMessage(
@@ -133,9 +119,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the lowest price for discounted products checking period must be lower
-     */
+    #[Then('I should be notified that the lowest price for discounted products checking period must be lower')]
     public function iShouldBeNotifiedThatTheLowestPriceForDiscountedProductsCheckingPeriodMustBeLower(): void
     {
         Assert::true($this->responseChecker->hasViolationWithMessage(
@@ -145,18 +129,14 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         ));
     }
 
-    /**
-     * @Then /^this channel should have ("[^"]+" taxon) excluded from displaying the lowest price of discounted products$/
-     */
+    #[Then('/^this channel should have ("[^"]+" taxon) excluded from displaying the lowest price of discounted products$/')]
     public function thisChannelShouldHaveTaxonExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(
         TaxonInterface $taxon,
     ): void {
         $this->thisChannelShouldHaveTaxonsExcludedFromDisplayingTheLowestPriceOfDiscountedProducts([$taxon]);
     }
 
-    /**
-     * @Then /^this channel should have ("([^"]+)" and "([^"]+)" taxons) excluded from displaying the lowest price of discounted products$/
-     */
+    #[Then('/^this channel should have ("([^"]+)" and "([^"]+)" taxons) excluded from displaying the lowest price of discounted products$/')]
     public function thisChannelShouldHaveTaxonsExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(
         iterable $taxons,
     ): void {
@@ -167,9 +147,7 @@ final class ManagingChannelPriceHistoryConfigContext implements Context
         }
     }
 
-    /**
-     * @Then /^this channel should not have ("[^"]+" taxon) excluded from displaying the lowest price of discounted products$/
-     */
+    #[Then('/^this channel should not have ("[^"]+" taxon) excluded from displaying the lowest price of discounted products$/')]
     public function thisChannelShouldNotHaveTaxonExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(
         TaxonInterface $taxon,
     ): void {

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsBillingDataContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsBillingDataContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -29,9 +30,7 @@ final readonly class ManagingChannelsBillingDataContext implements Context
     ) {
     }
 
-    /**
-     * @Then /^(this channel) company should be "([^"]+)"$/
-     */
+    #[Then('/^(this channel) company should be "([^"]+)"$/')]
     public function thisChannelCompanyShouldBe(ChannelInterface $channel, string $company): void
     {
         $shopBillingData = $this->getShopBillingDataFromChannel($channel);
@@ -39,9 +38,7 @@ final readonly class ManagingChannelsBillingDataContext implements Context
         Assert::same($shopBillingData['company'], $company);
     }
 
-    /**
-     * @Then /^(this channel) tax ID should be "([^"]+)"$/
-     */
+    #[Then('/^(this channel) tax ID should be "([^"]+)"$/')]
     public function thisChannelTaxIdShouldBe(ChannelInterface $channel, string $taxId): void
     {
         $shopBillingData = $this->getShopBillingDataFromChannel($channel);
@@ -49,10 +46,8 @@ final readonly class ManagingChannelsBillingDataContext implements Context
         Assert::same($shopBillingData['taxId'], $taxId);
     }
 
-    /**
-     * @Then /^(this channel) shop billing address should be "([^"]+)", "([^"]+)" "([^"]+)" and ("([^"]+)" country)$/
-     * @Then /^(this channel) shop billing address should still be "([^"]+)", "([^"]+)" "([^"]+)" and ("([^"]+)" country)$/
-     */
+    #[Then('/^(this channel) shop billing address should be "([^"]+)", "([^"]+)" "([^"]+)" and ("([^"]+)" country)$/')]
+    #[Then('/^(this channel) shop billing address should still be "([^"]+)", "([^"]+)" "([^"]+)" and ("([^"]+)" country)$/')]
     public function thisChannelShopBillingAddressShouldBe(
         ChannelInterface $channel,
         string $street,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingChannelsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -41,72 +43,56 @@ final class ManagingChannelsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new channel
-     */
+    #[When('I want to create a new channel')]
     public function iWantToCreateANewChannel(): void
     {
         $this->client->buildCreateRequest(Resources::CHANNELS);
     }
 
-    /**
-     * @When I delete channel :channel
-     */
+    #[When('I delete channel :channel')]
     public function iDeleteChannel(ChannelInterface $channel): void
     {
         $this->client->delete(Resources::CHANNELS, $channel->getCode());
     }
 
-    /**
-     * @When I want to modify a channel :channel
-     */
+    #[When('I want to modify a channel :channel')]
     public function iWantToModifyChannel(ChannelInterface $channel): void
     {
         $this->client->buildUpdateRequest(Resources::CHANNELS, $channel->getCode());
     }
 
-    /**
-     * @When I rename it to :name
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I rename it to :name')]
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iRenameIt(string $name = ''): void
     {
         $this->client->addRequestData('name', $name);
     }
 
-    /**
-     * @When /^I (enable|disable) it$/
-     */
+    #[When('/^I (enable|disable) it$/')]
     public function iDisableIt(string $toggleAction): void
     {
         $this->client->addRequestData('enabled', $toggleAction === 'enable');
     }
 
-    /**
-     * @When I change its menu taxon to :taxon
-     */
+    #[When('I change its menu taxon to :taxon')]
     public function iChangeItsMenuTaxonTo(TaxonInterface $taxon): void
     {
         $this->client->addRequestData('menuTaxon', $this->iriConverter->getIriFromResourceInSection($taxon, 'admin'));
     }
 
-    /**
-     * @When I specify its :field as :value
-     * @When I :field it :value
-     * @When I set its :field as :value
-     * @When I define its :field as :value
-     * @When I do not specify its :field
-     */
+    #[When('I specify its :field as :value')]
+    #[When('I :field it :value')]
+    #[When('I set its :field as :value')]
+    #[When('I define its :field as :value')]
+    #[When('I do not specify its :field')]
     public function iSpecifyItsAs(string $field, string $value = ''): void
     {
         $this->client->addRequestData($field, $value);
     }
 
-    /**
-     * @When I choose :currency as the base currency
-     * @When I do not choose base currency
-     */
+    #[When('I choose :currency as the base currency')]
+    #[When('I do not choose base currency')]
     public function iChooseAsTheBaseCurrency(?CurrencyInterface $currency = null): void
     {
         $this->client->addRequestData(
@@ -115,50 +101,38 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @When I allow for paying in :currency
-     */
+    #[When('I allow for paying in :currency')]
     public function iAllowToPayingForThisChannel(CurrencyInterface $currency): void
     {
         $this->client->addRequestData('currencies', [$this->iriConverter->getIriFromResource($currency)]);
     }
 
-    /**
-     * @When I select the :zone as default tax zone
-     */
+    #[When('I select the :zone as default tax zone')]
     public function iSelectDefaultTaxZone(ZoneInterface $zone): void
     {
         $this->client->addRequestData('defaultTaxZone', $this->iriConverter->getIriFromResource($zone));
     }
 
-    /**
-     * @When I remove its default tax zone
-     */
+    #[When('I remove its default tax zone')]
     public function iRemoveItsDefaultTaxZone(): void
     {
         $this->client->addRequestData('defaultTaxZone', null);
     }
 
-    /**
-     * @When I make it available in :locale
-     */
+    #[When('I make it available in :locale')]
     public function iMakeItAvailableInLocale(LocaleInterface $locale): void
     {
         $this->client->addRequestData('locales', [$this->iriConverter->getIriFromResourceInSection($locale, 'admin')]);
     }
 
-    /**
-     * @When I make it available only in :locale
-     */
+    #[When('I make it available only in :locale')]
     public function iMakeItAvailableOnlyInLocale(LocaleInterface $locale): void
     {
         $this->client->replaceRequestData('locales', [$this->iriConverter->getIriFromResourceInSection($locale, 'admin')]);
     }
 
-    /**
-     * @When I choose :locale as a default locale
-     * @When I do not choose default locale
-     */
+    #[When('I choose :locale as a default locale')]
+    #[When('I do not choose default locale')]
     public function iChooseAsADefaultLocale(?LocaleInterface $locale = null): void
     {
         $this->client->addRequestData(
@@ -167,33 +141,25 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @When I describe it as :description
-     */
+    #[When('I describe it as :description')]
     public function iDescribeItAs(string $description): void
     {
         $this->client->addRequestData('description', $description);
     }
 
-    /**
-     * @When I set its contact email as :contactEmail
-     */
+    #[When('I set its contact email as :contactEmail')]
     public function iSetItsContactEmailAs(string $contactEmail): void
     {
         $this->client->addRequestData('contactEmail', $contactEmail);
     }
 
-    /**
-     * @When I set its contact phone number as :contactPhoneNumber
-     */
+    #[When('I set its contact phone number as :contactPhoneNumber')]
     public function iSetItsContactPhoneNumberAs(string $contactPhoneNumber): void
     {
         $this->client->addRequestData('contactPhoneNumber', $contactPhoneNumber);
     }
 
-    /**
-     * @When I choose :country and :otherCountry as operating countries
-     */
+    #[When('I choose :country and :otherCountry as operating countries')]
     public function iChooseAndAsOperatingCountries(CountryInterface $country, CountryInterface $otherCountry): void
     {
         $this->client->addRequestData('countries', [
@@ -202,49 +168,37 @@ final class ManagingChannelsContext implements Context
         ]);
     }
 
-    /**
-     * @When I allow to skip shipping step if only one shipping method is available
-     */
+    #[When('I allow to skip shipping step if only one shipping method is available')]
     public function iAllowToSkipShippingStepIfOnlyOneShippingMethodIsAvailable(): void
     {
         $this->client->addRequestData('skippingShippingStepAllowed', true);
     }
 
-    /**
-     * @When I allow to skip payment step if only one payment method is available
-     */
+    #[When('I allow to skip payment step if only one payment method is available')]
     public function iAllowToSkipPaymentStepIfOnlyOnePaymentMethodIsAvailable(): void
     {
         $this->client->addRequestData('skippingPaymentStepAllowed', true);
     }
 
-    /**
-     * @When I specify menu taxon as :taxon
-     */
+    #[When('I specify menu taxon as :taxon')]
     public function iSpecifyMenuTaxonAs(TaxonInterface $taxon): void
     {
         $this->client->addRequestData('menuTaxon', $this->iriConverter->getIriFromResourceInSection($taxon, 'admin'));
     }
 
-    /**
-     * @When I specify company as :company
-     */
+    #[When('I specify company as :company')]
     public function iSpecifyCompanyAs(string $company): void
     {
         $this->shopBillingData['company'] = $company;
     }
 
-    /**
-     * @When I specify tax ID as :taxId
-     */
+    #[When('I specify tax ID as :taxId')]
     public function iSpecifyTaxIdAs(string $taxId): void
     {
         $this->shopBillingData['taxId'] = $taxId;
     }
 
-    /**
-     * @When /^I specify shop billing data for (this channel) as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" tax ID and ("([^"]+)" country)$/
-     */
+    #[When('/^I specify shop billing data for (this channel) as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" tax ID and ("([^"]+)" country)$/')]
     public function iSpecifyShopBillingDataAs(
         ChannelInterface $channel,
         string $company,
@@ -270,9 +224,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @When /^I specify new country code for (this channel) as "([^"]+)"$/
-     */
+    #[When('/^I specify new country code for (this channel) as "([^"]+)"$/')]
     public function iSpecifyNewCountryCodeForThisChannelAs(ChannelInterface $channel, string $code): void
     {
         $shopBillingDataId = $this->iriConverter->getIriFromResource($channel->getShopBillingData());
@@ -280,9 +232,7 @@ final class ManagingChannelsContext implements Context
         $this->client->addRequestData('shopBillingData', ['@id' => $shopBillingDataId, 'countryCode' => $code]);
     }
 
-    /**
-     * @When I specify shop billing address as :street, :postcode :city, :country
-     */
+    #[When('I specify shop billing address as :street, :postcode :city, :country')]
     public function specifyShopBillingAddressAs(
         string $street,
         string $postcode,
@@ -295,27 +245,21 @@ final class ManagingChannelsContext implements Context
         $this->shopBillingData['countryCode'] = $country->getCode();
     }
 
-    /**
-     * @Then I save it
-     */
+    #[Then('I save it')]
     public function iSaveIt(): void
     {
         $this->iAddIt();
         $this->client->update();
     }
 
-    /**
-     * @When I select the :taxCalculationStrategy as tax calculation strategy
-     */
+    #[When('I select the :taxCalculationStrategy as tax calculation strategy')]
     public function iSelectTaxCalculationStrategy(string $taxCalculationStrategy): void
     {
         $this->client->addRequestData('taxCalculationStrategy', StringInflector::nameToLowercaseCode($taxCalculationStrategy));
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->setSubResourceData('shopBillingData', $this->shopBillingData);
@@ -323,41 +267,31 @@ final class ManagingChannelsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When I want to browse channels
-     */
+    #[When('I want to browse channels')]
     public function iWantToBrowseChannels(): void
     {
         $this->client->index(Resources::CHANNELS);
     }
 
-    /**
-     * @When /^I choose (billing|shipping) address as a required address in the checkout$/
-     */
+    #[When('/^I choose (billing|shipping) address as a required address in the checkout$/')]
     public function iChooseAddressAsARequiredAddressInTheCheckout(string $type): void
     {
         $this->client->addRequestData('shippingAddressInCheckoutRequired', $type === 'shipping');
     }
 
-    /**
-     * @When /^I want to modify (this channel)$/
-     */
+    #[When('/^I want to modify (this channel)$/')]
     public function iWantToModifyThisChannel(ChannelInterface $channel): void
     {
         $this->client->buildUpdateRequest(Resources::CHANNELS, $channel->getCode());
     }
 
-    /**
-     * @When /^I specify its ([^"]+) as a too long string$/
-     */
+    #[When('/^I specify its ([^"]+) as a too long string$/')]
     public function iSpecifyItsFieldAsATooLongString(string $field): void
     {
         $this->client->addRequestData(StringInflector::nameToCamelCase($field), str_repeat('a@', 128));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -366,10 +300,8 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the channel :name should appear in the registry
-     * @Then the channel :name should be in the registry
-     */
+    #[Then('the channel :name should appear in the registry')]
+    #[Then('the channel :name should be in the registry')]
     public function theChannelShouldAppearInTheRegistry(string $name): void
     {
         Assert::true(
@@ -378,9 +310,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the channel :channel should have :taxon as a menu taxon
-     */
+    #[Then('the channel :channel should have :taxon as a menu taxon')]
     public function theChannelShouldHaveAsAMenuTaxon(ChannelInterface $channel, TaxonInterface $taxon): void
     {
         Assert::same(
@@ -390,9 +320,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -400,10 +328,8 @@ final class ManagingChannelsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then the base currency field should be disabled
-     * @Then I should not be able to edit its base currency
-     */
+    #[Then('the base currency field should be disabled')]
+    #[Then('I should not be able to edit its base currency')]
     public function theBaseCurrencyFieldShouldBeDisabled(): void
     {
         $this->client->updateRequestData(['baseCurrency' => 'PLN']);
@@ -411,9 +337,7 @@ final class ManagingChannelsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'baseCurrency', 'PLN'));
     }
 
-    /**
-     * @Then /^(this channel) name should be "([^"]*)"$/
-     */
+    #[Then('/^(this channel) name should be "([^"]*)"$/')]
     public function thisChannelNameShouldBe(ChannelInterface $channel, string $name): void
     {
         Assert::true(
@@ -422,9 +346,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the :channel channel should no longer exist in the registry
-     */
+    #[Then('the :channel channel should no longer exist in the registry')]
     public function theChannelShouldNoLongerExistInTheRegistry(string $name): void
     {
         Assert::false(
@@ -433,17 +355,13 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatChannelHasBeenDeleted(): void
     {
         Assert::true($this->responseChecker->isDeletionSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then /^(this channel) menu (taxon should be "([^"]+)")$/
-     */
+    #[Then('/^(this channel) menu (taxon should be "([^"]+)")$/')]
     public function thisChannelMenuTaxonShouldBe(ChannelInterface $channel, TaxonInterface $taxon): void
     {
         Assert::true(
@@ -458,17 +376,13 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count channels in the list
-     */
+    #[Then('I should see :count channels in the list')]
     public function iShouldSeeChannelsInTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then /^the required address in the checkout for this channel should be (billing|shipping)$/
-     */
+    #[Then('/^the required address in the checkout for this channel should be (billing|shipping)$/')]
     public function theRequiredAddressInTheCheckoutForTheChannelShouldBe(string $type): void
     {
         Assert::true($this->responseChecker->hasValue(
@@ -478,9 +392,7 @@ final class ManagingChannelsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that it cannot be deleted
-     */
+    #[Then('I should be notified that it cannot be deleted')]
     public function iShouldBeNotifiedThatItCannotBeDeleted(): void
     {
         Assert::contains(
@@ -489,9 +401,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that at least one channel has to be defined
-     */
+    #[Then('I should be notified that at least one channel has to be defined')]
     public function iShouldBeNotifiedThatAtLeastOneChannelHasToBeDefined(): void
     {
         Assert::contains(
@@ -500,10 +410,8 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then channel with name :channel should still be enabled
-     * @Then /^(this channel) should be enabled$/
-     */
+    #[Then('channel with name :channel should still be enabled')]
+    #[Then('/^(this channel) should be enabled$/')]
     public function channelWithNameShouldStillBeEnabled(ChannelInterface $channel): void
     {
         Assert::true(
@@ -512,9 +420,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then this channel should still be named :channel
-     */
+    #[Then('this channel should still be named :channel')]
     public function thisChannelShouldStillBeNamed(ChannelInterface $channel): void
     {
         Assert::true(
@@ -523,9 +429,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then paying in :currency should be possible for the :channel channel
-     */
+    #[Then('paying in :currency should be possible for the :channel channel')]
     public function payingInCurrencyShouldBePossibleForTheChannel(CurrencyInterface $currency, ChannelInterface $channel): void
     {
         $currencies = $this->responseChecker->getValue(
@@ -536,9 +440,7 @@ final class ManagingChannelsContext implements Context
         Assert::true(in_array($this->iriConverter->getIriFromResourceInSection($currency, 'admin'), $currencies));
     }
 
-    /**
-     * @Then channel :channel should not have default tax zone
-     */
+    #[Then('channel :channel should not have default tax zone')]
     public function channelShouldNotHaveDefaultTaxZone(ChannelInterface $channel): void
     {
         Assert::same(
@@ -548,9 +450,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the default tax zone for the :channel channel should be :zone
-     */
+    #[Then('the default tax zone for the :channel channel should be :zone')]
     public function theDefaultTaxZoneForTheChannelShouldBe(ChannelInterface $channel, ZoneInterface $zone): void
     {
         Assert::same(
@@ -560,9 +460,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the channel :channel should be available in :locale
-     */
+    #[Then('the channel :channel should be available in :locale')]
     public function theChannelShouldBeAvailableIn(ChannelInterface $channel, LocaleInterface $locale): void
     {
         $locales = $this->responseChecker->getValue(
@@ -573,9 +471,7 @@ final class ManagingChannelsContext implements Context
         Assert::true(in_array($this->iriConverter->getIriFromResourceInSection($locale, 'admin'), $locales));
     }
 
-    /**
-     * @Then I should be notified that the default locale has to be enabled
-     */
+    #[Then('I should be notified that the default locale has to be enabled')]
     public function iShouldBeNotifiedThatTheDefaultLocaleHasToBeEnabled(): void
     {
         Assert::contains(
@@ -584,9 +480,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this channel) should still be in the registry$/
-     */
+    #[Then('/^(this channel) should still be in the registry$/')]
     public function thisChannelShouldStillBeInTheRegistry(ChannelInterface $channel): void
     {
         Assert::true(
@@ -595,9 +489,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the tax calculation strategy for the :channel channel should be :taxCalculationStrategy
-     */
+    #[Then('the tax calculation strategy for the :channel channel should be :taxCalculationStrategy')]
     public function theTaxCalculationStrategyForTheChannelShouldBe(
         ChannelInterface $channel,
         string $taxCalculationStrategy,
@@ -609,9 +501,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this channel) should be disabled$/
-     */
+    #[Then('/^(this channel) should be disabled$/')]
     public function thisChannelShouldBeDisabled(ChannelInterface $channel): void
     {
         Assert::same(
@@ -621,9 +511,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -632,9 +520,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that base currency is required
-     */
+    #[Then('I should be notified that base currency is required')]
     public function iShouldBeNotifiedThatBaseCurrencyIsRequired(): void
     {
         Assert::contains(
@@ -643,9 +529,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that default locale is required
-     */
+    #[Then('I should be notified that default locale is required')]
     public function iShouldBeNotifiedThatDefaultLocaleIsRequired(): void
     {
         Assert::contains(
@@ -654,9 +538,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then channel with :element :value should not be added
-     */
+    #[Then('channel with :element :value should not be added')]
     public function channelWithShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false(
@@ -665,9 +547,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that channel with this code already exists
-     */
+    #[Then('I should be notified that channel with this code already exists')]
     public function iShouldBeNotifiedThatChannelWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -676,9 +556,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one channel with :element :value
-     */
+    #[Then('there should still be only one channel with :element :value')]
     public function thereShouldStillBeOnlyOneChannelWithCode(string $element, string $value): void
     {
         Assert::same(
@@ -688,9 +566,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is not a valid country
-     */
+    #[Then('I should be notified that it is not a valid country')]
     public function iShouldBeNotifiedThatItIsNotAValidCountryCode(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCountriesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -37,68 +39,52 @@ final class ManagingCountriesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to add a new country
-     */
+    #[When('I want to add a new country')]
     public function iWantToAddANewCountry(): void
     {
         $this->client->buildCreateRequest(Resources::COUNTRIES);
     }
 
-    /**
-     * @When I choose :countryName
-     */
+    #[When('I choose :countryName')]
     public function iChoose(string $countryName): void
     {
         $this->iSpecifyTheCountryCodeAs($this->getCountryCodeByName($countryName));
     }
 
-    /**
-     * @When I specify the country code as :code
-     */
+    #[When('I specify the country code as :code')]
     public function iSpecifyTheCountryCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When /^I want to edit (this country)$/
-     * @When /^I am editing (this country)$/
-     * @When /^I want to create a new province in (country "([^"]+)")$/
-     */
+    #[When('/^I want to edit (this country)$/')]
+    #[When('/^I am editing (this country)$/')]
+    #[When('/^I want to create a new province in (country "([^"]+)")$/')]
     public function iWantToEditThisCountry(CountryInterface $country): void
     {
         $this->client->buildUpdateRequest(Resources::COUNTRIES, $country->getCode());
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->addRequestData('enabled', true);
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->client->addRequestData('enabled', false);
     }
 
-    /**
-     * @When I name the province :provinceName
-     */
+    #[When('I name the province :provinceName')]
     public function iNameTheProvince(string $provinceName): void
     {
         $this->client->addSubResourceData(
@@ -107,9 +93,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @When I specify the province code as :provinceCode
-     */
+    #[When('I specify the province code as :provinceCode')]
     public function iSpecifyTheProvinceCodeAs(string $provinceCode): void
     {
         $this->client->addSubResourceData(
@@ -118,17 +102,13 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @When I provide a too long province code
-     */
+    #[When('I provide a too long province code')]
     public function iProvideATooLongProvinceCode(): void
     {
         $this->iSpecifyTheProvinceCodeAs(sprintf('XX-%s', str_repeat('A', $this->getMaxCodeLength())));
     }
 
-    /**
-     * @When I add the :provinceName province with :provinceCode code
-     */
+    #[When('I add the :provinceName province with :provinceCode code')]
     public function iAddTheProvinceWithCode(string $provinceName, string $provinceCode): void
     {
         $this->client->addSubResourceData(
@@ -137,9 +117,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @When I add the :name province with :code code and :abbreviation abbreviation
-     */
+    #[When('I add the :name province with :code code and :abbreviation abbreviation')]
     public function iAddTheProvinceWithCodeAndAbbreviation(string $name, string $code, string $abbreviation): void
     {
         $this->client->addSubResourceData(
@@ -148,9 +126,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @When /^I(?:| also) delete the ("[^"]+" province) of (this country)$/
-     */
+    #[When('/^I(?:| also) delete the ("[^"]+" province) of (this country)$/')]
     public function iDeleteTheProvinceOfThisCountry(ProvinceInterface $province, CountryInterface $country): void
     {
         $iri = $this->iriConverter->getIriFromResource($province);
@@ -163,19 +139,15 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @When I do not specify the country code
-     * @When I do not specify the province code
-     * @When I do not name the province
-     */
+    #[When('I do not specify the country code')]
+    #[When('I do not specify the province code')]
+    #[When('I do not name the province')]
     public function iDoNotSpecifyTheField(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I remove :province province name
-     */
+    #[When('I remove :province province name')]
     public function iRemoveProvinceName(ProvinceInterface $province): void
     {
         $this->client->buildUpdateRequest(
@@ -185,9 +157,7 @@ final class ManagingCountriesContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -196,9 +166,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then the country :country should appear in the store
-     */
+    #[Then('the country :country should appear in the store')]
     public function theCountryShouldAppearInTheStore(CountryInterface $country): void
     {
         Assert::true(
@@ -207,10 +175,8 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then the country :country should have the :province province
-     * @Then /^(this country) should(?:| still) have the ("[^"]*" province)$/
-     */
+    #[Then('the country :country should have the :province province')]
+    #[Then('/^(this country) should(?:| still) have the ("[^"]*" province)$/')]
     public function theCountryShouldHaveTheProvince(CountryInterface $country, ProvinceInterface $province): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(
@@ -220,9 +186,7 @@ final class ManagingCountriesContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this country) should(?:| still) have the ("[^"]*" and "[^"]*" provinces)$/
-     */
+    #[Then('/^(this country) should(?:| still) have the ("[^"]*" and "[^"]*" provinces)$/')]
     public function theCountryShouldHaveTheProvinceAndProvince(CountryInterface $country, array $provinces): void
     {
         foreach ($provinces as $province) {
@@ -230,9 +194,7 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @Then the province should still be named :province in this country
-     */
+    #[Then('the province should still be named :province in this country')]
     public function theProvinceShouldStillBeNamedInThisCountry(ProvinceInterface $province): void
     {
         /** @var CountryInterface $country */
@@ -244,9 +206,7 @@ final class ManagingCountriesContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not be able to choose :countryName
-     */
+    #[Then('I should not be able to choose :countryName')]
     public function iShouldNotBeAbleToChoose(string $countryName): void
     {
         $this->client->addRequestData('code', $this->getCountryCodeByName($countryName));
@@ -258,9 +218,7 @@ final class ManagingCountriesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Country ISO code must be unique.');
     }
 
-    /**
-     * @Then /^(this country) should be (enabled|disabled)$/
-     */
+    #[Then('/^(this country) should be (enabled|disabled)$/')]
     public function thisCountryShouldBe(CountryInterface $country, string $state): void
     {
         $isEnabled = 'enabled' === $state;
@@ -275,9 +233,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -285,9 +241,7 @@ final class ManagingCountriesContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then /^province with code ("[^"]*") should not be added in (this country)$/
-     */
+    #[Then('/^province with code ("[^"]*") should not be added in (this country)$/')]
     public function provinceWithCodeShouldNotBeAddedInThisCountry(string $provinceCode, CountryInterface $country): void
     {
         /** @var ProvinceInterface $province */
@@ -299,10 +253,8 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @Then this country should not have the :provinceName province
-     * @Then province with name :provinceName should not be added in this country
-     */
+    #[Then('this country should not have the :provinceName province')]
+    #[Then('province with name :provinceName should not be added in this country')]
     public function thisCountryShouldNotHaveTheProvince(string $provinceName): void
     {
         /** @var CountryInterface $country */
@@ -316,9 +268,7 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @Then /^I should be notified that province (code|name) must be unique$/
-     */
+    #[Then('/^I should be notified that province (code|name) must be unique$/')]
     public function iShouldBeNotifiedThatProvinceCodeMustBeUnique(string $field): void
     {
         Assert::regex(
@@ -327,9 +277,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that all province codes and names within this country need to be unique
-     */
+    #[Then('I should be notified that all province codes and names within this country need to be unique')]
     public function iShouldBeNotifiedThatAllProvinceCodesAndNamesWithinThisCountryNeedToBeUnique(): void
     {
         Assert::contains(
@@ -338,9 +286,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :field is required
-     */
+    #[Then('I should be notified that :field is required')]
     public function iShouldBeNotifiedThatFieldIsRequired(string $field): void
     {
         Assert::contains(
@@ -349,9 +295,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that the country code is (required|invalid)$/
-     */
+    #[Then('/^I should be notified that the country code is (required|invalid)$/')]
     public function iShouldBeNotifiedThatTheCountryCodeIsRequired(string $constraint): void
     {
         Assert::contains(
@@ -360,9 +304,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that name of the province is required
-     */
+    #[Then('I should be notified that name of the province is required')]
     public function iShouldBeNotifiedThatNameOfTheProvinceIsRequired(): void
     {
         Assert::contains(
@@ -371,9 +313,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that the provided province code is too long
-     */
+    #[Then('I should be informed that the provided province code is too long')]
     public function iShouldBeInformedThatTheProvinceCodeIsTooLong(): void
     {
         Assert::contains(
@@ -382,9 +322,7 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that provinces that are in use cannot be deleted
-     */
+    #[Then('I should be notified that provinces that are in use cannot be deleted')]
     public function iShouldBeNotifiedThatProvincesThatAreInUseCannotBeDeleted(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -27,43 +29,33 @@ final readonly class ManagingCurrenciesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to browse currencies of the store
-     */
+    #[When('I want to browse currencies of the store')]
     public function iWantToSeeAllCurrenciesInStore(): void
     {
         $this->client->index(Resources::CURRENCIES);
     }
 
-    /**
-     * @When I want to add a new currency
-     */
+    #[When('I want to add a new currency')]
     public function iWantToAddNewCurrency(): void
     {
         $this->client->buildCreateRequest(Resources::CURRENCIES);
     }
 
-    /**
-     * @When I choose :currencyCode
-     * @When I set code to :code
-     * @When I do not choose a code
-     */
+    #[When('I choose :currencyCode')]
+    #[When('I set code to :code')]
+    #[When('I do not choose a code')]
     public function iChoose(string $currencyCode = ''): void
     {
         $this->client->addRequestData('code', $currencyCode);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @Then I should see :count currencies on the list
-     */
+    #[Then('I should see :count currencies on the list')]
     public function iShouldSeeCurrenciesInTheList(int $count): void
     {
         $itemsCount = $this->responseChecker->countCollectionItems($this->client->getLastResponse());
@@ -71,10 +63,8 @@ final readonly class ManagingCurrenciesContext implements Context
         Assert::eq($count, $itemsCount, sprintf('Expected %d currencies, but got %d', $count, $itemsCount));
     }
 
-    /**
-     * @Then I should see the currency :currencyName on the list
-     * @Then the currency :currencyName should appear in the store
-     */
+    #[Then('I should see the currency :currencyName on the list')]
+    #[Then('the currency :currencyName should appear in the store')]
     public function currencyShouldAppearInTheStore(string $currencyName): void
     {
         Assert::true(
@@ -83,9 +73,7 @@ final readonly class ManagingCurrenciesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one currency with code :code
-     */
+    #[Then('there should still be only one currency with code :code')]
     public function thereShouldStillBeOnlyOneCurrencyWithCode(string $code): void
     {
         $response = $this->client->index(Resources::CURRENCIES);
@@ -96,9 +84,7 @@ final readonly class ManagingCurrenciesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that currency code must be unique
-     */
+    #[Then('I should be notified that currency code must be unique')]
     public function iShouldBeNotifiedThatCurrencyCodeMustBeUnique(): void
     {
         $response = $this->client->getLastResponse();
@@ -109,9 +95,7 @@ final readonly class ManagingCurrenciesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Currency code must be unique.');
     }
 
-    /**
-     * @Then I should be notified that a code is required
-     */
+    #[Then('I should be notified that a code is required')]
     public function iShouldBeNotifiedThatACodeIsRequired(): void
     {
         $response = $this->client->getLastResponse();
@@ -122,9 +106,7 @@ final readonly class ManagingCurrenciesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Please choose currency code.');
     }
 
-    /**
-     * @Then I should be notified that the code is invalid
-     */
+    #[Then('I should be notified that the code is invalid')]
     public function iShouldBeNotifiedThatTheCodeIsInvalid(): void
     {
         $response = $this->client->getLastResponse();
@@ -135,9 +117,7 @@ final readonly class ManagingCurrenciesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: This value is not a valid currency code.');
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCustomerGroupsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,18 +33,14 @@ final class ManagingCustomerGroupsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new customer group
-     */
+    #[When('I want to create a new customer group')]
     public function iWantToCreateANewCustomerGroup(): void
     {
         $this->client->buildCreateRequest(Resources::CUSTOMER_GROUPS);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -50,77 +48,59 @@ final class ManagingCustomerGroupsContext implements Context
         }
     }
 
-    /**
-     * @When I specify its name as :name
-     * @When I remove its name
-     */
+    #[When('I specify its name as :name')]
+    #[When('I remove its name')]
     public function iSpecifyItsNameAs(string $name = ''): void
     {
         $this->client->addRequestData('name', $name);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When /^I want to edit (this customer group)$/
-     */
+    #[When('/^I want to edit (this customer group)$/')]
     public function iWantToEditThisCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->client->buildUpdateRequest(Resources::CUSTOMER_GROUPS, $customerGroup->getCode());
     }
 
-    /**
-     * @When I browse customer groups
-     * @When I want to browse customer groups
-     */
+    #[When('I browse customer groups')]
+    #[When('I want to browse customer groups')]
     public function iWantToBrowseCustomerGroups(): void
     {
         $this->client->index(Resources::CUSTOMER_GROUPS);
     }
 
-    /**
-     * @When I delete the :customerGroup customer group
-     */
+    #[When('I delete the :customerGroup customer group')]
     public function iDeleteTheCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->client->delete(Resources::CUSTOMER_GROUPS, $customerGroup->getCode());
     }
 
-    /**
-     * @When I search for them with :phrase name
-     */
+    #[When('I search for them with :phrase name')]
     public function iSearchResourceWith(string $phrase): void
     {
         $this->client->addFilter('name', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When /^I sort them by the (code|name) in (asc|desc)ending order$/
-     */
+    #[When('/^I sort them by the (code|name) in (asc|desc)ending order$/')]
     public function iSortThemByTheField(string $field, string $order): void
     {
         $this->client->sort([$field => str_starts_with($order, 'de') ? 'desc' : 'asc']);
         $this->client->filter();
     }
 
-    /**
-     * @Then there should be :count customer groups in the list
-     */
+    #[Then('there should be :count customer groups in the list')]
     public function thereShouldBeCustomerGroupsInTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the customer group :customerGroup should appear in the store
-     */
+    #[Then('the customer group :customerGroup should appear in the store')]
     public function theCustomerGroupShouldAppearInTheStore(CustomerGroupInterface $customerGroup): void
     {
         Assert::true(
@@ -129,10 +109,8 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then this customer group with name :name should appear in the store
-     * @Then I should see the customer group :name in the list
-     */
+    #[Then('this customer group with name :name should appear in the store')]
+    #[Then('I should see the customer group :name in the list')]
     public function thisCustomerGroupWithNameShouldAppearInTheStore(string $name): void
     {
         Assert::true(
@@ -141,18 +119,14 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single customer group in the list
-     * @Then I should see :amountOfCustomerGroups customer groups in the list
-     */
+    #[Then('I should see a single customer group in the list')]
+    #[Then('I should see :amountOfCustomerGroups customer groups in the list')]
     public function iShouldSeeCustomerGroupsInTheList(int $amountOfCustomerGroups = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::CUSTOMER_GROUPS)), $amountOfCustomerGroups);
     }
 
-    /**
-     * @Then /^(this customer group) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this customer group) should still be named "([^"]+)"$/')]
     public function thisCustomerGroupShouldStillBeNamed(CustomerGroupInterface $customerGroup, string $name): void
     {
         Assert::true(
@@ -161,9 +135,7 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that name is required
-     */
+    #[Then('I should be notified that name is required')]
     public function iShouldBeNotifiedThatNameIsRequired(): void
     {
         Assert::contains(
@@ -172,9 +144,7 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that customer group with this code already exists
-     */
+    #[Then('I should be notified that customer group with this code already exists')]
     public function iShouldBeNotifiedThatCustomerGroupWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -183,17 +153,13 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that this form contains errors
-     */
+    #[Then('I should be informed that this form contains errors')]
     public function iShouldBeInformedThatThisFormContainsErrors(): void
     {
         Assert::notEmpty($this->responseChecker->getError($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -204,18 +170,14 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this customer group) should no longer exist in the registry$/
-     */
+    #[Then('/^(this customer group) should no longer exist in the registry$/')]
     public function thisCustomerGroupShouldNoLongerExistInTheRegistry(CustomerGroupInterface $customerGroup): void
     {
         $code = $customerGroup->getCode();
         Assert::false($this->isItemOnIndex('code', $code), sprintf('Customer group with code %s exist', $code));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -224,9 +186,7 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -237,9 +197,7 @@ final class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (\d+)(?:|st|nd|rd|th) customer group on the list should have (name|code) "([^"]+)" and (name|code) "([^"]+)"$/
-     */
+    #[Then('/^the (\d+)(?:|st|nd|rd|th) customer group on the list should have (name|code) "([^"]+)" and (name|code) "([^"]+)"$/')]
     public function theFirstCustomerGroupOnTheListShouldHave(
         int $position,
         string $firstField,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCustomersContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -40,29 +42,23 @@ final class ManagingCustomersContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new customer
-     * @When I want to create a new customer account
-     */
+    #[When('I want to create a new customer')]
+    #[When('I want to create a new customer account')]
     public function iWantToCreateANewCustomer(): void
     {
         $this->client->buildCreateRequest(Resources::CUSTOMERS);
     }
 
-    /**
-     * @When /^I want to edit (this customer)$/
-     * @When I want to enable :customer
-     * @When I want to disable :customer
-     * @When I want to verify :customer
-     */
+    #[When('/^I want to edit (this customer)$/')]
+    #[When('I want to enable :customer')]
+    #[When('I want to disable :customer')]
+    #[When('I want to verify :customer')]
     public function iWantToEditThisCustomer(CustomerInterface $customer): void
     {
         $this->client->buildUpdateRequest(Resources::CUSTOMERS, (string) $customer->getId());
     }
 
-    /**
-     * @When I browse orders of a customer :customer
-     */
+    #[When('I browse orders of a customer :customer')]
     public function iBrowseOrdersOfACustomer(CustomerInterface $customer): void
     {
         $this->client->index(Resources::ORDERS);
@@ -70,78 +66,60 @@ final class ManagingCustomersContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I specify their email as :email
-     * @When I do not specify their email
-     * @When I change their email to :email
-     * @When I remove its email
-     */
+    #[When('I specify their email as :email')]
+    #[When('I do not specify their email')]
+    #[When('I change their email to :email')]
+    #[When('I remove its email')]
     public function iChangeTheirEmailTo(?string $email = null): void
     {
         $this->client->addRequestData('email', (string) $email);
     }
 
-    /**
-     * @When /^I specify (?:their|his) first name as "([^"]*)"$/
-     * @When I remove its first name
-     */
+    #[When('/^I specify (?:their|his) first name as "([^"]*)"$/')]
+    #[When('I remove its first name')]
     public function iSpecifyTheirFirstNameAs(?string $name = null): void
     {
         $this->client->addRequestData('firstName', $name);
     }
 
-    /**
-     * @When /^I specify (?:their|his) last name as "([^"]*)"$/
-     * @When I remove its last name
-     */
+    #[When('/^I specify (?:their|his) last name as "([^"]*)"$/')]
+    #[When('I remove its last name')]
     public function iSpecifyTheirLastNameAs(?string $name = null): void
     {
         $this->client->addRequestData('lastName', $name);
     }
 
-    /**
-     * @When I specify its birthday as :birthday
-     */
+    #[When('I specify its birthday as :birthday')]
     public function iSpecifyItsBirthdayAs(string $birthday): void
     {
         $this->client->addRequestData('birthday', $birthday);
     }
 
-    /**
-     * @When I select :gender as its gender
-     */
+    #[When('I select :gender as its gender')]
     public function iSelectGender(string $gender): void
     {
         $this->client->addRequestData('gender', strtolower(substr($gender, 0, 1)));
     }
 
-    /**
-     * @When I select :customerGroup as their group
-     */
+    #[When('I select :customerGroup as their group')]
     public function iSelectGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->client->addRequestData('group', $this->iriConverter->getIriFromResource($customerGroup));
     }
 
-    /**
-     * @When I make them subscribed to the newsletter
-     */
+    #[When('I make them subscribed to the newsletter')]
     public function iMakeThemSubscribedToTheNewsletter(): void
     {
         $this->client->addRequestData('subscribedToNewsletter', true);
     }
 
-    /**
-     * @When I choose create account option
-     */
+    #[When('I choose create account option')]
     public function iChooseCreateAccountOption(): void
     {
         $this->client->addRequestData('user', []);
     }
 
-    /**
-     * @When I specify their password as :password
-     */
+    #[When('I specify their password as :password')]
     public function iSpecifyItsPasswordAs(string $password): void
     {
         $this->client->addRequestData('user', [
@@ -149,9 +127,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I (enable|disable) their account$/
-     */
+    #[When('/^I (enable|disable) their account$/')]
     public function iEnableIt(string $toggleAction): void
     {
         $this->client->addRequestData('user', [
@@ -159,9 +135,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I verify it
-     */
+    #[When('I verify it')]
     public function iVerifyIt(): void
     {
         $this->client->addRequestData('user', [
@@ -169,35 +143,27 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I (try to) add them
-     */
+    #[When('I (try to) add them')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I want to see all customers in store
-     */
+    #[When('I want to see all customers in store')]
     public function iWantToSeeAllCustomersInStore(): void
     {
         $this->client->index(Resources::CUSTOMERS);
     }
 
-    /**
-     * @When I view details of the customer :customer
-     * @When /^I view (their) details$/
-     */
+    #[When('I view details of the customer :customer')]
+    #[When('/^I view (their) details$/')]
     public function iViewDetailsOfTheCustomer(CustomerInterface $customer): void
     {
         $this->client->show(Resources::CUSTOMERS, (string) $customer->getId());
     }
 
-    /**
-     * @When I filter by group :groupName
-     * @When I filter by groups :firstGroup and :secondGroup
-     */
+    #[When('I filter by group :groupName')]
+    #[When('I filter by groups :firstGroup and :secondGroup')]
     public function iFilterByGroup(string ...$groupsNames): void
     {
         foreach ($groupsNames as $groupName) {
@@ -206,36 +172,28 @@ final class ManagingCustomersContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I search by :phrase email
-     */
+    #[When('I search by :phrase email')]
     public function iSearchByEmail(string $phrase): void
     {
         $this->client->addFilter('email', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I search by :phrase first name
-     */
+    #[When('I search by :phrase first name')]
     public function iSearchByFirstName(string $phrase): void
     {
         $this->client->addFilter('firstName', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I search by :phrase last name
-     */
+    #[When('I search by :phrase last name')]
     public function iSearchByLastName(string $phrase): void
     {
         $this->client->addFilter('lastName', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I sort the orders :sortType by channel
-     */
+    #[When('I sort the orders :sortType by channel')]
     public function iSortThemBy(string $sortType = 'ascending'): void
     {
         $this->client->sort([
@@ -243,9 +201,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I sort customers by :sortType registration date
-     */
+    #[When('I sort customers by :sortType registration date')]
     public function iSortCustomersByRegistrationDate(string $sortType): void
     {
         $this->client->sort([
@@ -253,9 +209,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I sort customers by :sortType email
-     */
+    #[When('I sort customers by :sortType email')]
     public function iSortCustomersByEmail(string $sortType): void
     {
         $this->client->sort([
@@ -263,9 +217,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I sort customers by :sortType first name
-     */
+    #[When('I sort customers by :sortType first name')]
     public function iSortCustomersByFirstName(string $sortType): void
     {
         $this->client->sort([
@@ -273,9 +225,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I sort customers by :sortType last name
-     */
+    #[When('I sort customers by :sortType last name')]
     public function iSortCustomersByLastName(string $sortType): void
     {
         $this->client->sort([
@@ -283,9 +233,7 @@ final class ManagingCustomersContext implements Context
         ]);
     }
 
-    /**
-     * @When I change the password of user :customer to :newPassword
-     */
+    #[When('I change the password of user :customer to :newPassword')]
     public function iChangeThePasswordOfUserTo(CustomerInterface $customer, string $newPassword): void
     {
         $this->iWantToEditThisCustomer($customer);
@@ -293,26 +241,20 @@ final class ManagingCustomersContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When I delete the account of :shopUser user
-     */
+    #[When('I delete the account of :shopUser user')]
     public function iDeleteAccount(ShopUserInterface $shopUser): void
     {
         $this->sharedStorage->set('customer', $shopUser->getCustomer());
         $this->client->delete(sprintf('customers/%s', $shopUser->getCustomer()->getId()), 'user');
     }
 
-    /**
-     * @When I do not specify any information
-     * @When I do not choose create account option
-     */
+    #[When('I do not specify any information')]
+    #[When('I do not choose create account option')]
     public function intentionallyLeftEmpty(): void
     {
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -321,9 +263,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -332,9 +272,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that email must be unique
-     */
+    #[Then('I should be notified that email must be unique')]
     public function iShouldBeNotifiedThatEmailMustBeUnique(): void
     {
         Assert::contains(
@@ -343,9 +281,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that ([^"]+) should be ([^"]+)$/
-     */
+    #[Then('/^I should be notified that ([^"]+) should be ([^"]+)$/')]
     public function iShouldBeNotifiedThatTheElementShouldBe(string $elementName, string $validationMessage): void
     {
         Assert::contains(
@@ -354,9 +290,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that email is not valid
-     */
+    #[Then('I should be notified that email is not valid')]
     public function iShouldBeNotifiedThatEmailIsNotValid(): void
     {
         Assert::contains(
@@ -365,10 +299,8 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then the customer :customer should appear in the store
-     * @Then the customer :customer should still have this email
-     */
+    #[Then('the customer :customer should appear in the store')]
+    #[Then('the customer :customer should still have this email')]
     public function theCustomerShouldAppearInTheStore(CustomerInterface $customer): void
     {
         Assert::true(
@@ -377,10 +309,8 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then the customer :customer should have an account created
-     * @Then /^(this customer) should have an account created$/
-     */
+    #[Then('the customer :customer should have an account created')]
+    #[Then('/^(this customer) should have an account created$/')]
     public function theyShouldHaveAnAccountCreated(CustomerInterface $customer): void
     {
         Assert::notNull(
@@ -389,19 +319,15 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count customers on the list
-     * @Then I should see a single customer on the list
-     */
+    #[Then('I should see :count customers on the list')]
+    #[Then('I should see a single customer on the list')]
     public function iShouldSeeZonesInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see the customer :email in the list
-     * @Then I should see the customer :email on the list
-     */
+    #[Then('I should see the customer :email in the list')]
+    #[Then('I should see the customer :email on the list')]
     public function iShouldSeeTheCustomerInTheList(string $email): void
     {
         Assert::true(
@@ -410,49 +336,37 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single order in the list
-     */
+    #[Then('I should see a single order in the list')]
     public function iShouldSeeASingleOrderInTheList(): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), 1);
     }
 
-    /**
-     * @Then their name should be :name
-     */
+    #[Then('their name should be :name')]
     public function theirNameShouldBe(string $name): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'fullName', $name));
     }
 
-    /**
-     * @Then he should be registered since :registrationDate
-     */
+    #[Then('he should be registered since :registrationDate')]
     public function hisRegistrationDateShouldBe(string $registrationDate): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'createdAt', $registrationDate));
     }
 
-    /**
-     * @Then their email should be :email
-     */
+    #[Then('their email should be :email')]
     public function theirEmailShouldBe(string $email): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'email', $email));
     }
 
-    /**
-     * @Then their phone number should be :phoneNumber
-     */
+    #[Then('their phone number should be :phoneNumber')]
     public function theirPhoneNumberShouldBe(string $phoneNumber): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'phoneNumber', $phoneNumber));
     }
 
-    /**
-     * @Then their default address should be :firstName :lastName, :street, :postcode :city, :country
-     */
+    #[Then('their default address should be :firstName :lastName, :street, :postcode :city, :country')]
     public function theirSDefaultAddressShouldBe(
         string $firstName,
         string $lastName,
@@ -471,36 +385,28 @@ final class ManagingCustomersContext implements Context
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'countryCode'), $country->getCode());
     }
 
-    /**
-     * @Then the province in the default address should be :provinceName
-     */
+    #[Then('the province in the default address should be :provinceName')]
     public function theProvinceInTheDefaultAddressShouldBe(string $provinceName): void
     {
         $this->client->showByIri($this->responseChecker->getValue($this->client->getLastResponse(), 'defaultAddress'));
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'provinceName'), $provinceName);
     }
 
-    /**
-     * @Then I should see information about no existing account for this customer
-     * @Then I should not see information about email verification
-     */
+    #[Then('I should see information about no existing account for this customer')]
+    #[Then('I should not see information about email verification')]
     public function iShouldSeeInformationAboutNoExistingAccountForThisCustomer(): void
     {
         Assert::null($this->responseChecker->getValue($this->client->getLastResponse(), 'user'));
     }
 
-    /**
-     * @Then I should see that this customer has verified the email
-     */
+    #[Then('I should see that this customer has verified the email')]
     public function iShouldSeeThatThisCustomerHasVerifiedTheEmail(): void
     {
         $user = $this->responseChecker->getValue($this->client->getLastResponse(), 'user');
         Assert::true($user['verified']);
     }
 
-    /**
-     * @Then I should see the order with number :orderNumber in the list
-     */
+    #[Then('I should see the order with number :orderNumber in the list')]
     public function iShouldSeeTheOrderWithNumberInTheList(string $orderNumber): void
     {
         Assert::true(
@@ -512,9 +418,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the password must be at least :amountOfCharacters characters long
-     */
+    #[Then('I should be notified that the password must be at least :amountOfCharacters characters long')]
     public function iShouldBeNotifiedThatThePasswordMustBeAtLeastCharactersLong(int $amountOfCharacters): void
     {
         Assert::contains(
@@ -523,9 +427,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the order with number :orderNumber in the list
-     */
+    #[Then('I should not see the order with number :orderNumber in the list')]
     public function iShouldNotSeeASingleOrderFromCustomer(string $orderNumber): void
     {
         Assert::false(
@@ -537,9 +439,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this customer) should be (enabled|disabled)$/
-     */
+    #[Then('/^(this customer) should be (enabled|disabled)$/')]
     public function thisCustomerShouldBeEnabled(CustomerInterface $customer, string $toggleAction): void
     {
         $user = $this->responseChecker->getValue(
@@ -549,9 +449,7 @@ final class ManagingCustomersContext implements Context
         Assert::same($user['enabled'], 'enabled' === $toggleAction);
     }
 
-    /**
-     * @Then /^(this customer) should be verified$/
-     */
+    #[Then('/^(this customer) should be verified$/')]
     public function thisCustomerShouldBeVerified(CustomerInterface $customer): void
     {
         $user = $this->responseChecker->getValue(
@@ -561,9 +459,7 @@ final class ManagingCustomersContext implements Context
         Assert::true($user['verified']);
     }
 
-    /**
-     * @Then there should still be only one customer with email :email
-     */
+    #[Then('there should still be only one customer with email :email')]
     public function thereShouldStillBeOnlyOneCustomerWithEmail(string $email): void
     {
         Assert::count(
@@ -573,10 +469,8 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this customer) should have an empty first name$/
-     * @Then the customer :customer should still have an empty first name
-     */
+    #[Then('/^(this customer) should have an empty first name$/')]
+    #[Then('the customer :customer should still have an empty first name')]
     public function theCustomerShouldStillHaveAnEmptyFirstName(CustomerInterface $customer): void
     {
         Assert::null(
@@ -587,10 +481,8 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this customer) should have an empty last name$/
-     * @Then the customer :customer should still have an empty last name
-     */
+    #[Then('/^(this customer) should have an empty last name$/')]
+    #[Then('the customer :customer should still have an empty last name')]
     public function theCustomerShouldStillHaveAnEmptyLastName(CustomerInterface $customer): void
     {
         Assert::null(
@@ -601,9 +493,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then the customer with email :email should not appear in the store
-     */
+    #[Then('the customer with email :email should not appear in the store')]
     public function theCustomerShouldNotAppearInTheStore(string $email): void
     {
         Assert::false(
@@ -615,9 +505,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this customer) with name "([^"]*)" should appear in the store$/
-     */
+    #[Then('/^(this customer) with name "([^"]*)" should appear in the store$/')]
     public function theCustomerWithNameShouldAppearInTheStore(CustomerInterface $customer, string $name): void
     {
         Assert::true(
@@ -629,10 +517,8 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then this customer should be subscribed to the newsletter
-     * @Then I should see that this customer is subscribed to the newsletter
-     */
+    #[Then('this customer should be subscribed to the newsletter')]
+    #[Then('I should see that this customer is subscribed to the newsletter')]
     public function thisCustomerShouldBeSubscribedToTheNewsletter(): void
     {
         Assert::true(
@@ -643,9 +529,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then this customer should have :customerGroup as their group
-     */
+    #[Then('this customer should have :customerGroup as their group')]
     public function thisCustomerShouldHaveAsTheirGroup(CustomerGroupInterface $customerGroup): void
     {
         Assert::same(
@@ -654,9 +538,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then the customer with this email should still exist
-     */
+    #[Then('the customer with this email should still exist')]
     public function customerShouldStillExist(): void
     {
         /** @var CustomerInterface $customer */
@@ -668,21 +550,17 @@ final class ManagingCustomersContext implements Context
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'email'), $customer->getEmail());
     }
 
-    /**
-     * @Then I should not see create account option
-     * @Then I should still be on the customer creation page
-     * @Then I should be able to specify their password
-     * @Then I should not be able to specify their password
-     * @Then I should be able to select create account option
-     * @Then I should not be able to select create account option
-     */
+    #[Then('I should not see create account option')]
+    #[Then('I should still be on the customer creation page')]
+    #[Then('I should be able to specify their password')]
+    #[Then('I should not be able to specify their password')]
+    #[Then('I should be able to select create account option')]
+    #[Then('I should not be able to select create account option')]
     public function intentionallyLeftBlank(): void
     {
     }
 
-    /**
-     * @Then the user account should be deleted
-     */
+    #[Then('the user account should be deleted')]
     public function accountShouldBeDeleted(): void
     {
         /** @var CustomerInterface $customer */
@@ -693,9 +571,7 @@ final class ManagingCustomersContext implements Context
         Assert::null($this->responseChecker->getValue($response, 'user'));
     }
 
-    /**
-     * @Then I should not be able to delete it again
-     */
+    #[Then('I should not be able to delete it again')]
     public function iShouldNotBeAbleToDeleteCustomerAgain(): void
     {
         $customer = $this->sharedStorage->get('customer');
@@ -704,9 +580,7 @@ final class ManagingCustomersContext implements Context
         Assert::same($this->client->getLastResponse()->getStatusCode(), 404);
     }
 
-    /**
-     * @Then /^the (first|last) customer should be "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) customer should be "([^"]+)"$/')]
     public function theFirstLastCustomerShouldBe(string $nth, string $email): void
     {
         $customers = $this->responseChecker->getCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingExchangeRatesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -32,10 +35,8 @@ final readonly class ManagingExchangeRatesContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am editing (this exchange rate)$/
-     * @When /^I want to edit (this exchange rate)$/
-     */
+    #[Given('/^I am editing (this exchange rate)$/')]
+    #[When('/^I want to edit (this exchange rate)$/')]
     public function iWantToEditThisExchangeRate(ExchangeRateInterface $exchangeRate): void
     {
         $this->client->buildUpdateRequest(Resources::EXCHANGE_RATES, (string) $exchangeRate->getId());
@@ -43,28 +44,22 @@ final readonly class ManagingExchangeRatesContext implements Context
         $this->sharedStorage->set('exchange_rate_id', (string) $exchangeRate->getId());
     }
 
-    /**
-     * @Given I am browsing exchange rates of the store
-     * @When I browse exchange rates
-     * @When I browse exchange rates of the store
-     */
+    #[Given('I am browsing exchange rates of the store')]
+    #[When('I browse exchange rates')]
+    #[When('I browse exchange rates of the store')]
     public function iBrowseExchangeRatesOfTheStore(): void
     {
         $this->client->index(Resources::EXCHANGE_RATES);
     }
 
-    /**
-     * @When I want to add a new exchange rate
-     */
+    #[When('I want to add a new exchange rate')]
     public function iWantToAddNewExchangeRate(): void
     {
         $this->client->buildCreateRequest(Resources::EXCHANGE_RATES);
     }
 
-    /**
-     * @When I specify its ratio as :ratio
-     * @When I don't specify its ratio
-     */
+    #[When('I specify its ratio as :ratio')]
+    #[When('I don\'t specify its ratio')]
     public function iSpecifyItsRatioAs(?string $ratio = null): void
     {
         if ($ratio !== null) {
@@ -72,9 +67,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         }
     }
 
-    /**
-     * @When I choose :currencyCode as the source currency
-     */
+    #[When('I choose :currencyCode as the source currency')]
     public function iChooseAsTheSourceCurrency(string $currencyCode): void
     {
         $this->client->addRequestData(
@@ -83,9 +76,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @When I choose :currencyCode as the target currency
-     */
+    #[When('I choose :currencyCode as the target currency')]
     public function iChooseAsTheTargetCurrency(string $currencyCode): void
     {
         $this->client->addRequestData(
@@ -94,66 +85,50 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I change ratio to :ratio
-     */
+    #[When('I change ratio to :ratio')]
     public function iChangeRatioTo(string $ratio): void
     {
         $this->client->updateRequestData(['ratio' => $ratio]);
     }
 
-    /**
-     * @When /^I delete the (exchange rate between "[^"]+" and "[^"]+")$/
-     */
+    #[When('/^I delete the (exchange rate between "[^"]+" and "[^"]+")$/')]
     public function iDeleteTheExchangeRateBetweenAnd(ExchangeRateInterface $exchangeRate): void
     {
         $this->client->delete(Resources::EXCHANGE_RATES, (string) $exchangeRate->getId());
     }
 
-    /**
-     * @When I choose :currency as a currency filter
-     */
+    #[When('I choose :currency as a currency filter')]
     public function iChooseCurrencyAsACurrencyFilter(CurrencyInterface $currency): void
     {
         $this->client->addFilter('currencyCode', $currency->getCode());
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see :count exchange rates on the list
-     */
+    #[Then('I should see :count exchange rates on the list')]
     public function iShouldSeeExchangeRatesOnTheList(int $count): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see a single exchange rate in the list
-     * @Then I should( still) see one exchange rate on the list
-     */
+    #[Then('I should see a single exchange rate in the list')]
+    #[Then('I should( still) see one exchange rate on the list')]
     public function iShouldSeeASingleExchangeRateInTheList(): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::EXCHANGE_RATES)), 1);
     }
 
-    /**
-     * @Then the exchange rate with ratio :ratio between :sourceCurrency and :targetCurrency should appear in the store
-     */
+    #[Then('the exchange rate with ratio :ratio between :sourceCurrency and :targetCurrency should appear in the store')]
     public function theExchangeRateWithRatioBetweenAndShouldAppearInTheStore(
         float $ratio,
         CurrencyInterface $sourceCurrency,
@@ -170,10 +145,8 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the exchange rate between :sourceCurrency and :targetCurrency in the list
-     * @Then I should (also) see an exchange rate between :sourceCurrency and :targetCurrency on the list
-     */
+    #[Then('I should see the exchange rate between :sourceCurrency and :targetCurrency in the list')]
+    #[Then('I should (also) see an exchange rate between :sourceCurrency and :targetCurrency on the list')]
     public function iShouldSeeTheExchangeRateBetweenAndInTheList(
         CurrencyInterface $sourceCurrency,
         CurrencyInterface $targetCurrency,
@@ -184,9 +157,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then it should have a ratio of :ratio
-     */
+    #[Then('it should have a ratio of :ratio')]
     public function itShouldHaveARatioOf(float $ratio): void
     {
         Assert::true(
@@ -195,9 +166,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this exchange rate) should no longer be on the list$/
-     */
+    #[Then('/^(this exchange rate) should no longer be on the list$/')]
     public function thisExchangeRateShouldNoLongerBeOnTheList(ExchangeRateInterface $exchangeRate): void
     {
         Assert::false(
@@ -215,9 +184,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then the exchange rate between :sourceCurrency and :targetCurrency should not be added
-     */
+    #[Then('the exchange rate between :sourceCurrency and :targetCurrency should not be added')]
     public function theExchangeRateBetweenAndShouldNotBeAdded(
         CurrencyInterface $sourceCurrency,
         CurrencyInterface $targetCurrency,
@@ -227,9 +194,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         Assert::null($this->getExchangeRateFromResponse($sourceCurrency, $targetCurrency));
     }
 
-    /**
-     * @Then /^(this exchange rate) should have a ratio of ([0-9\.]+)$/
-     */
+    #[Then('/^(this exchange rate) should have a ratio of ([0-9\.]+)$/')]
     public function thisExchangeRateShouldHaveARatioOf(ExchangeRateInterface $exchangeRate, float $ratio): void
     {
         $exchangeRate = $this->getExchangeRateFromResponse(
@@ -240,25 +205,19 @@ final readonly class ManagingExchangeRatesContext implements Context
         Assert::same($exchangeRate['ratio'], $ratio);
     }
 
-    /**
-     * @Then I should not be able to edit its source currency
-     */
+    #[Then('I should not be able to edit its source currency')]
     public function iShouldNotBeAbleToEditItsSourceCurrency(): void
     {
         $this->assertIfNotBeAbleToEditItCurrency('sourceCurrency');
     }
 
-    /**
-     * @Then I should not be able to edit its target currency
-     */
+    #[Then('I should not be able to edit its target currency')]
     public function iShouldNotBeAbleToEditItsTargetCurrency(): void
     {
         $this->assertIfNotBeAbleToEditItCurrency('targetCurrency');
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -267,9 +226,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the ratio must be greater than zero
-     */
+    #[Then('I should be notified that the ratio must be greater than zero')]
     public function iShouldBeNotifiedThatRatioMustBeGreaterThanZero(): void
     {
         Assert::contains(
@@ -278,9 +235,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the ratio must be less than :value
-     */
+    #[Then('I should be notified that the ratio must be less than :value')]
     public function iShouldBeNotifiedThatRatioMustBeLessThan(string $value): void
     {
         Assert::contains(
@@ -289,9 +244,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that source and target currencies must differ
-     */
+    #[Then('I should be notified that source and target currencies must differ')]
     public function iShouldBeNotifiedThatSourceAndTargetCurrenciesMustDiffer(): void
     {
         Assert::contains(
@@ -300,9 +253,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the currency pair must be unique
-     */
+    #[Then('I should be notified that the currency pair must be unique')]
     public function iShouldBeNotifiedThatTheCurrencyPairMustBeUnique(): void
     {
         Assert::contains(
@@ -311,9 +262,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -322,9 +271,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingLocalesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingLocalesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,43 +34,33 @@ final readonly class ManagingLocalesContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing locales
-     */
+    #[Given('I am browsing locales')]
     public function iAmBrowsingLocales(): void
     {
         $this->client->index(Resources::LOCALES);
     }
 
-    /**
-     * @Given /^I want to (?:create|add) a new locale$/
-     */
+    #[Given('/^I want to (?:create|add) a new locale$/')]
     public function iWantToAddNewLocale(): void
     {
         $this->client->buildCreateRequest(Resources::LOCALES);
     }
 
-    /**
-     * @When I choose :localeCode
-     * @When I set code to :code
-     * @When I do not choose a code
-     */
+    #[When('I choose :localeCode')]
+    #[When('I set code to :code')]
+    #[When('I do not choose a code')]
     public function iChoose(string $localeCode = ''): void
     {
         $this->client->addRequestData('code', $localeCode);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->client->addFilter(
@@ -77,17 +70,13 @@ final readonly class ManagingLocalesContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I remove :localeCode locale
-     */
+    #[When('I remove :localeCode locale')]
     public function iRemoveLocale(string $localeCode): void
     {
         $this->client->delete(Resources::LOCALES, $localeCode);
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -96,9 +85,7 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then the store should be available in the :localeCode language
-     */
+    #[Then('the store should be available in the :localeCode language')]
     public function theStoreShouldBeAvailableInTheLanguage(string $localeCode): void
     {
         $response = $this->client->index(Resources::LOCALES);
@@ -108,9 +95,7 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to choose :localeCode
-     */
+    #[Then('I should not be able to choose :localeCode')]
     public function iShouldNotBeAbleToChoose(string $localeCode): void
     {
         $this->client->addRequestData('code', $localeCode);
@@ -122,9 +107,7 @@ final readonly class ManagingLocalesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Locale code must be unique.');
     }
 
-    /**
-     * @Then I should be notified that a code is required
-     */
+    #[Then('I should be notified that a code is required')]
     public function iShouldBeNotifiedThatACodeIsRequired(): void
     {
         $response = $this->client->getLastResponse();
@@ -135,9 +118,7 @@ final readonly class ManagingLocalesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Please choose locale code.');
     }
 
-    /**
-     * @Then I should be notified that the code is invalid
-     */
+    #[Then('I should be notified that the code is invalid')]
     public function iShouldBeNotifiedThatTheCodeIsInvalid(): void
     {
         $response = $this->client->getLastResponse();
@@ -148,17 +129,13 @@ final readonly class ManagingLocalesContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: This value is not a valid locale code.');
     }
 
-    /**
-     * @Then I should be informed that locale :localeCode has been deleted
-     */
+    #[Then('I should be informed that locale :localeCode has been deleted')]
     public function iShouldBeInformedThatLocaleHasBeenDeleted(string $localeCode): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_NO_CONTENT);
     }
 
-    /**
-     * @Then only the :localeCode locale should be present in the system
-     */
+    #[Then('only the :localeCode locale should be present in the system')]
     public function onlyTheLocaleShouldBePresentInTheSystem(string $localeCode): void
     {
         $response = $this->client->index(Resources::LOCALES);
@@ -169,18 +146,14 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that locale :localeCode is in use and cannot be deleted
-     */
+    #[Then('I should be informed that locale :localeCode is in use and cannot be deleted')]
     public function iShouldBeInformedThatLocaleIsInUseAndCannotBeDeleted(string $localeCode): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_UNPROCESSABLE_ENTITY);
         Assert::same($this->responseChecker->getError($this->client->getLastResponse()), sprintf('Locale "%s" is used.', $localeCode));
     }
 
-    /**
-     * @Then the :localeCode locale should be still present in the system
-     */
+    #[Then('the :localeCode locale should be still present in the system')]
     public function theLocaleShouldBeStillPresentInTheSystem(string $localeCode): void
     {
         $response = $this->client->index(Resources::LOCALES);
@@ -190,9 +163,7 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single locale in the list
-     */
+    #[Then('I should see a single locale in the list')]
     public function iShouldSeeLocaleInTheList(int $amount = 1): void
     {
         Assert::same(
@@ -201,9 +172,7 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the locale :localeName
-     */
+    #[Then('I should see the locale :localeName')]
     public function iShouldSeeTheLocale(string $localeName): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingOrdersContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
@@ -53,12 +54,10 @@ final readonly class ManagingOrdersContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am viewing the summary of (this order)$/
-     * @Given I am viewing the summary of the order :order
-     * @When I view the summary of the order :order
-     * @When /^I view the summary of the (order placed by "[^"]+")$/
-     */
+    #[Given('/^I am viewing the summary of (this order)$/')]
+    #[Given('I am viewing the summary of the order :order')]
+    #[When('I view the summary of the order :order')]
+    #[When('/^I view the summary of the (order placed by "[^"]+")$/')]
     public function iSeeTheOrder(OrderInterface $order): void
     {
         $response = $this->client->show(Resources::ORDERS, $order->getTokenValue());
@@ -73,50 +72,38 @@ final readonly class ManagingOrdersContext implements Context
         $this->client->show(Resources::ORDERS, $order->getTokenValue());
     }
 
-    /**
-     * @Given I am browsing orders
-     * @When I browse orders
-     */
+    #[Given('I am browsing orders')]
+    #[When('I browse orders')]
     public function iBrowseOrders(): void
     {
         $this->client->index(Resources::ORDERS);
     }
 
-    /**
-     * @When I browse order's :order history
-     */
+    #[When('I browse order\'s :order history')]
     public function iBrowseOrderHistory(OrderInterface $order): void
     {
         $this->iSeeTheOrder($order);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @When I choose :channel as a channel filter
-     */
+    #[When('I choose :channel as a channel filter')]
     public function iChooseChannelAsAChannelFilter(ChannelInterface $channel): void
     {
         $this->client->addFilter('channel.code', $channel->getCode());
     }
 
-    /**
-     * @When I specify filter date from as :dateTime
-     */
+    #[When('I specify filter date from as :dateTime')]
     public function iSpecifyFilterDateFromAs(string $dateTime): void
     {
         $this->client->addFilter('checkoutCompletedAt[after]', $dateTime);
     }
 
-    /**
-     * @When specify its tracking code as :trackingCode
-     */
+    #[When('specify its tracking code as :trackingCode')]
     public function specifyItsTrackingCodeAs(string $trackingCode): void
     {
         $shipment = $this->sharedStorage->get('order')->getShipments()->first();
@@ -130,25 +117,19 @@ final readonly class ManagingOrdersContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When /^I try to view the summary of the (customer's latest cart)$/
-     */
+    #[When('/^I try to view the summary of the (customer\'s latest cart)$/')]
     public function iTryToViewTheSummaryOfTheCustomersLatestCart(OrderInterface $cart): void
     {
         $this->client->show(Resources::ORDERS, $cart->getTokenValue());
     }
 
-    /**
-     * @When I specify filter date to as :dateTime
-     */
+    #[When('I specify filter date to as :dateTime')]
     public function iSpecifyFilterDateToAs(string $dateTime): void
     {
         $this->client->addFilter('checkoutCompletedAt[before]', $dateTime);
     }
 
-    /**
-     * @When I resend the order confirmation email
-     */
+    #[When('I resend the order confirmation email')]
     public function iResendTheOrderConfirmationEmail(): void
     {
         $this->client->customItemAction(
@@ -159,10 +140,8 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @When I filter by product :productName
-     * @When I filter by products :firstProduct and :secondProduct
-     */
+    #[When('I filter by product :productName')]
+    #[When('I filter by products :firstProduct and :secondProduct')]
     public function iFilterByProduct(string ...$productNames): void
     {
         foreach ($productNames as $productName) {
@@ -172,18 +151,14 @@ final readonly class ManagingOrdersContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by customer :customer
-     */
+    #[When('I filter by customer :customer')]
     public function iFilterByCustomer(CustomerInterface $customer): void
     {
         $this->client->addFilter('customer.id', $customer->getId());
         $this->client->filter();
     }
 
-    /**
-     * @When I resend the shipment confirmation email
-     */
+    #[When('I resend the shipment confirmation email')]
     public function iResendTheShipmentConfirmationEmail(): void
     {
         $this->client->customItemAction(
@@ -194,25 +169,19 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @When I choose :shippingMethod as a shipping method filter
-     */
+    #[When('I choose :shippingMethod as a shipping method filter')]
     public function iChooseAsAShippingMethodFilter(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->addFilter('shipments.method.code', $shippingMethod->getCode());
     }
 
-    /**
-     * @When I choose :currency as the filter currency
-     */
+    #[When('I choose :currency as the filter currency')]
     public function iChooseCurrencyAsTheFilterCurrency(CurrencyInterface $currency): void
     {
         $this->client->addFilter('currencyCode', $currency->getCode());
     }
 
-    /**
-     * @When I specify filter total being greater than :total
-     */
+    #[When('I specify filter total being greater than :total')]
     public function iSpecifyFilterTotalBeingGreaterThan(string $total): void
     {
         if (str_contains($total, '.')) {
@@ -225,18 +194,14 @@ final readonly class ManagingOrdersContext implements Context
         $this->client->addFilter('total[gt]', $total . '00');
     }
 
-    /**
-     * @When I specify filter total being less than :total
-     */
+    #[When('I specify filter total being less than :total')]
     public function iSpecifyFilterTotalBeingLessThan(string $total): void
     {
         $this->client->addFilter('total[lt]', $total . '00');
     }
 
-    /**
-     * @When I filter by variant :variantName
-     * @When I filter by variants :firstVariant and :secondVariant
-     */
+    #[When('I filter by variant :variantName')]
+    #[When('I filter by variants :firstVariant and :secondVariant')]
     public function iFilterByVariant(string ...$variantsNames): void
     {
         foreach ($variantsNames as $variantName) {
@@ -246,18 +211,14 @@ final readonly class ManagingOrdersContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I switch the way orders are sorted by :fieldName
-     */
+    #[When('I switch the way orders are sorted by :fieldName')]
     public function iSwitchSortingBy(string $fieldName): void
     {
         $this->client->addFilter('order[number]', 'asc');
         $this->client->filter();
     }
 
-    /**
-     * @When /^I cancel (this order)$/
-     */
+    #[When('/^I cancel (this order)$/')]
     public function iCancelThisOrder(OrderInterface $order): void
     {
         $this->client->applyTransition(
@@ -267,9 +228,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @When /^I mark (this order) as paid$/
-     */
+    #[When('/^I mark (this order) as paid$/')]
     public function iMarkThisOrderAsAPaid(OrderInterface $order): void
     {
         $this->client->applyTransition(
@@ -279,9 +238,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @When /^I mark (this order)'s payment as refunded$/
-     */
+    #[When('/^I mark (this order)\'s payment as refunded$/')]
     public function iMarkThisOrderSPaymentAsRefunded(OrderInterface $order): void
     {
         $this->client->applyTransition(
@@ -291,9 +248,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @When /^I ship (this order)$/
-     */
+    #[When('/^I ship (this order)$/')]
     public function iShipThisOrder(OrderInterface $order): void
     {
         $shipment = $order->getShipments()->last();
@@ -308,18 +263,14 @@ final readonly class ManagingOrdersContext implements Context
         $this->sharedStorage->set('shipment', $shipment);
     }
 
-    /**
-     * @When I limit number of items to :limit
-     */
+    #[When('I limit number of items to :limit')]
     public function iLimitNumberOfItemsTo(int $limit): void
     {
         $this->client->addFilter('itemsPerPage', $limit);
         $this->client->filter();
     }
 
-    /**
-     * @When I check :itemName data
-     */
+    #[When('I check :itemName data')]
     public function iCheckData(string $itemName): void
     {
         /** @var string $lastResponseContent */
@@ -338,9 +289,7 @@ final readonly class ManagingOrdersContext implements Context
         throw new \InvalidArgumentException(sprintf('There is no item with name "%s".', $itemName));
     }
 
-    /**
-     * @Then I should see a single order from customer :customer
-     */
+    #[Then('I should see a single order from customer :customer')]
     public function iShouldSeeASingleOrderFromCustomer(CustomerInterface $customer): void
     {
         Assert::true(
@@ -353,35 +302,27 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that the (order|shipment) confirmation email has been successfully resent to the customer$/
-     */
+    #[Then('/^I should be notified that the (order|shipment) confirmation email has been successfully resent to the customer$/')]
     public function iShouldBeNotifiedThatTheOrderConfirmationEmailHasBeenSuccessfullyResentToTheCustomer(): void
     {
         $this->responseChecker->isCreationSuccessful($this->client->getLastResponse());
     }
 
-    /**
-     * @Then it should( still) have a :state state
-     */
+    #[Then('it should( still) have a :state state')]
     public function itShouldHaveState(string $state): void
     {
         Assert::true($this->responseChecker->hasItemWithValue($this->client->getLastResponse(), 'state', $state));
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), 1);
     }
 
-    /**
-     * @Then I should see a single order in the list
-     * @Then I should see :number orders in the list
-     */
+    #[Then('I should see a single order in the list')]
+    #[Then('I should see :number orders in the list')]
     public function iShouldSeeASingleOrderInTheList(int $number = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $number);
     }
 
-    /**
-     * @Then I should be notified that it has been successfully updated
-     */
+    #[Then('I should be notified that it has been successfully updated')]
     public function iShouldBeNotifiedAboutItHasBeenSuccessfullyCanceled(): void
     {
         $response = $this->client->getLastResponse();
@@ -391,10 +332,8 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then this order should have state :state
-     * @Then its state should be :state
-     */
+    #[Then('this order should have state :state')]
+    #[Then('its state should be :state')]
     public function itsStateShouldBe(string $state): void
     {
         /** @var OrderInterface $order */
@@ -404,10 +343,8 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($orderState, strtolower($state));
     }
 
-    /**
-     * @Then /^(it) should have shipment in state "([^"]+)"$/
-     * @Then /^(order "[^"]+") should have shipment state "([^"]+)"$/
-     */
+    #[Then('/^(it) should have shipment in state "([^"]+)"$/')]
+    #[Then('/^(order "[^"]+") should have shipment state "([^"]+)"$/')]
     public function itShouldHaveShipmentState(OrderInterface $order, string $state): void
     {
         $shipmentIri = $this->responseChecker->getValue(
@@ -421,10 +358,8 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have payment state :state
-     * @Then it should have payment with state :paymentState
-     */
+    #[Then('it should have payment state :state')]
+    #[Then('it should have payment with state :paymentState')]
     public function itShouldHavePaymentState(string $state): void
     {
         $paymentIri = $this->responseChecker->getValue(
@@ -438,9 +373,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(its) payment state should be refunded$/
-     */
+    #[Then('/^(its) payment state should be refunded$/')]
     public function itsPaymentStateShouldBeRefunded(OrderInterface $order): void
     {
         $response = $this->client->show(Resources::ORDERS, $order->getTokenValue());
@@ -448,9 +381,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->responseChecker->getValue($response, 'paymentState'), 'refunded');
     }
 
-    /**
-     * @Then /^there should be(?:| only) (\d+) payments?$/
-     */
+    #[Then('/^there should be(?:| only) (\d+) payments?$/')]
     public function theOrderShouldHaveNumberOfPayments(int $number): void
     {
         Assert::count(
@@ -459,10 +390,8 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the order :order should have order payment state :orderPaymentState
-     * @Then /^(this order) should have order payment state "([^"]+)"$/
-     */
+    #[Then('the order :order should have order payment state :orderPaymentState')]
+    #[Then('/^(this order) should have order payment state "([^"]+)"$/')]
     public function theOrderShouldHavePaymentState(OrderInterface $order, string $paymentState): void
     {
         Assert::true(
@@ -487,17 +416,13 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have :amount items
-     */
+    #[Then('it should have :amount items')]
     public function itShouldHaveAmountOfItems(int $amount): void
     {
         Assert::count($this->responseChecker->getValue($this->client->getLastResponse(), 'items'), $amount);
     }
 
-    /**
-     * @Then the product named :productName should be in the items list
-     */
+    #[Then('the product named :productName should be in the items list')]
     public function theProductShouldBeInTheItemsList(string $productName): void
     {
         $items = $this->responseChecker->getValue($this->client->getLastResponse(), 'items');
@@ -511,25 +436,19 @@ final readonly class ManagingOrdersContext implements Context
         throw new \InvalidArgumentException('There is no product with given name.');
     }
 
-    /**
-     * @Then /^the order's shipping total should be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s shipping total should be ("[^"]+")$/')]
     public function theOrdersShippingTotalShouldBe(int $shippingTotal): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'shippingTotal'), $shippingTotal);
     }
 
-    /**
-     * @Then /^the order's tax total should(?:| still) be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s tax total should(?:| still) be ("[^"]+")$/')]
     public function theOrdersTaxTotalShouldBe(int $taxTotal): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'taxTotal'), $taxTotal);
     }
 
-    /**
-     * @Then I should not be able to resend the shipment confirmation email
-     */
+    #[Then('I should not be able to resend the shipment confirmation email')]
     public function iShouldNotBeAbleToResendTheShipmentConfirmationEmail(): void
     {
         $this->client->customItemAction(
@@ -545,17 +464,13 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^the order's items total should be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s items total should be ("[^"]+")$/')]
     public function theOrdersItemsTotalShouldBe(int $itemsTotal): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'itemsTotal'), $itemsTotal);
     }
 
-    /**
-     * @Then /^the order's payment should(?:| also) be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s payment should(?:| also) be ("[^"]+")$/')]
     public function theOrdersPaymentShouldBe(int $paymentAmount): void
     {
         $response = $this->client->showByIri(
@@ -565,9 +480,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->responseChecker->getValue($response, 'amount'), $paymentAmount);
     }
 
-    /**
-     * @Then /^I should not be able to cancel (this order)$/
-     */
+    #[Then('/^I should not be able to cancel (this order)$/')]
     public function iShouldNotBeAbleToCancelThisOrder(OrderInterface $order): void
     {
         $this->iCancelThisOrder($order);
@@ -577,9 +490,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^the order's total should(?:| still) be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s total should(?:| still) be ("[^"]+")$/')]
     public function theOrdersTotalShouldBe(int $total): void
     {
         $response = $this->client->show(Resources::ORDERS, $this->sharedStorage->get('order')->getTokenValue());
@@ -590,9 +501,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^the order's promotion total should(?:| still) be ("[^"]+")$/
-     */
+    #[Then('/^the order\'s promotion total should(?:| still) be ("[^"]+")$/')]
     public function theOrdersPromotionTotalShouldBe(int $promotionTotal): void
     {
         $response = $this->client->show(Resources::ORDERS, $this->sharedStorage->get('order')->getTokenValue());
@@ -603,9 +512,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the order's promotion discount should be :promotionAmount from :promotionName promotion
-     */
+    #[Then('the order\'s promotion discount should be :promotionAmount from :promotionName promotion')]
     public function theOrdersPromotionDiscountShouldBeFromPromotion(string $promotionAmount, string $promotionName): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -618,9 +525,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the order's shipping promotion should be :promotionAmount
-     */
+    #[Then('the order\'s shipping promotion should be :promotionAmount')]
     public function theOrdersShippingPromotionDiscountShouldBe(string $promotionAmount): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -632,9 +537,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then there should be a shipping charge :shippingCharge for :shippingMethodName method
-     */
+    #[Then('there should be a shipping charge :shippingCharge for :shippingMethodName method')]
     public function thereShouldBeAShippingChargeForMethod(string $shippingCharge, string $shippingMethodName): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -647,9 +550,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then there should be a shipping tax :shippingTax for :shippingMethodName method
-     */
+    #[Then('there should be a shipping tax :shippingTax for :shippingMethodName method')]
     public function thereShouldBeAShippingTaxForMethod(string $shippingTax, string $shippingMethodName): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -662,9 +563,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/
-     */
+    #[Then('/^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/')]
     public function theAdministratorShouldSeeThatThisOrderHasBeenPlacedIn(
         AdminUserInterface $user,
         OrderInterface $order,
@@ -677,9 +576,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($currencyCode, $currency);
     }
 
-    /**
-     * @Then I should see an order with :orderNumber number
-     */
+    #[Then('I should see an order with :orderNumber number')]
     public function iShouldSeeOrderWithNumber(string $orderNumber): void
     {
         $response = $this->client->getLastResponse();
@@ -690,9 +587,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see an order with :orderNumber number
-     */
+    #[Then('I should not see an order with :orderNumber number')]
     public function iShouldNotSeeOrderWithNumber(string $orderNumber)
     {
         $response = $this->client->getLastResponse();
@@ -703,9 +598,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see any orders with currency :currencyCode
-     */
+    #[Then('I should not see any orders with currency :currencyCode')]
     public function iShouldNotSeeAnyOrderWithCurrency(string $currencyCode): void
     {
         $response = $this->client->getLastResponse();
@@ -716,9 +609,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the first order should have number :number
-     */
+    #[Then('the first order should have number :number')]
     public function theFirstOrderShouldHaveNumber(string $number): void
     {
         $items = $this->responseChecker->getValue($this->client->getLastResponse(), 'hydra:member');
@@ -727,9 +618,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($firstItem['number'], str_replace('#', '', $number));
     }
 
-    /**
-     * @Then /^I should see the order "([^"]+)" with total ("[^"]+")$/
-     */
+    #[Then('/^I should see the order "([^"]+)" with total ("[^"]+")$/')]
     public function iShouldSeeTheOrderWithTotal(string $orderNumber, int $total): void
     {
         $order = $this->responseChecker->getCollectionItemsWithValue(
@@ -744,9 +633,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the administrator should see the order with total :total in order list
-     */
+    #[Then('the administrator should see the order with total :total in order list')]
     public function theAdministratorShouldSeeTheOrderWithTotalInOrderList(string $total): void
     {
         $adminUser = $this->sharedStorage->get('administrator');
@@ -770,9 +657,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($firstItem['total'], $total);
     }
 
-    /**
-     * @Then it should have been placed by the customer :customer
-     */
+    #[Then('it should have been placed by the customer :customer')]
     public function itShouldHaveBeenPlacedByTheCustomer(CustomerInterface $customer): void
     {
         Assert::same(
@@ -781,9 +666,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should be shipped via the :shippingMethod shipping method
-     */
+    #[Then('it should be shipped via the :shippingMethod shipping method')]
     public function itShouldBeShippedViaTheShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         Assert::same(
@@ -792,9 +675,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should be paid with :paymentMethod
-     */
+    #[Then('it should be paid with :paymentMethod')]
     public function itShouldBePaidWith(PaymentMethodInterface $paymentMethod): void
     {
         Assert::same(
@@ -803,17 +684,13 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have no shipping address set
-     */
+    #[Then('it should have no shipping address set')]
     public function itShouldHaveNoShippingAddressSet(): void
     {
         Assert::null($this->responseChecker->getValue($this->client->getLastResponse(), 'shippingAddress'));
     }
 
-    /**
-     * @Then it should be shipped to :customerName, :street, :postcode, :city, :countryName
-     */
+    #[Then('it should be shipped to :customerName, :street, :postcode, :city, :countryName')]
     public function itShouldBeShippedTo(
         string $customerName,
         string $street,
@@ -833,9 +710,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have :customerName, :street, :postcode, :city, :countryName as its billing address
-     */
+    #[Then('it should have :customerName, :street, :postcode, :city, :countryName as its billing address')]
     public function itShouldHaveAddressAsItBillingAddress(
         string $customerName,
         string $street,
@@ -855,9 +730,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :provinceName as province in the shipping address
-     */
+    #[Then('I should see :provinceName as province in the shipping address')]
     public function iShouldSeeAsProvinceInTheShippingAddress(string $provinceName): void
     {
         Assert::same(
@@ -866,9 +739,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :provinceName as province in the billing address
-     */
+    #[Then('I should see :provinceName as province in the billing address')]
     public function iShouldSeeAsProvinceInTheBillingAddress(string $provinceName): void
     {
         Assert::same(
@@ -877,9 +748,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the shipping date as :dateTime
-     */
+    #[Then('I should see the shipping date as :dateTime')]
     public function iShouldSeeTheShippingDateAs(string $dateTime): void
     {
         $response = $this->client->show(Resources::SHIPMENTS, (string) $this->sharedStorage->get('shipment')->getId());
@@ -890,41 +759,31 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^(its) unit price should be ([^"]+)$/
-     */
+    #[Then('/^(its) unit price should be ([^"]+)$/')]
     public function itemUnitPriceShouldBe(array $orderItem, string $unitPrice): void
     {
         Assert::same($this->getTotalAsInt($unitPrice), $orderItem['unitPrice']);
     }
 
-    /**
-     * @Then /^(its) total should be ([^"]+)$/
-     */
+    #[Then('/^(its) total should be ([^"]+)$/')]
     public function itemTotalShouldBe(array $orderItem, string $total): void
     {
         Assert::same($this->getTotalAsInt($total), $orderItem['total']);
     }
 
-    /**
-     * @Then /^(its) code should be "([^"]+)"$/
-     */
+    #[Then('/^(its) code should be "([^"]+)"$/')]
     public function itemCodeShouldBe(array $orderItem, string $code): void
     {
         Assert::endsWith($orderItem['variant'], $code);
     }
 
-    /**
-     * @Then /^(its) quantity should be ([^"]+)$/
-     */
+    #[Then('/^(its) quantity should be ([^"]+)$/')]
     public function itemQuantityShouldBe(array $orderItem, int $quantity): void
     {
         Assert::same($quantity, $orderItem['quantity']);
     }
 
-    /**
-     * @Then /^its discounted unit price should be ([^"]+)$/
-     */
+    #[Then('/^its discounted unit price should be ([^"]+)$/')]
     public function itemDiscountedUnitPriceShouldBe(string $discountedUnitPrice): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -936,9 +795,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^its subtotal should be ([^"]+)$/
-     */
+    #[Then('/^its subtotal should be ([^"]+)$/')]
     public function itemSubtotalShouldBe(string $subtotal): void
     {
         $orderItem = $this->sharedStorage->get('item');
@@ -953,9 +810,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->getTotalAsInt($subtotal), $orderItem['unitPrice'] * $orderItem['quantity'] + $unitPromotionAdjustments);
     }
 
-    /**
-     * @Then /^its discount should be ([^"]+)$/
-     */
+    #[Then('/^its discount should be ([^"]+)$/')]
     public function theItemShouldHaveDiscount(string $discount): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -967,9 +822,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^its tax should be ([^"]+)$/
-     */
+    #[Then('/^its tax should be ([^"]+)$/')]
     public function itemTaxShouldBe(string $tax): void
     {
         $this->responseChecker->hasItemWithValues(
@@ -981,9 +834,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^its tax included in price should be ([^"]+)$/
-     */
+    #[Then('/^its tax included in price should be ([^"]+)$/')]
     public function itsTaxIncludedInPriceShouldBe(string $tax): void
     {
         $unitPromotionAdjustments = $this->responseChecker->getCollectionItemsWithValue(
@@ -1011,10 +862,8 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^the order "[^"]+" should have order shipping state "([^"]+)"$/
-     * @Then it should have order's shipping state :orderShippingState
-     */
+    #[Then('/^the order "[^"]+" should have order shipping state "([^"]+)"$/')]
+    #[Then('it should have order\'s shipping state :orderShippingState')]
     public function theOrderShouldHaveShippingState(string $orderShippingState): void
     {
         $ordersResponse = $this->client->index(Resources::ORDERS, forgetResponse: true);
@@ -1025,9 +874,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see information about shipments
-     */
+    #[Then('I should not see information about shipments')]
     public function iShouldNotSeeInformationAboutShipping(): void
     {
         Assert::same(
@@ -1036,9 +883,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then the :productName product's unit price should be :price
-     */
+    #[Then('the :productName product\'s unit price should be :price')]
     public function productUnitPriceShouldBe(string $productName, string $price): void
     {
         $this->iCheckData($productName);
@@ -1046,27 +891,21 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->getTotalAsInt($price), $orderItem['unitPrice']);
     }
 
-    /**
-     * @Then the :productName product's discounted unit price should be :price
-     */
+    #[Then('the :productName product\'s discounted unit price should be :price')]
     public function productDiscountedUnitPriceShouldBe(string $productName, string $price): void
     {
         $orderItem = $this->sharedStorage->get('item');
         Assert::same($this->getTotalAsInt($price), $orderItem['fullDiscountedUnitPrice']);
     }
 
-    /**
-     * @Then the :productName product's quantity should be :quantity
-     */
+    #[Then('the :productName product\'s quantity should be :quantity')]
     public function productQuantityShouldBe(string $productName, int $quantity): void
     {
         $orderItem = $this->sharedStorage->get('item');
         Assert::same($quantity, $orderItem['quantity']);
     }
 
-    /**
-     * @Then the :productName product's item discount should be :price
-     */
+    #[Then('the :productName product\'s item discount should be :price')]
     public function productItemDiscountShouldBe(string $productName, string $price): void
     {
         $orderItem = $this->sharedStorage->get('item');
@@ -1086,9 +925,7 @@ final readonly class ManagingOrdersContext implements Context
         }
     }
 
-    /**
-     * @Then the :productName product's order discount should be :price
-     */
+    #[Then('the :productName product\'s order discount should be :price')]
     public function productOrderDiscountShouldBe(string $productName, string $price): void
     {
         $orderItem = $this->sharedStorage->get('item');
@@ -1108,9 +945,7 @@ final readonly class ManagingOrdersContext implements Context
         }
     }
 
-    /**
-     * @Then the :productName product's subtotal should be :subTotal
-     */
+    #[Then('the :productName product\'s subtotal should be :subTotal')]
     public function productSubtotalShouldBe(string $productName, string $subTotal): void
     {
         $orderItem = $this->sharedStorage->get('item');
@@ -1128,9 +963,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->getTotalAsInt($subTotal), $orderItem['unitPrice'] * $orderItem['quantity'] + $unitPromotionAdjustments);
     }
 
-    /**
-     * @Then I should be notified that the order has been successfully shipped
-     */
+    #[Then('I should be notified that the order has been successfully shipped')]
     public function iShouldBeNotifiedThatTheOrderHasBeenSuccessfullyShipped(): void
     {
         $response = $this->client->getLastResponse();
@@ -1140,9 +973,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have shipment in state shipped
-     */
+    #[Then('it should have shipment in state shipped')]
     public function itShouldHaveShipmentInStateShipped(): void
     {
         $shipmentIri = $this->responseChecker->getValue(
@@ -1156,9 +987,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then this order should have order shipping state :orderShippingState
-     */
+    #[Then('this order should have order shipping state :orderShippingState')]
     public function thisOrderShouldHaveOrderShippingState(string $orderShippingState): void
     {
         $ordersResponse = $this->client->index(Resources::ORDERS);
@@ -1169,9 +998,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to ship this order
-     */
+    #[Then('I should not be able to ship this order')]
     public function iShouldNotBeAbleToShipThisOrder(): void
     {
         $order = $this->sharedStorage->get('order');
@@ -1188,9 +1015,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that the order does not exist
-     */
+    #[Then('I should be informed that the order does not exist')]
     public function iShouldBeInformedThatTheOrderDoesNotExist(): void
     {
         Assert::same(
@@ -1199,9 +1024,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then there should be :count shipping address changes in the registry
-     */
+    #[Then('there should be :count shipping address changes in the registry')]
     public function thereShouldBeCountShippingAddressChangesInTheRegistry(int $count): void
     {
         $order = $this->sharedStorage->get('order');
@@ -1213,9 +1036,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->responseChecker->countCollectionItems($response), $count);
     }
 
-    /**
-     * @Then I should not be able to resend the order confirmation email
-     */
+    #[Then('I should not be able to resend the order confirmation email')]
     public function iShouldNotBeAbleToResendTheOrderConfirmationEmail(): void
     {
         $this->client->customItemAction(
@@ -1231,9 +1052,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then there should be :count billing address changes in the registry
-     */
+    #[Then('there should be :count billing address changes in the registry')]
     public function thereShouldBeCountBillingAddressChangesInTheRegistry(int $count): void
     {
         $order = $this->sharedStorage->get('order');
@@ -1245,25 +1064,19 @@ final readonly class ManagingOrdersContext implements Context
         Assert::same($this->responseChecker->countCollectionItems($response), $count);
     }
 
-    /**
-     * @Then I should be notified that the order's payment has been successfully completed
-     */
+    #[Then('I should be notified that the order\'s payment has been successfully completed')]
     public function iShouldBeNotifiedThatTheOrdersPaymentHasBeenSuccessfullyCompleted(): void
     {
         Assert::true($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that the order's payment has been successfully refunded
-     */
+    #[Then('I should be notified that the order\'s payment has been successfully refunded')]
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyRefunded(): void
     {
         Assert::true($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then /^I should not be able to mark (this order) as paid again$/
-     */
+    #[Then('/^I should not be able to mark (this order) as paid again$/')]
     public function iShouldNotBeAbleToMarkThisOrderAsPaidAgain(OrderInterface $order): void
     {
         $this->client->applyTransition(
@@ -1275,9 +1088,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::false($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that the order's payment could not be finalized due to insufficient stock
-     */
+    #[Then('I should be notified that the order\'s payment could not be finalized due to insufficient stock')]
     public function iShouldBeNotifiedThatTheOrdersPaymentCouldNotBeFinalizedDueToInsufficientStock(): void
     {
         Assert::contains(
@@ -1286,9 +1097,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see this customer's IP address
-     */
+    #[Then('I should see this customer\'s IP address')]
     public function iShouldSeeCustomersIpAddress(): void
     {
         Assert::notEmpty($this->responseChecker->getValue($this->client->getLastResponse(), 'customerIp'));

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentMethodsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -40,9 +43,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I search by "([^"]+)" (code|name)$/
-     */
+    #[When('/^I search by "([^"]+)" (code|name)$/')]
     public function iSearchByName(string $phrase, string $field): void
     {
         $field = $field === 'name' ? 'translations.name' : $field;
@@ -51,33 +52,25 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I choose enabled filter
-     */
+    #[When('I choose enabled filter')]
     public function iChooseEnabledFilter(): void
     {
         $this->client->addFilter('enabled', true);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @When I want to modify the :paymentMethod payment method
-     */
+    #[When('I want to modify the :paymentMethod payment method')]
     public function iWantToModifyAPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->client->buildUpdateRequest(Resources::PAYMENT_METHODS, $paymentMethod->getCode());
     }
 
-    /**
-     * @When /^I set its "Username" as "([^"]+)", "Password" as "([^"]+)" and "Signature" as "([^"]+)"$/
-     */
+    #[When('/^I set its "Username" as "([^"]+)", "Password" as "([^"]+)" and "Signature" as "([^"]+)"$/')]
     public function iSetItsUsernameAsPasswordAsAndSignatureAs(string $username, string $password, string $signature): void
     {
         $this->updateGatewayConfig([
@@ -87,9 +80,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I set its "Publishable key" as "([^"]+)" and "Secret key" as "([^"]+)"$/
-     */
+    #[When('/^I set its "Publishable key" as "([^"]+)" and "Secret key" as "([^"]+)"$/')]
     public function iSetItsPublishableKeyAsAndSecretKeyAs(string $publishableKey, string $secretKey): void
     {
         $this->updateGatewayConfig([
@@ -98,9 +89,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When I update its :field with :value
-     */
+    #[When('I update its :field with :value')]
     public function iUpdateItsWith(string $field, string $value): void
     {
         $availableFields = ['Publishable key', 'Secret key', 'Username', 'Password', 'Signature', 'Sandbox'];
@@ -112,61 +101,47 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->updateGatewayConfig([StringInflector::nameToLowercaseCode($field) => $value]);
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I rename it to :name in :localeCode
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I rename it to :name in :localeCode')]
+    #[When('I remove its name from :localeCode translation')]
     public function iNameItIn(string $localeCode, ?string $name = null): void
     {
         $this->client->addRequestData('translations', [$localeCode => ['name' => $name]]);
     }
 
-    /**
-     * @When I enable sandbox mode
-     */
+    #[When('I enable sandbox mode')]
     public function iEnableSandboxMode(): void
     {
         $this->client->addRequestData('gatewayConfig', ['config' => ['sandbox' => true]]);
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->addRequestData('enabled', true);
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->client->addRequestData('enabled', false);
     }
 
-    /**
-     * @When I delete the :paymentMethod payment method
-     * @When I try to delete the :paymentMethod payment method
-     */
+    #[When('I delete the :paymentMethod payment method')]
+    #[When('I try to delete the :paymentMethod payment method')]
     public function iDeletePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->client->delete(Resources::PAYMENT_METHODS, $paymentMethod->getCode());
     }
 
-    /**
-     * @When I want to create a new offline payment method
-     * @When I want to create a new payment method with :factory gateway factory
-     */
+    #[When('I want to create a new offline payment method')]
+    #[When('I want to create a new payment method with :factory gateway factory')]
     public function iWantToCreateANewPaymentMethod(string $factory = 'Offline'): void
     {
         $factory = str_replace(' ', '_', strtolower($factory));
@@ -175,18 +150,14 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->addRequestData('gatewayConfig', ['factoryName' => $factory, 'gatewayName' => $factory]);
     }
 
-    /**
-     * @When I want to create a new payment method without gateway configuration
-     */
+    #[When('I want to create a new payment method without gateway configuration')]
     public function iWantToCreateANewPaymentMethodWithoutGatewayConfiguration(): void
     {
         $this->client->buildCreateRequest(Resources::PAYMENT_METHODS);
         $this->client->addRequestData('code', 'TEST');
     }
 
-    /**
-     * @When I want to create a new payment method without gateway name
-     */
+    #[When('I want to create a new payment method without gateway name')]
     public function iWantToCreateANewPaymentMethodWithoutGatewayName(): void
     {
         $this->client->buildCreateRequest(Resources::PAYMENT_METHODS);
@@ -194,9 +165,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->addRequestData('gatewayConfig', ['factoryName' => 'offline']);
     }
 
-    /**
-     * @When I want to create a new payment method without factory name
-     */
+    #[When('I want to create a new payment method without factory name')]
     public function iWantToCreateANewPaymentMethodWithoutFactoryName(): void
     {
         $this->client->buildCreateRequest(Resources::PAYMENT_METHODS);
@@ -204,9 +173,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->addRequestData('gatewayConfig', ['gatewayName' => 'offline']);
     }
 
-    /**
-     * @When I want to create a new payment method with wrong factory name
-     */
+    #[When('I want to create a new payment method with wrong factory name')]
     public function iWantToCreateANewPaymentMethodWithWrongFactoryName(): void
     {
         $this->client->buildCreateRequest(Resources::PAYMENT_METHODS);
@@ -214,53 +181,41 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->addRequestData('gatewayConfig', ['factoryName' => 'gateway_with_wrong_factory_name', 'gatewayName' => 'gateway with wrong factory name']);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $this->client->addRequestData('translations', [$localeCode => ['description' => $description]]);
     }
 
-    /**
-     * @When make it available in channel :channel
-     */
+    #[When('make it available in channel :channel')]
     public function iMakeItAvailableInChannel(ChannelInterface $channel): void
     {
         $this->client->replaceRequestData('channels', [$this->iriConverter->getIriFromResourceInSection($channel, 'admin')]);
     }
 
-    /**
-     * @When I set its instruction as :instructions in :localeCode
-     */
+    #[When('I set its instruction as :instructions in :localeCode')]
     public function iSetItsInstructionAsIn(string $instructions, string $localeCode): void
     {
         $this->client->addRequestData('translations', [$localeCode => ['instructions' => $instructions]]);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I start sorting payment methods by name
-     * @When the payment methods are already sorted by name
-     * @When I switch the way payment methods are sorted to :sortType by name
-     */
+    #[When('I start sorting payment methods by name')]
+    #[When('the payment methods are already sorted by name')]
+    #[When('I switch the way payment methods are sorted to :sortType by name')]
     public function iSortShippingMethodsByName(string $sortType = 'ascending'): void
     {
         $this->client->sort([
@@ -269,11 +224,9 @@ final readonly class ManagingPaymentMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @Given the payment methods are already sorted by code
-     * @When I start sorting payment methods by code
-     * @When I switch the way payment methods are sorted to :sortType by code
-     */
+    #[Given('the payment methods are already sorted by code')]
+    #[When('I start sorting payment methods by code')]
+    #[When('I switch the way payment methods are sorted to :sortType by code')]
     public function iSortShippingMethodsByCode(string $sortType = 'ascending'): void
     {
         $this->client->sort([
@@ -282,9 +235,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When I configure it for username :username with :signature signature
-     */
+    #[When('I configure it for username :username with :signature signature')]
     public function iConfigureItForUsernameWithSignature(string $username, string $signature): void
     {
         $this->client->addRequestData(
@@ -299,9 +250,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I configure it for username :username with :signature signature and password, but without sandbox
-     */
+    #[When('I configure it for username :username with :signature signature and password, but without sandbox')]
     public function iConfigureItForUsernameWithSignatureButWithoutSandbox(string $username, string $signature): void
     {
         $this->client->addRequestData(
@@ -317,9 +266,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I configure it for username :username with :signature signature and password, but with sandbox that has wrong type
-     */
+    #[When('I configure it for username :username with :signature signature and password, but with sandbox that has wrong type')]
     public function iConfigureItForUsernameWithSignatureButWithWrongSandboxType(string $username, string $signature): void
     {
         $this->client->addRequestData(
@@ -335,9 +282,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I configure it with only :element
-     */
+    #[When('I configure it with only :element')]
     public function iConfigureItWithOnly(string $element): void
     {
         $element = str_replace(' ', '_', strtolower($element));
@@ -353,9 +298,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I do not specify configuration password
-     */
+    #[When('I do not specify configuration password')]
     public function iDoNotSpecifyConfigurationPassword(): void
     {
         $this->client->addRequestData(
@@ -368,18 +311,14 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Given I am browsing payment methods
-     * @When I browse payment methods
-     */
+    #[Given('I am browsing payment methods')]
+    #[When('I browse payment methods')]
     public function iBrowsePaymentMethods(): void
     {
         $this->client->index(Resources::PAYMENT_METHODS);
     }
 
-    /**
-     * @When I change my locale to :localeCode
-     */
+    #[When('I change my locale to :localeCode')]
     public function iChangeMyLocaleTo(string $localeCode): void
     {
         /** @var AdminUserInterface $adminUser */
@@ -391,9 +330,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @Then the first payment method on the list should have :field :value
-     */
+    #[Then('the first payment method on the list should have :field :value')]
     public function theFirstPaymentMethodOnTheListShouldHave(string $field, string $value): void
     {
         $response = $this->client->getLastResponse();
@@ -403,9 +340,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::same($this->getFieldValueOfFirstPaymentMethod($paymentMethods[0], $field), $value);
     }
 
-    /**
-     * @Then the last payment method on the list should have :field :value
-     */
+    #[Then('the last payment method on the list should have :field :value')]
     public function theLastPaymentMethodOnTheListShouldHave(string $field, string $value): void
     {
         $response = $this->client->index(Resources::PAYMENT_METHODS);
@@ -426,18 +361,14 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single payment method in the list
-     * @Then I should see :amount payment methods in the list
-     */
+    #[Then('I should see a single payment method in the list')]
+    #[Then('I should see :amount payment methods in the list')]
     public function iShouldSeePaymentMethodsInTheList(int $amount = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $amount);
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::contains(
@@ -446,9 +377,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to specify payment method :element
-     */
+    #[Then('I should be notified that I have to specify payment method :element')]
     public function iShouldBeNotifiedThatINeedToSpecifyPaymentMethodName(string $element): void
     {
         Assert::contains(
@@ -457,9 +386,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to specify gateway configuration
-     */
+    #[Then('I should be notified that I have to specify gateway configuration')]
     public function iShouldBeNotifiedThatIHaveToSpecifyGatewayConfiguration(): void
     {
         Assert::same(
@@ -468,9 +395,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to specify gateway name
-     */
+    #[Then('I should be notified that I have to specify gateway name')]
     public function iShouldBeNotifiedThatIHaveToSpecifyGatewayName(): void
     {
         Assert::same(
@@ -479,9 +404,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to specify factory name
-     */
+    #[Then('I should be notified that I have to specify factory name')]
     public function iShouldBeNotifiedThatIHaveToSpecifyFactoryName(): void
     {
         Assert::same(
@@ -490,9 +413,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to specify factory name that is available
-     */
+    #[Then('I should be notified that I have to specify factory name that is available')]
     public function iShouldBeNotifiedThatIHaveToSpecifyFactoryNameThatIsAvailable(): void
     {
         Assert::contains(
@@ -501,9 +422,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the payment method with :element :value should not be added
-     */
+    #[Then('the payment method with :element :value should not be added')]
     public function thePaymentMethodWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         if ($element === 'name') {
@@ -524,9 +443,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then this payment method should still be named :paymentMethodName
-     */
+    #[Then('this payment method should still be named :paymentMethodName')]
     public function thisPaymentMethodNameShouldStillBeNamed(string $paymentMethodName): void
     {
         Assert::inArray(
@@ -536,10 +453,8 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the code field should be disabled
-     * @Then I should not be able to edit its code
-     */
+    #[Then('the code field should be disabled')]
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -547,9 +462,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then the factory name field should be disabled
-     */
+    #[Then('the factory name field should be disabled')]
     public function theFactoryNameFieldShouldBeDisabled(): void
     {
         $this->client->addRequestData('gatewayConfig', ['factoryName' => 'NEWFACTORYNAME']);
@@ -558,9 +471,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->getLastResponse(), 'gatewayConfig', 'NEWFACTORYNAME'));
     }
 
-    /**
-     * @Then /^(this payment method) should be enabled/
-     */
+    #[Then('/^(this payment method) should be enabled/')]
     public function thisPaymentMethodShouldBeEnabled(PaymentMethodInterface $paymentMethod): void
     {
         Assert::true(
@@ -573,9 +484,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this payment method) should be disabled$/
-     */
+    #[Then('/^(this payment method) should be disabled$/')]
     public function thisShippingMethodShouldBeDisabled(PaymentMethodInterface $paymentMethod): void
     {
         Assert::true(
@@ -588,9 +497,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the payment method :paymentMethod should have instructions :instructions in :localeCode
-     */
+    #[Then('the payment method :paymentMethod should have instructions :instructions in :localeCode')]
     public function thePaymentMethodShouldHaveInstructionsIn(
         PaymentMethodInterface $paymentMethod,
         string $instructions,
@@ -605,9 +512,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the payment method :paymentMethod should be available in channel :channel
-     */
+    #[Then('the payment method :paymentMethod should be available in channel :channel')]
     public function thePaymentMethodShouldBeAvailableInChannel(
         PaymentMethodInterface $paymentMethod,
         ChannelInterface $channel,
@@ -618,9 +523,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::true(in_array($this->iriConverter->getIriFromResourceInSection($channel, 'admin'), $channelsArray));
     }
 
-    /**
-     * @Then /^(this payment method) should no longer exist in the registry$/
-     */
+    #[Then('/^(this payment method) should no longer exist in the registry$/')]
     public function thisPaymentMethodShouldNoLongerExistInTheRegistry(PaymentMethodInterface $paymentMethod): void
     {
         Assert::false(
@@ -629,9 +532,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that payment method with this code already exists
-     */
+    #[Then('I should be notified that payment method with this code already exists')]
     public function iShouldBeNotifiedThatPaymentMethodWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -645,9 +546,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one payment method with :element :code
-     */
+    #[Then('there should still be only one payment method with :element :code')]
     public function thereShouldStillBeOnlyOnePaymentMethodWith(string $element, string $code): void
     {
         $response = $this->client->index(Resources::PAYMENT_METHODS);
@@ -657,9 +556,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::true($this->responseChecker->hasItemWithValue($response, $element, $code));
     }
 
-    /**
-     * @Then /^this payment method "([^"]+)" should be "([^"]+)"$/
-     */
+    #[Then('/^this payment method "([^"]+)" should be "([^"]+)"$/')]
     public function thisPaymentMethodElementShouldBe(
         string $element,
         string $value,
@@ -680,9 +577,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^its gateway configuration "([^"]+)" should be "([^"]+)"$/
-     */
+    #[Then('/^its gateway configuration "([^"]+)" should be "([^"]+)"$/')]
     public function itsGatewayConfigurationShouldBe(string $element, string $value): void
     {
         $gatewayConfig = $this->responseChecker->getValue($this->client->getLastResponse(), 'gatewayConfig');
@@ -694,9 +589,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then this payment method should be in sandbox mode
-     */
+    #[Then('this payment method should be in sandbox mode')]
     public function thisPaymentMethodShouldBeInSandboxMode(): void
     {
         $gatewayConfig = $this->responseChecker->getValue($this->client->getLastResponse(), 'gatewayConfig');
@@ -708,9 +601,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -719,9 +610,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -730,9 +619,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is in use
-     */
+    #[Then('I should be notified that it is in use')]
     public function iShouldBeNotifiedThatItIsInUse(): void
     {
         Assert::contains(
@@ -741,11 +628,9 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the payment method :paymentMethodName should appear in the registry
-     * @Then the payment method :paymentMethodName should be in the registry
-     * @Then I should see the payment method :paymentMethodName in the list
-     */
+    #[Then('the payment method :paymentMethodName should appear in the registry')]
+    #[Then('the payment method :paymentMethodName should be in the registry')]
+    #[Then('I should see the payment method :paymentMethodName in the list')]
     public function thePaymentMethodShouldAppearInTheRegistry(string $paymentMethodName): void
     {
         Assert::inArray(
@@ -755,9 +640,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the payment method :paymentMethodName
-     */
+    #[Then('I should see the payment method :paymentMethodName')]
     public function iShouldSeeThePaymentMethod(string $paymentMethodName): void
     {
         Assert::true(
@@ -766,9 +649,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the payment method :paymentMethodName
-     */
+    #[Then('I should not see the payment method :paymentMethodName')]
     public function iShouldNotSeeThePaymentMethod(string $paymentMethodName): void
     {
         Assert::false(
@@ -777,9 +658,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this payment method) should still be in the registry$/
-     */
+    #[Then('/^(this payment method) should still be in the registry$/')]
     public function thisPaymentMethodShouldStillBeInTheRegistry(PaymentMethodInterface $paymentMethod): void
     {
         $this->thePaymentMethodShouldAppearInTheRegistry($paymentMethod->getName());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentRequestsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentRequestsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -40,9 +42,7 @@ final readonly class ManagingPaymentRequestsContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse payment requests of an order :order
-     */
+    #[When('I browse payment requests of an order :order')]
     public function iBrowseOrdersOfACustomer(OrderInterface $order): void
     {
         $this->client->subResourceIndex(
@@ -52,9 +52,7 @@ final readonly class ManagingPaymentRequestsContext implements Context
         );
     }
 
-    /**
-     * @When I view details of the payment request for the :order order
-     */
+    #[When('I view details of the payment request for the :order order')]
     public function iViewDetailsOfThePaymentRequestForTheOrder(OrderInterface $order): void
     {
         $paymentRequest = $this->paymentRequestRepository->findOneBy(['payment' => $order->getLastPayment()]);
@@ -62,52 +60,40 @@ final readonly class ManagingPaymentRequestsContext implements Context
         $this->client->show(Resources::PAYMENT_REQUESTS, (string) $paymentRequest->getHash());
     }
 
-    /**
-     * @When I filter by the :action action
-     */
+    #[When('I filter by the :action action')]
     public function iFilterByTheAction(string $action): void
     {
         $this->client->addFilter('action', $action);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by the :paymentMethod payment method
-     */
+    #[When('I filter by the :paymentMethod payment method')]
     public function iFilterByThePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->client->addFilter('method.code', $paymentMethod->getCode());
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by the :state state
-     */
+    #[When('I filter by the :state state')]
     public function iFilterByTheState(string $state): void
     {
         $this->client->addFilter('state', $state);
         $this->client->filter();
     }
 
-    /**
-     * @Then /^there should be (\d+) payment requests? on the list$/
-     */
+    #[Then('/^there should be (\d+) payment requests? on the list$/')]
     public function thereShouldBeProductVariantsOnTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then it should be the payment request with action :action
-     */
+    #[Then('it should be the payment request with action :action')]
     public function itShouldBeThePaymentRequestWithAction(string $action): void
     {
         Assert::true($this->responseChecker->hasItemWithValue($this->client->getLastResponse(), 'action', $action));
     }
 
-    /**
-     * @Then it should be the payment request with payment method :paymentMethod
-     */
+    #[Then('it should be the payment request with payment method :paymentMethod')]
     public function itShouldBeThePaymentRequestWithPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         Assert::true(
@@ -119,9 +105,7 @@ final readonly class ManagingPaymentRequestsContext implements Context
         );
     }
 
-    /**
-     * @Then its method should be :paymentMethod
-     */
+    #[Then('its method should be :paymentMethod')]
     public function itsMethodShouldBe(PaymentMethodInterface $paymentMethod): void
     {
         Assert::true(
@@ -133,33 +117,25 @@ final readonly class ManagingPaymentRequestsContext implements Context
         );
     }
 
-    /**
-     * @Then /^its (action|state) should be "([^"]+)"$/
-     */
+    #[Then('/^its (action|state) should be "([^"]+)"$/')]
     public function itsActionStateShouldBe(string $field, string $value): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), $field, strtolower($value)));
     }
 
-    /**
-     * @Then its payload should has empty value
-     */
+    #[Then('its payload should has empty value')]
     public function itsPayloadShouldHasEmptyValue(): void
     {
         Assert::isEmpty($this->responseChecker->getValue($this->client->getLastResponse(), 'payload'));
     }
 
-    /**
-     * @Then its response data should has empty value
-     */
+    #[Then('its response data should has empty value')]
     public function itsResponseDataShouldHasEmptyValue(): void
     {
         Assert::isEmpty($this->responseChecker->getValue($this->client->getLastResponse(), 'responseData'));
     }
 
-    /**
-     * @Then the administrator should see the payment request with action :action for :paymentMethod payment method and state :state
-     */
+    #[Then('the administrator should see the payment request with action :action for :paymentMethod payment method and state :state')]
     public function administratorShouldSeeThePaymentRequestWithActionAndState(string $action, PaymentMethodInterface $paymentMethod, string $state): void
     {
         $adminUser = $this->sharedStorage->get('administrator');

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPaymentsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -36,18 +39,14 @@ final readonly class ManagingPaymentsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing payments
-     * @When I browse payments
-     */
+    #[Given('I am browsing payments')]
+    #[When('I browse payments')]
     public function iAmBrowsingPayments(): void
     {
         $this->client->index(Resources::PAYMENTS);
     }
 
-    /**
-     * @When I go to the details of the first payment's order
-     */
+    #[When('I go to the details of the first payment\'s order')]
     public function iGoToTheDetailsOfTheFirstPaymentSOrder(): void
     {
         $firstPayment = $this->responseChecker->getCollection($this->client->getLastResponse())[0];
@@ -58,9 +57,7 @@ final readonly class ManagingPaymentsContext implements Context
         $this->client->customItemAction(Resources::ORDERS, $order->getTokenValue(), HttpRequest::METHOD_GET, 'payments');
     }
 
-    /**
-     * @When I want to view the payment requests of the first payment
-     */
+    #[When('I want to view the payment requests of the first payment')]
     public function iWantToViewThePaymentRequestsOfTheFirstPayment(): void
     {
         $response = $this->client->getLastResponse();
@@ -72,9 +69,7 @@ final readonly class ManagingPaymentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the details of order :order
-     */
+    #[Then('I should see the details of order :order')]
     public function iShouldSeeOrderWithDetails(OrderInterface $order): void
     {
         Assert::true(
@@ -87,9 +82,7 @@ final readonly class ManagingPaymentsContext implements Context
         );
     }
 
-    /**
-     * @When I complete the payment of order :order
-     */
+    #[When('I complete the payment of order :order')]
     public function iCompleteThePaymentOfOrder(OrderInterface $order): void
     {
         $payment = $order->getLastPayment();
@@ -102,51 +95,39 @@ final readonly class ManagingPaymentsContext implements Context
         );
     }
 
-    /**
-     * @When I choose :state as a payment state
-     */
+    #[When('I choose :state as a payment state')]
     public function iChooseAsAPaymentState(string $state): void
     {
         $this->client->addFilter('state', $state);
     }
 
-    /**
-     * @When I choose :channel as a channel filter
-     */
+    #[When('I choose :channel as a channel filter')]
     public function iChooseChannelAsAChannelFilter(ChannelInterface $channel): void
     {
         $this->client->addFilter('order.channel.code', $channel->getCode());
     }
 
-    /**
-     * @When /^I sort payments by date in (ascending|descending) order$/
-     */
+    #[When('/^I sort payments by date in (ascending|descending) order$/')]
     public function iSortPaymentsByRegistrationDate(string $order): void
     {
         $this->client->sort(['createdAt' => str_starts_with($order, 'de') ? 'desc' : 'asc']);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see a single payment in the list
-     * @Then I should see :count payments in the list
-     */
+    #[Then('I should see a single payment in the list')]
+    #[Then('I should see :count payments in the list')]
     public function iShouldSeePaymentsInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the payment of the :orderNumber order should be :paymentState for :customer
-     */
+    #[Then('the payment of the :orderNumber order should be :paymentState for :customer')]
     public function thePaymentOfTheOrderShouldBeFor(
         string $orderNumber,
         string $paymentState,
@@ -177,9 +158,7 @@ final readonly class ManagingPaymentsContext implements Context
         throw new \InvalidArgumentException('There is no payment with given data.');
     }
 
-    /**
-     * @Then /^I should see payment for the ("[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/
-     */
+    #[Then('/^I should see payment for the ("[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/')]
     public function iShouldSeePaymentForTheOrderInTheList(OrderInterface $order, int $position): void
     {
         Assert::true($this->responseChecker->hasItemOnPositionWithValue(
@@ -190,17 +169,13 @@ final readonly class ManagingPaymentsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the payment has been completed
-     */
+    #[Then('I should be notified that the payment has been completed')]
     public function iShouldBeNotifiedThatThePaymentHasBeenCompleted(): void
     {
         Assert::true($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()), 'Resource could not be completed');
     }
 
-    /**
-     * @Then I should see the payment of order :order as :paymentState
-     */
+    #[Then('I should see the payment of order :order as :paymentState')]
     public function iShouldSeeThePaymentOfOrderAs(OrderInterface $order, string $paymentState): void
     {
         $payment = $order->getLastPayment();
@@ -213,9 +188,7 @@ final readonly class ManagingPaymentsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see (also) the payment of the :order order
-     */
+    #[Then('I should see (also) the payment of the :order order')]
     public function iShouldSeeThePaymentOfTheOrder(OrderInterface $order): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(
@@ -225,9 +198,7 @@ final readonly class ManagingPaymentsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not see the payment of the :order order
-     */
+    #[Then('I should not see the payment of the :order order')]
     public function iShouldNotSeeThePaymentOfTheOrder(OrderInterface $order): void
     {
         Assert::false($this->responseChecker->hasItemWithValue(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPlacedOrderAddressesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPlacedOrderAddressesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -41,9 +43,7 @@ final class ManagingPlacedOrderAddressesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to modify a customer's billing address of this order
-     */
+    #[When('I want to modify a customer\'s billing address of this order')]
     public function iWantToModifyCustomerBillingAddress(): void
     {
         $this->client->buildUpdateRequest(
@@ -52,9 +52,7 @@ final class ManagingPlacedOrderAddressesContext implements Context
         );
     }
 
-    /**
-     * @When I want to modify a customer's shipping address of this order
-     */
+    #[When('I want to modify a customer\'s shipping address of this order')]
     public function iWantToModifyCustomerShippingAddress(): void
     {
         $this->client->buildUpdateRequest(
@@ -63,25 +61,19 @@ final class ManagingPlacedOrderAddressesContext implements Context
         );
     }
 
-    /**
-     * @When /^I clear the (?:billing|shipping) address information$/
-     */
+    #[When('/^I clear the (?:billing|shipping) address information$/')]
     public function iClearTheAddressInformation(): void
     {
         $this->client->updateRequestData(array_fill_keys(array_keys($this->addressProperties), ''));
     }
 
-    /**
-     * @When /^I do not specify new information$/
-     */
+    #[When('/^I do not specify new information$/')]
     public function iDoNotSpecifyNewInformation(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When /^I specify their (?:|new )(?:billing|shipping) (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     */
+    #[When('/^I specify their (?:|new )(?:billing|shipping) (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
     public function iSpecifyTheirAddressAs(AddressInterface $address): void
     {
         $this->client->addRequestData('firstName', $address->getFirstName());
@@ -91,9 +83,7 @@ final class ManagingPlacedOrderAddressesContext implements Context
         $this->client->addRequestData('city', $address->getCity());
     }
 
-    /**
-     * @Then /^this order should(?:| still) have ("([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address)$/
-     */
+    #[Then('/^this order should(?:| still) have ("([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address)$/')]
     public function itsBillingAddressShouldContain(AddressInterface $address): void
     {
         $response = $this->client->show(
@@ -104,9 +94,7 @@ final class ManagingPlacedOrderAddressesContext implements Context
         $this->assertAddressResponseProperties($response, $address);
     }
 
-    /**
-     * @Then /^this order should(?:| still) (be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
-     */
+    #[Then('/^this order should(?:| still) (be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/')]
     public function itShouldBeShippedTo(AddressInterface $address): void
     {
         $response = $this->client->show(
@@ -117,9 +105,7 @@ final class ManagingPlacedOrderAddressesContext implements Context
         $this->assertAddressResponseProperties($response, $address);
     }
 
-    /**
-     * @Then /^I should be notified that all mandatory (?:shipping|billing) address details are incomplete$/
-     */
+    #[Then('/^I should be notified that all mandatory (?:shipping|billing) address details are incomplete$/')]
     public function iShouldBeNotifiedThatAllMandatoryAddressDetailsAreIncomplete(): void
     {
         /** @var array<string, array<string, string>> $mandatoryAddressProperties */

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationTypesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -30,26 +32,20 @@ final readonly class ManagingProductAssociationTypesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new product association type
-     */
+    #[When('I want to create a new product association type')]
     public function iWantToCreateANewProductAssociationType(): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_ASSOCIATION_TYPES);
     }
 
-    /**
-     * @When I specify its code as :productAssociationTypeCode
-     */
+    #[When('I specify its code as :productAssociationTypeCode')]
     public function iSpecifyItsCodeAs(string $productAssociationTypeCode): void
     {
         $this->client->addRequestData('code', $productAssociationTypeCode);
     }
 
-    /**
-     * @When I name it :productAssociationTypeName in :localeCode
-     * @When I do not name it
-     */
+    #[When('I name it :productAssociationTypeName in :localeCode')]
+    #[When('I do not name it')]
     public function iNameItIn(?string $productAssociationTypeName = null, string $localeCode = 'en_US'): void
     {
         $this->client->updateRequestData([
@@ -61,17 +57,13 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         ]);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I remove its name from :localeCode translation')]
     public function iRemoveItsNameFromTranslation(string $localeCode): void
     {
         $this->client->updateRequestData([
@@ -83,76 +75,58 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         ]);
     }
 
-    /**
-     * @When I sort the product associations :sortType by code
-     */
+    #[When('I sort the product associations :sortType by code')]
     public function iSortProductAssociationsByCode(string $sortType = 'ascending'): void
     {
         $this->client->sort(['code' => self::SORT_TYPES[$sortType]]);
     }
 
-    /**
-     * @When I am browsing product association types
-     * @When I want to browse product association types
-     */
+    #[When('I am browsing product association types')]
+    #[When('I want to browse product association types')]
     public function iBrowseProductAssociationTypes(): void
     {
         $this->client->index(Resources::PRODUCT_ASSOCIATION_TYPES);
     }
 
-    /**
-     * @When I delete the :productAssociationType product association type
-     */
+    #[When('I delete the :productAssociationType product association type')]
     public function iDeleteTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->client->delete(Resources::PRODUCT_ASSOCIATION_TYPES, $productAssociationType->getCode());
     }
 
-    /**
-     * @When I want to modify the :productAssociationType product association type
-     */
+    #[When('I want to modify the :productAssociationType product association type')]
     public function iWantToModifyTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCT_ASSOCIATION_TYPES, $productAssociationType->getCode());
     }
 
-    /**
-     * @When I rename it to :name in :localeCode
-     */
+    #[When('I rename it to :name in :localeCode')]
     public function iRenameItToIn(string $name, string $localeCode): void
     {
         $this->client->updateRequestData(['translations' => [$localeCode => ['name' => $name]]]);
     }
 
-    /**
-     * @When I filter product association types with code containing :value
-     */
+    #[When('I filter product association types with code containing :value')]
     public function iFilterProductAssociationTypesWithCodeContaining(string $value): void
     {
         $this->client->addFilter('code', $value);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter product association types with name containing :value
-     */
+    #[When('I filter product association types with name containing :value')]
     public function iFilterProductAssociationTypesWithNameContaining(string $value): void
     {
         $this->client->addFilter('translations.name', $value);
         $this->client->filter();
     }
 
-    /**
-     * @When I do not specify its code
-     */
+    #[When('I do not specify its code')]
     public function iDoNotSpecifyItsCode(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -161,9 +135,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then the product association type :name should appear in the store
-     */
+    #[Then('the product association type :name should appear in the store')]
     public function theProductAssociationTypeShouldAppearInTheStore(string $name): void
     {
         Assert::true(
@@ -172,19 +144,15 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count product association types in the list
-     * @Then I should see a single product association type in the list
-     */
+    #[Then('I should see :count product association types in the list')]
+    #[Then('I should see a single product association type in the list')]
     public function iShouldSeeProductAssociationTypesInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see the product association type :name in the list
-     * @Then this product association type should still be named :name
-     */
+    #[Then('I should see the product association type :name in the list')]
+    #[Then('this product association type should still be named :name')]
     public function iShouldSeeTheProductAssociationTypeInTheList(string $name): void
     {
         Assert::true(
@@ -193,9 +161,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that it has been successfully deleted$/
-     */
+    #[Then('/^I should be notified that it has been successfully deleted$/')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -206,9 +172,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product association type) should no longer exist in the registry$/
-     */
+    #[Then('/^(this product association type) should no longer exist in the registry$/')]
     public function thisProductAssociationTypeShouldNoLongerExistInTheRegistry(ProductAssociationTypeInterface $productAssociationType): void
     {
         Assert::false(
@@ -217,9 +181,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product association type) name should be "([^"]+)"$/
-     */
+    #[Then('/^(this product association type) name should be "([^"]+)"$/')]
     public function thisProductAssociationTypeNameShouldBe(ProductAssociationTypeInterface $productAssociationType, string $name): void
     {
         Assert::true(
@@ -228,9 +190,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', 'NEW_CODE');
@@ -241,17 +201,13 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see only one product association type in the list
-     */
+    #[Then('I should see only one product association type in the list')]
     public function iShouldSeeOnlyOneProductAssociationTypeInTheList(): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), 1);
     }
 
-    /**
-     * @Then I should be notified that product association type with this code already exists
-     */
+    #[Then('I should be notified that product association type with this code already exists')]
     public function iShouldBeNotifiedThatProductAssociationTypeWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -260,9 +216,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one product association type with a code :code
-     */
+    #[Then('there should still be only one product association type with a code :code')]
     public function thereShouldStillBeOnlyOneProductAssociationTypeWithACode(string $code): void
     {
         Assert::count(
@@ -272,9 +226,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :type is required
-     */
+    #[Then('I should be notified that :type is required')]
     public function iShouldBeNotifiedThatCodeIsRequired(string $type): void
     {
         Assert::contains(
@@ -283,9 +235,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then the product association type with :type :value should not be added
-     */
+    #[Then('the product association type with :type :value should not be added')]
     public function theProductAssociationTypeWithNameShouldNotBeAdded(string $type, string $value): void
     {
         Assert::false(
@@ -294,9 +244,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then the first product association on the list should have code :value
-     */
+    #[Then('the first product association on the list should have code :value')]
     public function theFirstProductAssociationOnTheListShouldHave(string $value): void
     {
         $productAssociations = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -304,9 +252,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::same(reset($productAssociations)['code'], $value);
     }
 
-    /**
-     * @Then the last product association on the list should have code :value
-     */
+    #[Then('the last product association on the list should have code :value')]
     public function theLastProductAssociationOnTheListShouldHave(string $value): void
     {
         $productAssociations = $this->responseChecker->getCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAssociationsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -36,9 +38,7 @@ final readonly class ManagingProductAssociationsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I (associate as "[^"]+") the (product "[^"]+") with the ("[^"]+" product)$/
-     */
+    #[When('/^I (associate as "[^"]+") the (product "[^"]+") with the ("[^"]+" product)$/')]
     public function iAssociateAsTypeTheProductWithTheProduct(
         ProductAssociationTypeInterface $type,
         ProductInterface $owner,
@@ -47,9 +47,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->iAssociateAsTypeTheProductWithTheProducts($type, $owner, [$product]);
     }
 
-    /**
-     * @When /^I (associate as "[^"]+") the (product "[^"]+") with the (products "[^"]+" and "[^"]+")$/
-     */
+    #[When('/^I (associate as "[^"]+") the (product "[^"]+") with the (products "[^"]+" and "[^"]+")$/')]
     public function iAssociateAsTypeTheProductWithTheProducts(
         ProductAssociationTypeInterface $type,
         ProductInterface $owner,
@@ -77,9 +75,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->sharedStorage->set('product', $association->getOwner());
     }
 
-    /**
-     * @When /^I add the (product "[^"]+") to (this product association)$/
-     */
+    #[When('/^I add the (product "[^"]+") to (this product association)$/')]
     public function iAddTheProductToThisProductAssociation(
         ProductInterface $product,
         ProductAssociationInterface $association,
@@ -97,9 +93,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->sharedStorage->set('association', $association);
     }
 
-    /**
-     * @When /^I change (this product association)'s product to the ("[^"]+" product)$/
-     */
+    #[When('/^I change (this product association)\'s product to the ("[^"]+" product)$/')]
     public function iChangeThisProductAssociationProductToProduct(
         ProductAssociationInterface $association,
         ProductInterface $product,
@@ -111,9 +105,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->sharedStorage->set('association', $association);
     }
 
-    /**
-     * @When /^I remove the (product "[^"]+") from (this product association)$/
-     */
+    #[When('/^I remove the (product "[^"]+") from (this product association)$/')]
     public function iRemoveTheProductFromThisProductAssociation(
         ProductInterface $product,
         ProductAssociationInterface $association,
@@ -133,9 +125,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->sharedStorage->set('association', $association);
     }
 
-    /**
-     * @Then /^(this product) should have an (association "[^"]+")$/
-     */
+    #[Then('/^(this product) should have an (association "[^"]+")$/')]
     public function thisProductShouldHaveAnAssociation(
         ProductInterface $product,
         ProductAssociationTypeInterface $type,
@@ -161,9 +151,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this association) should only have (product "[^"]+")$/
-     */
+    #[Then('/^(this association) should only have (product "[^"]+")$/')]
     public function thisAssociationShouldOnlyHaveProduct(
         ProductAssociationInterface $association,
         ProductInterface $product,
@@ -171,9 +159,7 @@ final readonly class ManagingProductAssociationsContext implements Context
         $this->thisAssociationShouldHaveProducts($association, [$product]);
     }
 
-    /**
-     * @Then /^(this association) should have (products "[^"]+" and "[^"]+")$/
-     */
+    #[Then('/^(this association) should have (products "[^"]+" and "[^"]+")$/')]
     public function thisAssociationShouldHaveProducts(
         ProductAssociationInterface $association,
         array $products,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductAttributesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Ramsey\Uuid\Uuid;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -31,43 +33,33 @@ final readonly class ManagingProductAttributesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to see all product attributes in store
-     * @When I am browsing product attributes
-     */
+    #[When('I want to see all product attributes in store')]
+    #[When('I am browsing product attributes')]
     public function iWantToBrowseProductAttributes(): void
     {
         $this->client->index(Resources::PRODUCT_ATTRIBUTES);
     }
 
-    /**
-     * @When /^I(?:| try to) delete (this product attribute)$/
-     */
+    #[When('/^I(?:| try to) delete (this product attribute)$/')]
     public function iDeleteThisProductAttribute(ProductAttributeInterface $attribute): void
     {
         $this->client->delete(Resources::PRODUCT_ATTRIBUTES, $attribute->getCode());
     }
 
-    /**
-     * @When I want to create a new :type product attribute
-     */
+    #[When('I want to create a new :type product attribute')]
     public function iWantToCreateANewTypedProductAttribute(string $type): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_ATTRIBUTES);
         $this->client->addRequestData('type', $type);
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When /^I search by "([^"]+)" (code|name)$/
-     */
+    #[When('/^I search by "([^"]+)" (code|name)$/')]
     public function iSearchBy(string $phrase, string $field): void
     {
         $field = $field === 'name' ? 'translations.name' : $field;
@@ -76,10 +68,8 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I choose :type in the type filter
-     * @When I choose :firstType and :secondType in the type filter
-     */
+    #[When('I choose :type in the type filter')]
+    #[When('I choose :firstType and :secondType in the type filter')]
     public function iChooseInTheTypeFilter(string ...$types): void
     {
         foreach ($types as $type) {
@@ -87,9 +77,7 @@ final readonly class ManagingProductAttributesContext implements Context
         }
     }
 
-    /**
-     * @When I choose :translatable in the translatable filter
-     */
+    #[When('I choose :translatable in the translatable filter')]
     public function iChooseInTheTranslatableFilter(string $translatable): void
     {
         match ($translatable) {
@@ -99,28 +87,22 @@ final readonly class ManagingProductAttributesContext implements Context
         };
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I change its name to :name in :localeCode
-     * @When I do not name it
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I change its name to :name in :localeCode')]
+    #[When('I do not name it')]
+    #[When('I remove its name from :localeCode translation')]
     public function iNameItIn(string $name = '', string $localeCode = 'en_US'): void
     {
         $this->client->updateRequestData(['translations' => [$localeCode => ['name' => $name]]]);
     }
 
-    /**
-     * @When I (also) add value :value in :localeCode
-     */
+    #[When('I (also) add value :value in :localeCode')]
     public function iAddValueIn(string $value, string $localeCode): void
     {
         $uuid = Uuid::uuid4()->toString();
@@ -128,43 +110,33 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->client->addRequestData('configuration', ['choices' => [$uuid => [$localeCode => $value]]]);
     }
 
-    /**
-     * @When I disable its translatability
-     */
+    #[When('I disable its translatability')]
     public function iDisableItsTranslatability(): void
     {
         $this->client->addRequestData('translatable', false);
     }
 
-    /**
-     * @When I check multiple option
-     */
+    #[When('I check multiple option')]
     public function iCheckMultipleOption(): void
     {
         $this->client->addRequestData('configuration', ['multiple' => true]);
     }
 
-    /**
-     * @When I do not check multiple option
-     * @When I do not specify its code
-     */
+    #[When('I do not check multiple option')]
+    #[When('I do not specify its code')]
     public function intentionallyBlank(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I specify its :limitType entries value as :count
-     * @When I specify its :limitType length as :count
-     */
+    #[When('I specify its :limitType entries value as :count')]
+    #[When('I specify its :limitType length as :count')]
     public function iSpecifyItsLimitTypeEntriesAs(string $limitType, int $count): void
     {
         $this->client->addRequestData('configuration', [$limitType => $count]);
     }
 
-    /**
-     * @When /^I want to edit (this product attribute)$/
-     */
+    #[When('/^I want to edit (this product attribute)$/')]
     public function iWantToEditThisProductAttribute(ProductAttributeInterface $productAttribute): void
     {
         $this->sharedStorage->set('product_attribute', $productAttribute);
@@ -172,18 +144,14 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->client->buildUpdateRequest(Resources::PRODUCT_ATTRIBUTES, $productAttribute->getCode());
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When /^I change (its) value "([^"]+)" to "([^"]+)"$/
-     */
+    #[When('/^I change (its) value "([^"]+)" to "([^"]+)"$/')]
     public function iChangeItsValueTo(
         ProductAttributeInterface $productAttribute,
         string $oldValue,
@@ -204,9 +172,7 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->client->updateRequestData(['configuration' => ['choices' => $choices]]);
     }
 
-    /**
-     * @When I delete value :value
-     */
+    #[When('I delete value :value')]
     public function iDeleteValue(string $value): void
     {
         /** @var ProductAttributeInterface $productAttribute */
@@ -226,18 +192,14 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->client->setRequestData(['configuration' => ['choices' => $choices]]);
     }
 
-    /**
-     * @Then I should see :count product attributes in the list
-     * @Then I should see a single product attribute in the list
-     */
+    #[Then('I should see :count product attributes in the list')]
+    #[Then('I should see a single product attribute in the list')]
     public function iShouldSeeCountProductAttributesInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the first product attribute on the list should have name :name
-     */
+    #[Then('the first product attribute on the list should have name :name')]
     public function theFirstProductAttributeOnTheListShouldHaveName(string $name): void
     {
         $first = $this->responseChecker->getCollection($this->client->getLastResponse())[0];
@@ -245,9 +207,7 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::same($first['translations']['en_US']['name'], $name);
     }
 
-    /**
-     * @Then the last product attribute on the list should have name :name
-     */
+    #[Then('the last product attribute on the list should have name :name')]
     public function theLastProductAttributeOnTheListShouldHaveName(string $name): void
     {
         $collection = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -256,9 +216,7 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::same($last['translations']['en_US']['name'], $name);
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product attribute "([^"]+)" in the list$/
-     */
+    #[Then('/^I should(?:| also) see the product attribute "([^"]+)" in the list$/')]
     public function iShouldSeeTheProductAttributeInTheList(string $attributeName): void
     {
         Assert::true($this->responseChecker->hasItemWithTranslation(
@@ -269,17 +227,13 @@ final readonly class ManagingProductAttributesContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         $this->responseChecker->isDeletionSuccessful($this->client->getLastResponse());
     }
 
-    /**
-     * @Then /^(this product attribute) should no longer exist in the registry$/
-     */
+    #[Then('/^(this product attribute) should no longer exist in the registry$/')]
     public function thisProductAttributeShouldNoLongerExistInTheRegistry(ProductAttributeInterface $productAttribute): void
     {
         $response = $this->client->index(Resources::PRODUCT_ATTRIBUTES);
@@ -290,9 +244,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is in use
-     */
+    #[Then('I should be notified that it is in use')]
     public function iShouldBeNotifiedThatItIsInUse(): void
     {
         Assert::contains(
@@ -301,9 +253,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -312,10 +262,8 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then the :type attribute :name should appear in the store
-     * @Then the :type attribute :name should still be in the store
-     */
+    #[Then('the :type attribute :name should appear in the store')]
+    #[Then('the :type attribute :name should still be in the store')]
     public function theAttributeShouldAppearInTheStore(string $type, string $name): void
     {
         $response = $this->client->index(Resources::PRODUCT_ATTRIBUTES);
@@ -334,9 +282,7 @@ final readonly class ManagingProductAttributesContext implements Context
         ));
     }
 
-    /**
-     * @Then the attribute with :field :value should not appear in the store
-     */
+    #[Then('the attribute with :field :value should not appear in the store')]
     public function theAttributeWithCodeShouldNotAppearInTheStore(string $field, string $value): void
     {
         $response = $this->client->index(Resources::PRODUCT_ATTRIBUTES);
@@ -347,9 +293,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the value :value in :localeCode locale
-     */
+    #[Then('I should see the value :value in :localeCode locale')]
     public function iShouldSeeTheValueInLocale(string $value, string $localeCode): void
     {
         $content = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -368,10 +312,8 @@ final readonly class ManagingProductAttributesContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this product attribute) should have value "([^"]+)"$/
-     * @Then /^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/
-     */
+    #[Then('/^(this product attribute) should have value "([^"]+)"$/')]
+    #[Then('/^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/')]
     public function thisProductAttributeShouldHaveValue(
         ProductAttributeInterface $productAttribute,
         string $value,
@@ -381,9 +323,7 @@ final readonly class ManagingProductAttributesContext implements Context
         $this->iShouldSeeTheValueInLocale($value, 'en_US');
     }
 
-    /**
-     * @Then /^(this product attribute) should not have value "([^"]+)"$/
-     */
+    #[Then('/^(this product attribute) should not have value "([^"]+)"$/')]
     public function thisProductAttributeShouldNotHaveValue(
         ProductAttributeInterface $productAttribute,
         string $value,
@@ -402,9 +342,7 @@ final readonly class ManagingProductAttributesContext implements Context
         }
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatFieldIsRequired(string $field): void
     {
         Assert::contains(
@@ -413,9 +351,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that product attribute with this code already exists
-     */
+    #[Then('I should be notified that product attribute with this code already exists')]
     public function iShouldBeNotifiedThatProductAttributeWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -424,9 +360,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that max length must be greater or equal to the min length
-     */
+    #[Then('I should be notified that max length must be greater or equal to the min length')]
     public function iShouldBeNotifiedThatMaxLengthMustBeGreaterOrEqualToTheMinLength(): void
     {
         Assert::contains(
@@ -435,9 +369,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one product attribute with code :code
-     */
+    #[Then('there should still be only one product attribute with code :code')]
     public function thereShouldStillBeOnlyOneProductAttributeWithCode(string $code): void
     {
         $items = $this->responseChecker->getCollectionItemsWithValue(
@@ -449,9 +381,7 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::count($items, 1, sprintf('More than one attribute with code %s found', $code));
     }
 
-    /**
-     * @Then I should be notified that max entries value must be greater or equal to the min entries value
-     */
+    #[Then('I should be notified that max entries value must be greater or equal to the min entries value')]
     public function iShouldBeNotifiedThatMaxEntriesValueMustBeGreaterOrEqualToTheMinEntriesValue(): void
     {
         Assert::contains(
@@ -460,9 +390,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that min entries value must be lower or equal to the number of added choices
-     */
+    #[Then('I should be notified that min entries value must be lower or equal to the number of added choices')]
     public function iShouldBeNotifiedThatMinEntriesValueMustBeLowerOrEqualToTheNumberOfAddedChoices(): void
     {
         Assert::contains(
@@ -471,9 +399,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that multiple must be true if min or max entries values are specified
-     */
+    #[Then('I should be notified that multiple must be true if min or max entries values are specified')]
     public function iShouldBeNotifiedThatMultipleMustBeTrueIfMinOrMaxEntriesValuesAreSpecified(): void
     {
         Assert::contains(
@@ -482,9 +408,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -495,9 +419,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its type
-     */
+    #[Then('I should not be able to edit its type')]
     public function iShouldNotBeAbleToEditItsType(): void
     {
         $this->client->updateRequestData(['type' => 'percent']);

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductImagesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductImagesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestBuilder;
@@ -36,25 +38,19 @@ final readonly class ManagingProductImagesContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I attach the "([^"]+)" image with "([^"]+)" type to (this product)$/
-     */
+    #[When('/^I attach the "([^"]+)" image with "([^"]+)" type to (this product)$/')]
     public function iAttachTheImageWithTypeToThisProduct(string $path, string $type, ProductInterface $product): void
     {
         $this->createProductImage($path, $product, $type);
     }
 
-    /**
-     * @When /^I attach the "([^"]+)" image to (this product)$/
-     */
+    #[When('/^I attach the "([^"]+)" image to (this product)$/')]
     public function iAttachTheImageToThisProduct(string $path, ProductInterface $product): void
     {
         $this->createProductImage($path, $product);
     }
 
-    /**
-     * @When /^I attach the "([^"]+)" image with selected ("[^"]+" variant) to (this product)$/
-     */
+    #[When('/^I attach the "([^"]+)" image with selected ("[^"]+" variant) to (this product)$/')]
     public function iAttachImageWithSelectedVariantToThisProduct(
         string $path,
         ProductVariantInterface $productVariant,
@@ -63,9 +59,7 @@ final readonly class ManagingProductImagesContext implements Context
         $this->createProductImage($path, $product, null, [$productVariant]);
     }
 
-    /**
-     * @When I( also) remove an image with :type type
-     */
+    #[When('I( also) remove an image with :type type')]
     public function iRemoveAnImageWithType(string $type): void
     {
         /** @var ProductInterface $product */
@@ -77,9 +71,7 @@ final readonly class ManagingProductImagesContext implements Context
         $this->removeProductImage($product->getCode(), (string) $productImage->getId());
     }
 
-    /**
-     * @When I remove the first image
-     */
+    #[When('I remove the first image')]
     public function iRemoveTheFirstImage(): void
     {
         /** @var ProductInterface $product */
@@ -91,9 +83,7 @@ final readonly class ManagingProductImagesContext implements Context
         $this->removeProductImage($product->getCode(), (string) $productImage->getId());
     }
 
-    /**
-     * @When I change the first image type to :type
-     */
+    #[When('I change the first image type to :type')]
     public function iChangeTheFirstImageTypeTo(string $type): void
     {
         /** @var ProductInterface $product */
@@ -112,9 +102,7 @@ final readonly class ManagingProductImagesContext implements Context
         $this->client->request($builder->build());
     }
 
-    /**
-     * @When I select :productVariant variant for the first image
-     */
+    #[When('I select :productVariant variant for the first image')]
     public function iSelectVariantForTheFirstImage(ProductVariantInterface $productVariant): void
     {
         /** @var ProductInterface $product */
@@ -133,11 +121,9 @@ final readonly class ManagingProductImagesContext implements Context
         $this->client->request($builder->build());
     }
 
-    /**
-     * @Then the product :product should have an image with :type type
-     * @Then /^(this product) should(?:| also) have an image with "([^"]*)" type$/
-     * @Then /^(it) should(?:| also) have an image with "([^"]*)" type$/
-     */
+    #[Then('the product :product should have an image with :type type')]
+    #[Then('/^(this product) should(?:| also) have an image with "([^"]*)" type$/')]
+    #[Then('/^(it) should(?:| also) have an image with "([^"]*)" type$/')]
     public function theProductShouldHaveAnImageWithType(ProductInterface $product, string $type): void
     {
         Assert::true(
@@ -150,9 +136,7 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then its image should have :productVariant variant selected
-     */
+    #[Then('its image should have :productVariant variant selected')]
     public function itsImageShouldHaveVariantSelected(ProductVariantInterface $productVariant): void
     {
         $images = $this->responseChecker->getValue(
@@ -167,10 +151,8 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should not have(?:| also) any images with "([^"]*)" type$/
-     * @Then /^(it) should not have(?:| also) any images with "([^"]*)" type$/
-     */
+    #[Then('/^(this product) should not have(?:| also) any images with "([^"]*)" type$/')]
+    #[Then('/^(it) should not have(?:| also) any images with "([^"]*)" type$/')]
     public function thisProductShouldNotHaveAnyImagesWithType(ProductInterface $product, string $type): void
     {
         Assert::false(
@@ -183,10 +165,8 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should(?:| still) have only one image$/
-     * @Then /^(this product) should(?:| still) have (\d+) images?$/
-     */
+    #[Then('/^(this product) should(?:| still) have only one image$/')]
+    #[Then('/^(this product) should(?:| still) have (\d+) images?$/')]
     public function thisProductShouldHaveImages(ProductInterface $product, int $count = 1): void
     {
         Assert::count(
@@ -195,17 +175,13 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should not have any images$/
-     */
+    #[Then('/^(this product) should not have any images$/')]
     public function thisProductShouldNotHaveAnyImages(ProductInterface $product): void
     {
         $this->thisProductShouldHaveImages($product, 0);
     }
 
-    /**
-     * @Then I should be notified that the changes have been successfully applied
-     */
+    #[Then('I should be notified that the changes have been successfully applied')]
     public function iShouldBeNotifiedThatTheChangesHaveBeenSuccessfullyApplied(): void
     {
         $response = $this->client->getLastResponse();
@@ -214,9 +190,7 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that the ("[^"]+" variant) does not belong to (this product)$/
-     */
+    #[Then('/^I should be notified that the ("[^"]+" variant) does not belong to (this product)$/')]
     public function iShouldBeNotifiedThatTheProductVariantDoesNotBelongToTheOwner(ProductVariantInterface $productVariant, ProductInterface $product): void
     {
         Assert::contains(
@@ -229,9 +203,7 @@ final readonly class ManagingProductImagesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that svg file is not allowed
-     */
+    #[Then('I should be notified that svg file is not allowed')]
     public function iShouldBeNotifiedThatSvgFileIsNotAllowed(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -36,36 +39,28 @@ final class ManagingProductOptionsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I want to create a new product option
-     */
+    #[Given('I want to create a new product option')]
     public function iWantToCreateANewProductOption(): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_OPTIONS);
     }
 
-    /**
-     * @Given I am browsing product options
-     * @When I browse product options
-     */
+    #[Given('I am browsing product options')]
+    #[When('I browse product options')]
     public function iBrowseProductOptions(): void
     {
         $this->client->index(Resources::PRODUCT_OPTIONS);
     }
 
-    /**
-     * @When I want to modify the :productOption product option
-     */
+    #[When('I want to modify the :productOption product option')]
     public function iWantToModifyProductOption(ProductOptionInterface $productOption): void
     {
         $this->sharedStorage->set('product_option', $productOption);
         $this->client->buildUpdateRequest(Resources::PRODUCT_OPTIONS, $productOption->getCode());
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I do not name it
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I do not name it')]
     public function iNameItInLanguage(?string $name = null, ?string $localeCode = 'en_US'): void
     {
         $data = ['translations' => [$localeCode => []]];
@@ -76,26 +71,20 @@ final class ManagingProductOptionsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I rename it to :name in :localeCode
-     */
+    #[When('I rename it to :name in :localeCode')]
     public function iRenameItInLanguage(string $name, string $localeCode): void
     {
         $this->client->updateRequestData(['translations' => [$localeCode => ['name' => $name]]]);
     }
 
-    /**
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I remove its name from :localeCode translation')]
     public function iRemoveItsNameFromTranslation(string $localeCode): void
     {
         $this->client->updateRequestData(['translations' => [$localeCode => ['name' => '']]]);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -103,10 +92,8 @@ final class ManagingProductOptionsContext implements Context
         }
     }
 
-    /**
-     * @When I add the :value option value identified by :code
-     * @When I add the :value option value identified by :code in :localeCode
-     */
+    #[When('I add the :value option value identified by :code')]
+    #[When('I add the :value option value identified by :code in :localeCode')]
     public function iAddTheOptionValueWithCodeAndValue(string $value, string $code, string $localeCode = 'en_US'): void
     {
         $this->client->addSubResourceData(
@@ -115,43 +102,33 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @When I delete the :optionValue option value of this product option
-     */
+    #[When('I delete the :optionValue option value of this product option')]
     public function iDeleteTheOptionValueOfThisProductOption(ProductOptionValueInterface $optionValue): void
     {
         $optionValueIri = $this->iriConverter->getIriFromResource($optionValue);
         $this->client->removeSubResourceObject('values', $optionValueIri, 'value');
     }
 
-    /**
-     * @When I do not add an option value
-     */
+    #[When('I do not add an option value')]
     public function iDoNotAddAnOptionValue(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When /^I search for product options with "([^"]+)" (code|name)$/
-     */
+    #[When('/^I search for product options with "([^"]+)" (code|name)$/')]
     public function iSearchForProductOptionsWith(string $phrase, string $field): void
     {
         $this->client->addFilter($field === 'name' ? 'translations.name' : 'code', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see :count product options in the list
-     */
+    #[Then('I should see :count product options in the list')]
     public function iShouldSeeProductOptionsInTheList(int $count): void
     {
         $itemsCount = $this->responseChecker->countCollectionItems($this->client->getLastResponse());
@@ -159,10 +136,8 @@ final class ManagingProductOptionsContext implements Context
         Assert::eq($count, $itemsCount, sprintf('Expected %d product options, but got %d', $count, $itemsCount));
     }
 
-    /**
-     * @Then the product option :productOption should be in the registry
-     * @Then the product option :productOption should appear in the registry
-     */
+    #[Then('the product option :productOption should be in the registry')]
+    #[Then('the product option :productOption should appear in the registry')]
     public function theProductOptionShouldAppearInTheRegistry(ProductOptionInterface $productOption): void
     {
         $this->sharedStorage->set('product_option', $productOption);
@@ -174,9 +149,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then the first product option in the list should have :field :value
-     */
+    #[Then('the first product option in the list should have :field :value')]
     public function theFirstProductOptionInTheListShouldHave(string $field, string $value): void
     {
         Assert::true(
@@ -185,9 +158,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then the last product option in the list should have :field :value
-     */
+    #[Then('the last product option in the list should have :field :value')]
     public function theLastProductOptionInTheListShouldHave(string $field, string $value): void
     {
         $count = $this->responseChecker->countCollectionItems($this->client->getLastResponse());
@@ -198,9 +169,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then the product option with :element :value should not be added
-     */
+    #[Then('the product option with :element :value should not be added')]
     public function theProductOptionWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false(
@@ -209,9 +178,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one product option with :element :value
-     */
+    #[Then('there should still be only one product option with :element :value')]
     public function thereShouldStillBeOnlyOneProductOptionWith(string $element, string $value): void
     {
         $response = $this->client->index(Resources::PRODUCT_OPTIONS);
@@ -221,20 +188,16 @@ final class ManagingProductOptionsContext implements Context
         Assert::true($this->responseChecker->hasItemWithValue($response, $element, $value));
     }
 
-    /**
-     * @Then /^(this product option) name should be "([^"]+)"$/
-     * @Then /^(this product option) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this product option) name should be "([^"]+)"$/')]
+    #[Then('/^(this product option) should still be named "([^"]+)"$/')]
     public function thisProductOptionNameShouldBe(ProductOptionInterface $productOption, string $name): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->show(Resources::PRODUCT_OPTIONS, $productOption->getCode()), 'name', $name));
     }
 
-    /**
-     * @Then /^(product option "[^"]+") should have the "([^"]+)" option value$/
-     * @Then /^(product option "[^"]+") should still have the "([^"]+)" option value$/
-     * @Then /^(this product option) should have the "([^"]*)" option value$/
-     */
+    #[Then('/^(product option "[^"]+") should have the "([^"]+)" option value$/')]
+    #[Then('/^(product option "[^"]+") should still have the "([^"]+)" option value$/')]
+    #[Then('/^(this product option) should have the "([^"]*)" option value$/')]
     public function productOptionShouldHaveTheOptionValue(
         ProductOptionInterface $productOption,
         string $optionValueName,
@@ -248,9 +211,9 @@ final class ManagingProductOptionsContext implements Context
     }
 
     /**
-     * @Then /^(this product option) should not have the "([^"]*)" option value$/
-     * @Then /^(this product option) should not have the "([^"]*)" option value in ("([^"]+)" locale)$/
+     *      * @Then /^(this product option) should not have the "([^"]*)" option value in ("([^"]+)" locale)$/
      */
+    #[Then('/^(this product option) should not have the "([^"]*)" option value$/')]
     public function thisProductOptionShouldNotHaveTheOptionValue(
         ProductOptionInterface $productOption,
         string $optionValueName,
@@ -263,9 +226,7 @@ final class ManagingProductOptionsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -274,9 +235,7 @@ final class ManagingProductOptionsContext implements Context
         Assert::false($this->responseChecker->hasValue($res, 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then I should be notified that product option with this code already exists
-     */
+    #[Then('I should be notified that product option with this code already exists')]
     public function iShouldBeNotifiedThatProductOptionWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -290,9 +249,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::contains(
@@ -301,9 +258,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is in use
-     */
+    #[Then('I should be notified that it is in use')]
     public function iShouldBeNotifiedThatItIsInUse(): void
     {
         Assert::contains(
@@ -312,9 +267,7 @@ final class ManagingProductOptionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductReviewsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -33,52 +36,40 @@ final class ManagingProductReviewsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing product reviews
-     * @When I (want to) browse product reviews
-     */
+    #[Given('I am browsing product reviews')]
+    #[When('I (want to) browse product reviews')]
     public function iWantToBrowseProductReviews(): void
     {
         $this->client->index(Resources::PRODUCT_REVIEWS);
     }
 
-    /**
-     * @When I choose :status as a status filter
-     */
+    #[When('I choose :status as a status filter')]
     public function iChooseAsStatusFilter(string $status): void
     {
         $this->client->addFilter('status', $status);
     }
 
-    /**
-     * @When I filter with title containing :title
-     */
+    #[When('I filter with title containing :title')]
     public function iFilterWithTitleContaining(string $title): void
     {
         $this->client->addFilter('title', $title);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter by :product product
-     */
+    #[When('I filter by :product product')]
     public function iFilterByProduct(ProductInterface $product): void
     {
         $this->client->addFilter('reviewSubject', $this->iriConverter->getIriFromResourceInSection($product, 'admin'));
         $this->client->filter();
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @When I sort the product reviews :sortingOrder by :field
-     */
+    #[When('I sort the product reviews :sortingOrder by :field')]
     public function iSortProductReviewsBy(string $sortingOrder, string $field): void
     {
         $field = $field === 'date' ? 'createdAt' : $field;
@@ -86,51 +77,39 @@ final class ManagingProductReviewsContext implements Context
         $this->client->sort([$field => $sortingOrder === 'descending' ? 'desc' : 'asc']);
     }
 
-    /**
-     * @When I want to modify the :productReview product review
-     */
+    #[When('I want to modify the :productReview product review')]
     public function iWantToModifyTheProductReview(ReviewInterface $productReview): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCT_REVIEWS, (string) $productReview->getId());
     }
 
-    /**
-     * @When I change its title to :title
-     * @When I remove its title
-     */
+    #[When('I change its title to :title')]
+    #[When('I remove its title')]
     public function iChangeItsTitleTo(?string $title = ''): void
     {
         $this->client->addRequestData('title', $title);
     }
 
-    /**
-     * @When I change its comment to :comment
-     * @When I remove its comment
-     */
+    #[When('I change its comment to :comment')]
+    #[When('I remove its comment')]
     public function iChangeItsCommentTo(?string $comment = ''): void
     {
         $this->client->updateRequestData(['comment' => $comment]);
     }
 
-    /**
-     * @When I choose :rating as its rating
-     */
+    #[When('I choose :rating as its rating')]
     public function iChooseAsItsRating(int $rating): void
     {
         $this->client->updateRequestData(['rating' => $rating]);
     }
 
-    /**
-     * @When /^I (accept|reject) the ("([^"]+)" product review)$/
-     */
+    #[When('/^I (accept|reject) the ("([^"]+)" product review)$/')]
     public function iChangeStateTheProductReview(string $state, ReviewInterface $productReview): void
     {
         $this->client->applyTransition(Resources::PRODUCT_REVIEWS, (string) $productReview->getId(), $state);
     }
 
-    /**
-     * @When I delete the :productReview product review
-     */
+    #[When('I delete the :productReview product review')]
     public function iDeleteTheProductReview(ReviewInterface $productReview): void
     {
         $this->sharedStorage->set('product_review_id', $productReview->getId());
@@ -138,9 +117,7 @@ final class ManagingProductReviewsContext implements Context
         $this->client->delete(Resources::PRODUCT_REVIEWS, (string) $productReview->getId());
     }
 
-    /**
-     * @Then I should (also) see the product review :title in the list
-     */
+    #[Then('I should (also) see the product review :title in the list')]
     public function iShouldSeeTheProductReviewTitleInTheList(string $title): void
     {
         Assert::true(
@@ -149,50 +126,38 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single product review in the list
-     * @Then I should see :amount reviews in the list
-     */
+    #[Then('I should see a single product review in the list')]
+    #[Then('I should see :amount reviews in the list')]
     public function iShouldSeeReviewsInTheList(int $amount = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $amount);
     }
 
-    /**
-     * @Then /^(this product review) (comment|title) should be "([^"]+)"$/
-     */
+    #[Then('/^(this product review) (comment|title) should be "([^"]+)"$/')]
     public function thisProductReviewElementShouldBeValue(ReviewInterface $productReview, string $element, string $value): void
     {
         $this->assertIfReviewHasElementWithValue($productReview, $element, $value);
     }
 
-    /**
-     * @Then /^(this product review) rating should be (\d+)$/
-     */
+    #[Then('/^(this product review) rating should be (\d+)$/')]
     public function thisProductReviewRatingShouldBe(ReviewInterface $productReview, int $rating): void
     {
         $this->assertIfReviewHasElementWithValue($productReview, 'rating', $rating);
     }
 
-    /**
-     * @Then /^(this product review) status should be "([^"]+)"$/
-     */
+    #[Then('/^(this product review) status should be "([^"]+)"$/')]
     public function thisProductReviewStatusShouldBe(ReviewInterface $productReview, string $status): void
     {
         $this->assertIfReviewHasElementWithValue($productReview, 'status', $status);
     }
 
-    /**
-     * @Then /^I should be notified that it has been successfully (accepted|rejected)$/
-     */
+    #[Then('/^I should be notified that it has been successfully (accepted|rejected)$/')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyUpdated(string $action): void
     {
         $this->assertIfReviewHasElementWithValue($this->sharedStorage->get('product_review'), 'status', $action);
     }
 
-    /**
-     * @Then this product review should no longer exist in the registry
-     */
+    #[Then('this product review should no longer exist in the registry')]
     public function thisProductReviewShouldNoLongerExistInTheRegistry(): void
     {
         $id = (string) $this->sharedStorage->get('product_review_id');
@@ -202,9 +167,7 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::contains(
@@ -213,25 +176,19 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product review) should still be titled "([^"]+)"$/
-     */
+    #[Then('/^(this product review) should still be titled "([^"]+)"$/')]
     public function thisProductReviewTitleShouldBeTitled(ReviewInterface $productReview, string $title): void
     {
         $this->assertIfReviewHasElementWithValue($productReview, 'title', $title);
     }
 
-    /**
-     * @Then /^(this product review) should still have a comment "([^"]+)"$/
-     */
+    #[Then('/^(this product review) should still have a comment "([^"]+)"$/')]
     public function thisProductReviewShouldStillHaveAComment(ReviewInterface $productReview, string $comment): void
     {
         $this->assertIfReviewHasElementWithValue($productReview, 'comment', $comment);
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -240,9 +197,7 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @Then average rating of product :product should be :expectedRating
-     */
+    #[Then('average rating of product :product should be :expectedRating')]
     public function averageRatingOfProductShouldBe(ProductInterface $product, int $expectedRating): void
     {
         $averageRating = $this->responseChecker->getValue($this->client->show(Resources::PRODUCTS, (string) $product->getCode()), 'averageRating');
@@ -254,9 +209,7 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (first|last) product review in the list should have title "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) product review in the list should have title "([^"]+)"$/')]
     public function theNthProductReviewInTheListShouldHaveTitle(string $nth, string $title): void
     {
         $reviews = $this->responseChecker->getCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductTaxonsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -34,10 +36,8 @@ final class ManagingProductTaxonsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I am browsing the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/
-     * @When /^I go to the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/
-     */
+    #[When('/^I am browsing the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/')]
+    #[When('/^I go to the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/')]
     public function iAmBrowsingThePageOfProductsFromTaxon(int $page, TaxonInterface $taxon): void
     {
         $this->iAmBrowsingProductsFromTaxon($taxon);
@@ -47,9 +47,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When /^I am browsing products from ("([^"]+)" taxon)$/
-     */
+    #[When('/^I am browsing products from ("([^"]+)" taxon)$/')]
     public function iAmBrowsingProductsFromTaxon(TaxonInterface $taxon): void
     {
         $this->client->index(Resources::PRODUCT_TAXONS);
@@ -60,9 +58,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I filter them by :product product
-     */
+    #[When('I filter them by :product product')]
     public function iFilterThemByProduct(ProductInterface $product): void
     {
         $this->client->addFilter('product.code', $product->getCode());
@@ -71,18 +67,14 @@ final class ManagingProductTaxonsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I set the position of :product to :position
-     */
+    #[When('I set the position of :product to :position')]
     public function iSetThePositionOfProductTo(ProductInterface $product, int|string $position): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCT_TAXONS, (string) $product->getProductTaxons()->current()->getId());
         $this->client->updateRequestData(['position' => is_numeric($position) ? (int) $position : $position]);
     }
 
-    /**
-     * @When I (try to) add :taxon taxon to the :product product
-     */
+    #[When('I (try to) add :taxon taxon to the :product product')]
     public function iAddTaxonToTheProduct(ProductInterface $product, TaxonInterface $taxon): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_TAXONS);
@@ -91,9 +83,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When I try to assign an empty taxon to the :product product
-     */
+    #[When('I try to assign an empty taxon to the :product product')]
     public function iTryToAssignAnEmptyTaxonToTheProduct(ProductInterface $product): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_TAXONS);
@@ -101,9 +91,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When I try to assign an empty product to the :taxon taxon
-     */
+    #[When('I try to assign an empty product to the :taxon taxon')]
     public function iTryToAssignAnEmptyProductToTheTaxon(TaxonInterface $taxon): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_TAXONS);
@@ -111,9 +99,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->client->create();
     }
 
-    /**
-     * @When /^I try to assign the product taxon of (product "[^"]+") and (taxon "[^"]+") to the (product "[^"]+")$/
-     */
+    #[When('/^I try to assign the product taxon of (product "[^"]+") and (taxon "[^"]+") to the (product "[^"]+")$/')]
     public function iTryToAssignTheProductTaxonOfProductAndTaxonToTheProduct(
         ProductInterface $productTaxonProduct,
         TaxonInterface $productTaxonTaxon,
@@ -121,9 +107,7 @@ final class ManagingProductTaxonsContext implements Context
         $this->iAddTaxonToTheProduct($productTaxonProduct, $productTaxonTaxon);
     }
 
-    /**
-     * @When I change that the :product product does not belong to the :taxon taxon
-     */
+    #[When('I change that the :product product does not belong to the :taxon taxon')]
     public function iChangeThatTheProductDoesNotBelongToTheTaxon(
         ProductInterface $product,
         TaxonInterface $taxon,
@@ -135,27 +119,21 @@ final class ManagingProductTaxonsContext implements Context
         $this->client->delete(Resources::PRODUCT_TAXONS, (string) $productTaxon->getId());
     }
 
-    /**
-     * @When I sort this taxon's products :order by :field
-     */
+    #[When('I sort this taxon\'s products :order by :field')]
     public function iSortProductsBy(string $order, string $field): void
     {
         $this->client->sort([$field => ManagingProductsContext::SORT_TYPES[$order]]);
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I save my new configuration
-     */
+    #[When('I save my new configuration')]
     public function iSaveMyNewConfiguration(): void
     {
         $this->client->update();
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @Then /^the (first|last) product on the list within this taxon should have name "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) product on the list within this taxon should have name "([^"]+)"$/')]
     public function theLastProductOnTheListWithinThisTaxonShouldHaveName(string $position, string $name): void
     {
         $productTaxons = $this->responseChecker->getCollection($this->sharedStorage->get('response'));
@@ -167,9 +145,7 @@ final class ManagingProductTaxonsContext implements Context
         Assert::same($product->getTranslation()->getName(), $name);
     }
 
-    /**
-     * @Then I should be notified that specifying a :part is required
-     */
+    #[Then('I should be notified that specifying a :part is required')]
     public function iShouldBeNotifiedThatSpecifyingAIsRequired(string $part): void
     {
         Assert::contains(
@@ -178,9 +154,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that product taxons cannot be duplicated
-     */
+    #[Then('I should be notified that product taxons cannot be duplicated')]
     public function iShouldBeNotifiedThatProductTaxonsCannotBeDuplicated(): void
     {
         Assert::contains(
@@ -189,9 +163,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the position :position is invalid
-     */
+    #[Then('I should be notified that the position :position is invalid')]
     public function iShouldBeNotifiedThatThePositionIsInvalid(): void
     {
         Assert::contains(
@@ -200,9 +172,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the :taxon taxon
-     */
+    #[Then('I should see the :taxon taxon')]
     public function iShouldSeeTheTaxon(TaxonInterface $taxon): void
     {
         Assert::true(
@@ -211,9 +181,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the :product product
-     */
+    #[Then('I should see the :product product')]
     public function iShouldSeeTheProduct(ProductInterface $product): void
     {
         Assert::true(
@@ -222,9 +190,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the :taxon taxon
-     */
+    #[Then('I should not see the :taxon taxon')]
     public function iShouldNotSeeTheTaxon(TaxonInterface $taxon): void
     {
         Assert::false(
@@ -233,9 +199,7 @@ final class ManagingProductTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the :product product
-     */
+    #[Then('I should not see the :product product')]
     public function iShouldNotSeeTheProduct(ProductInterface $product): void
     {
         Assert::false(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -45,26 +47,20 @@ final class ManagingProductVariantsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I want to create a new variant of (this product)$/
-     */
+    #[When('/^I want to create a new variant of (this product)$/')]
     public function iWantToCreateANewProductVariant(ProductInterface $product): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_VARIANTS);
         $this->client->addRequestData('product', $this->iriConverter->getIriFromResource($product));
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     */
+    #[When('I name it :name in :localeCode')]
     public function iNameItIn(string $name, string $localeCode): void
     {
         $this->client->addRequestData('translations', [
@@ -74,9 +70,7 @@ final class ManagingProductVariantsContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I set its price to ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[When('/^I set its price to ("[^"]+") for ("[^"]+" channel)$/')]
     public function iSetItsPriceToForChannel(int $price, ChannelInterface $channel): void
     {
         $this->client->addRequestData('channelPricings', [
@@ -87,33 +81,25 @@ final class ManagingProductVariantsContext implements Context
         ]);
     }
 
-    /**
-     * @When I set its price to a huge number for the :channel channel
-     */
+    #[When('I set its price to a huge number for the :channel channel')]
     public function iSetItsPriceToHugeNumberForTheChannel(ChannelInterface $channel): void
     {
         $this->iSetItsPriceToForChannel(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When I set its original price to a huge number for the :channel channel
-     */
+    #[When('I set its original price to a huge number for the :channel channel')]
     public function iSetItsOriginalPriceToHugeNumberForTheChannel(ChannelInterface $channel): void
     {
         $this->iSetItsOriginalPriceToForChannel(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When I set its minimum price to a huge number for the :channel channel
-     */
+    #[When('I set its minimum price to a huge number for the :channel channel')]
     public function iSetItsMinimumPriceAsOutOfRangeValueForChannel(ChannelInterface $channel): void
     {
         $this->iSetItsMinimumPriceToForChannel(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When I remove its price from :channel channel
-     */
+    #[When('I remove its price from :channel channel')]
     public function iRemoveItsPriceForChannel(ChannelInterface $channel): void
     {
         $content = $this->client->getContent();
@@ -122,28 +108,22 @@ final class ManagingProductVariantsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I do not set its price
-     * @When I do not specify its code
-     * @When I do not set its :optionName option
-     * @When I do not set its :firstOptionName and :secondOptionName options
-     */
+    #[When('I do not set its price')]
+    #[When('I do not specify its code')]
+    #[When('I do not set its :optionName option')]
+    #[When('I do not set its :firstOptionName and :secondOptionName options')]
     public function iDoNotSetValue(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I do not specify its current stock
-     */
+    #[When('I do not specify its current stock')]
     public function iDoNotSpecifyItsCurrentStock(): void
     {
         $this->client->addRequestData('onHand', null);
     }
 
-    /**
-     * @When /^I set its original price to ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[When('/^I set its original price to ("[^"]+") for ("[^"]+" channel)$/')]
     public function iSetItsOriginalPriceToForChannel(int $originalPrice, ChannelInterface $channel): void
     {
         $this->client->addRequestData('channelPricings', [
@@ -154,9 +134,7 @@ final class ManagingProductVariantsContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I set its minimum price to ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[When('/^I set its minimum price to ("[^"]+") for ("[^"]+" channel)$/')]
     public function iSetItsMinimumPriceToForChannel(int $minimumPrice, ChannelInterface $channel): void
     {
         $content = $this->client->getContent();
@@ -165,25 +143,19 @@ final class ManagingProductVariantsContext implements Context
         $this->client->updateRequestData($content);
     }
 
-    /**
-     * @When I( try to) add it
-     */
+    #[When('I( try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I want to modify the :variant product variant
-     */
+    #[When('I want to modify the :variant product variant')]
     public function iWantToModifyProductVariant(ProductVariantInterface $variant): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCT_VARIANTS, $variant->getCode());
     }
 
-    /**
-     * @When /^I change its price to ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[When('/^I change its price to ("[^"]+") for ("[^"]+" channel)$/')]
     public function iChangeItsPriceToForChannel(int $originalPrice, ChannelInterface $channel): void
     {
         $this->client->addRequestData('channelPricings', [
@@ -194,9 +166,7 @@ final class ManagingProductVariantsContext implements Context
         ]);
     }
 
-    /**
-     * @When I set its :optionName option to :optionValue
-     */
+    #[When('I set its :optionName option to :optionValue')]
     public function iSetItsOptionAs(string $optionName, ProductOptionValueInterface $optionValue): void
     {
         $content = $this->client->getContent();
@@ -205,9 +175,7 @@ final class ManagingProductVariantsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I change its :productOption option to :productOptionValue
-     */
+    #[When('I change its :productOption option to :productOptionValue')]
     public function iChangeItsOptionTo(
         ProductOptionInterface $productOption,
         ProductOptionValueInterface $productOptionValue,
@@ -226,9 +194,7 @@ final class ManagingProductVariantsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I add additionally :productOptionValue value as :productOptionName option
-     */
+    #[When('I add additionally :productOptionValue value as :productOptionName option')]
     public function iAddAdditionallyValueAsOption(
         ProductOptionValueInterface $productOptionValue,
         string $productOptionName,
@@ -239,26 +205,20 @@ final class ManagingProductVariantsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I set its shipping category as :shippingCategory
-     */
+    #[When('I set its shipping category as :shippingCategory')]
     public function iSetItsShippingCategoryAs(ShippingCategoryInterface $shippingCategory): void
     {
         $this->client->addRequestData('shippingCategory', $this->iriConverter->getIriFromResource($shippingCategory));
     }
 
-    /**
-     * @When I do not want to have shipping required for this product variant
-     */
+    #[When('I do not want to have shipping required for this product variant')]
     public function iDoNotWantToHaveShippingRequiredForThisProductVariant(): void
     {
         $this->client->addRequestData('shippingRequired', false);
     }
 
-    /**
-     * @When /^I want to view all variants of (this product)$/
-     * @When /^I view(?:| all) variants of the (product "[^"]+")(?:| again)$/
-     */
+    #[When('/^I want to view all variants of (this product)$/')]
+    #[When('/^I view(?:| all) variants of the (product "[^"]+")(?:| again)$/')]
     public function iWantToViewAllVariantsOfThisProduct(ProductInterface $product): void
     {
         $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -267,50 +227,38 @@ final class ManagingProductVariantsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When /^I delete the ("[^"]+" variant of product "[^"]+")$/
-     * @When /^I try to delete the ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[When('/^I delete the ("[^"]+" variant of product "[^"]+")$/')]
+    #[When('/^I try to delete the ("[^"]+" variant of product "[^"]+")$/')]
     public function iDeleteTheVariantOfProduct(ProductVariantInterface $productVariant): void
     {
         $this->client->delete(Resources::PRODUCT_VARIANTS, $productVariant->getCode());
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->client->updateRequestData(['enabled' => false]);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->updateRequestData(['enabled' => true]);
     }
 
-    /**
-     * @When I disable its inventory tracking
-     */
+    #[When('I disable its inventory tracking')]
     public function iDisableItsTracking(): void
     {
         $this->client->updateRequestData(['tracked' => false]);
     }
 
-    /**
-     * @When I enable its inventory tracking
-     */
+    #[When('I enable its inventory tracking')]
     public function iEnableItsTracking(): void
     {
         $this->client->updateRequestData(['tracked' => true]);
     }
 
-    /**
-     * @When I set its height, width, depth and weight to :value
-     */
+    #[When('I set its height, width, depth and weight to :value')]
     public function iSetItsDimensionsTo(float $value): void
     {
         $this->client->updateRequestData([
@@ -321,17 +269,13 @@ final class ManagingProductVariantsContext implements Context
         ]);
     }
 
-    /**
-     * @When I change its quantity of inventory to :amount
-     */
+    #[When('I change its quantity of inventory to :amount')]
     public function iChangeItsQuantityOfInventoryTo(int $amount): void
     {
         $this->client->updateRequestData(['onHand' => $amount]);
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -343,9 +287,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then the :productVariantCode variant of the :productName product should appear in the store
-     */
+    #[Then('the :productVariantCode variant of the :productName product should appear in the store')]
     public function theProductVariantShouldAppearInTheShop(string $productVariantCode, string $productName): void
     {
         $response = $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -353,9 +295,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::true($this->responseChecker->hasItemWithValue($response, 'code', $productVariantCode));
     }
 
-    /**
-     * @Then the :productVariantCode variant of the :productName product should not appear in the store
-     */
+    #[Then('the :productVariantCode variant of the :productName product should not appear in the store')]
     public function theProductVariantShouldNotAppearInTheShop(string $productVariantCode, string $productName): void
     {
         $response = $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -363,9 +303,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::false($this->responseChecker->hasItemWithValue($response, 'code', $productVariantCode));
     }
 
-    /**
-     * @Then /^the (?:variant with code "[^"]+") should be named "([^"]+)" in ("([^"]+)" locale)$/
-     */
+    #[Then('/^the (?:variant with code "[^"]+") should be named "([^"]+)" in ("([^"]+)" locale)$/')]
     public function theVariantWithCodeShouldBeNamedIn(string $name, string $localeCode): void
     {
         $response = $this->responseChecker->getCollection($this->client->index(Resources::PRODUCT_VARIANTS));
@@ -383,10 +321,8 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the variant with code "([^"]+)" should be priced at ("[^"]+") for (channel "[^"]+")$/
-     * @Then I should not have configured price for :channel channel
-     */
+    #[Then('/^the variant with code "([^"]+)" should be priced at ("[^"]+") for (channel "[^"]+")$/')]
+    #[Then('I should not have configured price for :channel channel')]
     public function theVariantWithCodeShouldBePricedAtForChannel(
         ?string $variantCode = null,
         ?int $price = null,
@@ -397,10 +333,8 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($response[self::FIRST_COLLECTION_ITEM]['channelPricings'][$channel->getCode()]['price'], $price);
     }
 
-    /**
-     * @Then /^the variant with code "([^"]+)" should have an original price of ("[^"]+") for (channel "[^"]+")$/
-     * @Then /^the variant with code "([^"]+)" should be originally priced at ("[^"]+") for (channel "[^"]+")$/
-     */
+    #[Then('/^the variant with code "([^"]+)" should have an original price of ("[^"]+") for (channel "[^"]+")$/')]
+    #[Then('/^the variant with code "([^"]+)" should be originally priced at ("[^"]+") for (channel "[^"]+")$/')]
     public function theVariantWithCodeShouldHaveAnOriginalPriceOfForChannel(
         ?string $variantCode,
         int $originalPrice,
@@ -411,9 +345,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($response[self::FIRST_COLLECTION_ITEM]['channelPricings'][$channel->getCode()]['originalPrice'], $originalPrice);
     }
 
-    /**
-     * @Then /^I should have original price equal to ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[Then('/^I should have original price equal to ("[^"]+") in ("[^"]+" channel)$/')]
     public function iShouldHaveOriginalPriceEqualToInChannel(
         int $originalPrice,
         ChannelInterface $channel,
@@ -421,9 +353,7 @@ final class ManagingProductVariantsContext implements Context
         $this->theVariantWithCodeShouldHaveAnOriginalPriceOfForChannel(null, $originalPrice, $channel);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should have minimum price ("[^"]+") for (channel "([^"]+)")$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should have minimum price ("[^"]+") for (channel "([^"]+)")$/')]
     public function theVariantWithCodeShouldHaveMinimumPriceForChannel(ProductVariantInterface $productVariant, int $minimumPrice, ChannelInterface $channel): void
     {
         $response = $this->responseChecker->getCollection($this->client->index(Resources::PRODUCT_VARIANTS));
@@ -431,25 +361,19 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($response[self::FIRST_COLLECTION_ITEM]['channelPricings'][$channel->getCode()]['minimumPrice'], $minimumPrice);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should not have shipping required$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should not have shipping required$/')]
     public function theVariantWithCodeShouldNotHaveShippingRequired(ProductVariantInterface $productVariant): void
     {
         Assert::false($this->responseChecker->getValue($this->client->getLastResponse(), 'shippingRequired'));
     }
 
-    /**
-     * @Then I should see :amount variant(s) in the list
-     */
+    #[Then('I should see :amount variant(s) in the list')]
     public function iShouldSeeNumberOfProductVariantsInTheList(int $amount): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $amount);
     }
 
-    /**
-     * @Then I should see that the :productVariant variant is not tracked
-     */
+    #[Then('I should see that the :productVariant variant is not tracked')]
     public function iShouldSeeThatVariantIsNotTracked(ProductVariantInterface $productVariant): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -458,9 +382,7 @@ final class ManagingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see that the :productVariant variant has zero on hand quantity
-     */
+    #[Then('I should see that the :productVariant variant has zero on hand quantity')]
     public function iShouldSeeThatTheVariantHasZeroOnHandQuantity(ProductVariantInterface $productVariant): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -469,9 +391,7 @@ final class ManagingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see that the :productVariant variant is enabled
-     */
+    #[Then('I should see that the :productVariant variant is enabled')]
     public function iShouldSeeThatTheVariantIsEnabled(ProductVariantInterface $productVariant): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -480,25 +400,19 @@ final class ManagingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then this variant should be disabled
-     */
+    #[Then('this variant should be disabled')]
     public function thisVariantShouldBeDisabled(): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'enabled', false));
     }
 
-    /**
-     * @Then this variant should be enabled
-     */
+    #[Then('this variant should be enabled')]
     public function thisVariantShouldBeEnabled(): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'enabled', true));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -507,9 +421,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this variant) should not exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should not exist in the product catalog$/')]
     public function thisProductVariantShouldNotExistInTheProductCatalog(ProductVariantInterface $productVariant): void
     {
         Assert::false(
@@ -522,9 +434,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this variant) should still exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should still exist in the product catalog$/')]
     public function thisProductVariantShouldStillExistInTheProductCatalog(ProductVariantInterface $productVariant): void
     {
         Assert::true(
@@ -537,9 +447,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this variant is in use and cannot be deleted
-     */
+    #[Then('I should be notified that this variant is in use and cannot be deleted')]
     public function iShouldBeNotifiedThatThisVariantIsInUseAndCannotBeDeleted(): void
     {
         Assert::contains(
@@ -548,25 +456,19 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then inventory of this variant should not be tracked
-     */
+    #[Then('inventory of this variant should not be tracked')]
     public function inventoryOfThisVariantShouldNotBeTracked(): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'tracked', false));
     }
 
-    /**
-     * @Then inventory of this variant should be tracked
-     */
+    #[Then('inventory of this variant should be tracked')]
     public function inventoryOfThisVariantShouldBeTracked(): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'tracked', true));
     }
 
-    /**
-     * @Then I should be notified that prices in :channel channel must be defined
-     */
+    #[Then('I should be notified that prices in :channel channel must be defined')]
     public function iShouldBeNotifiedThatPricesInAllChannelsMustBeDefined(ChannelInterface $channel): void
     {
         Assert::contains(
@@ -575,9 +477,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that price cannot be lower than 0
-     */
+    #[Then('I should be notified that price cannot be lower than 0')]
     public function iShouldBeNotifiedThatPriceCannotBeLowerThanZero(): void
     {
         Assert::contains(
@@ -586,9 +486,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that price cannot be greater than max value allowed
-     */
+    #[Then('I should be notified that price cannot be greater than max value allowed')]
     public function iShouldBeNotifiedThatPriceCannotBeGreaterThanMaxValueAllowed(): void
     {
         Assert::contains(
@@ -597,9 +495,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code is required
-     */
+    #[Then('I should be notified that code is required')]
     public function iShouldBeNotifiedThatCodeIsRequired(): void
     {
         Assert::contains(
@@ -608,9 +504,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that current stock is required
-     */
+    #[Then('I should be notified that current stock is required')]
     public function iShouldBeNotifiedThatCurrentStockIsRequired(): void
     {
         Assert::contains(
@@ -619,27 +513,21 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then the :product product should have no variants
-     */
+    #[Then('the :product product should have no variants')]
     public function theProductShouldHaveNoVariants(ProductInterface $product): void
     {
         $this->iWantToViewAllVariantsOfThisProduct($product);
         $this->iShouldSeeNumberOfProductVariantsInTheList(0);
     }
 
-    /**
-     * @Then the :product product should have only one variant
-     */
+    #[Then('the :product product should have only one variant')]
     public function theProductShouldHaveOnlyOneVariant(ProductInterface $product): void
     {
         $this->iWantToViewAllVariantsOfThisProduct($product);
         $this->iShouldSeeNumberOfProductVariantsInTheList(1);
     }
 
-    /**
-     * @Then /^(\d+) units of (this product) should be (on hand|on hold)$/
-     */
+    #[Then('/^(\d+) units of (this product) should be (on hand|on hold)$/')]
     public function unitsOfThisProductShouldBeOn(
         int $quantity,
         ProductInterface $product,
@@ -653,18 +541,14 @@ final class ManagingProductVariantsContext implements Context
         $this->theVariantShouldHaveItemsOn($variant, $quantity, $field);
     }
 
-    /**
-     * @Then /^there should be no units of (this product) on hold$/
-     */
+    #[Then('/^there should be no units of (this product) on hold$/')]
     public function thereShouldBeNoUnitsOfThisProductOnHold(ProductInterface $product): void
     {
         $this->unitsOfThisProductShouldBeOn(0, $product, 'on hold');
     }
 
-    /**
-     * @Then /^the ("[^"]+" variant) should have (\d+) items (on hand|on hold)$/
-     * @Then /^the (variant "[^"]+") should have (\d+) items (on hand|on hold)$/
-     */
+    #[Then('/^the ("[^"]+" variant) should have (\d+) items (on hand|on hold)$/')]
+    #[Then('/^the (variant "[^"]+") should have (\d+) items (on hand|on hold)$/')]
     public function theVariantShouldHaveItemsOn(ProductVariantInterface $variant, int $quantity, string $field): void
     {
         $variantsData = $this->responseChecker->getCollectionItemsWithValue(
@@ -681,11 +565,9 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the ("[^"]+" variant of product "[^"]+") should have (\d+) items (on hand|on hold)$/
-     * @Then /^the ("[^"]+" variant of "[^"]+" product) should have (\d+) items (on hand|on hold)$/
-     * @Then /^(this variant) should have a (\d+) item currently in stock$/
-     */
+    #[Then('/^the ("[^"]+" variant of product "[^"]+") should have (\d+) items (on hand|on hold)$/')]
+    #[Then('/^the ("[^"]+" variant of "[^"]+" product) should have (\d+) items (on hand|on hold)$/')]
+    #[Then('/^(this variant) should have a (\d+) item currently in stock$/')]
     public function theVariantOfProductShouldHaveItemsOn(
         ProductVariantInterface $variant,
         int $quantity,
@@ -702,9 +584,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code has to be unique
-     */
+    #[Then('I should be notified that code has to be unique')]
     public function iShouldBeNotifiedThatCodeHasToBeUnique(): void
     {
         Assert::contains(
@@ -713,9 +593,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this variant already exists
-     */
+    #[Then('I should be notified that this variant already exists')]
     public function iShouldBeNotifiedThatThisVariantAlreadyExists(): void
     {
         Assert::contains(
@@ -724,9 +602,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that height, width, depth and weight cannot be lower than 0
-     */
+    #[Then('I should be notified that height, width, depth and weight cannot be lower than 0')]
     public function iShouldBeNotifiedThatIsHeightWidthDepthAndWeightCannotBeLowerThanZero(): void
     {
         $errors = $this->responseChecker->getError($this->client->getLastResponse());
@@ -737,9 +613,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::contains($errors, 'Weight cannot be negative.');
     }
 
-    /**
-     * @Then the variant :productVariantName should have :optionName option as :optionValue
-     */
+    #[Then('the variant :productVariantName should have :optionName option as :optionValue')]
     public function theVariantShouldHaveOptionAs(
         string $productVariantName,
         string $optionName,
@@ -752,9 +626,7 @@ final class ManagingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the variant can have only one value configured for a single option
-     */
+    #[Then('I should be notified that the variant can have only one value configured for a single option')]
     public function iShouldBeNotifiedThatTheVariantCanHaveOnlyOneValueConfiguredForASingleOption(): void
     {
         Assert::contains(
@@ -763,9 +635,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that required options have not been configured
-     */
+    #[Then('I should be notified that required options have not been configured')]
     public function iShouldBeNotifiedThatRequiredOptionsHaveNotBeenConfigured(): void
     {
         Assert::contains(
@@ -774,9 +644,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that on hand quantity must be greater than the number of on hold units
-     */
+    #[Then('I should be notified that on hand quantity must be greater than the number of on hold units')]
     public function iShouldBeNotifiedThatOnHandQuantityMustBeGreaterThanTheNumberOfOnHoldUnits(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsPricesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsPricesContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Context\Api\Resources;
@@ -25,9 +26,7 @@ final class ManagingProductVariantsPricesContext implements Context
     {
     }
 
-    /**
-     * @When /^I change the price of the ("[^"]+" product variant) to ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[When('/^I change the price of the ("[^"]+" product variant) to ("[^"]+") in ("[^"]+" channel)$/')]
     public function iChangeThePriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         int $price,
@@ -36,9 +35,7 @@ final class ManagingProductVariantsPricesContext implements Context
         $this->updateChannelPricingField($variant, $channel, $price, 'price');
     }
 
-    /**
-     * @When /^I change the original price of the ("[^"]+" product variant) to ("[^"]+") in ("[^"]+" channel)$/
-     */
+    #[When('/^I change the original price of the ("[^"]+" product variant) to ("[^"]+") in ("[^"]+" channel)$/')]
     public function iChangeTheOriginalPriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -47,9 +44,7 @@ final class ManagingProductVariantsPricesContext implements Context
         $this->updateChannelPricingField($variant, $channel, $originalPrice, 'originalPrice');
     }
 
-    /**
-     * @When /^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/
-     */
+    #[When('/^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/')]
     public function iRemoveTheOriginalPriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         ChannelInterface $channel,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestBuilder;
@@ -52,12 +55,10 @@ final readonly class ManagingProductsContext implements Context
     ) {
     }
 
-    /**
-     * @Given the products are already sorted :sortType by name
-     * @When I start sorting products by name
-     * @When I sort the products :sortType by name
-     * @When I switch the way products are sorted :sortType by name
-     */
+    #[Given('the products are already sorted :sortType by name')]
+    #[When('I start sorting products by name')]
+    #[When('I sort the products :sortType by name')]
+    #[When('I switch the way products are sorted :sortType by name')]
     public function iStartSortingProductsByName(string $sortType = 'ascending'): void
     {
         $this->client->sort([
@@ -68,11 +69,9 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @Given I am browsing products
-     * @When I browse products
-     * @When I want to browse products
-     */
+    #[Given('I am browsing products')]
+    #[When('I browse products')]
+    #[When('I want to browse products')]
     public function iWantToBrowseProducts(): void
     {
         $this->client->index(Resources::PRODUCTS);
@@ -80,9 +79,7 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I change my locale to :localeCode
-     */
+    #[When('I change my locale to :localeCode')]
     public function iSwitchTheLocaleToTheLocale(string $localeCode): void
     {
         /** @var AdminUserInterface $adminUser */
@@ -94,35 +91,27 @@ final readonly class ManagingProductsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When I want to create a new configurable product
-     */
+    #[When('I want to create a new configurable product')]
     public function iWantToCreateANewConfigurableProduct(): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCTS);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank.
     }
 
-    /**
-     * @When I name it :name in :localeCode locale
-     * @When I rename it to :name in :localeCode locale
-     */
+    #[When('I name it :name in :localeCode locale')]
+    #[When('I rename it to :name in :localeCode locale')]
     public function iRenameItToInLocale(string $name, string $localeCode): void
     {
         $data['translations'][$localeCode]['name'] = $name;
@@ -130,19 +119,15 @@ final readonly class ManagingProductsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I generate its slug in :localeCode locale
-     */
+    #[When('I generate its slug in :localeCode locale')]
     public function iGenerateItsSlugIn(string $localeCode): void
     {
         // Intentionally left blank, as this is a UI-specific action.
     }
 
-    /**
-     * @When I set its slug to :slug
-     * @When I set its slug to :slug in :localeCode locale
-     * @When I remove its slug
-     */
+    #[When('I set its slug to :slug')]
+    #[When('I set its slug to :slug in :localeCode locale')]
+    #[When('I remove its slug')]
     public function iSetItsSlugTo(?string $slug = null, $localeCode = 'en_US'): void
     {
         $data = [
@@ -156,33 +141,25 @@ final readonly class ManagingProductsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I add the :productOption option to it
-     */
+    #[When('I add the :productOption option to it')]
     public function iAddTheOptionToIt(ProductOptionInterface $productOption): void
     {
         $this->client->updateRequestData(['options' => [$this->iriConverter->getIriFromResourceInSection($productOption, 'admin')]]);
     }
 
-    /**
-     * @When /^I choose main (taxon "[^"]+")$/
-     */
+    #[When('/^I choose main (taxon "[^"]+")$/')]
     public function iChooseMainTaxon(TaxonInterface $taxon): void
     {
         $this->client->updateRequestData(['mainTaxon' => $this->iriConverter->getIriFromResourceInSection($taxon, 'admin')]);
     }
 
-    /**
-     * @When I filter them by :taxon taxon
-     */
+    #[When('I filter them by :taxon taxon')]
     public function iFilterThemByTaxon(TaxonInterface $taxon): void
     {
         $this->client->addFilter('productTaxons.taxon.code', $taxon->getCode());
@@ -191,37 +168,29 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I search for products with :name name
-     */
+    #[When('I search for products with :name name')]
     public function iSearchForProductsWithName(string $name): void
     {
         $this->client->addFilter('translations.name', $name);
         $this->client->filter();
     }
 
-    /**
-     * @When I search for products with :code code
-     */
+    #[When('I search for products with :code code')]
     public function iSearchForProductsWithCode(string $code): void
     {
         $this->client->addFilter('code', $code);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter them by :taxon main taxon
-     */
+    #[When('I filter them by :taxon main taxon')]
     public function iFilterThemByMainTaxon(TaxonInterface $taxon): void
     {
         $this->client->addFilter('mainTaxon.code', $taxon->getCode());
         $this->client->filter();
     }
 
-    /**
-     * @When I start sorting products by code
-     * @When I switch the way products are sorted :sortType by code
-     */
+    #[When('I start sorting products by code')]
+    #[When('I switch the way products are sorted :sortType by code')]
     public function iSwitchTheWayProductsAreSortedByCode(string $sortType = 'ascending'): void
     {
         $this->client->sort(['code' => self::SORT_TYPES[$sortType]]);
@@ -229,29 +198,23 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @When I (try to) delete the :product product
-     */
+    #[When('I (try to) delete the :product product')]
     public function iDeleteProduct(ProductInterface $product): void
     {
         $this->client->delete(Resources::PRODUCTS, $product->getCode());
     }
 
-    /**
-     * @When /^I want to modify (this product)$/
-     * @When I (want to) modify the :product product
-     */
+    #[When('/^I want to modify (this product)$/')]
+    #[When('I (want to) modify the :product product')]
     public function iWantToModifyAProduct(ProductInterface $product): void
     {
         $this->client->buildUpdateRequest(Resources::PRODUCTS, $product->getCode());
     }
 
-    /**
-     * @Then I should see the product :productName in the list
-     * @Then the product :productName should appear in the store
-     * @Then the product :productName should be in the shop
-     * @Then this product should still be named :productName
-     */
+    #[Then('I should see the product :productName in the list')]
+    #[Then('the product :productName should appear in the store')]
+    #[Then('the product :productName should be in the shop')]
+    #[Then('this product should still be named :productName')]
     public function theProductShouldAppearInTheShop(string $productName): void
     {
         $response = $this->client->index(Resources::PRODUCTS);
@@ -261,9 +224,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I remove its name from :localeCode translation')]
     public function iRemoveItsNameFromTranslation(string $localeCode): void
     {
         $this->client->updateRequestData([
@@ -275,9 +236,7 @@ final readonly class ManagingProductsContext implements Context
         ]);
     }
 
-    /**
-     * @When I set its meta keywords to too long string in :localeCode
-     */
+    #[When('I set its meta keywords to too long string in :localeCode')]
     public function iSetItsMetaKeywordsToTooLongStringIn(string $localeCode): void
     {
         $this->client->updateRequestData([
@@ -289,9 +248,7 @@ final readonly class ManagingProductsContext implements Context
         ]);
     }
 
-    /**
-     * @When I set its meta description to too long string in :localeCode
-     */
+    #[When('I set its meta description to too long string in :localeCode')]
     public function iSetItsMetaDescriptionToTooLongStringIn(string $localeCode): void
     {
         $this->client->updateRequestData([
@@ -303,9 +260,7 @@ final readonly class ManagingProductsContext implements Context
         ]);
     }
 
-    /**
-     * @When I set its non-translatable :attribute attribute to :value
-     */
+    #[When('I set its non-translatable :attribute attribute to :value')]
     public function iSetItsNonTranslatableAttributeTo(ProductAttributeInterface $attribute, string $value): void
     {
         $this->client->addSubResourceData(
@@ -317,9 +272,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I set the invalid integer value of the non-translatable :attribute attribute to :value
-     */
+    #[When('I set the invalid integer value of the non-translatable :attribute attribute to :value')]
     public function iSetTheInvalidIntegerValueOfTheNonTranslatableAttributeTo(ProductAttributeInterface $attribute, int $value): void
     {
         $this->client->addSubResourceData(
@@ -331,9 +284,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I set the invalid string value of the non-translatable :attribute attribute to :value
-     */
+    #[When('I set the invalid string value of the non-translatable :attribute attribute to :value')]
     public function iSetTheInvalidStringValueOfTheNonTranslatableAttributeTo(ProductAttributeInterface $attribute, string $value): void
     {
         $this->client->addSubResourceData(
@@ -345,17 +296,13 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I want to modify the images of :product product
-     */
+    #[When('I want to modify the images of :product product')]
     public function iWantToModifyTheImagesOfProduct(ProductInterface $product): void
     {
         $this->sharedStorage->set('productIri', $this->iriConverter->getIriFromResource($product));
     }
 
-    /**
-     * @When I change the :type image position to :position
-     */
+    #[When('I change the :type image position to :position')]
     public function iChangeTheImagePositionTo(string $imageType, int $position): void
     {
         $images = $this->responseChecker->getValue($this->client->showByIri($this->sharedStorage->get('productIri')), 'images');
@@ -378,12 +325,10 @@ final readonly class ManagingProductsContext implements Context
         $this->client->request($builder->build());
     }
 
-    /**
-     * @When I set its :attribute attribute to :value
-     * @When I set its :attribute attribute to :value in :localeCode locale
-     * @When I do not set its :attribute attribute in :localeCode locale
-     * @When I set the :attribute attribute value to :value in :localeCode locale
-     */
+    #[When('I set its :attribute attribute to :value')]
+    #[When('I set its :attribute attribute to :value in :localeCode locale')]
+    #[When('I do not set its :attribute attribute in :localeCode locale')]
+    #[When('I set the :attribute attribute value to :value in :localeCode locale')]
     public function iSetItsAttributeTo(
         ProductAttributeInterface $attribute,
         ?string $value = null,
@@ -399,9 +344,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I remove its :attribute attribute
-     */
+    #[When('I remove its :attribute attribute')]
     public function iRemoveItsAttribute(ProductAttributeInterface $attribute): void
     {
         $attributeIri = $this->iriConverter->getIriFromResourceInSection($attribute, 'admin');
@@ -416,18 +359,14 @@ final readonly class ManagingProductsContext implements Context
         $this->client->setRequestData($content);
     }
 
-    /**
-     * @When I add the :attributeName attribute
-     * @When I add the :attributeName attribute to it
-     */
+    #[When('I add the :attributeName attribute')]
+    #[When('I add the :attributeName attribute to it')]
     public function iAddTheAttribute(string $attributeName): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I select :value value in :localeCode for the :attribute attribute
-     */
+    #[When('I select :value value in :localeCode for the :attribute attribute')]
     public function iSelectValueInForTheAttribute(
         string $value,
         string $localeCode,
@@ -443,9 +382,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I select :value value for the :attribute attribute
-     */
+    #[When('I select :value value for the :attribute attribute')]
     public function iSelectValueForTheAttribute(
         string $value,
         ProductAttributeInterface $attribute,
@@ -459,33 +396,25 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I enable it in channel :channel
-     */
+    #[When('I enable it in channel :channel')]
     public function iEnableItInChannel(ChannelInterface $channel): void
     {
         $this->client->addRequestData('channels', [$this->iriConverter->getIriFromResource($channel)]);
     }
 
-    /**
-     * @When I access the :product product
-     */
+    #[When('I access the :product product')]
     public function iAccessTheProduct(ProductInterface $product): void
     {
         $this->client->show(Resources::PRODUCTS, $product->getCode());
     }
 
-    /**
-     * @When I choose :channel as a channel filter
-     */
+    #[When('I choose :channel as a channel filter')]
     public function iChooseChannelAsAChannelFilter(ChannelInterface $channel): void
     {
         $this->client->addFilter('channel', $this->iriConverter->getIriFromResource($channel));
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
@@ -493,9 +422,7 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('response', $this->client->getLastResponse());
     }
 
-    /**
-     * @Then I should see main taxon is :taxon
-     */
+    #[Then('I should see main taxon is :taxon')]
     public function iShouldSeeMainTaxonIs(TaxonInterface $taxon): void
     {
         Assert::same(
@@ -504,9 +431,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see product taxon :taxon
-     */
+    #[Then('I should see product taxon :taxon')]
     public function iShouldSeeProductTaxon(TaxonInterface $taxon): void
     {
         $product = $this->sharedStorage->get('product');
@@ -523,9 +448,7 @@ final readonly class ManagingProductsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see option :productOption
-     */
+    #[Then('I should see option :productOption')]
     public function iShouldSeeOption(ProductOptionInterface $productOption): void
     {
         Assert::true($this->responseChecker->hasValueInCollection(
@@ -535,9 +458,7 @@ final readonly class ManagingProductsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see :count variants
-     */
+    #[Then('I should see :count variants')]
     public function iShouldSeeVariants(int $count): void
     {
         Assert::count(
@@ -546,9 +467,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the :variant variant
-     */
+    #[Then('I should see the :variant variant')]
     public function iShouldSeeTheVariant(ProductVariantInterface $variant): void
     {
         Assert::true($this->responseChecker->hasValueInCollection(
@@ -558,34 +477,26 @@ final readonly class ManagingProductsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see product :field is :value
-     * @Then I should see product's :field is :value
-     */
+    #[Then('I should see product :field is :value')]
+    #[Then('I should see product\'s :field is :value')]
     public function iShouldSeeProductFieldIs(string $field, string $value): void
     {
         $this->assertResponseHasTranslationFieldWithValue($field, $value);
     }
 
-    /**
-     * @Then I should see product's meta keyword(s) is/are :metaKeywords
-     */
+    #[Then('I should see product\'s meta keyword(s) is/are :metaKeywords')]
     public function iShouldSeeProductMetaKeywordsAre(string $metaKeywords): void
     {
         $this->assertResponseHasTranslationFieldWithValue('metaKeywords', $metaKeywords);
     }
 
-    /**
-     * @Then I should see product's short description is :shortDescription
-     */
+    #[Then('I should see product\'s short description is :shortDescription')]
     public function iShouldSeeProductShortDescriptionIs(string $shortDescription): void
     {
         $this->assertResponseHasTranslationFieldWithValue('shortDescription', $shortDescription);
     }
 
-    /**
-     * @Then I should see product association type :productAssociationType
-     */
+    #[Then('I should see product association type :productAssociationType')]
     public function iShouldSeeProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
         $associations = $this->responseChecker->getValue($this->client->getLastResponse(), 'associations');
@@ -602,17 +513,13 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true($this->responseChecker->isCreationSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that this product is in use and cannot be deleted
-     */
+    #[Then('I should be notified that this product is in use and cannot be deleted')]
     public function iShouldBeNotifiedThatThisProductIsInUseAndCannotBeDeleted(): void
     {
         Assert::false(
@@ -621,9 +528,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -632,9 +537,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that (code|name) is required$/
-     */
+    #[Then('/^I should be notified that (code|name) is required$/')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -643,9 +546,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then the one before last image on the list should have type :type with position :position
-     */
+    #[Then('the one before last image on the list should have type :type with position :position')]
     public function theOneBeforeLastImageOnTheListShouldHaveNameWithPosition(string $imageType, int $position): void
     {
         $images = $this->responseChecker->getValue($this->client->showByIri($this->sharedStorage->get('productIri')), 'images');
@@ -654,9 +555,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($images[count($images) - 2]['position'], $position);
     }
 
-    /**
-     * @Then the last image on the list should have type :type with position :position
-     */
+    #[Then('the last image on the list should have type :type with position :position')]
     public function theLastImageOnTheListShouldHaveNameWithPosition(string $imageType, int $position): void
     {
         $images = $this->responseChecker->getValue($this->client->showByIri($this->sharedStorage->get('productIri')), 'images');
@@ -665,9 +564,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($images[count($images) - 1]['position'], $position);
     }
 
-    /**
-     * @Then I should be notified that meta keywords are too long
-     */
+    #[Then('I should be notified that meta keywords are too long')]
     public function iShouldBeNotifiedThatMetaKeywordsAreTooLong(): void
     {
         Assert::contains(
@@ -676,9 +573,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that meta description is too long
-     */
+    #[Then('I should be notified that meta description is too long')]
     public function iShouldBeNotifiedThatMetaDescriptionIsTooLong(): void
     {
         Assert::contains(
@@ -687,9 +582,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code has to be unique
-     */
+    #[Then('I should be notified that code has to be unique')]
     public function iShouldBeNotifiedThatCodeHasToBeUnique(): void
     {
         Assert::contains(
@@ -698,18 +591,14 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single product in the list
-     * @Then I should see :count products in the list
-     */
+    #[Then('I should see a single product in the list')]
+    #[Then('I should see :count products in the list')]
     public function iShouldSeeProductsInTheList(int $count = 1): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see a product with :field :value
-     */
+    #[Then('I should see a product with :field :value')]
     public function iShouldSeeProductWith(string $field, string $value): void
     {
         $response = $this->getLastResponse();
@@ -720,9 +609,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see any product with :field :value
-     */
+    #[Then('I should not see any product with :field :value')]
     public function iShouldNotSeeAnyProductWith(string $field, string $value): void
     {
         $response = $this->getLastResponse();
@@ -733,9 +620,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', '_NEW');
@@ -753,10 +638,8 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) main (taxon should be "[^"]+")$/
-     * @Then main taxon of product :product should be :taxon
-     */
+    #[Then('/^(this product) main (taxon should be "[^"]+")$/')]
+    #[Then('main taxon of product :product should be :taxon')]
     public function thisProductMainTaxonShouldBe(ProductInterface $product, TaxonInterface $taxon): void
     {
         $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -766,9 +649,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($mainTaxon, $this->iriConverter->getIriFromResourceInSection($taxon, 'admin'));
     }
 
-    /**
-     * @Then the product :product should have the :taxon taxon
-     */
+    #[Then('the product :product should have the :taxon taxon')]
     public function thisProductTaxonShouldBe(ProductInterface $product, TaxonInterface $taxon): void
     {
         $this->client->index(Resources::PRODUCT_TAXONS);
@@ -780,9 +661,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then the product :product should not have the :taxon taxon
-     */
+    #[Then('the product :product should not have the :taxon taxon')]
     public function thisProductTaxonShouldHaveNotTheTaxon(ProductInterface $product, TaxonInterface $taxon): void
     {
         $this->client->index(Resources::PRODUCT_TAXONS);
@@ -795,9 +674,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) name should be "([^"]+)" in ("([^"]+)" locale)$/
-     */
+    #[Then('/^(this product) name should be "([^"]+)" in ("([^"]+)" locale)$/')]
     public function thisProductNameShouldBe(ProductInterface $product, string $name, string $localeCode): void
     {
         $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -808,9 +685,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should not exist in the product catalog$/
-     */
+    #[Then('/^(this product) should not exist in the product catalog$/')]
     public function productShouldNotExist(ProductInterface $product): void
     {
         $response = $this->client->index(Resources::PRODUCTS);
@@ -821,9 +696,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should have (?:a|an) ("[^"]+" option)$/
-     */
+    #[Then('/^(this product) should have (?:a|an) ("[^"]+" option)$/')]
     public function thisProductShouldHaveOption(ProductInterface $product, ProductOptionInterface $productOption): void
     {
         $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -836,9 +709,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then the first product on the list should have :field :value
-     */
+    #[Then('the first product on the list should have :field :value')]
     public function theFirstProductOnTheListShouldHave(string $field, string $value): void
     {
         $products = $this->responseChecker->getCollection($this->getLastResponse());
@@ -846,9 +717,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->getFieldValueOfProduct($products[0], $field), $value);
     }
 
-    /**
-     * @Then the last product on the list should have name :name
-     */
+    #[Then('the last product on the list should have name :name')]
     public function theLastProductOnTheListShouldHaveName(string $name): void
     {
         $products = $this->responseChecker->getCollection($this->getLastResponse());
@@ -856,9 +725,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->getFieldValueOfProduct(end($products), 'name'), $name);
     }
 
-    /**
-     * @Then /^the (first|last) product on the list shouldn't have a name$/
-     */
+    #[Then('/^the (first|last) product on the list shouldn\'t have a name$/')]
     public function theProductOnTheListShouldNotHaveAName(string $position): void
     {
         $products = $this->responseChecker->getCollection($this->getLastResponse());
@@ -868,11 +735,9 @@ final readonly class ManagingProductsContext implements Context
         Assert::null($this->getFieldValueOfProduct($product, 'name'));
     }
 
-    /**
-     * @Then /^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)"$/
-     * @Then /^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)" (in the "[^"]+" locale)$/
-     * @Then /^(this product) should(?:| still) have slug "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Then('/^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)"$/')]
+    #[Then('/^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)" (in the "[^"]+" locale)$/')]
+    #[Then('/^(this product) should(?:| still) have slug "([^"]+)" in ("[^"]+" locale)$/')]
     public function productSlugShouldBe(ProductInterface $product, string $slug, string $localeCode = 'en_US'): void
     {
         $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -883,9 +748,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^there should be no reviews of (this product)$/
-     */
+    #[Then('/^there should be no reviews of (this product)$/')]
     public function thereAreNoProductReviews(ProductInterface $product): void
     {
         $response = $this->client->index(Resources::PRODUCT_REVIEWS);
@@ -900,9 +763,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should still exist in the product catalog$/
-     */
+    #[Then('/^(this product) should still exist in the product catalog$/')]
     public function productShouldExistInTheProductCatalog(ProductInterface $product): void
     {
         $response = $this->client->index(Resources::PRODUCTS);
@@ -914,9 +775,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (product "[^"]+") should still have an accessible image$/
-     */
+    #[Then('/^the (product "[^"]+") should still have an accessible image$/')]
     public function productShouldStillHaveAnAccessibleImage(ProductInterface $product): void
     {
         $response = $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -924,18 +783,14 @@ final readonly class ManagingProductsContext implements Context
         Assert::true($this->hasProductImage($response, $product), 'Image does not exists');
     }
 
-    /**
-     * @Then /^product with (name|code) "([^"]+)" should not be added$/
-     */
+    #[Then('/^product with (name|code) "([^"]+)" should not be added$/')]
     public function productWithNameShouldNotBeAdded(string $field, string $value): void
     {
         Assert::false($this->hasProductWithFieldValue($this->client->index(Resources::PRODUCTS), $field, $value));
     }
 
-    /**
-     * @Then non-translatable attribute :attribute of product :product should be :value
-     * @Then select attribute :attribute of product :product should be :value
-     */
+    #[Then('non-translatable attribute :attribute of product :product should be :value')]
+    #[Then('select attribute :attribute of product :product should be :value')]
     public function nonTranslatableAttributeOfProductShouldBe(
         ProductAttributeInterface $attribute,
         ProductInterface $product,
@@ -946,19 +801,15 @@ final readonly class ManagingProductsContext implements Context
         $this->hasAttributeWithValueInLastResponse($attribute, $value);
     }
 
-    /**
-     * @Then I should see non-translatable attribute :attribute with value :value%
-     */
+    #[Then('I should see non-translatable attribute :attribute with value :value%')]
     public function iShouldSeeNonTranslatableAttributeWithValue(ProductAttributeInterface $attribute, int $value): void
     {
         $this->hasAttributeWithValueInLastResponse($attribute, (string) ($value / 100));
     }
 
-    /**
-     * @Then attribute :attribute of product :product should be :value
-     * @Then attribute :attribute of product :product should be :value in :localeCode locale
-     * @Then select attribute :attribute of product :product should be :value in :localeCode locale
-     */
+    #[Then('attribute :attribute of product :product should be :value')]
+    #[Then('attribute :attribute of product :product should be :value in :localeCode locale')]
+    #[Then('select attribute :attribute of product :product should be :value in :localeCode locale')]
     public function attributeOfProductShouldBe(
         ProductAttributeInterface $attribute,
         ProductInterface $product,
@@ -970,9 +821,7 @@ final readonly class ManagingProductsContext implements Context
         $this->hasAttributeWithValueInLastResponse($attribute, $value, $localeCode);
     }
 
-    /**
-     * @Then product :product should not have a :attribute attribute
-     */
+    #[Then('product :product should not have a :attribute attribute')]
     public function productShouldNotHaveAttribute(ProductInterface $product, ProductAttributeInterface $attribute): void
     {
         $attributes = $this->responseChecker->getValue($this->client->getLastResponse(), 'attributes');
@@ -985,9 +834,7 @@ final readonly class ManagingProductsContext implements Context
         }
     }
 
-    /**
-     * @Then I should not be able to edit its options
-     */
+    #[Then('I should not be able to edit its options')]
     public function iShouldNotBeAbleToEditItsOptions(): void
     {
         $productOption = $this->sharedStorage->get('product_option');
@@ -1002,9 +849,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to define product variants' prices for newly assigned channels first
-     */
+    #[Then('I should be notified that I have to define product variants\' prices for newly assigned channels first')]
     public function iShouldBeNotifiedThatIHaveToDefineProductVariantsPricesForNewlyAssignedChannelsFirst(): void
     {
         Assert::contains(
@@ -1013,9 +858,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that slug has to be unique
-     */
+    #[Then('I should be notified that slug has to be unique')]
     public function iShouldBeNotifiedThatSlugHasToBeUnique(): void
     {
         Assert::contains(
@@ -1024,9 +867,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to define the :attributeName attribute in :localeCode locale
-     */
+    #[Then('I should be notified that I have to define the :attributeName attribute in :localeCode locale')]
     public function iShouldBeNotifiedThatIHaveToDefineTheAttributeInLocale(string $attributeName, string $localeCode): void
     {
         Assert::regex(
@@ -1035,9 +876,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the :attributeName attribute in :localeCode locale should be longer than :number
-     */
+    #[Then('I should be notified that the :attributeName attribute in :localeCode locale should be longer than :number')]
     public function iShouldBeNotifiedThatTheAttributeInShouldBeLongerThan(
         string $attributeName,
         string $localeCode,
@@ -1049,9 +888,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the value of the :attributeName attribute has invalid type
-     */
+    #[Then('I should be notified that the value of the :attributeName attribute has invalid type')]
     public function iShouldBeNotifiedThatTheValueOfTheAttributeHasInvalidType(
         string $attributeName,
     ): void {
@@ -1061,17 +898,13 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see an image related to this product
-     */
+    #[Then('I should see an image related to this product')]
     public function iShouldSeeImageRelatedToThisProduct(): void
     {
         Assert::notEmpty($this->responseChecker->getValue($this->client->getLastResponse(), 'images'));
     }
 
-    /**
-     * @Then I should see attribute :attribute with value :value in :locale locale
-     */
+    #[Then('I should see attribute :attribute with value :value in :locale locale')]
     public function iShouldSeeAttributeWithValueInLocale(
         ProductAttributeInterface $attribute,
         string $value,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionCouponsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -37,44 +40,34 @@ final readonly class ManagingPromotionCouponsContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am browsing coupons of (this promotion)$/
-     * @When /^I want to view all coupons of (this promotion)$/
-     * @When /^I browse all coupons of ("[^"]+" promotion)$/
-     */
+    #[Given('/^I am browsing coupons of (this promotion)$/')]
+    #[When('/^I want to view all coupons of (this promotion)$/')]
+    #[When('/^I browse all coupons of ("[^"]+" promotion)$/')]
     public function iWantToViewAllCouponsOfThisPromotion(PromotionInterface $promotion): void
     {
         $this->client->requestGet(sprintf('promotions/%s/coupons', $promotion->getCode()));
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->client->addFilter('code', $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @When I want to create a new coupon for a non-existing promotion
-     */
+    #[When('I want to create a new coupon for a non-existing promotion')]
     public function iWantToCreateANewCouponForNonExistingPromotion(): void
     {
         $this->client->buildCreateRequest('promotions/non-existing-promotion/coupons');
     }
 
-    /**
-     * @When /^I want to create a new coupon for (this promotion)$/
-     */
+    #[When('/^I want to create a new coupon for (this promotion)$/')]
     public function iWantToCreateANewCouponForPromotion(PromotionInterface $promotion): void
     {
         $this->client->buildCreateRequest(sprintf('promotions/%s/coupons', $promotion->getCode()));
     }
 
-    /**
-     * @When /^I want to modify the ("[^"]+" coupon) for (this promotion)$/
-     */
+    #[When('/^I want to modify the ("[^"]+" coupon) for (this promotion)$/')]
     public function iWantToModifyTheCouponForThisPromotion(PromotionCouponInterface $coupon, PromotionInterface $promotion): void
     {
         $this->client->buildUpdateRequest(
@@ -82,17 +75,13 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @When /^I want to generate new coupons for (this promotion)$/
-     */
+    #[When('/^I want to generate new coupons for (this promotion)$/')]
     public function iWantToGenerateNewCouponsForThisPromotion(PromotionInterface $promotion): void
     {
         $this->client->buildCreateRequest(sprintf('promotions/%s/coupons/generate', $promotion->getCode()));
     }
 
-    /**
-     * @When I (try to) delete :coupon coupon related to this promotion
-     */
+    #[When('I (try to) delete :coupon coupon related to this promotion')]
     public function iDeleteCouponRelatedToThisPromotion(PromotionCouponInterface $coupon): void
     {
         $this->client->requestDelete(
@@ -100,165 +89,125 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I limit its usage to :times time(s)
-     * @When I change its usage limit to :times
-     */
+    #[When('I limit its usage to :times time(s)')]
+    #[When('I change its usage limit to :times')]
     public function iLimitItsUsageToTimes(int $times): void
     {
         $this->client->addRequestData('usageLimit', $times);
     }
 
-    /**
-     * @When I limit its per customer usage to :times time(s)
-     * @When I change its per customer usage limit to :times
-     */
+    #[When('I limit its per customer usage to :times time(s)')]
+    #[When('I change its per customer usage limit to :times')]
     public function iLimitItsPerCustomerUsageToTimes(int $times): void
     {
         $this->client->addRequestData('perCustomerUsageLimit', $times);
     }
 
-    /**
-     * @When I make it valid until :date
-     * @When I change its expiration date to :date
-     */
+    #[When('I make it valid until :date')]
+    #[When('I change its expiration date to :date')]
     public function iMakeItValidUntil(\DateTime $date): void
     {
         $this->client->addRequestData('expiresAt', $date->format('d-m-Y'));
     }
 
-    /**
-     * @When I make it not reusable from cancelled orders
-     */
+    #[When('I make it not reusable from cancelled orders')]
     public function iMakeItNotReusableFromCancelledOrders(): void
     {
         $this->client->addRequestData('reusableFromCancelledOrders', false);
     }
 
-    /**
-     * @When I choose the amount of :amount coupons to be generated
-     */
+    #[When('I choose the amount of :amount coupons to be generated')]
     public function iSpecifyItsAmountAs(int $amount): void
     {
         $this->client->updateRequestData(['amount' => $amount]);
     }
 
-    /**
-     * @When I specify their prefix as :prefix
-     */
+    #[When('I specify their prefix as :prefix')]
     public function iSpecifyPrefixAs(string $prefix): void
     {
         $this->client->updateRequestData(['prefix' => $prefix]);
     }
 
-    /**
-     * @When I specify their suffix as :suffix
-     */
+    #[When('I specify their suffix as :suffix')]
     public function iSpecifySuffixAs(string $suffix): void
     {
         $this->client->updateRequestData(['suffix' => $suffix]);
     }
 
-    /**
-     * @When /^I specify their code length as (\d+)$/
-     * @When I do not specify their code length
-     */
+    #[When('/^I specify their code length as (\d+)$/')]
+    #[When('I do not specify their code length')]
     public function iSpecifyTheirCodeLengthAs(?int $codeLength = null): void
     {
         $this->client->updateRequestData(['codeLength' => $codeLength]);
     }
 
-    /**
-     * @When /^I limit generated coupons usage to (\d+) times?$/
-     */
+    #[When('/^I limit generated coupons usage to (\d+) times?$/')]
     public function iSetGeneratedCouponsUsageLimitTo(int $limit): void
     {
         $this->client->updateRequestData(['usageLimit' => $limit]);
     }
 
-    /**
-     * @When I make generated coupons valid until :date
-     */
+    #[When('I make generated coupons valid until :date')]
     public function iMakeGeneratedCouponsValidUntil(\DateTimeInterface $date): void
     {
         $this->client->updateRequestData(['expiresAt' => $date->format('Y-m-d')]);
     }
 
-    /**
-     * @When I do not specify its :field
-     */
+    #[When('I do not specify its :field')]
     public function iDoNotSpecifyIts(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I (try to) generate these coupons
-     */
+    #[When('I (try to) generate these coupons')]
     public function iGenerateTheseCoupons(): void
     {
         $this->client->request();
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) number of uses$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) number of uses$/')]
     public function iSortCouponsByNumberOfUses(string $order): void
     {
         $this->sortBy($order, 'used');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) code$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) code$/')]
     public function iSortCouponsByCode(string $order): void
     {
         $this->sortBy($order, 'code');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) usage limit$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) usage limit$/')]
     public function iSortCouponsByUsageLimit(string $order): void
     {
         $this->sortBy($order, 'usageLimit');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) usage limit per customer$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) usage limit per customer$/')]
     public function iSortCouponsByPerCustomerUsageLimit(string $order): void
     {
         $this->sortBy($order, 'perCustomerUsageLimit');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) expiration date$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) expiration date$/')]
     public function iSortCouponsByExpirationDate(string $order): void
     {
         $this->sortBy($order, 'expiresAt');
     }
 
-    /**
-     * @Then /^there should(?:| still) be (\d+) coupons? related to (this promotion)$/
-     */
+    #[Then('/^there should(?:| still) be (\d+) coupons? related to (this promotion)$/')]
     public function thereShouldBeCountCouponsRelatedToThisPromotion(int $count, PromotionInterface $promotion): void
     {
         $coupons = $this->responseChecker->getCollection(
@@ -267,9 +216,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         Assert::same(count($coupons), $count);
     }
 
-    /**
-     * @Then there should be a :promotion promotion with a coupon code :code
-     */
+    #[Then('there should be a :promotion promotion with a coupon code :code')]
     public function thereShouldBeACouponWithCode(PromotionInterface $promotion, string $code): void
     {
         Assert::true(
@@ -281,9 +228,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then there should be no coupon with code :code
-     */
+    #[Then('there should be no coupon with code :code')]
     public function thereShouldBeNoCouponWithCode(string $code): void
     {
         Assert::false($this->responseChecker->hasItemWithValue(
@@ -293,17 +238,13 @@ final readonly class ManagingPromotionCouponsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see :count coupons on the list
-     */
+    #[Then('I should see :count coupons on the list')]
     public function iShouldSeeCountCouponsOnTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the first coupon should have code :code
-     */
+    #[Then('the first coupon should have code :code')]
     public function theFirstCouponShouldHaveCode(string $code): void
     {
         Assert::true($this->responseChecker->hasItemOnPositionWithValue(
@@ -314,9 +255,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -325,9 +264,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then this coupon should be valid until :date
-     */
+    #[Then('this coupon should be valid until :date')]
     public function thisCouponShouldBeValidUntil(\DateTime $date): void
     {
         $actualDate = \DateTime::createFromFormat(
@@ -341,9 +278,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then this coupon should have :limit usage limit
-     */
+    #[Then('this coupon should have :limit usage limit')]
     public function thisCouponShouldHaveUsageLimit(int $limit): void
     {
         Assert::same(
@@ -352,9 +287,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then this coupon should have :limit per customer usage limit
-     */
+    #[Then('this coupon should have :limit per customer usage limit')]
     public function thisCouponShouldHavePerCustomerUsageLimit(int $limit): void
     {
         Assert::same(
@@ -363,9 +296,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then this coupon should not be reusable from cancelled orders
-     */
+    #[Then('this coupon should not be reusable from cancelled orders')]
     public function thisCouponShouldNotBeReusableFromCancelledOrders(): void
     {
         Assert::false($this->responseChecker->getValue(
@@ -374,9 +305,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -385,9 +314,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this coupon) should no longer exist in the coupon registry$/
-     */
+    #[Then('/^(this coupon) should no longer exist in the coupon registry$/')]
     public function couponShouldNotExistInTheRegistry(PromotionCouponInterface $coupon): void
     {
         Assert::false($this->responseChecker->hasItemWithValue(
@@ -397,9 +324,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this coupon) should still exist in the registry$/
-     */
+    #[Then('/^(this coupon) should still exist in the registry$/')]
     public function couponShouldStillExistInTheRegistry(PromotionCouponInterface $coupon): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(
@@ -409,9 +334,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         ));
     }
 
-    /**
-     * @Then all of the coupon codes should be prefixed with :prefix
-     */
+    #[Then('all of the coupon codes should be prefixed with :prefix')]
     public function allOfTheCouponCodesShouldBePrefixedWith(string $prefix): void
     {
         foreach ($this->responseChecker->getCollection($this->client->getLastResponse()) as $promotionCoupon) {
@@ -419,9 +342,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         }
     }
 
-    /**
-     * @Then all of the coupon codes should be suffixed with :suffix
-     */
+    #[Then('all of the coupon codes should be suffixed with :suffix')]
     public function allOfTheCouponCodesShouldBeSuffixedWith(string $suffix): void
     {
         foreach ($this->responseChecker->getCollection($this->client->getLastResponse()) as $promotionCoupon) {
@@ -429,9 +350,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         }
     }
 
-    /**
-     * @Then /^there should still be only one coupon with code "([^"]+)" related to (this promotion)$/
-     */
+    #[Then('/^there should still be only one coupon with code "([^"]+)" related to (this promotion)$/')]
     public function thereShouldStillBeOnlyOneCouponWithCodeRelatedTo(string $code, PromotionInterface $promotion): void
     {
         $coupons = $this->responseChecker->getCollectionItemsWithValue(
@@ -443,9 +362,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         Assert::count($coupons, 1);
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedThatItIsInUseAndCannotBeDeleted(): void
     {
         Assert::contains(
@@ -454,9 +371,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code is required
-     */
+    #[Then('I should be notified that code is required')]
     public function iShouldBeNotifiedThatCodeIsRequired(): void
     {
         $response = $this->client->getLastResponse();
@@ -467,9 +382,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         Assert::same($this->responseChecker->getError($response), 'code: Please enter coupon code.');
     }
 
-    /**
-     * @Then I should be notified that coupon usage limit must be at least one
-     */
+    #[Then('I should be notified that coupon usage limit must be at least one')]
     public function iShouldBeNotifiedThatCouponUsageLimitMustBeAtLeastOne(): void
     {
         $response = $this->client->getLastResponse();
@@ -483,9 +396,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that coupon usage limit per customer must be at least one
-     */
+    #[Then('I should be notified that coupon usage limit per customer must be at least one')]
     public function iShouldBeNotifiedThatCouponUsageLimitPerCustomerMustBeAtLeastOne(): void
     {
         $response = $this->client->getLastResponse();
@@ -499,9 +410,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that promotion is required
-     */
+    #[Then('I should be notified that promotion is required')]
     public function iShouldBeNotifiedThatPromotionIsRequired(): void
     {
         $response = $this->client->getLastResponse();
@@ -515,9 +424,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that only coupon based promotions can have coupons
-     */
+    #[Then('I should be notified that only coupon based promotions can have coupons')]
     public function iShouldBeNotifiedThatOnlyCouponBasedPromotionsCanHaveCoupons(): void
     {
         $response = $this->client->getLastResponse();
@@ -531,9 +438,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that generating :amount coupons with code length equal to :codeLength is not possible
-     */
+    #[Then('I should be notified that generating :amount coupons with code length equal to :codeLength is not possible')]
     public function iShouldBeNotifiedThatGeneratingCouponsWithCodeLengthIsNotPossible(int $amount, int $codeLength): void
     {
         Assert::contains(
@@ -546,9 +451,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that generate amount is required
-     */
+    #[Then('I should be notified that generate amount is required')]
     public function iShouldBeNotifiedThatGenerateAmountIsRequired(): void
     {
         Assert::same(
@@ -557,9 +460,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that generate code length is required
-     */
+    #[Then('I should be notified that generate code length is required')]
     public function iShouldBeNotifiedThatCodeLengthIsRequired(): void
     {
         Assert::same(
@@ -568,9 +469,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that generate code length is out of range
-     */
+    #[Then('I should be notified that generate code length is out of range')]
     public function iShouldBeNotifiedThatCodeLengthIsOutOfRange(): void
     {
         Assert::same(
@@ -579,9 +478,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that they have been successfully generated
-     */
+    #[Then('I should be notified that they have been successfully generated')]
     public function iShouldBeNotifiedThatTheyHaveBeenSuccessfullyGenerated(): void
     {
         Assert::true(
@@ -590,9 +487,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that coupon with this code already exists
-     */
+    #[Then('I should be notified that coupon with this code already exists')]
     public function iShouldBeNotifiedThatCouponWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -606,9 +501,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -616,9 +509,7 @@ final readonly class ManagingPromotionCouponsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then /^("[^"]+" coupon) should be used (\d+) time(?:|s)$/
-     */
+    #[Then('/^("[^"]+" coupon) should be used (\d+) time(?:|s)$/')]
     public function couponShouldHaveUsageLimit(PromotionCouponInterface $promotionCoupon, int $used): void
     {
         $returnedPromotionCoupon = current($this->responseChecker->getCollectionItemsWithValue(
@@ -634,17 +525,13 @@ final readonly class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single promotion coupon in the list
-     */
+    #[Then('I should see a single promotion coupon in the list')]
     public function iShouldSeeASinglePromotionCouponInTheList(): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), 1);
     }
 
-    /**
-     * @Then I should see the promotion coupon :coupon in the list
-     */
+    #[Then('I should see the promotion coupon :coupon in the list')]
     public function iShouldSeeThePromotionCouponInTheList(PromotionCouponInterface $coupon): void
     {
         Assert::true($this->responseChecker->hasItemWithValue(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingPromotionsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -48,55 +50,43 @@ final readonly class ManagingPromotionsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to browse promotions
-     * @When I browse promotions
-     */
+    #[When('I want to browse promotions')]
+    #[When('I browse promotions')]
     public function iWantToBrowsePromotions(): void
     {
         $this->client->index(Resources::PROMOTIONS);
     }
 
-    /**
-     * @When I want to create a new promotion
-     */
+    #[When('I want to create a new promotion')]
     public function iWantToCreateANewPromotion(): void
     {
         $this->client->buildCreateRequest(Resources::PROMOTIONS);
     }
 
-    /**
-     * @When I want to modify a :promotion promotion
-     * @When /^I want to modify (this promotion)$/
-     * @When I modify a :promotion promotion
-     */
+    #[When('I want to modify a :promotion promotion')]
+    #[When('/^I want to modify (this promotion)$/')]
+    #[When('I modify a :promotion promotion')]
     public function iWantToModifyAPromotion(PromotionInterface $promotion): void
     {
         $this->client->buildUpdateRequest(Resources::PROMOTIONS, $promotion->getCode());
     }
 
-    /**
-     * @When I archive the :promotion promotion
-     */
+    #[When('I archive the :promotion promotion')]
     public function iArchiveThePromotion(PromotionInterface $promotion): void
     {
         $this->client->customItemAction(Resources::PROMOTIONS, $promotion->getCode(), Request::METHOD_PATCH, 'archive');
         $this->client->index(Resources::PROMOTIONS);
     }
 
-    /**
-     * @When I restore the :promotion promotion
-     */
+    #[When('I restore the :promotion promotion')]
     public function iRestoreThePromotion(PromotionInterface $promotion): void
     {
         $this->client->customItemAction(Resources::PROMOTIONS, $promotion->getCode(), Request::METHOD_PATCH, 'restore');
     }
 
-    /**
-     * @When I specify its :field as :value
-     * @When I do not specify its :field
-     * @When I :field it :value
-     */
+    #[When('I specify its :field as :value')]
+    #[When('I do not specify its :field')]
+    #[When('I :field it :value')]
     public function iSpecifyItsAs(string $field, ?string $value = null): void
     {
         if (null !== $value) {
@@ -104,67 +94,51 @@ final readonly class ManagingPromotionsContext implements Context
         }
     }
 
-    /**
-     * @When I set it as not applies to discounted by catalog promotion items
-     */
+    #[When('I set it as not applies to discounted by catalog promotion items')]
     public function iSetItAsNotAppliesToDiscountedByCatalogPromotionItems(): void
     {
         $this->client->updateRequestData(['appliesToDiscounted' => false]);
     }
 
-    /**
-     * @When I set its usage limit to :usageLimit
-     */
+    #[When('I set its usage limit to :usageLimit')]
     public function iSetItsUsageLimitTo(int $usageLimit): void
     {
         $this->client->addRequestData('usageLimit', $usageLimit);
     }
 
-    /**
-     * @When I set it as exclusive
-     */
+    #[When('I set it as exclusive')]
     public function iSetItAsExclusive(): void
     {
         $this->client->addRequestData('exclusive', true);
     }
 
-    /**
-     * @When I make it coupon based
-     */
+    #[When('I make it coupon based')]
     public function iMakeItCouponBased(): void
     {
         $this->client->addRequestData('couponBased', true);
     }
 
-    /**
-     * @When I set its priority to :priority
-     * @When I remove its priority
-     */
+    #[When('I set its priority to :priority')]
+    #[When('I remove its priority')]
     public function iRemoveItsPriority(?int $priority = null): void
     {
         $this->client->addRequestData('priority', $priority);
     }
 
-    /**
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iNameIt(string $name = ''): void
     {
         $this->client->addRequestData('name', $name);
     }
 
-    /**
-     * @When I make it applicable for the :channel channel
-     */
+    #[When('I make it applicable for the :channel channel')]
     public function iMakeItApplicableForTheChannel(ChannelInterface $channel): void
     {
         $this->client->addRequestData('channels', [$this->iriConverter->getIriFromResource($channel)]);
     }
 
-    /**
-     * @When I make it available from :startsDate to :endsDate
-     */
+    #[When('I make it available from :startsDate to :endsDate')]
     public function iMakeItAvailableFromTo(\DateTimeInterface $startsDate, \DateTimeInterface $endsDate): void
     {
         $this->client->updateRequestData([
@@ -173,9 +147,7 @@ final readonly class ManagingPromotionsContext implements Context
         ]);
     }
 
-    /**
-     * @When I specify its label as :label in :localeCode locale
-     */
+    #[When('I specify its label as :label in :localeCode locale')]
     public function iSpecifyItsLabelInLocaleCode(string $label, string $localeCode): void
     {
         $data['translations'][$localeCode]['label'] = $label;
@@ -183,17 +155,13 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When I replace its label with a string exceeding the limit in :localeCode locale
-     */
+    #[When('I replace its label with a string exceeding the limit in :localeCode locale')]
     public function iSpecifyItsLabelWithAStringExceedingTheLimitInLocale(string $localeCode): void
     {
         $this->iSpecifyItsLabelInLocaleCode(str_repeat('a', 256), $localeCode);
     }
 
-    /**
-     * @When /^I add the "([^"]+)" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "([^"]+)" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function iAddTheActionConfiguredWithAmountForChannel(
         string $actionType,
         int $amount,
@@ -214,9 +182,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When /^I add the "Item percentage discount" action configured with a percentage value of ("[^"]+") for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Item percentage discount" action configured with a percentage value of ("[^"]+") for ("[^"]+" channel)$/')]
     public function iAddTheActionConfiguredWithAPercentageValueForChannel(
         float $percentage,
         ChannelInterface $channel,
@@ -231,9 +197,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I add the "Item percentage discount" action configured without a percentage value for :channel channel
-     */
+    #[When('I add the "Item percentage discount" action configured without a percentage value for :channel channel')]
     public function iAddTheActionConfiguredWithoutAPercentageValueForChannel(ChannelInterface $channel): void
     {
         $this->addToRequestAction(
@@ -246,10 +210,8 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When /^I add the "([^"]+)" action configured with a percentage value of ("[^"]+")$/
-     * @When I add the :actionType action configured without a percentage value
-     */
+    #[When('/^I add the "([^"]+)" action configured with a percentage value of ("[^"]+")$/')]
+    #[When('I add the :actionType action configured without a percentage value')]
     public function iAddTheActionConfiguredWithAPercentageValue(string $actionType, ?float $percentage = null): void
     {
         $actionTypeMapping = [
@@ -265,9 +227,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When /^it is(?:| also) configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^it is(?:| also) configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function itIsConfiguredWithAmountForChannel(float $amount, ChannelInterface $channel): void
     {
         $actions = $this->getActions();
@@ -276,9 +236,7 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I edit (this promotion) percentage action to have ("[^"]+")$/
-     */
+    #[When('/^I edit (this promotion) percentage action to have ("[^"]+")$/')]
     public function iEditPromotionToHaveDiscount(PromotionInterface $promotion, float $percentage): void
     {
         $actions = $this->getActions();
@@ -287,9 +245,7 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price greater than "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price greater than "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMinPriceFilterRangeForChannel(ChannelInterface $channel, int|string $minimum): void
     {
         $actions = $this->getActions();
@@ -298,9 +254,7 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price lesser than "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price lesser than "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMaxPriceFilterRangeForChannel(ChannelInterface $channel, int|string $maximum): void
     {
         $actions = $this->getActions();
@@ -309,18 +263,14 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price between "(?:€|£|\$)([^"]+)" and "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price between "(?:€|£|\$)([^"]+)" and "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMinMaxPriceFilterRangeForChannel(ChannelInterface $channel, int $minimum, int $maximum): void
     {
         $this->iAddAMinPriceFilterRangeForChannel($channel, $minimum);
         $this->iAddAMaxPriceFilterRangeForChannel($channel, $maximum);
     }
 
-    /**
-     * @When I specify that this action should be applied to items from :taxon category for :channel channel
-     */
+    #[When('I specify that this action should be applied to items from :taxon category for :channel channel')]
     public function iSpecifyThatThisActionShouldBeAppliedToItemsFromCategory(
         TaxonInterface $taxon,
         ChannelInterface $channel,
@@ -331,9 +281,7 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When I specify that this action should be applied to the :product product for :channel channel
-     */
+    #[When('I specify that this action should be applied to the :product product for :channel channel')]
     public function iSpecifyThatThisActionShouldBeAppliedToTheProduct(
         ProductInterface $product,
         ChannelInterface $channel,
@@ -344,10 +292,8 @@ final readonly class ManagingPromotionsContext implements Context
         $this->client->addRequestData('actions', $actions);
     }
 
-    /**
-     * @When /^I add the "Has at least one from taxons" rule configured with ("[^"]+" taxon)$/
-     * @When /^I add the "Has at least one from taxons" rule configured with ("[^"]+" taxon) and ("[^"]+" taxon)$/
-     */
+    #[When('/^I add the "Has at least one from taxons" rule configured with ("[^"]+" taxon)$/')]
+    #[When('/^I add the "Has at least one from taxons" rule configured with ("[^"]+" taxon) and ("[^"]+" taxon)$/')]
     public function iAddTheHasTaxonRuleConfiguredWith(TaxonInterface ...$taxons): void
     {
         $this->addToRequestRule(
@@ -358,9 +304,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When /^I add the "Total price of items from taxon" rule configured with ("[^"]+" taxon) and ("[^"]+") amount for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Total price of items from taxon" rule configured with ("[^"]+" taxon) and ("[^"]+") amount for ("[^"]+" channel)$/')]
     public function iAddTheRuleConfiguredWith(TaxonInterface $taxon, int $amount, ChannelInterface $channel): void
     {
         $this->addToRequestRule(
@@ -374,9 +318,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When /^I add the "Item total" rule configured with ("[^"]+") amount for ("[^"]+" channel) and ("[^"]+") amount for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Item total" rule configured with ("[^"]+") amount for ("[^"]+" channel) and ("[^"]+") amount for ("[^"]+" channel)$/')]
     public function iAddTheItemTotalRuleConfiguredWithTwoChannel(
         int $firstAmount,
         ChannelInterface $firstChannel,
@@ -396,9 +338,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I add the "Contains product" rule configured with the :product product
-     */
+    #[When('I add the "Contains product" rule configured with the :product product')]
     public function iAddTheRuleConfiguredWithTheProduct(ProductInterface $product): void
     {
         $this->addToRequestRule(
@@ -409,9 +349,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I add the "Customer group" rule for :customerGroup group
-     */
+    #[When('I add the "Customer group" rule for :customerGroup group')]
     public function iAddTheCustomerGroupRuleConfiguredForGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->addToRequestRule(
@@ -422,37 +360,29 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I filter promotions by coupon code equal :value
-     */
+    #[When('I filter promotions by coupon code equal :value')]
     public function iFilterPromotionsByCouponCodeEqual(string $value): void
     {
         $this->client->addFilter('coupons.code', $value);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter archival promotions
-     */
+    #[When('I filter archival promotions')]
     public function iFilterArchivalPromotions(): void
     {
         $this->client->addFilter('exists[archivedAt]', true);
         $this->client->filter();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @Then I should see a single promotion in the list
-     * @Then there should be :amount promotions
-     */
+    #[Then('I should see a single promotion in the list')]
+    #[Then('there should be :amount promotions')]
     public function thereShouldBePromotion(int $amount = 1): void
     {
         Assert::same(
@@ -461,12 +391,10 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotionName promotion should appear in the registry
-     * @Then the :promotionName promotion should exist in the registry
-     * @Then promotion :promotionName should still exist in the registry
-     * @Then this promotion should still be named :promotionName
-     */
+    #[Then('the :promotionName promotion should appear in the registry')]
+    #[Then('the :promotionName promotion should exist in the registry')]
+    #[Then('promotion :promotionName should still exist in the registry')]
+    #[Then('this promotion should still be named :promotionName')]
     public function thePromotionShouldAppearInTheRegistry(string $promotionName): void
     {
         Assert::true(
@@ -475,9 +403,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the promotion :promotionName in the list
-     */
+    #[Then('I should see the promotion :promotionName in the list')]
     public function iShouldSeeThePromotionInTheList(string $promotionName): void
     {
         Assert::true(
@@ -486,9 +412,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the promotion :promotionName in the list
-     */
+    #[Then('I should not see the promotion :promotionName in the list')]
     public function iShouldNotSeeThePromotionInTheList(string $promotionName): void
     {
         Assert::false(
@@ -497,9 +421,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this promotion) should be coupon based$/
-     */
+    #[Then('/^(this promotion) should be coupon based$/')]
     public function thisPromotionShouldBeCouponBased(PromotionInterface $promotion): void
     {
         $returnedPromotion = current($this->responseChecker->getCollectionItemsWithValue(
@@ -514,9 +436,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be able to manage coupons for (this promotion)$/
-     */
+    #[Then('/^I should be able to manage coupons for (this promotion)$/')]
     public function iShouldBeAbleToManageCouponsForThisPromotion(PromotionInterface $promotion): void
     {
         $returnedPromotion = current($this->responseChecker->getCollectionItemsWithValue(
@@ -528,18 +448,14 @@ final readonly class ManagingPromotionsContext implements Context
         Assert::keyExists($returnedPromotion, 'coupons');
     }
 
-    /**
-     * @When /^I delete a ("([^"]+)" promotion)$/
-     * @When /^I try to delete a ("([^"]+)" promotion)$/
-     */
+    #[When('/^I delete a ("([^"]+)" promotion)$/')]
+    #[When('/^I try to delete a ("([^"]+)" promotion)$/')]
     public function iDeletePromotion(PromotionInterface $promotion): void
     {
         $this->client->delete(Resources::PROMOTIONS, $promotion->getCode());
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -548,9 +464,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this promotion) should no longer exist in the promotion registry$/
-     */
+    #[Then('/^(this promotion) should no longer exist in the promotion registry$/')]
     public function promotionShouldNotExistInTheRegistry(PromotionInterface $promotion): void
     {
         $response = $this->client->index(Resources::PROMOTIONS);
@@ -562,26 +476,20 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotionName promotion should be successfully created
-     */
+    #[Then('the :promotionName promotion should be successfully created')]
     public function thePromotionShouldBeSuccessfullyCreated(string $promotionName): void
     {
         $this->iShouldBeNotifiedThatItHasBeenSuccessfullyCreated();
         $this->thePromotionShouldAppearInTheRegistry($promotionName);
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true($this->responseChecker->isCreationSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then the :promotion promotion should not applies to discounted items
-     */
+    #[Then('the :promotion promotion should not applies to discounted items')]
     public function thePromotionShouldNotAppliesToDiscountedItems(PromotionInterface $promotion): void
     {
         Assert::false(
@@ -589,9 +497,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotion promotion should be available to be used only :usageLimit times
-     */
+    #[Then('the :promotion promotion should be available to be used only :usageLimit times')]
     public function thePromotionShouldBeAvailableToUseOnlyTimes(PromotionInterface $promotion, int $usageLimit): void
     {
         Assert::true(
@@ -603,9 +509,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotion promotion should be exclusive
-     */
+    #[Then('the :promotion promotion should be exclusive')]
     public function thePromotionShouldBeExclusive(PromotionInterface $promotion): void
     {
         Assert::true(
@@ -616,9 +520,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotion promotion should be coupon based
-     */
+    #[Then('the :promotion promotion should be coupon based')]
     public function thePromotionShouldBeCouponBased(PromotionInterface $promotion): void
     {
         Assert::true(
@@ -629,9 +531,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the :promotion promotion should be applicable for the :channel channel
-     */
+    #[Then('the :promotion promotion should be applicable for the :channel channel')]
     public function thePromotionShouldBeApplicableForTheChannel(PromotionInterface $promotion, ChannelInterface $channel): void
     {
         Assert::true(
@@ -643,9 +543,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When the :promotion promotion should have a label :label in :localeCode locale
-     */
+    #[When('the :promotion promotion should have a label :label in :localeCode locale')]
     public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $localeCode): void
     {
         $response = $this->client->show(Resources::PROMOTIONS, $promotion->getCode());
@@ -653,9 +551,7 @@ final readonly class ManagingPromotionsContext implements Context
         Assert::true($this->responseChecker->hasTranslation($response, $localeCode, 'label', $label));
     }
 
-    /**
-     * @Then /^it should have ("[^"]+") of item percentage discount configured for ("[^"]+" channel)$/
-     */
+    #[Then('/^it should have ("[^"]+") of item percentage discount configured for ("[^"]+" channel)$/')]
     public function itShouldHaveOfItemPercentageDiscount(float $percentage, ChannelInterface $channel): void
     {
         $actions = $this->responseChecker->getValue($this->client->getLastResponse(), 'actions');
@@ -666,18 +562,14 @@ final readonly class ManagingPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then /^it should have ("[^"]+") of order percentage discount$/
-     */
+    #[Then('/^it should have ("[^"]+") of order percentage discount$/')]
     public function itShouldHaveOfOrderPercentageDiscount(float $percentage): void
     {
         $actions = $this->responseChecker->getValue($this->client->getLastResponse(), 'actions');
         Assert::same((float) $actions[0]['configuration']['percentage'], $percentage);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -685,9 +577,7 @@ final readonly class ManagingPromotionsContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then the :promotion promotion should be available from :startsDate to :endsDate
-     */
+    #[Then('the :promotion promotion should be available from :startsDate to :endsDate')]
     public function thePromotionShouldBeAvailableFromTo(
         PromotionInterface $promotion,
         \DateTimeInterface $startsDate,
@@ -705,9 +595,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be able to modify a :promotion promotion
-     */
+    #[Then('I should be able to modify a :promotion promotion')]
     public function iShouldBeAbleToModifyAPromotion(PromotionInterface $promotion): void
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -716,9 +604,7 @@ final readonly class ManagingPromotionsContext implements Context
         Assert::true($this->responseChecker->hasValue($this->client->update(), 'name', 'NEW_NAME'));
     }
 
-    /**
-     * @Then the :promotion promotion should have priority :priority
-     */
+    #[Then('the :promotion promotion should have priority :priority')]
     public function thePromotionsShouldHavePriority(PromotionInterface $promotion, int $priority): void
     {
         Assert::true(
@@ -732,9 +618,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedThatItIsIUseAndCannotBeDeleted(): void
     {
         Assert::contains(
@@ -743,9 +627,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that promotion with this code already exists
-     */
+    #[Then('I should be notified that promotion with this code already exists')]
     public function iShouldBeNotifiedThatPromotionWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -756,9 +638,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one promotion with :element :value
-     */
+    #[Then('there should still be only one promotion with :element :value')]
     public function thereShouldStillBeOnlyOnePromotionWith(string $element, string $value): void
     {
         Assert::count(
@@ -767,17 +647,13 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then promotion with :element :value should not be added
-     */
+    #[Then('promotion with :element :value should not be added')]
     public function promotionWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false($this->responseChecker->hasItemWithValue($this->client->index(Resources::PROMOTIONS), $element, $value));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -786,9 +662,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that promotion cannot end before it starts
-     */
+    #[Then('I should be notified that promotion cannot end before it starts')]
     public function iShouldBeNotifiedThatPromotionCannotEndBeforeItsEvenStarts(): void
     {
         Assert::contains(
@@ -797,9 +671,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that promotion label in :localeCode locale is too long
-     */
+    #[Then('I should be notified that promotion label in :localeCode locale is too long')]
     public function iShouldBeNotifiedThatPromotionLabelIsTooLong(string $localeCode): void
     {
         Assert::contains(
@@ -808,9 +680,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this value should not be blank
-     */
+    #[Then('I should be notified that this value should not be blank')]
     public function iShouldBeNotifiedThatThisValueShouldNotBeBlank(): void
     {
         Assert::contains(
@@ -819,11 +689,9 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a percentage discount value must be between 0% and 100%
-     * @Then I should be notified that a percentage discount value must be at least 0%
-     * @Then I should be notified that the maximum value of a percentage discount is 100%
-     */
+    #[Then('I should be notified that a percentage discount value must be between 0% and 100%')]
+    #[Then('I should be notified that a percentage discount value must be at least 0%')]
+    #[Then('I should be notified that the maximum value of a percentage discount is 100%')]
     public function iShouldBeNotifiedThatPercentageDiscountShouldBeBetween(): void
     {
         Assert::contains(
@@ -832,9 +700,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a minimum value should be a numeric value
-     */
+    #[Then('I should be notified that a minimum value should be a numeric value')]
     public function iShouldBeNotifiedThatAMinimalValueShouldBeNumeric(): void
     {
         Assert::contains(
@@ -843,9 +709,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a maximum value should be a numeric value
-     */
+    #[Then('I should be notified that a maximum value should be a numeric value')]
     public function iShouldBeNotifiedThatAMaximumValueShouldBeNumeric(): void
     {
         Assert::contains(
@@ -854,18 +718,14 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count promotions on the list
-     * @Then I should see a single promotion on the list
-     */
+    #[Then('I should see :count promotions on the list')]
+    #[Then('I should see a single promotion on the list')]
     public function iShouldSeePromotionInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then /^the (first|last) promotion on the list should have ([^"]+) "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) promotion on the list should have ([^"]+) "([^"]+)"$/')]
     public function theFirstPromotionOnTheListShouldHave(string $togglePosition, string $field, string $value): void
     {
         $items = $this->responseChecker->getValue($this->client->getLastResponse(), 'hydra:member');
@@ -878,10 +738,8 @@ final readonly class ManagingPromotionsContext implements Context
         Assert::same($item[$field], $value);
     }
 
-    /**
-     * @Then the promotion :promotion should be used :usage time(s)
-     * @Then the promotion :promotion should not be used
-     */
+    #[Then('the promotion :promotion should be used :usage time(s)')]
+    #[Then('the promotion :promotion should not be used')]
     public function thePromotionShouldBeUsedTime(PromotionInterface $promotion, int $usage = 0): void
     {
         $returnedPromotion = current($this->responseChecker->getCollectionItemsWithValue(
@@ -897,9 +755,7 @@ final readonly class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be viewing non archival promotions
-     */
+    #[Then('I should be viewing non archival promotions')]
     public function iShouldBeViewingNonArchivalPromotions(): void
     {
         $this->client->index(Resources::PROMOTIONS);

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShipmentsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -41,25 +43,19 @@ final class ManagingShipmentsContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse shipments
-     */
+    #[When('I browse shipments')]
     public function iBrowseShipments(): void
     {
         $this->client->index(Resources::SHIPMENTS);
     }
 
-    /**
-     * @When I choose :state as a shipment state
-     */
+    #[When('I choose :state as a shipment state')]
     public function iChooseShipmentState(string $state): void
     {
         $this->client->addFilter('state', $state);
     }
 
-    /**
-     * @When I move to the details of first shipment's order
-     */
+    #[When('I move to the details of first shipment\'s order')]
     public function iMoveToDetailsOfFirstShipment(): void
     {
         $firstShipment = $this->responseChecker->getCollection($this->client->getLastResponse())[0];
@@ -67,33 +63,25 @@ final class ManagingShipmentsContext implements Context
         $this->client->showByIri($firstShipment['order']);
     }
 
-    /**
-     * @When I choose :channel as a channel filter
-     */
+    #[When('I choose :channel as a channel filter')]
     public function iChooseChannelAsAChannelFilter(ChannelInterface $channel): void
     {
         $this->client->addFilter('order.channel.code', $channel->getCode());
     }
 
-    /**
-     * @When I choose :shippingMethod as a shipping method filter
-     */
+    #[When('I choose :shippingMethod as a shipping method filter')]
     public function iChooseAsAShippingMethodFilter(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->addFilter('method.code', $shippingMethod->getCode());
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->client->filter();
     }
 
-    /**
-     * @When I view the first shipment of the order :order
-     */
+    #[When('I view the first shipment of the order :order')]
     public function iViewTheShipmentOfTheOrder(OrderInterface $order): void
     {
         $response = $this->client->show(Resources::SHIPMENTS, (string) $order->getShipments()->first()->getId());
@@ -101,26 +89,20 @@ final class ManagingShipmentsContext implements Context
         $this->sharedStorage->set('response', $response);
     }
 
-    /**
-     * @Then I should see( only) :count shipment(s) in the list
-     * @Then I should see a single shipment in the list
-     */
+    #[Then('I should see( only) :count shipment(s) in the list')]
+    #[Then('I should see a single shipment in the list')]
     public function iShouldSeeCountShipmentsInList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @When I ship the shipment of order :order
-     */
+    #[When('I ship the shipment of order :order')]
     public function iShipShipmentOfOrder(OrderInterface $order): void
     {
         $this->client->applyTransition(Resources::SHIPMENTS, (string) $order->getShipments()->first()->getId(), ShipmentTransitions::TRANSITION_SHIP);
     }
 
-    /**
-     * @When I try to ship the shipment of order :order
-     */
+    #[When('I try to ship the shipment of order :order')]
     public function iTryToShipShipmentOfOrder(OrderInterface $order): void
     {
         /** @var ShipmentInterface $shipment */
@@ -132,9 +114,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @When I ship the shipment of order :order with :trackingCode tracking code
-     */
+    #[When('I ship the shipment of order :order with :trackingCode tracking code')]
     public function iShipTheShipmentOfOrderWithTrackingCode(OrderInterface $order, string $trackingCode): void
     {
         $this->client->applyTransition(
@@ -145,9 +125,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the shipment has been successfully shipped
-     */
+    #[Then('I should be notified that the shipment has been successfully shipped')]
     public function iShouldBeNotifiedThatTheShipmentHasBeenSuccessfullyShipped(): void
     {
         Assert::true(
@@ -156,9 +134,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that shipment has been already shipped
-     */
+    #[Then('I should be notified that shipment has been already shipped')]
     public function iShouldBeNotifiedThatTheShipmentHasBeenAlreadyShipped(): void
     {
         Assert::contains(
@@ -168,9 +144,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see the shipment of (order "[^"]+") as "([^"]+)"$/
-     */
+    #[Then('/^I should see the shipment of (order "[^"]+") as "([^"]+)"$/')]
     public function iShouldSeeTheShipmentOfOrderAs(OrderInterface $order, string $shippingState): void
     {
         Assert::true(
@@ -182,9 +156,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see shipment for the ("[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/
-     */
+    #[Then('/^I should see shipment for the ("[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/')]
     public function iShouldSeeShipmentForTheOrderInTheList(OrderInterface $order, int $position): void
     {
         Assert::true(
@@ -198,9 +170,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the shipment of order :order shipped at :dateTime
-     */
+    #[Then('I should see the shipment of order :order shipped at :dateTime')]
     public function iShouldSeeTheShippingDateAs(OrderInterface $order, string $dateTime): void
     {
         Assert::eq(
@@ -210,10 +180,8 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then the shipment of the :orderNumber order should be :shippingState for :customer
-     * @Then the shipment of the :orderNumber order should be :shippingState for :customer in :channel channel
-     */
+    #[Then('the shipment of the :orderNumber order should be :shippingState for :customer')]
+    #[Then('the shipment of the :orderNumber order should be :shippingState for :customer in :channel channel')]
     public function shipmentOfOrderShouldBe(
         string $orderNumber,
         string $shippingState,
@@ -250,9 +218,7 @@ final class ManagingShipmentsContext implements Context
         throw new \InvalidArgumentException('There is no shipment with given data');
     }
 
-    /**
-     * @Then I should see a shipment of order :order
-     */
+    #[Then('I should see a shipment of order :order')]
     public function iShouldSeeShipmentWithOrderNumber(OrderInterface $order): void
     {
         Assert::true(
@@ -261,9 +227,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see a shipment of order :order
-     */
+    #[Then('I should not see a shipment of order :order')]
     public function iShouldNotSeeShipmentWithOrderNumber(OrderInterface $order): void
     {
         Assert::false(
@@ -272,9 +236,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :amount :product units in the list
-     */
+    #[Then('I should see :amount :product units in the list')]
     public function iShouldSeeUnitsInTheList(int $amount, ProductInterface $product): void
     {
         $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
@@ -301,9 +263,7 @@ final class ManagingShipmentsContext implements Context
         Assert::same($productUnitsCounter, $amount);
     }
 
-    /**
-     * @Then I should see the details of order :order
-     */
+    #[Then('I should see the details of order :order')]
     public function iShouldSeeOrderWithDetails(OrderInterface $order): void
     {
         Assert::same(
@@ -313,9 +273,7 @@ final class ManagingShipmentsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the shipment state as :shipmentState
-     */
+    #[Then('I should see the shipment state as :shipmentState')]
     public function iShouldSeeTheShipmentStateAs(string $shipmentState): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShippingCategoriesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,50 +33,38 @@ final class ManagingShippingCategoriesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new shipping category
-     */
+    #[When('I want to create a new shipping category')]
     public function iWantToCreateANewShippingCategory(): void
     {
         $this->client->buildCreateRequest(Resources::SHIPPING_CATEGORIES);
     }
 
-    /**
-     * @When I want to modify a shipping category :shippingCategory
-     */
+    #[When('I want to modify a shipping category :shippingCategory')]
     public function iWantToModifyAShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
         $this->client->buildUpdateRequest(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I delete shipping category :shippingCategory
-     */
+    #[When('I delete shipping category :shippingCategory')]
     public function iDeleteShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
         $this->client->delete(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
-    /**
-     * @When I browse shipping categories
-     */
+    #[When('I browse shipping categories')]
     public function iBrowseShippingCategories(): void
     {
         $this->client->index(Resources::SHIPPING_CATEGORIES);
     }
 
-    /**
-     * @When I do not specify its code
-     * @When I specify its code as :code
-     */
+    #[When('I do not specify its code')]
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -82,11 +72,9 @@ final class ManagingShippingCategoriesContext implements Context
         }
     }
 
-    /**
-     * @When I name it :name
-     * @When I do not specify its name
-     * @When I rename it to :name
-     */
+    #[When('I name it :name')]
+    #[When('I do not specify its name')]
+    #[When('I rename it to :name')]
     public function iNameIt(?string $name = null): void
     {
         if ($name !== null) {
@@ -94,25 +82,19 @@ final class ManagingShippingCategoriesContext implements Context
         }
     }
 
-    /**
-     * @When I modify a shipping category :shippingCategory
-     */
+    #[When('I modify a shipping category :shippingCategory')]
     public function iModifyAShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
         $this->client->buildUpdateRequest(Resources::SHIPPING_CATEGORIES, $shippingCategory->getCode());
     }
 
-    /**
-     * @When I specify its description as :description
-     */
+    #[When('I specify its description as :description')]
     public function iSpecifyItsDescriptionAs(string $description): void
     {
         $this->client->addRequestData('description', $description);
     }
 
-    /**
-     * @Then I should be notified that shipping category with this code already exists
-     */
+    #[Then('I should be notified that shipping category with this code already exists')]
     public function iShouldBeNotifiedThatShippingCategoryWithThisCodeAlreadyExists(): void
     {
         Assert::same(
@@ -121,9 +103,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::same(
@@ -132,19 +112,15 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single shipping category in the list
-     * @Then I should see :count shipping categories in the list
-     */
+    #[Then('I should see a single shipping category in the list')]
+    #[Then('I should see :count shipping categories in the list')]
     public function iShouldSeeShippingCategoriesInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::SHIPPING_CATEGORIES)), $count);
     }
 
-    /**
-     * @Then the shipping category :shippingMethodName should be in the registry
-     * @Then the shipping category :shippingMethodName should appear in the registry
-     */
+    #[Then('the shipping category :shippingMethodName should be in the registry')]
+    #[Then('the shipping category :shippingMethodName should appear in the registry')]
     public function theShippingCategoryShouldAppearInTheRegistry(string $shippingCategoryName): void
     {
         Assert::true(
@@ -153,9 +129,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then shipping category with name :name should not be added
-     */
+    #[Then('shipping category with name :name should not be added')]
     public function shippingCategoryWithNameShouldNotBeAdded(string $name): void
     {
         Assert::false(
@@ -164,9 +138,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping category) should no longer exist in the registry$/
-     */
+    #[Then('/^(this shipping category) should no longer exist in the registry$/')]
     public function thisShippingCategoryShouldNoLongerExistInTheRegistry(
         ShippingCategoryInterface $shippingCategory,
     ): void {
@@ -177,9 +149,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', 'NEW_CODE');
@@ -190,9 +160,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one shipping category with code :code
-     */
+    #[Then('there should still be only one shipping category with code :code')]
     public function thereShouldStillBeOnlyOneShippingCategoryWith(string $code): void
     {
         Assert::same(
@@ -201,9 +169,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then this shipping category name should be :name
-     */
+    #[Then('this shipping category name should be :name')]
     public function thisShippingCategoryNameShouldBe(string $name): void
     {
         Assert::true(
@@ -212,9 +178,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -223,9 +187,7 @@ final class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingShippingMethodsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -43,9 +46,7 @@ final readonly class ManagingShippingMethodsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing archival shipping methods
-     */
+    #[Given('I am browsing archival shipping methods')]
     public function iAmBrowsingArchivalShippingMethods(): void
     {
         $this->client->index(Resources::SHIPPING_METHODS);
@@ -53,11 +54,9 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @Given the shipping methods are already sorted :sortType by name
-     * @When I sort the shipping methods :sortType by name
-     * @When I switch the way shipping methods are sorted :sortType by name
-     */
+    #[Given('the shipping methods are already sorted :sortType by name')]
+    #[When('I sort the shipping methods :sortType by name')]
+    #[When('I switch the way shipping methods are sorted :sortType by name')]
     public function iSortShippingMethodsByName(string $sortType = 'ascending'): void
     {
         $this->client->sort([
@@ -66,9 +65,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When I add the :rule rule configured with :weight
-     */
+    #[When('I add the :rule rule configured with :weight')]
     public function iAddTheRuleConfiguredWithWeight(string $rule, int $weight): void
     {
         $type = StringInflector::nameToLowercaseCode($rule);
@@ -80,9 +77,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]]);
     }
 
-    /**
-     * @When I add the "Total weight greater than or equal" rule configured with invalid data
-     */
+    #[When('I add the "Total weight greater than or equal" rule configured with invalid data')]
     public function iAddTheTotalWeightGreaterThanOrEqualRuleConfiguredWithInvalidData(): void
     {
         $this->client->addRequestData('rules', [
@@ -95,9 +90,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I add the "([^"]+)" rule configured with (?:€|£|\$)([^"]+) for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "([^"]+)" rule configured with (?:€|£|\$)([^"]+) for ("[^"]+" channel)$/')]
     public function iAddTheRuleConfiguredWithForChannel(string $rule, int $value, ChannelInterface $channel): void
     {
         match ($rule) {
@@ -125,9 +118,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         };
     }
 
-    /**
-     * @When /^I add the "Items total less than or equal" rule configured with invalid data for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Items total less than or equal" rule configured with invalid data for ("[^"]+" channel)$/')]
     public function iAddTheItemsTotalLessThanOrEqualRuleConfiguredWithInvalidData(ChannelInterface $channel): void
     {
         $this->client->addRequestData('rules', [
@@ -142,9 +133,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When I change my locale to :localeCode
-     */
+    #[When('I change my locale to :localeCode')]
     public function iSwitchTheLocaleToTheLocale(string $localeCode): void
     {
         /** @var AdminUserInterface $adminUser */
@@ -156,12 +145,10 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When I am browsing shipping methods
-     * @When I want to browse shipping methods
-     * @When I try to browse shipping methods
-     * @When I browse shipping methods
-     */
+    #[When('I am browsing shipping methods')]
+    #[When('I want to browse shipping methods')]
+    #[When('I try to browse shipping methods')]
+    #[When('I browse shipping methods')]
     public function iBrowseShippingMethods(): void
     {
         $response = $this->client->index(Resources::SHIPPING_METHODS);
@@ -169,26 +156,20 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->sharedStorage->set('response', $response);
     }
 
-    /**
-     * @When I (try to )delete shipping method :shippingMethod
-     */
+    #[When('I (try to )delete shipping method :shippingMethod')]
     public function iDeleteShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->delete(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
-    /**
-     * @When I want to create a new shipping method
-     * @When I try to create a new shipping method
-     */
+    #[When('I want to create a new shipping method')]
+    #[When('I try to create a new shipping method')]
     public function iWantToCreateANewShippingMethod(): void
     {
         $this->client->buildCreateRequest(Resources::SHIPPING_METHODS);
     }
 
-    /**
-     * @When I try to create a new shipping method with valid data
-     */
+    #[When('I try to create a new shipping method with valid data')]
     public function iTryToCreateANewShippingMethodWithValidData(): void
     {
         $this->client->buildCreateRequest(Resources::SHIPPING_METHODS);
@@ -202,9 +183,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]);
     }
 
-    /**
-     * @When I do not specify amount for :calculatorName calculator
-     */
+    #[When('I do not specify amount for :calculatorName calculator')]
     public function iDoNotSpecifyAmountForCalculator(string $calculatorName): void
     {
         match ($calculatorName) {
@@ -217,61 +196,47 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->client->addRequestData('configuration', [$channelCode => ['amount' => null]]);
     }
 
-    /**
-     * @When I remove its zone
-     */
+    #[When('I remove its zone')]
     public function iRemoveItsZone(): void
     {
         $this->client->replaceRequestData('zone', null);
     }
 
-    /**
-     * @When I try to show :shippingMethod shipping method
-     */
+    #[When('I try to show :shippingMethod shipping method')]
     public function iTryToShowShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->show(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = ''): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I specify its position as :position
-     */
+    #[When('I specify its position as :position')]
     public function iSpecifyItsPositionAs(int $position): void
     {
         $this->client->addRequestData('position', $position);
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I rename it to :name in :localeCode
-     * @When I do not name it
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I rename it to :name in :localeCode')]
+    #[When('I do not name it')]
+    #[When('I remove its name from :localeCode translation')]
     public function iNameItIn(?string $name = '', ?string $localeCode = 'en_US'): void
     {
         $this->client->updateRequestData(['translations' => [$localeCode => ['name' => $name]]]);
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $data = ['translations' => [$localeCode => []]];
@@ -280,10 +245,8 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->client->updateRequestData($data);
     }
 
-    /**
-     * @When /^I define it for the (zone named "[^"]+")$/
-     * @When I do not specify its zone
-     */
+    #[When('/^I define it for the (zone named "[^"]+")$/')]
+    #[When('I do not specify its zone')]
     public function iDefineItForTheZone(?ZoneInterface $zone = null): void
     {
         if (null !== $zone) {
@@ -291,120 +254,92 @@ final readonly class ManagingShippingMethodsContext implements Context
         }
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->client->addRequestData('enabled', false);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->client->addRequestData('enabled', true);
     }
 
-    /**
-     * @When I make it available in channel :channel
-     */
+    #[When('I make it available in channel :channel')]
     public function iMakeItAvailableInChannel(ChannelInterface $channel): void
     {
         $this->client->addRequestData('channels', [$this->iriConverter->getIriFromResource($channel)]);
     }
 
-    /**
-     * @When I choose :shippingCalculator calculator
-     */
+    #[When('I choose :shippingCalculator calculator')]
     public function iChooseCalculator(string $shippingCalculator): void
     {
         $this->client->addRequestData('calculator', $shippingCalculator);
     }
 
-    /**
-     * @When I (try to) archive the :shippingMethod shipping method
-     */
+    #[When('I (try to) archive the :shippingMethod shipping method')]
     public function iArchiveTheShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->customItemAction(Resources::SHIPPING_METHODS, $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'archive');
         $this->client->index(Resources::SHIPPING_METHODS);
     }
 
-    /**
-     * @When I (try to) restore the :shippingMethod shipping method
-     */
+    #[When('I (try to) restore the :shippingMethod shipping method')]
     public function iTryToRestoreTheShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->customItemAction(Resources::SHIPPING_METHODS, $shippingMethod->getCode(), HttpRequest::METHOD_PATCH, 'restore');
     }
 
-    /**
-     * @When I specify its amount as :amount for :channel channel
-     */
+    #[When('I specify its amount as :amount for :channel channel')]
     public function iSpecifyItsAmountAsForChannel(ChannelInterface $channel, int $amount): void
     {
         $this->client->addRequestData('configuration', [$channel->getCode() => ['amount' => $amount]]);
     }
 
-    /**
-     * @When I want to modify a shipping method :shippingMethod
-     * @When I try to modify a shipping method :shippingMethod
-     * @When /^I want to modify (this shipping method)$/
-     */
+    #[When('I want to modify a shipping method :shippingMethod')]
+    #[When('I try to modify a shipping method :shippingMethod')]
+    #[When('/^I want to modify (this shipping method)$/')]
     public function iWantToModifyShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->client->buildUpdateRequest(Resources::SHIPPING_METHODS, $shippingMethod->getCode());
     }
 
-    /**
-     * @When I sort the shipping methods :sortType by code
-     * @When I switch the way shipping methods are sorted :sortType by code
-     */
+    #[When('I sort the shipping methods :sortType by code')]
+    #[When('I switch the way shipping methods are sorted :sortType by code')]
     public function iSortShippingMethodsByCode(string $sortType = 'ascending'): void
     {
         $this->client->sort(['code' => self::SORT_TYPES[$sortType]]);
     }
 
-    /**
-     * @When I switch the way shipping methods are sorted by code
-     */
+    #[When('I switch the way shipping methods are sorted by code')]
     public function iSwitchTheWayShippingMethodsAreSortedByCode(): void
     {
         $this->client->sort(['code' => 'desc']);
     }
 
-    /**
-     * @When I switch the way shipping methods are sorted by name
-     */
+    #[When('I switch the way shipping methods are sorted by name')]
     public function iSwitchTheWayShippingMethodsAreSortedByName(): void
     {
         $this->client->sort(['translation.name' => 'desc']);
     }
 
-    /**
-     * @When I filter archival shipping methods
-     */
+    #[When('I filter archival shipping methods')]
     public function iFilterArchivalShippingMethods(): void
     {
         $this->client->addFilter('exists[archivedAt]', true);
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see :count shipping methods in the list
-     */
+    #[Then('I should see :count shipping methods in the list')]
     public function iShouldSeeShippingMethodsInTheList(int $count): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then the shipping method :shippingMethod should be in the registry
-     * @Then the shipping method :shippingMethod should appear in the registry
-     * @Then the :shippingMethod shipping method should be successfully created
-     */
+    #[Then('the shipping method :shippingMethod should be in the registry')]
+    #[Then('the shipping method :shippingMethod should appear in the registry')]
+    #[Then('the :shippingMethod shipping method should be successfully created')]
     public function theShippingMethodShouldAppearInTheRegistry(string $name): void
     {
         Assert::true(
@@ -413,9 +348,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the shipping method :name should not appear in the registry
-     */
+    #[Then('the shipping method :name should not appear in the registry')]
     public function theShippingMethodShouldNotAppearInTheRegistry(string $name): void
     {
         Assert::false(
@@ -424,9 +357,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping method) should still be in the registry$/
-     */
+    #[Then('/^(this shipping method) should still be in the registry$/')]
     public function thisShippingMethodShouldAppearInTheRegistry(ShippingMethodInterface $shippingMethod): void
     {
         $name = $shippingMethod->getName();
@@ -437,9 +368,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -448,9 +377,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping method) should no longer exist in the registry$/
-     */
+    #[Then('/^(this shipping method) should no longer exist in the registry$/')]
     public function thisShippingMethodShouldNoLongerExistInTheRegistry(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethodName = $shippingMethod->getName();
@@ -461,9 +388,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -472,17 +397,13 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that my access has been denied
-     */
+    #[Then('I should be notified that my access has been denied')]
     public function iShouldBeNotifiedThatMyAccessHasBeenDenied(): void
     {
         Assert::true($this->responseChecker->hasAccessDenied($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then the shipping method :shippingMethod should be available in channel :channel
-     */
+    #[Then('the shipping method :shippingMethod should be available in channel :channel')]
     public function theShippingMethodShouldBeAvailableInChannel(ShippingMethodInterface $shippingMethod, ChannelInterface $channel): void
     {
         Assert::true(
@@ -495,10 +416,8 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping method) name should be "([^"]+)"$/
-     * @Then /^(this shipping method) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this shipping method) name should be "([^"]+)"$/')]
+    #[Then('/^(this shipping method) should still be named "([^"]+)"$/')]
     public function thisShippingMethodNameShouldBe(ShippingMethodInterface $shippingMethod, string $name): void
     {
         Assert::true(
@@ -512,9 +431,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping method) should be disabled$/
-     */
+    #[Then('/^(this shipping method) should be disabled$/')]
     public function thisShippingMethodShouldBeDisabled(ShippingMethodInterface $shippingMethod): void
     {
         Assert::true(
@@ -527,9 +444,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this shipping method) should be enabled$/
-     */
+    #[Then('/^(this shipping method) should be enabled$/')]
     public function thisShippingMethodShouldBeEnabled(ShippingMethodInterface $shippingMethod): void
     {
         Assert::true(
@@ -542,9 +457,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', 'NEW_CODE');
@@ -555,9 +468,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that shipping method with this code already exists
-     */
+    #[Then('I should be notified that shipping method with this code already exists')]
     public function iShouldBeNotifiedThatShippingMethodWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -571,9 +482,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one shipping method with code :value
-     */
+    #[Then('there should still be only one shipping method with code :value')]
     public function thereShouldStillBeOnlyOneShippingMethodWith(string $value): void
     {
         $response = $this->client->index(Resources::SHIPPING_METHODS);
@@ -583,9 +492,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::true($this->responseChecker->hasItemWithValue($response, 'code', $value));
     }
 
-    /**
-     * @Then the only shipping method on the list should be :name
-     */
+    #[Then('the only shipping method on the list should be :name')]
     public function theOnlyShippingMethodOnTheListShouldBe(string $name): void
     {
         $response = $this->client->getLastResponse();
@@ -595,9 +502,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::true($this->responseChecker->hasItemWithTranslation($response, 'en_US', 'name', $name));
     }
 
-    /**
-     * @Then I should see :amount shipping methods on the list
-     */
+    #[Then('I should see :amount shipping methods on the list')]
     public function iShouldSeeShippingMethodOnTheList(int $amount): void
     {
         $this->client->index(Resources::SHIPPING_METHODS);
@@ -608,9 +513,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same($itemsCount, $amount, sprintf('Expected 1 shipping method, but got %d', $itemsCount));
     }
 
-    /**
-     * @Then I should be notified that it is in use
-     */
+    #[Then('I should be notified that it is in use')]
     public function iShouldBeNotifiedThatItIsInUse(): void
     {
         Assert::contains(
@@ -619,9 +522,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::contains(
@@ -630,9 +531,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that zone has to be selected
-     */
+    #[Then('I should be notified that zone has to be selected')]
     public function iShouldBeNotifiedThatZoneHasToBeSelected(): void
     {
         Assert::contains(
@@ -641,9 +540,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the zone is required
-     */
+    #[Then('I should be notified that the zone is required')]
     public function iShouldBeNotifiedThatZoneHasToBeIriAndCannotBeNull(): void
     {
         Assert::contains(
@@ -652,9 +549,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then shipping method with :element :value should not be added
-     */
+    #[Then('shipping method with :element :value should not be added')]
     public function theShippingMethodWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         Assert::false(
@@ -663,9 +558,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the first shipping method on the list should have code :value
-     */
+    #[Then('the first shipping method on the list should have code :value')]
     public function theFirstProductOnTheListShouldHave(string $value): void
     {
         $shippingMethods = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -673,9 +566,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same(reset($shippingMethods)['code'], $value);
     }
 
-    /**
-     * @Then the first shipping method on the list should have name :value
-     */
+    #[Then('the first shipping method on the list should have name :value')]
     public function theFirstShippingMethodOnTheListShouldHave(string $value): void
     {
         $shippingMethods = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -683,9 +574,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same(reset($shippingMethods)['translations'][$this->getAdminLocaleCode()]['name'], $value);
     }
 
-    /**
-     * @Then the last shipping method on the list should have name :value
-     */
+    #[Then('the last shipping method on the list should have name :value')]
     public function theLastShippingMethodOnTheListShouldHave(string $value): void
     {
         $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
@@ -695,17 +584,13 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same(end($shippingMethods)['translations']['en_US']['name'], $value);
     }
 
-    /**
-     * @Then I should be viewing non archival shipping methods
-     */
+    #[Then('I should be viewing non archival shipping methods')]
     public function iShouldBeViewingNonArchivalShippingMethods(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then shipping method :shippingMethod should still have code :code
-     */
+    #[Then('shipping method :shippingMethod should still have code :code')]
     public function shippingMethodShouldStillHaveCode(ShippingMethodInterface $shippingMethod, string $code): void
     {
         Assert::same(
@@ -714,9 +599,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that amount for :channel channel should not be blank
-     */
+    #[Then('I should be notified that amount for :channel channel should not be blank')]
     public function iShouldBeNotifiedThatAmountForChannelShouldNotBeBlank(ChannelInterface $channel): void
     {
         Assert::contains(
@@ -725,9 +608,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code needs to contain only specific symbols
-     */
+    #[Then('I should be notified that code needs to contain only specific symbols')]
     public function iShouldBeNotifiedThatCodeNeedsToContainOnlySpecificSymbols(): void
     {
         Assert::contains(
@@ -736,9 +617,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that shipping charge for :channel channel cannot be lower than 0
-     */
+    #[Then('I should be notified that shipping charge for :channel channel cannot be lower than 0')]
     public function iShouldBeNotifiedThatShippingChargeForChannelCannotBeLowerThan0(ChannelInterface $channel): void
     {
         Assert::contains(
@@ -747,9 +626,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the weight rule has an invalid configuration
-     */
+    #[Then('I should be notified that the weight rule has an invalid configuration')]
     public function iShouldBeNotifiedThatTheWeightRuleHasAnInvalidConfiguration(): void
     {
         Assert::contains(
@@ -758,9 +635,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the amount rule has an invalid configuration in :channel channel
-     */
+    #[Then('I should be notified that the amount rule has an invalid configuration in :channel channel')]
     public function iShouldBeNotifiedThatTheAmountRuleHasAnInvalidConfigurationInChannel(ChannelInterface $channel): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxCategoriesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,44 +34,34 @@ final class ManagingTaxCategoriesContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing tax categories
-     * @When I browse tax categories
-     */
+    #[Given('I am browsing tax categories')]
+    #[When('I browse tax categories')]
     public function iWantToBrowseTaxCategories(): void
     {
         $this->client->index(Resources::TAX_CATEGORIES);
     }
 
-    /**
-     * @When I want to create a new tax category
-     */
+    #[When('I want to create a new tax category')]
     public function iWantToCreateNewTaxCategory(): void
     {
         $this->client->buildCreateRequest(Resources::TAX_CATEGORIES);
     }
 
-    /**
-     * @When I want to modify a tax category :taxCategory
-     * @When /^I want to modify (this tax category)$/
-     */
+    #[When('I want to modify a tax category :taxCategory')]
+    #[When('/^I want to modify (this tax category)$/')]
     public function iWantToModifyTaxCategory(TaxCategoryInterface $taxCategory): void
     {
         $this->client->buildUpdateRequest(Resources::TAX_CATEGORIES, $taxCategory->getCode());
     }
 
-    /**
-     * @When I delete tax category :taxCategory
-     */
+    #[When('I delete tax category :taxCategory')]
     public function iDeleteTaxCategory(TaxCategoryInterface $taxCategory): void
     {
         $this->client->delete(Resources::TAX_CATEGORIES, $taxCategory->getCode());
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -76,11 +69,9 @@ final class ManagingTaxCategoriesContext implements Context
         }
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     * @When I do not name it
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
+    #[When('I do not name it')]
     public function iNameIt(?string $name = null): void
     {
         if ($name !== null) {
@@ -88,42 +79,32 @@ final class ManagingTaxCategoriesContext implements Context
         }
     }
 
-    /**
-     * @When I remove its name
-     */
+    #[When('I remove its name')]
     public function iRemoveItsName(): void
     {
         $this->client->addRequestData('name', '');
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I describe it as :description
-     */
+    #[When('I describe it as :description')]
     public function iDescribeItAs(string $description): void
     {
         $this->client->addRequestData('description', $description);
     }
 
-    /**
-     * @When /^I search by "([^"]+)" (code|name)$/
-     */
+    #[When('/^I search by "([^"]+)" (code|name)$/')]
     public function iSearchByName(string $phrase, string $field): void
     {
         $this->client->addFilter($field, $phrase);
         $this->client->filter();
     }
 
-    /**
-     * @Then /^(this tax category) should no longer exist in the registry$/
-     */
+    #[Then('/^(this tax category) should no longer exist in the registry$/')]
     public function thisTaxCategoryShouldNoLongerExistInTheRegistry(TaxCategoryInterface $taxCategory): void
     {
         $code = $taxCategory->getCode();
@@ -133,11 +114,9 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the tax category :taxCategoryName in the list
-     * @Then I should see the tax category :taxCategoryName
-     * @Then the tax category :taxCategoryName should appear in the registry
-     */
+    #[Then('I should see the tax category :taxCategoryName in the list')]
+    #[Then('I should see the tax category :taxCategoryName')]
+    #[Then('the tax category :taxCategoryName should appear in the registry')]
     public function theTaxCategoryShouldAppearInTheRegistry(string $taxCategoryName): void
     {
         Assert::true(
@@ -146,9 +125,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the tax category :taxCategoryName
-     */
+    #[Then('I should not see the tax category :taxCategoryName')]
     public function iShouldNotSeeTheTaxCategory(string $taxCategoryName): void
     {
         Assert::false(
@@ -157,9 +134,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', 'NEW_CODE');
@@ -170,10 +145,8 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this tax category) name should be "([^"]+)"$/
-     * @Then /^(this tax category) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this tax category) name should be "([^"]+)"$/')]
+    #[Then('/^(this tax category) should still be named "([^"]+)"$/')]
     public function thisTaxCategoryNameShouldBe(TaxCategoryInterface $taxCategory, string $taxCategoryName): void
     {
         Assert::true(
@@ -182,9 +155,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that tax category with this code already exists
-     */
+    #[Then('I should be notified that tax category with this code already exists')]
     public function iShouldBeNotifiedThatTaxCategoryWithThisCodeAlreadyExists(): void
     {
         Assert::same(
@@ -193,9 +164,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one tax category with :element :value
-     */
+    #[Then('there should still be only one tax category with :element :value')]
     public function thereShouldStillBeOnlyOneTaxCategoryWith(string $element, string $value): void
     {
         Assert::same(
@@ -204,9 +173,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -215,18 +182,14 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then tax category with :element :name should not be added
-     */
+    #[Then('tax category with :element :name should not be added')]
     public function taxCategoryWithNamedElementShouldNotBeAdded(string $element, string $name): void
     {
         Assert::false($this->isItemOnIndex($element, $name), sprintf('Tax category with %s %s does not exist', $element, $name));
     }
 
-    /**
-     * @Then I should see :count tax categories in the list
-     * @Then I should see a single tax category in the list
-     */
+    #[Then('I should see :count tax categories in the list')]
+    #[Then('I should see a single tax category in the list')]
     public function iShouldSeeCountTaxCategoriesInTheList(int $count = 1): void
     {
         Assert::same(
@@ -235,9 +198,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -246,9 +207,7 @@ final class ManagingTaxCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxRatesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxRatesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -37,165 +39,127 @@ class ManagingTaxRatesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new tax rate
-     */
+    #[When('I want to create a new tax rate')]
     public function iWantToCreateANewTaxRate(): void
     {
         $this->client->buildCreateRequest(Resources::TAX_RATES);
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
     public function iNameIt(string $name): void
     {
         $this->client->addRequestData('name', $name);
     }
 
-    /**
-     * @When I define it for the :zone zone
-     * @When I change its zone to :zone
-     */
+    #[When('I define it for the :zone zone')]
+    #[When('I change its zone to :zone')]
     public function iDefineItForTheZone(ZoneInterface $zone): void
     {
         $this->client->addRequestData('zone', $this->iriConverter->getIriFromResource($zone));
     }
 
-    /**
-     * @When I make it applicable for the :taxCategory tax category
-     * @When I change it to be applicable for the :taxCategory tax category
-     */
+    #[When('I make it applicable for the :taxCategory tax category')]
+    #[When('I change it to be applicable for the :taxCategory tax category')]
     public function iMakeItApplicableForTheTaxCategory(TaxCategoryInterface $taxCategory): void
     {
         $this->client->addRequestData('category', $this->iriConverter->getIriFromResource($taxCategory));
     }
 
-    /**
-     * @When I specify its amount as :amount%
-     */
+    #[When('I specify its amount as :amount%')]
     public function iSpecifyItsAmountAs(string $amount): void
     {
         $this->client->addRequestData('amount', $amount);
     }
 
-    /**
-     * @When I do not specify related tax category
-     * @When I do not specify its zone
-     * @When I do not name it
-     * @When I do not specify its code
-     */
+    #[When('I do not specify related tax category')]
+    #[When('I do not specify its zone')]
+    #[When('I do not name it')]
+    #[When('I do not specify its code')]
     public function iDoNotSpecifyItsField(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I choose the default tax calculator
-     */
+    #[When('I choose the default tax calculator')]
     public function iChooseTheDefaultTaxCalculator(): void
     {
         $this->client->addRequestData('calculator', 'default');
     }
 
-    /**
-     * @When I make it start at :startDate and end at :endDate
-     */
+    #[When('I make it start at :startDate and end at :endDate')]
     public function iMakeItStartAtAndEndAt(string $startDate, string $endDate): void
     {
         $this->client->addRequestData('startDate', $startDate);
         $this->client->addRequestData('endDate', $endDate);
     }
 
-    /**
-     * @When I set the start date to :startDate
-     */
+    #[When('I set the start date to :startDate')]
     public function iSetTheStartDateTo(string $startDate): void
     {
         $this->client->addRequestData('startDate', $startDate);
     }
 
-    /**
-     * @When I set the end date to :endDate
-     */
+    #[When('I set the end date to :endDate')]
     public function iSetTheEndDateTo(string $endDate): void
     {
         $this->client->addRequestData('endDate', $endDate);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I choose "Included in price" option
-     */
+    #[When('I choose "Included in price" option')]
     public function iChooseOption()
     {
         $this->client->addRequestData('includedInPrice', true);
     }
 
-    /**
-     * @When /^I want to modify (this tax rate)$/
-     * @When I want to modify a tax rate :taxRate
-     */
+    #[When('/^I want to modify (this tax rate)$/')]
+    #[When('I want to modify a tax rate :taxRate')]
     public function iWantToModifyThisTaxRate(TaxRateInterface $taxRate): void
     {
         $this->client->buildUpdateRequest(Resources::TAX_RATES, (string) $taxRate->getCode());
         $this->client->addRequestData('amount', (string) $taxRate->getAmount());
     }
 
-    /**
-     * @When I browse tax rates
-     */
+    #[When('I browse tax rates')]
     public function iBrowseTaxRates(): void
     {
         $this->client->index(Resources::TAX_RATES);
     }
 
-    /**
-     * @When I remove its name
-     */
+    #[When('I remove its name')]
     public function iRemoveItsName(): void
     {
         $this->client->addRequestData('name', '');
     }
 
-    /**
-     * @When I filter tax rates by start date from :startDate
-     */
+    #[When('I filter tax rates by start date from :startDate')]
     public function iFilterTaxRatesByStartDateFrom(string $startDate): void
     {
         $this->client->addFilter('startDate[after]', $startDate);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter tax rates by start date up to :startDate
-     */
+    #[When('I filter tax rates by start date up to :startDate')]
     public function iFilterTaxRatesByStartDateUpTo(string $startDate): void
     {
         $this->client->addFilter('startDate[before]', $startDate);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter tax rates by start date from :startDate up to :endDate
-     */
+    #[When('I filter tax rates by start date from :startDate up to :endDate')]
     public function iFilterTaxRatesByStartDateFromUpTo(string $startDate, string $endDate): void
     {
         $this->client->addFilter('startDate[after]', $startDate);
@@ -203,27 +167,21 @@ class ManagingTaxRatesContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I filter tax rates by end date from :endDate
-     */
+    #[When('I filter tax rates by end date from :endDate')]
     public function iFilterTaxRatesByEndDateFrom(string $endDate): void
     {
         $this->client->addFilter('endDate[after]', $endDate);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter tax rates by end date up to :endDate
-     */
+    #[When('I filter tax rates by end date up to :endDate')]
     public function iFilterTaxRatesByEndDateUpTo(string $endDate): void
     {
         $this->client->addFilter('endDate[before]', $endDate);
         $this->client->filter();
     }
 
-    /**
-     * @When I filter tax rates by end date from :startDate up to :endDate
-     */
+    #[When('I filter tax rates by end date from :startDate up to :endDate')]
     public function iFilterTaxRatesByEndDateFromUpTo(string $startDate, string $endDate): void
     {
         $this->client->addFilter('endDate[after]', $startDate);
@@ -231,17 +189,13 @@ class ManagingTaxRatesContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I delete tax rate :taxRate
-     */
+    #[When('I delete tax rate :taxRate')]
     public function iDeleteTaxRate(TaxRateInterface $taxRate): void
     {
         $this->client->delete(Resources::TAX_RATES, (string) $taxRate->getCode());
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -250,10 +204,8 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then the tax rate :taxRate should appear in the registry
-     * @Then I should see the tax rate :taxRate in the list
-     */
+    #[Then('the tax rate :taxRate should appear in the registry')]
+    #[Then('I should see the tax rate :taxRate in the list')]
     public function theTaxRateShouldAppearInTheRegistry(TaxRateInterface $taxRate): void
     {
         $this->sharedStorage->set('tax_rate', $taxRate);
@@ -266,9 +218,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then the tax rate :taxRate should be included in price
-     */
+    #[Then('the tax rate :taxRate should be included in price')]
     public function theTaxRateShouldIncludePrice(TaxRateInterface $taxRate): void
     {
         Assert::true(
@@ -277,9 +227,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -288,9 +236,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this tax rate) should no longer exist in the registry$/
-     */
+    #[Then('/^(this tax rate) should no longer exist in the registry$/')]
     public function thisTaxRateShouldNoLongerExistInTheRegistry(TaxRateInterface $taxRate): void
     {
         $name = $taxRate->getName();
@@ -301,17 +247,13 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single tax rate in the list
-     */
+    #[Then('I should see a single tax rate in the list')]
     public function iShouldSeeASingleTaxRateInTheList(): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::TAX_RATES)), 1);
     }
 
-    /**
-     * @Then I should be notified that tax rate with this code already exists
-     */
+    #[Then('I should be notified that tax rate with this code already exists')]
     public function iShouldBeNotifiedThatTaxRateWithThisCodeAlreadyExists(): void
     {
         $response = $this->client->getLastResponse();
@@ -325,9 +267,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one tax rate with code :code
-     */
+    #[Then('there should still be only one tax rate with code :code')]
     public function thereShouldStillBeOnlyOneTaxRateWithCode(string $code): void
     {
         Assert::count(
@@ -337,9 +277,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::contains(
@@ -348,9 +286,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then tax rate with :element :code should not be added
-     */
+    #[Then('tax rate with :element :code should not be added')]
     public function taxRateWithCodeShouldNotBeAdded(string $element, string $code): void
     {
         Assert::false(
@@ -359,9 +295,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that zone has to be selected
-     */
+    #[Then('I should be notified that zone has to be selected')]
     public function iShouldBeNotifiedThatZoneHasToBeSelected(): void
     {
         Assert::contains(
@@ -370,9 +304,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that category has to be selected
-     */
+    #[Then('I should be notified that category has to be selected')]
     public function iShouldBeNotifiedThatCategoryHasToBeSelected(): void
     {
         Assert::contains(
@@ -381,9 +313,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see a tax rate with name :name
-     */
+    #[Then('I should not see a tax rate with name :name')]
     public function iShouldNotSeeATaxRateWithName(string $name): void
     {
         Assert::false(
@@ -392,10 +322,8 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this tax rate) should still be named "([^"]+)"$/
-     * @Then /^(this tax rate) name should be "([^"]*)"$/
-     */
+    #[Then('/^(this tax rate) should still be named "([^"]+)"$/')]
+    #[Then('/^(this tax rate) name should be "([^"]*)"$/')]
     public function thisTaxRateShouldStillBeNamed(TaxRateInterface $taxRate, string $taxRateName): void
     {
         Assert::true(
@@ -404,10 +332,8 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then the code field should be disabled
-     * @Then I should not be able to edit its code
-     */
+    #[Then('the code field should be disabled')]
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -415,9 +341,7 @@ class ManagingTaxRatesContext implements Context
         Assert::false($this->responseChecker->hasValue($this->client->update(), 'code', 'NEW_CODE'));
     }
 
-    /**
-     * @Then /^(this tax rate) amount should be ([^"]+)%$/
-     */
+    #[Then('/^(this tax rate) amount should be ([^"]+)%$/')]
     public function thisTaxRateAmountShouldBe(TaxRateInterface $taxRate, int $taxRateAmount): void
     {
         Assert::true(
@@ -426,9 +350,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this tax rate) should be applicable for the ("[^"]+" tax category)$/
-     */
+    #[Then('/^(this tax rate) should be applicable for the ("[^"]+" tax category)$/')]
     public function thisTaxRateShouldBeApplicableForTheTaxCategory(TaxRateInterface $taxRate, TaxCategoryInterface $taxCategory): void
     {
         Assert::true(
@@ -437,9 +359,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this tax rate) should be applicable in ("[^"]+" zone)$/
-     */
+    #[Then('/^(this tax rate) should be applicable in ("[^"]+" zone)$/')]
     public function thisTaxRateShouldBeApplicableInZone(TaxRateInterface $taxRate, ZoneInterface $zone): void
     {
         Assert::true(
@@ -448,9 +368,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that amount is invalid
-     */
+    #[Then('I should be notified that amount is invalid')]
     public function iShouldBeNotifiedThatAmountIsInvalid(): void
     {
         Assert::true(
@@ -462,9 +380,7 @@ class ManagingTaxRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that tax rate should not end before it starts
-     */
+    #[Then('I should be notified that tax rate should not end before it starts')]
     public function iShouldBeNotifiedThatTaxRateShouldNotEndBeforeItStarts(): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonImagesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonImagesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestBuilder;
@@ -34,9 +36,7 @@ final readonly class ManagingTaxonImagesContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I attach the "([^"]+)" image with "([^"]+)" type to (this taxon)$/
-     */
+    #[When('/^I attach the "([^"]+)" image with "([^"]+)" type to (this taxon)$/')]
     public function iAttachTheImageWithTypeToThisTaxon(string $path, ?string $type, TaxonInterface $taxon): void
     {
         $builder = RequestBuilder::createPost(
@@ -54,17 +54,13 @@ final readonly class ManagingTaxonImagesContext implements Context
         $this->client->request($builder->build());
     }
 
-    /**
-     * @When /^I attach the "([^"]+)" image to (this taxon)$/
-     */
+    #[When('/^I attach the "([^"]+)" image to (this taxon)$/')]
     public function iAttachTheImageToThisTaxon(string $path, TaxonInterface $taxon): void
     {
         $this->iAttachTheImageWithTypeToThisTaxon($path, null, $taxon);
     }
 
-    /**
-     * @When I( also) remove an image with :type type
-     */
+    #[When('I( also) remove an image with :type type')]
     public function iRemoveAnImageWithType(string $type): void
     {
         /** @var TaxonInterface $taxon */
@@ -77,9 +73,7 @@ final readonly class ManagingTaxonImagesContext implements Context
         $this->removeTaxonImage($taxon, $taxonImage);
     }
 
-    /**
-     * @When I remove the first image
-     */
+    #[When('I remove the first image')]
     public function iRemoveTheFirstImage(): void
     {
         /** @var TaxonInterface $taxon */
@@ -92,9 +86,7 @@ final readonly class ManagingTaxonImagesContext implements Context
         $this->removeTaxonImage($taxon, $taxonImage);
     }
 
-    /**
-     * @When I change the first image type to :type
-     */
+    #[When('I change the first image type to :type')]
     public function iChangeTheFirstImageTypeTo(string $type): void
     {
         /** @var TaxonInterface $taxon */
@@ -113,9 +105,7 @@ final readonly class ManagingTaxonImagesContext implements Context
         $this->client->request($builder->build());
     }
 
-    /**
-     * @Then I should be notified that the changes have been successfully applied
-     */
+    #[Then('I should be notified that the changes have been successfully applied')]
     public function iShouldBeNotifiedThatTheChangesHaveBeenSuccessfullyApplied(): void
     {
         $response = $this->client->getLastResponse();
@@ -124,10 +114,8 @@ final readonly class ManagingTaxonImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this taxon) should(?:| also) have an image with "([^"]*)" type$/
-     * @Then /^(it) should(?:| also) have an image with "([^"]*)" type$/
-     */
+    #[Then('/^(this taxon) should(?:| also) have an image with "([^"]*)" type$/')]
+    #[Then('/^(it) should(?:| also) have an image with "([^"]*)" type$/')]
     public function thisTaxonShouldHaveAnImageWithType(TaxonInterface $taxon, string $type): void
     {
         Assert::true($this->responseChecker->hasValuesInAnySubresourceObjectCollection(
@@ -137,10 +125,8 @@ final readonly class ManagingTaxonImagesContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this taxon) should not have(?:| also) any images with "([^"]*)" type$/
-     * @Then /^(it) should not have(?:| also) any images with "([^"]*)" type$/
-     */
+    #[Then('/^(this taxon) should not have(?:| also) any images with "([^"]*)" type$/')]
+    #[Then('/^(it) should not have(?:| also) any images with "([^"]*)" type$/')]
     public function thisTaxonShouldNotHaveAnyImagesWithType(TaxonInterface $taxon, string $type): void
     {
         Assert::false($this->responseChecker->hasValuesInAnySubresourceObjectCollection(
@@ -150,10 +136,8 @@ final readonly class ManagingTaxonImagesContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this taxon) should have only one image$/
-     * @Then /^(this taxon) should(?:| still) have (\d+) images?$/
-     */
+    #[Then('/^(this taxon) should have only one image$/')]
+    #[Then('/^(this taxon) should(?:| still) have (\d+) images?$/')]
     public function thisTaxonShouldHaveImages(TaxonInterface $taxon, int $count = 1): void
     {
         Assert::count(
@@ -162,9 +146,7 @@ final readonly class ManagingTaxonImagesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this taxon) should not have any images$/
-     */
+    #[Then('/^(this taxon) should not have any images$/')]
     public function thisTaxonShouldNotHaveAnyImages(TaxonInterface $taxon): void
     {
         $this->thisTaxonShouldHaveImages($taxon, 0);

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -37,34 +39,26 @@ final readonly class ManagingTaxonsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to see all taxons in store
-     */
+    #[When('I want to see all taxons in store')]
     public function iWantToSeeAllTaxonsInStore(): void
     {
         $this->client->index(Resources::TAXONS);
     }
 
-    /**
-     * @When I want to create a new taxon
-     */
+    #[When('I want to create a new taxon')]
     public function iWantToCreateNewTaxon(): void
     {
         $this->client->buildCreateRequest(Resources::TAXONS);
     }
 
-    /**
-     * @When I want to create a new taxon for :parentTaxon
-     */
+    #[When('I want to create a new taxon for :parentTaxon')]
     public function iWantToCreateANewTaxonForParent(TaxonInterface $parentTaxon): void
     {
         $this->iWantToCreateNewTaxon();
         $this->iSetItsParentTaxonTo($parentTaxon);
     }
 
-    /**
-     * @When I want to modify the :taxon taxon
-     */
+    #[When('I want to modify the :taxon taxon')]
     public function iWantToModifyATaxon(TaxonInterface $taxon): void
     {
         $this->sharedStorage->set('taxon', $taxon);
@@ -72,10 +66,8 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->buildUpdateRequest(Resources::TAXONS, $taxon->getCode());
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         if ($code !== null) {
@@ -83,71 +75,55 @@ final readonly class ManagingTaxonsContext implements Context
         }
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I rename it to :name in :localeCode
-     * @When I do not specify its name
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I rename it to :name in :localeCode')]
+    #[When('I do not specify its name')]
     public function iNameItIn(?string $name = null, string $localeCode = 'en_US'): void
     {
         $this->updateTranslations($localeCode, 'name', $name);
     }
 
-    /**
-     * @When I set its slug to :slug in :localeCode
-     */
+    #[When('I set its slug to :slug in :localeCode')]
     public function iSetItsSlugTo(string $slug, string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'slug', $slug);
     }
 
-    /**
-     * @When I generate its slug in :localeCode
-     */
+    #[When('I generate its slug in :localeCode')]
     public function iGenerateItsSlugIn(string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'slug', '');
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     * @When I change its description to :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
+    #[When('I change its description to :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $this->updateTranslations($localeCode, 'description', $description);
     }
 
-    /**
-     * @When I set its parent taxon to :parentTaxon
-     * @When I change its parent taxon to :parentTaxon
-     */
+    #[When('I set its parent taxon to :parentTaxon')]
+    #[When('I change its parent taxon to :parentTaxon')]
     public function iSetItsParentTaxonTo(TaxonInterface $parentTaxon): void
     {
         $this->client->addRequestData('parent', $this->iriConverter->getIriFromResourceInSection($parentTaxon, 'admin'));
     }
 
-    /**
-     * @When /^I (enable|disable) it$/
-     */
+    #[When('/^I (enable|disable) it$/')]
     public function iEnableIt(string $toggleAction): void
     {
         $this->client->addRequestData('enabled', $toggleAction === 'enable');
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I remove taxon named :name
-     * @When I delete taxon named :name
-     * @When I try to delete taxon named :name
-     */
+    #[When('I remove taxon named :name')]
+    #[When('I delete taxon named :name')]
+    #[When('I try to delete taxon named :name')]
     public function iRemoveTaxonNamed(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -155,9 +131,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->delete(Resources::TAXONS, $code);
     }
 
-    /**
-     * @When I move down :taxonName taxon
-     */
+    #[When('I move down :taxonName taxon')]
     public function iMoveDownTaxon(string $taxonName): void
     {
         $lastResponse = $this->client->getLastResponse();
@@ -172,9 +146,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -183,9 +155,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the taxon named :name in the list
-     */
+    #[Then('I should see the taxon named :name in the list')]
     public function iShouldSeeTheTaxonNamedInTheList(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -195,10 +165,8 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^taxon named "([^"]+)" should not be added$/
-     * @Then the taxon named :name should no longer exist in the registry
-     */
+    #[Then('/^taxon named "([^"]+)" should not be added$/')]
+    #[Then('the taxon named :name should no longer exist in the registry')]
     public function taxonNamedShouldNotBeAdded(string $name): void
     {
         $code = StringInflector::nameToLowercaseCode($name);
@@ -208,9 +176,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the ("[^"]+" taxon) should appear in the registry$/
-     */
+    #[Then('/^the ("[^"]+" taxon) should appear in the registry$/')]
     public function theTaxonShouldAppearInTheRegistry(TaxonInterface $taxon): void
     {
         Assert::true(
@@ -220,9 +186,7 @@ final readonly class ManagingTaxonsContext implements Context
         $this->sharedStorage->set('taxon', $taxon);
     }
 
-    /**
-     * @Then I should be notified that I cannot delete a menu taxon of any channel
-     */
+    #[Then('I should be notified that I cannot delete a menu taxon of any channel')]
     public function iShouldBeNotifiedThatICannotDeleteAMenuTaxonOfAnyChannel(): void
     {
         $lastResponse = $this->client->getLastResponse();
@@ -230,9 +194,7 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::false($this->responseChecker->isDeletionSuccessful($lastResponse));
     }
 
-    /**
-     * @Then /^(it) should not belong to any other taxon$/
-     */
+    #[Then('/^(it) should not belong to any other taxon$/')]
     public function itShouldNotBelongToAnyOtherTaxon(TaxonInterface $taxon): void
     {
         Assert::true($this->responseChecker->hasItemWithValues(
@@ -244,9 +206,7 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this taxon) should (belongs to "[^"]+")$/
-     */
+    #[Then('/^(this taxon) should (belongs to "[^"]+")$/')]
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon, TaxonInterface $parentTaxon): void
     {
         $this->iWantToSeeAllTaxonsInStore();
@@ -260,34 +220,26 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see :count taxons on the list
-     */
+    #[Then('I should see :count taxons on the list')]
     public function iShouldSeeTaxonsInTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then this taxon :field should be :value
-     * @Then this taxon should have :field :value in :localeCode
-     */
+    #[Then('this taxon :field should be :value')]
+    #[Then('this taxon should have :field :value in :localeCode')]
     public function thisTaxonFieldShouldBe(string $field, string $value, string $localeCode = 'en_US'): void
     {
         Assert::true($this->responseChecker->hasTranslation($this->client->getLastResponse(), $localeCode, $field, $value));
     }
 
-    /**
-     * @Then the :field of the :taxonName taxon should( still) be :value
-     */
+    #[Then('the :field of the :taxonName taxon should( still) be :value')]
     public function theFieldOfTheTaxonShouldStillBe(string $field, string $taxonName, string $value): void
     {
         $this->thisTaxonFieldShouldBe($field, $value);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->updateRequestData(['code' => 'NEW_CODE']);
@@ -298,9 +250,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(it) should be (enabled|disabled)$/
-     */
+    #[Then('/^(it) should be (enabled|disabled)$/')]
     public function itShouldBeDisabled(TaxonInterface $taxon, string $enabled): void
     {
         Assert::true($this->responseChecker->hasValue(
@@ -310,9 +260,7 @@ final readonly class ManagingTaxonsContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that :field is required
-     */
+    #[Then('I should be notified that :field is required')]
     public function iShouldBeNotifiedThatFieldIsRequired(string $field): void
     {
         Assert::contains(
@@ -321,9 +269,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that taxon slug must be unique
-     */
+    #[Then('I should be notified that taxon slug must be unique')]
     public function iShouldBeNotifiedThatTaxonSlugMustBeUnique(): void
     {
         Assert::contains(
@@ -332,9 +278,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that taxon with this code already exists
-     */
+    #[Then('I should be notified that taxon with this code already exists')]
     public function iShouldBeNotifiedThatTaxonWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -343,9 +287,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one taxon with code :code
-     */
+    #[Then('there should still be only one taxon with code :code')]
     public function thereShouldStillBeOnlyOneTaxonWithCode(string $code): void
     {
         Assert::count(
@@ -355,9 +297,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then the product :product should no longer have a main taxon
-     */
+    #[Then('the product :product should no longer have a main taxon')]
     public function theProductShouldNoLongerHaveAMainTaxon(ProductInterface $product): void
     {
         Assert::null($product->getMainTaxon());

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingZonesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -36,44 +38,34 @@ final readonly class ManagingZonesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new zone consisting of :memberType
-     */
+    #[When('I want to create a new zone consisting of :memberType')]
     public function iWantToCreateANewZoneConsistingOfCountry(string $memberType): void
     {
         $this->client->buildCreateRequest(Resources::ZONES);
         $this->client->addRequestData('type', $memberType);
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
     public function iNameIt(string $name): void
     {
         $this->client->addRequestData('name', $name);
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(string $code): void
     {
         $this->client->addRequestData('code', $code);
     }
 
-    /**
-     * @When I do not specify its :type
-     * @When I do not add a country member
-     */
+    #[When('I do not specify its :type')]
+    #[When('I do not add a country member')]
     public function iDoNotSpecifyItsField(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I add a country :country
-     */
+    #[When('I add a country :country')]
     public function iAddACountry(CountryInterface $country): void
     {
         $this->client->addSubResourceData('members', [
@@ -81,9 +73,7 @@ final readonly class ManagingZonesContext implements Context
         ]);
     }
 
-    /**
-     * @When I add a province :province
-     */
+    #[When('I add a province :province')]
     public function iAddAProvince(ProvinceInterface $province): void
     {
         $this->client->addSubResourceData('members', [
@@ -91,9 +81,7 @@ final readonly class ManagingZonesContext implements Context
         ]);
     }
 
-    /**
-     * @When I add a zone :zone
-     */
+    #[When('I add a zone :zone')]
     public function iAddAZone(ZoneInterface $zone): void
     {
         $this->client->addSubResourceData('members', [
@@ -101,9 +89,7 @@ final readonly class ManagingZonesContext implements Context
         ]);
     }
 
-    /**
-     * @When I add a member with a code :code
-     */
+    #[When('I add a member with a code :code')]
     public function iAddAMemberWithACode(string $code): void
     {
         $this->client->addSubResourceData('members', [
@@ -111,9 +97,7 @@ final readonly class ManagingZonesContext implements Context
         ]);
     }
 
-    /**
-     * @When I provide a too long zone member code
-     */
+    #[When('I provide a too long zone member code')]
     public function iProvideATooLongZoneMemberCode(): void
     {
         $this->client->addSubResourceData('members', [
@@ -121,50 +105,38 @@ final readonly class ManagingZonesContext implements Context
         ]);
     }
 
-    /**
-     * @When I select its scope as :scope
-     */
+    #[When('I select its scope as :scope')]
     public function iSelectItsScopeAs(string $scope): void
     {
         $this->client->addRequestData('scope', $scope);
     }
 
-    /**
-     * @When I set its priority to :priority
-     */
+    #[When('I set its priority to :priority')]
     public function iSetsItsPriorityTo(int $priority): void
     {
         $this->client->addRequestData('priority', $priority);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I want to see all zones in store
-     * @When I browse zones
-     */
+    #[When('I want to see all zones in store')]
+    #[When('I browse zones')]
     public function iWantToSeeAllZonesInStore(): void
     {
         $this->client->index(Resources::ZONES);
     }
 
-    /**
-     * @When /^I(?:| try to) delete the (zone named "([^"]*)")$/
-     */
+    #[When('/^I(?:| try to) delete the (zone named "([^"]*)")$/')]
     public function iDeleteZoneNamed(ZoneInterface $zone): void
     {
         $this->client->delete(Resources::ZONES, $zone->getCode());
     }
 
-    /**
-     * @When I want to modify the zone named :zone
-     */
+    #[When('I want to modify the zone named :zone')]
     public function iWantToModifyTheZoneNamed(ZoneInterface $zone): void
     {
         $this->sharedStorage->set('zone', $zone);
@@ -172,17 +144,13 @@ final readonly class ManagingZonesContext implements Context
         $this->client->buildUpdateRequest(Resources::ZONES, $zone->getCode());
     }
 
-    /**
-     * @When /^I(?:| also) remove the ("([^"]+)" country) member$/
-     */
+    #[When('/^I(?:| also) remove the ("([^"]+)" country) member$/')]
     public function iRemoveTheCountryMember(CountryInterface $country): void
     {
         $this->removeZoneMember($country);
     }
 
-    /**
-     * @When /^I(?:| also) remove the ("([^"]+)", "([^"]+)" and "([^"]+)" country) members$/
-     */
+    #[When('/^I(?:| also) remove the ("([^"]+)", "([^"]+)" and "([^"]+)" country) members$/')]
     public function iRemoveCountryMembers(array $countries): void
     {
         foreach ($countries as $country) {
@@ -190,25 +158,19 @@ final readonly class ManagingZonesContext implements Context
         }
     }
 
-    /**
-     * @When I remove the :province province member
-     */
+    #[When('I remove the :province province member')]
     public function iRemoveTheProvinceMember(ProvinceInterface $province): void
     {
         $this->removeZoneMember($province);
     }
 
-    /**
-     * @When I remove the :zone zone member
-     */
+    #[When('I remove the :zone zone member')]
     public function iRemoveTheZoneMember(ZoneInterface $zone): void
     {
         $this->removeZoneMember($zone);
     }
 
-    /**
-     * @When I add the country :country again
-     */
+    #[When('I add the country :country again')]
     public function iAddTheCountryToTheZoneNamedAgain(CountryInterface $country): void
     {
         $this->iWantToModifyTheZoneNamed($this->sharedStorage->get('zone'));
@@ -219,9 +181,7 @@ final readonly class ManagingZonesContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @Then the zone named :zone with the :country country member should appear in the registry
-     */
+    #[Then('the zone named :zone with the :country country member should appear in the registry')]
     public function theZoneNamedWithTheCountryMemberShouldAppearInTheRegistry(
         ZoneInterface $zone,
         CountryInterface $country,
@@ -233,9 +193,7 @@ final readonly class ManagingZonesContext implements Context
         Assert::inArray($country->getCode(), array_column($members, 'code'));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $this->client->addRequestData('code', 'NEW_CODE');
@@ -246,9 +204,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should not be able to add the ("[^"]+" zone) as a member$/
-     */
+    #[Then('/^I should not be able to add the ("[^"]+" zone) as a member$/')]
     public function iShouldNotBeAbleToAddZoneAsAMember(ZoneInterface $zone): void
     {
         $this->client->addSubResourceData('members', [
@@ -261,9 +217,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then the zone named :zone with the :province province member should appear in the registry
-     */
+    #[Then('the zone named :zone with the :province province member should appear in the registry')]
     public function theZoneNamedWithTheProvinceMemberShouldAppearInTheRegistry(
         ZoneInterface $zone,
         ProvinceInterface $province,
@@ -275,9 +229,7 @@ final readonly class ManagingZonesContext implements Context
         Assert::inArray($province->getCode(), array_column($members, 'code'));
     }
 
-    /**
-     * @Then the zone named :zone with the :otherZone zone member should appear in the registry
-     */
+    #[Then('the zone named :zone with the :otherZone zone member should appear in the registry')]
     public function theZoneNamedWithTheZoneMemberShouldAppearInTheRegistry(
         ZoneInterface $zone,
         ZoneInterface $otherZone,
@@ -289,9 +241,7 @@ final readonly class ManagingZonesContext implements Context
         Assert::inArray($otherZone->getCode(), array_column($members, 'code'));
     }
 
-    /**
-     * @Then its scope should be :scope
-     */
+    #[Then('its scope should be :scope')]
     public function itsScopeShouldBe(string $scope): void
     {
         Assert::true(
@@ -300,19 +250,15 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :count zones in the list
-     * @Then I should see a single zone in the list
-     */
+    #[Then('I should see :count zones in the list')]
+    #[Then('I should see a single zone in the list')]
     public function iShouldSeeZonesInTheList(int $count = 1): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::ZONES)), $count);
     }
 
-    /**
-     * @Then I should see the zone named :name in the list
-     * @Then I should still see the zone named :name in the list
-     */
+    #[Then('I should see the zone named :name in the list')]
+    #[Then('I should still see the zone named :name in the list')]
     public function iShouldSeeTheZoneNamedInTheList(string $name): void
     {
         Assert::true(
@@ -321,9 +267,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one zone with code :code
-     */
+    #[Then('there should still be only one zone with code :code')]
     public function thereShouldStillBeOnlyOneZoneWithCode(string $code): void
     {
         Assert::count(
@@ -333,9 +277,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then the zone named :name should no longer exist in the registry
-     */
+    #[Then('the zone named :name should no longer exist in the registry')]
     public function theZoneNamedShouldNoLongerExistInTheRegistry(string $name): void
     {
         Assert::false(
@@ -344,9 +286,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^zone with (code|name) "([^"]*)" should not be added$/
-     */
+    #[Then('/^zone with (code|name) "([^"]*)" should not be added$/')]
     public function zoneShouldNotBeAdded(string $field, string $value): void
     {
         Assert::false(
@@ -355,9 +295,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this zone) should have only (the "([^"]*)" (?:country|province|zone) member)$/
-     */
+    #[Then('/^(this zone) should have only (the "([^"]*)" (?:country|province|zone) member)$/')]
     public function thisZoneShouldHaveOnlyTheProvinceMember(ZoneInterface $zone, ZoneMemberInterface $zoneMember): void
     {
         $members = $this->responseChecker->getValue(
@@ -368,9 +306,7 @@ final readonly class ManagingZonesContext implements Context
         Assert::count($members, 1);
     }
 
-    /**
-     * @Then /^(this zone) should have ("([^"]+)" and "([^"]+)" country members)$/
-     */
+    #[Then('/^(this zone) should have ("([^"]+)" and "([^"]+)" country members)$/')]
     public function thisZoneShouldHaveTheCountryAndTheProvinceMembers(
         ZoneInterface $zone,
         array $zoneMembers,
@@ -391,9 +327,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this zone) name should be "([^"]*)"$/
-     */
+    #[Then('/^(this zone) name should be "([^"]*)"$/')]
     public function thisZoneNameShouldBe(ZoneInterface $zone, string $name): void
     {
         Assert::true(
@@ -402,9 +336,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyCreated(): void
     {
         Assert::true(
@@ -413,9 +345,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully deleted
-     */
+    #[Then('I should be notified that it has been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(): void
     {
         Assert::true(
@@ -426,10 +356,8 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this zone cannot be deleted
-     * @Then I should be notified that the zone is in use and cannot be deleted
-     */
+    #[Then('I should be notified that this zone cannot be deleted')]
+    #[Then('I should be notified that the zone is in use and cannot be deleted')]
     public function iShouldBeNotifiedThatThisZoneCannotBeDeleted(): void
     {
         Assert::contains(
@@ -438,9 +366,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that zone with this code already exists
-     */
+    #[Then('I should be notified that zone with this code already exists')]
     public function iShouldBeNotifiedThatZoneWithThisCodeAlreadyExists(): void
     {
         Assert::contains(
@@ -449,9 +375,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that (code|name) is required$/
-     */
+    #[Then('/^I should be notified that (code|name) is required$/')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::contains(
@@ -460,9 +384,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that at least one zone member is required
-     */
+    #[Then('I should be notified that at least one zone member is required')]
     public function iShouldBeNotifiedThatAtLeastOneZoneMemberIsRequired(): void
     {
         Assert::contains(
@@ -471,9 +393,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that the provided zone member code is too long
-     */
+    #[Then('I should be informed that the provided zone member code is too long')]
     public function iShouldBeNotifiedThatTheZoneMemberCodeIsTooLong(): void
     {
         Assert::contains(
@@ -482,9 +402,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that "([^"]*)" is not a valid (country|province|zone) code$/
-     */
+    #[Then('/^I should be notified that "([^"]*)" is not a valid (country|province|zone) code$/')]
     public function iShouldBeNotifiedThatIsNotAValidElementCode(string $code, string $element): void
     {
         Assert::contains(
@@ -493,9 +411,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :type is not a valid zone type
-     */
+    #[Then('I should be notified that :type is not a valid zone type')]
     public function iShouldBeNotifiedThatIsNotAValidZoneType(string $type): void
     {
         Assert::contains(
@@ -504,9 +420,7 @@ final readonly class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (first|last) zone on the list should have ([^"]+) "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) zone on the list should have ([^"]+) "([^"]+)"$/')]
     public function theFirstZoneOnTheListShouldHave(string $togglePosition, string $field, string $value): void
     {
         $items = $this->responseChecker->getValue($this->client->getLastResponse(), 'hydra:member');
@@ -519,9 +433,7 @@ final readonly class ManagingZonesContext implements Context
         Assert::same($item[$field], $value);
     }
 
-    /**
-     * @Then the :zone zone should have priority :priority
-     */
+    #[Then('the :zone zone should have priority :priority')]
     public function theZoneShouldHavePriority(ZoneInterface $zone, int $priority): void
     {
         Assert::true(

--- a/src/Sylius/Behat/Context/Api/Admin/RemovingProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/RemovingProductContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -28,17 +30,13 @@ final readonly class RemovingProductContext implements Context
     ) {
     }
 
-    /**
-     * @When I (try to) delete the :product product
-     */
+    #[When('I (try to) delete the :product product')]
     public function iDeleteProduct(ProductInterface $product): void
     {
         $this->client->delete(Resources::PRODUCTS, $product->getCode());
     }
 
-    /**
-     * @Then /^(this product) should still exist$/
-     */
+    #[Then('/^(this product) should still exist$/')]
     public function theProductShouldStillExist(ProductInterface $product): void
     {
         $this->client->show(Resources::PRODUCTS, $product->getCode());
@@ -46,9 +44,7 @@ final readonly class RemovingProductContext implements Context
         Assert::true($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that this product could not be deleted as it is in use by a promotion rule
-     */
+    #[Then('I should be notified that this product could not be deleted as it is in use by a promotion rule')]
     public function iShouldBeNotifiedThatThisProductCouldNotBeDeleted(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/RemovingTaxonContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/RemovingTaxonContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -28,17 +30,13 @@ final class RemovingTaxonContext implements Context
     ) {
     }
 
-    /**
-     * @When I (try to) delete taxon named :taxon
-     */
+    #[When('I (try to) delete taxon named :taxon')]
     public function iDeleteTaxon(TaxonInterface $taxon): void
     {
         $this->client->delete(Resources::TAXONS, $taxon->getCode());
     }
 
-    /**
-     * @Then the :taxon taxon should still exist
-     */
+    #[Then('the :taxon taxon should still exist')]
     public function theTaxonShouldStillExist(TaxonInterface $taxon): void
     {
         $this->client->show(Resources::TAXONS, $taxon->getCode());
@@ -46,9 +44,7 @@ final class RemovingTaxonContext implements Context
         Assert::true($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that this taxon could not be deleted as it is in use by a promotion rule
-     */
+    #[Then('I should be notified that this taxon could not be deleted as it is in use by a promotion rule')]
     public function iShouldBeNotifiedThatThisTaxonCouldNotBeDeleted(): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ResettingPasswordContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -41,35 +42,27 @@ final class ResettingPasswordContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to reset password
-     */
+    #[When('I want to reset password')]
     public function iWantToResetPassword(): void
     {
         $this->request = $this->requestFactory->create('admin', 'administrators/reset-password', 'Bearer');
     }
 
-    /**
-     * @When I specify email as :email
-     * @When I do not specify an email
-     */
+    #[When('I specify email as :email')]
+    #[When('I do not specify an email')]
     public function iSpecifyEmailAs(string $email = ''): void
     {
         $this->request->updateContent(['email' => $email]);
     }
 
-    /**
-     * @When I reset it
-     * @When I try to reset it
-     */
+    #[When('I reset it')]
+    #[When('I try to reset it')]
     public function iResetIt(): void
     {
         $this->client->executeCustomRequest($this->request);
     }
 
-    /**
-     * @When /^(I)(?:| try to) follow the instructions to reset my password$/
-     */
+    #[When('/^(I)(?:| try to) follow the instructions to reset my password$/')]
     public function iFollowTheInstructionsToResetMyPassword(AdminUserInterface $admin): void
     {
         $this->request = $this->requestFactory->custom(
@@ -78,43 +71,33 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @When I specify my new password as :password
-     * @When I do not specify my new password
-     */
+    #[When('I specify my new password as :password')]
+    #[When('I do not specify my new password')]
     public function iSpecifyMyNewPassword(string $password = ''): void
     {
         $this->request->updateContent(['newPassword' => $this->replaceWithSecurePassword($password)]);
     }
 
-    /**
-     * @When I confirm my new password as :password
-     * @When I do not confirm my new password
-     */
+    #[When('I confirm my new password as :password')]
+    #[When('I do not confirm my new password')]
     public function iConfirmMyNewPassword(string $password = ''): void
     {
         $this->request->updateContent(['confirmNewPassword' => $this->confirmSecurePassword($password)]);
     }
 
-    /**
-     * @Then I should be notified that email with reset instruction has been sent
-     */
+    #[Then('I should be notified that email with reset instruction has been sent')]
     public function iShouldBeNotifiedThatEmailResetInstructionHasBeenSent(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_ACCEPTED);
     }
 
-    /**
-     * @Then I should be notified that my password has been successfully changed
-     */
+    #[Then('I should be notified that my password has been successfully changed')]
     public function iShouldBeNotifiedThatMyPasswordHasBeenSuccessfullyChanged(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_ACCEPTED);
     }
 
-    /**
-     * @Then I should not be able to change my password again with the same token
-     */
+    #[Then('I should not be able to change my password again with the same token')]
     public function iShouldNotBeAbleToChangeMyPasswordAgainWithTheSameToken(): void
     {
         $this->client->executeCustomRequest($this->request);
@@ -126,9 +109,7 @@ final class ResettingPasswordContext implements Context
         Assert::startsWith($message, 'No user found with reset token:');
     }
 
-    /**
-     * @Then I should be notified that the email is required
-     */
+    #[Then('I should be notified that the email is required')]
     public function iShouldBeNotifiedThatTheEmailIsRequired(): void
     {
         Assert::contains(
@@ -137,9 +118,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the email is not valid
-     */
+    #[Then('I should be notified that the email is not valid')]
     public function iShouldBeNotifiedThatTheEmailIsNotValid(): void
     {
         Assert::contains(
@@ -148,34 +127,26 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the password reset token has expired
-     */
+    #[Then('I should be notified that the password reset token has expired')]
     public function iShouldBeNotifiedThatThePasswordResetTokenHasExpired(): void
     {
         $message = $this->responseChecker->getError($this->client->getLastResponse());
         Assert::same($message, 'The password reset token has expired.');
     }
 
-    /**
-     * @Then I should be notified that the new password is required
-     */
+    #[Then('I should be notified that the new password is required')]
     public function iShouldBeNotifiedThatTheNewPasswordIsRequired(): void
     {
         $this->assertResponseHasValidationMessageForNewPassword('Please enter the password.');
     }
 
-    /**
-     * @Then I should be notified that the entered passwords do not match
-     */
+    #[Then('I should be notified that the entered passwords do not match')]
     public function iShouldBeNotifiedThatTheEnteredPasswordsDoNotMatch(): void
     {
         $this->assertResponseHasValidationMessageForNewPassword('The entered passwords do not match.');
     }
 
-    /**
-     * @Then I should be notified that the password should be at least :length characters long
-     */
+    #[Then('I should be notified that the password should be at least :length characters long')]
     public function iShouldBeNotifiedThatThePasswordShouldBeAtLeastCharactersLong(int $length): void
     {
         $this->assertResponseHasValidationMessageForNewPassword(

--- a/src/Sylius/Behat/Context/Api/Admin/TranslationContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/TranslationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -26,9 +27,7 @@ final class TranslationContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should be notified that the locale is not available
-     */
+    #[Then('I should be notified that the locale is not available')]
     public function iShouldBeNotifiedThatLocaleIsNotAvailable(): void
     {
         Assert::contains($this->responseChecker->getError($this->client->getLastResponse()), 'Please choose one of the available locales');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Modernized Behat test context annotations across admin API tests, converting from traditional docblock-style declarations to PHP 8 attributes for improved code consistency and maintainability.

* **Refactor**
  * Updated test infrastructure to leverage PHP 8 native attribute syntax, streamlining test step definitions without behavioral changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->