### PR TITLE
Convert Behat annotations to PHP attributes in Api Shop contexts

### DIFF
--- a/src/Sylius/Behat/Context/Api/Shop/AddressContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/AddressContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -33,25 +36,19 @@ final readonly class AddressContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am editing the (address of "([^"]+)")$/
-     */
+    #[Given('/^I am editing the (address of "([^"]+)")$/')]
     public function iAmEditingTheAddressOf(AddressInterface $address): void
     {
         $this->client->buildUpdateRequest(Resources::ADDRESSES, (string) $address->getId());
     }
 
-    /**
-     * @When I want to add a new address to my address book
-     */
+    #[When('I want to add a new address to my address book')]
     public function iWantToAddANewAddressToMyAddressBook(): void
     {
         $this->client->buildCreateRequest(Resources::ADDRESSES);
     }
 
-    /**
-     * @When /^I specify the (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
-     */
+    #[When('/^I specify the (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/')]
     public function iSpecifyTheAddressAs(AddressInterface $address): void
     {
         $this->client->setRequestData([
@@ -65,66 +62,50 @@ final readonly class AddressContext implements Context
         ]);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I leave every field empty
-     */
+    #[When('I leave every field empty')]
     public function iLeaveEveryFieldEmpty(): void
     {
         $this->client->setRequestData([]);
     }
 
-    /**
-     * @When I choose :countryCode as my country
-     */
+    #[When('I choose :countryCode as my country')]
     public function iChooseAsMyCountry(string $countryCode): void
     {
         $this->client->addRequestData('countryCode', $countryCode);
     }
 
-    /**
-     * @When I do not specify province
-     */
+    #[When('I do not specify province')]
     public function iDoNotSpecifyProvince(): void
     {
         $this->client->addRequestData('provinceName', '');
         $this->client->addRequestData('provinceCode', '');
     }
 
-    /**
-     * @When I remove the street
-     */
+    #[When('I remove the street')]
     public function iRemoveTheStreet(): void
     {
         $this->client->addRequestData('street', null);
     }
 
-    /**
-     * @When I save my changed address
-     */
+    #[When('I save my changed address')]
     public function iSaveMyChangedAddress(): void
     {
         $this->client->update();
     }
 
-    /**
-     * @When I browse my address book
-     */
+    #[When('I browse my address book')]
     public function iBrowseMyAddresses(): void
     {
         $this->client->index(Resources::ADDRESSES);
     }
 
-    /**
-     * @When I delete the :fullName address
-     */
+    #[When('I delete the :fullName address')]
     public function iDeleteTheAddress(string $fullName): void
     {
         $id = $this->getAddressIdFromAddressBookByFullName($fullName);
@@ -132,17 +113,13 @@ final readonly class AddressContext implements Context
         $this->client->delete(Resources::ADDRESSES, $id);
     }
 
-    /**
-     * @When /^I try to delete (address belongs to "([^"]+)")$/
-     */
+    #[When('/^I try to delete (address belongs to "([^"]+)")$/')]
     public function iDeleteTheAddressBelongsTo(AddressInterface $address): void
     {
         $this->client->delete(Resources::ADDRESSES, (string) $address->getId());
     }
 
-    /**
-     * @When I set the address of :fullName as default
-     */
+    #[When('I set the address of :fullName as default')]
     public function iSetTheAddressOfAsDefault(string $fullName): void
     {
         $addressIri = $this->getAddressIriFromAddressBookByFullName($fullName);
@@ -152,89 +129,67 @@ final readonly class AddressContext implements Context
         $this->client->update();
     }
 
-    /**
-     * @When /^I try to edit the (address of "([^"]+)")$/
-     */
+    #[When('/^I try to edit the (address of "([^"]+)")$/')]
     public function iTryToEditTheAddressOf(AddressInterface $address): void
     {
         $this->client->buildUpdateRequest(Resources::ADDRESSES, (string) $address->getId());
     }
 
-    /**
-     * @When I change the first name to :firstName
-     */
+    #[When('I change the first name to :firstName')]
     public function iChangeTheFirstNameTo(string $firstName): void
     {
         $this->client->addRequestData('firstName', $firstName);
     }
 
-    /**
-     * @When I change the last name to :lastName
-     */
+    #[When('I change the last name to :lastName')]
     public function iChangeTheLastNameTo(string $lastName): void
     {
         $this->client->addRequestData('lastName', $lastName);
     }
 
-    /**
-     * @When I change the street to :street
-     */
+    #[When('I change the street to :street')]
     public function iChangeTheStreetTo(string $street): void
     {
         $this->client->addRequestData('street', $street);
     }
 
-    /**
-     * @When I change the city to :city
-     */
+    #[When('I change the city to :city')]
     public function iChangeTheCityTo(string $city): void
     {
         $this->client->addRequestData('city', $city);
     }
 
-    /**
-     * @When I change the postcode to :postcode
-     */
+    #[When('I change the postcode to :postcode')]
     public function iChangeThePostcodeTo(string $postcode): void
     {
         $this->client->addRequestData('postcode', $postcode);
     }
 
-    /**
-     * @When I choose :province as my province
-     */
+    #[When('I choose :province as my province')]
     public function iChooseAsMyProvince(ProvinceInterface $province): void
     {
         $this->client->addRequestData('provinceCode', $province->getCode());
     }
 
-    /**
-     * @When I specify :provinceName as my province
-     */
+    #[When('I specify :provinceName as my province')]
     public function iSpecifyProvince(string $provinceName): void
     {
         $this->client->addRequestData('provinceName', $provinceName);
     }
 
-    /**
-     * @Then it should contain country :countryCode
-     */
+    #[Then('it should contain country :countryCode')]
     public function itShouldContainCountry(string $countryCode): void
     {
         $this->itShouldContain($countryCode);
     }
 
-    /**
-     * @Then it should contain province :province
-     */
+    #[Then('it should contain province :province')]
     public function itShouldContainProvince(ProvinceInterface $province): void
     {
         $this->itShouldContain($province->getCode());
     }
 
-    /**
-     * @Then it should contain :value
-     */
+    #[Then('it should contain :value')]
     public function itShouldContain(string $value): void
     {
         Assert::true(
@@ -245,43 +200,33 @@ final readonly class AddressContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the address has been successfully updated
-     */
+    #[Then('I should be notified that the address has been successfully updated')]
     public function iShouldBeNotifiedThatTheAddressHasBeenSuccessfullyUpdated(): void
     {
         Assert::true($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be unable to edit their address
-     */
+    #[Then('I should be unable to edit their address')]
     public function iShouldBeUnableToEditTheirAddress(): void
     {
         Assert::false($this->responseChecker->isUpdateSuccessful($this->client->update()));
     }
 
-    /**
-     * @When /^I try to view details of (address belongs to "([^"]+)")$/
-     */
+    #[When('/^I try to view details of (address belongs to "([^"]+)")$/')]
     public function iTryToViewDetailsOfAddressBelongingTo(AddressInterface $address): void
     {
         $this->client->showByIri($this->iriConverter->getIriFromResource($address));
     }
 
-    /**
-     * @Then /^I should(?:| still) have a single address in my address book$/
-     * @Then /^I should(?:| still) have (\d+) addresses in my address book$/
-     */
+    #[Then('/^I should(?:| still) have a single address in my address book$/')]
+    #[Then('/^I should(?:| still) have (\d+) addresses in my address book$/')]
     public function iShouldHaveAddresses(int $count = 1): void
     {
         Assert::same(count($this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES))), $count);
     }
 
-    /**
-     * @Then this address should be assigned to :fullName
-     * @Then the address assigned to :fullName should be in my book
-     */
+    #[Then('this address should be assigned to :fullName')]
+    #[Then('the address assigned to :fullName should be in my book')]
     public function thisAddressShouldBeAssignedTo(string $fullName): void
     {
         Assert::notNull(
@@ -290,9 +235,7 @@ final readonly class AddressContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the address assigned to :fullName
-     */
+    #[Then('I should not see the address assigned to :fullName')]
     public function iShouldNotSeeTheAddressAssignedTo(string $fullName): void
     {
         /** @var AddressInterface $address */
@@ -303,34 +246,26 @@ final readonly class AddressContext implements Context
         Assert::false($this->addressBookHasAddress($addressBook, $address));
     }
 
-    /**
-     * @Then there should be no addresses
-     */
+    #[Then('there should be no addresses')]
     public function thereShouldBeNoAddresses(): void
     {
         Assert::same(count($this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES))), 0);
     }
 
-    /**
-     * @Then I should be notified that the address has been successfully deleted
-     */
+    #[Then('I should be notified that the address has been successfully deleted')]
     public function iShouldBeNotifiedThatAddressHasBeenDeleted(): void
     {
         Assert::true($this->responseChecker->isDeletionSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should be notified that the address has been successfully added
-     */
+    #[Then('I should be notified that the address has been successfully added')]
     public function iShouldBeNotifiedThatTheAddressHasBeenSuccessfullyAdded(): void
     {
         Assert::true($this->responseChecker->isCreationSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then /^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) should(?:| still) be marked as my default address$/
-     * @Then /^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) should(?:| still) be set as my default address$/
-     */
+    #[Then('/^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) should(?:| still) be marked as my default address$/')]
+    #[Then('/^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+"(?:|, "[^"]+")) should(?:| still) be set as my default address$/')]
     public function addressShouldBeMarkedAsMyDefaultAddress(AddressInterface $address): void
     {
         $customerResponse = $this->client->show(Resources::CUSTOMERS, (string) $this->sharedStorage->get('user')->getCustomer()->getId());
@@ -344,17 +279,13 @@ final readonly class AddressContext implements Context
         Assert::true($this->responseChecker->hasValue($addressResponse, 'provinceName', $address->getProvinceName()));
     }
 
-    /**
-     * @Then I should still be on the address addition page
-     */
+    #[Then('I should still be on the address addition page')]
     public function iShouldStillBeOnTheAddressAdditionPage(): void
     {
         // Intentionally left empty
     }
 
-    /**
-     *  @Then I should be notified about :expectedCount errors
-     */
+    #[Then('I should be notified about :expectedCount errors')]
     public function iShouldBeNotifiedAboutErrors(int $expectedCount): void
     {
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -362,9 +293,7 @@ final readonly class AddressContext implements Context
         Assert::same(count($response['violations']), $expectedCount);
     }
 
-    /**
-     * @Then I should be notified that the province needs to be specified
-     */
+    #[Then('I should be notified that the province needs to be specified')]
     public function iShouldBeNotifiedThatTheProvinceNeedsToBeSpecified(): void
     {
         Assert::true(
@@ -375,26 +304,20 @@ final readonly class AddressContext implements Context
         );
     }
 
-    /**
-     * @Then I should still be on the :fullName address edit page
-     */
+    #[Then('I should still be on the :fullName address edit page')]
     public function iShouldStillBeOnTheAddressEditPage(string $fullName): void
     {
         // Intentionally left empty
     }
 
-    /**
-     * @Then I should still have :provinceName as my specified province
-     * @Then I should still have :provinceName as my chosen province
-     */
+    #[Then('I should still have :provinceName as my specified province')]
+    #[Then('I should still have :provinceName as my chosen province')]
     public function iShouldStillHaveAsMySpecifiedProvince(string $provinceName): void
     {
         Assert::false($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not have a default address
-     */
+    #[Then('I should not have a default address')]
     public function iShouldHaveNoDefaultAddress(): void
     {
         $userShowResponse = $this->client->show(Resources::CUSTOMERS, (string) $this->sharedStorage->get('user')->getCustomer()->getId());
@@ -404,33 +327,25 @@ final readonly class AddressContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the address has been set as default
-     */
+    #[Then('I should be notified that the address has been set as default')]
     public function iShouldBeNotifiedThatAddressHasBeenSetAsDefault(): void
     {
         Assert::true($this->responseChecker->isUpdateSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not see any details of address
-     */
+    #[Then('I should not see any details of address')]
     public function iShouldNotSeeAnyDetailsOfAddress(): void
     {
         Assert::true($this->responseChecker->hasAccessDenied($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not be able to add it
-     */
+    #[Then('I should not be able to add it')]
     public function iShouldNotBeAbleToDoIt(): void
     {
         Assert::true($this->responseChecker->hasAccessDenied($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not be able to delete it
-     */
+    #[Then('I should not be able to delete it')]
     public function iShouldNotBeAbleToDeleteIt(): void
     {
         Assert::true($this->responseChecker->hasAccessDenied($this->client->getLastResponse()));

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\Given;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
@@ -48,9 +49,7 @@ final class CartContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I clear my (cart)$/
-     */
+    #[When('/^I clear my (cart)$/')]
     public function iClearMyCart(string $tokenValue): void
     {
         $this->shopClient->delete(Resources::ORDERS, $tokenValue);
@@ -58,11 +57,9 @@ final class CartContext implements Context
         $this->sharedStorage->remove('cart_token');
     }
 
-    /**
-     * @When /^I see the summary of my (cart)$/
-     * @When /^the visitor try to see the summary of ((?:visitor|customer)'s cart)$/
-     * @When /^the (?:visitor|customer) see the summary of ((?:|their )cart)$/
-     */
+    #[When('/^I see the summary of my (cart)$/')]
+    #[When('/^the visitor try to see the summary of ((?:visitor|customer)\'s cart)$/')]
+    #[When('/^the (?:visitor|customer) see the summary of ((?:|their )cart)$/')]
     public function iSeeTheSummaryOfMyCart(?string $tokenValue): void
     {
         if ($tokenValue === null) {
@@ -78,20 +75,16 @@ final class CartContext implements Context
         $this->shopClient->show(Resources::ORDERS, $cart->getTokenValue());
     }
 
-    /**
-     * @When /^the administrator try to see the summary of ((?:visitor|customer)'s cart)$/
-     */
+    #[When('/^the administrator try to see the summary of ((?:visitor|customer)\'s cart)$/')]
     public function theAdministratorTryToSeeTheSummaryOfCart(?string $tokenValue): void
     {
         $this->adminClient->show(Resources::ORDERS, $tokenValue);
     }
 
-    /**
-     * @When /^I add(?:| the) (this product) to the (cart)$/
-     * @When /^I add(?:| the) ("[^"]+" product) to the (cart)$/
-     * @When /^I add(?:| the) (product "[^"]+") to the (cart)$/
-     * @When /^the (?:visitor|customer) adds(?:| the) ("[^"]+" product) to the (cart)$/
-     */
+    #[When('/^I add(?:| the) (this product) to the (cart)$/')]
+    #[When('/^I add(?:| the) ("[^"]+" product) to the (cart)$/')]
+    #[When('/^I add(?:| the) (product "[^"]+") to the (cart)$/')]
+    #[When('/^the (?:visitor|customer) adds(?:| the) ("[^"]+" product) to the (cart)$/')]
     public function iAddThisProductToTheCart(ProductInterface $product, ?string $tokenValue): void
     {
         $this->putProductToCart($product, $tokenValue);
@@ -99,10 +92,8 @@ final class CartContext implements Context
         $this->sharedStorage->set('product', $product);
     }
 
-    /**
-     * @When /^I add (products "([^"]+)" and "([^"]+)") to the cart$/
-     * @When /^I add (products "([^"]+)", "([^"]+)" and "([^"]+)") to the cart$/
-     */
+    #[When('/^I add (products "([^"]+)" and "([^"]+)") to the cart$/')]
+    #[When('/^I add (products "([^"]+)", "([^"]+)" and "([^"]+)") to the cart$/')]
     public function iAddMultipleProductsToTheCart(array $products): void
     {
         $tokenValue = $this->pickupCart();
@@ -112,11 +103,9 @@ final class CartContext implements Context
         }
     }
 
-    /**
-     * @When /^I add (\d+) of (them) to (?:the|my) (cart)$/
-     * @When /^I add(?:| again) (\d+) (products "[^"]+") to the (cart)$/
-     * @When /^I try to add (\d+) (products "[^"]+") to the (cart)$/
-     */
+    #[When('/^I add (\d+) of (them) to (?:the|my) (cart)$/')]
+    #[When('/^I add(?:| again) (\d+) (products "[^"]+") to the (cart)$/')]
+    #[When('/^I try to add (\d+) (products "[^"]+") to the (cart)$/')]
     public function iAddOfThemToMyCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->putProductToCart($product, $tokenValue, $quantity);
@@ -124,10 +113,8 @@ final class CartContext implements Context
         $this->sharedStorage->set('product', $product);
     }
 
-    /**
-     * @When /^I add ("[^"]+" variant) of (this product) to the (cart)$/
-     * @When /^I add ("[^"]+" variant) of (product "[^"]+") to the (cart)$/
-     */
+    #[When('/^I add ("[^"]+" variant) of (this product) to the (cart)$/')]
+    #[When('/^I add ("[^"]+" variant) of (product "[^"]+") to the (cart)$/')]
     public function iAddVariantOfThisProductToTheCart(
         ProductVariantInterface $productVariant,
         ProductInterface $product,
@@ -137,9 +124,7 @@ final class CartContext implements Context
         $this->sharedStorage->set('variant', $productVariant);
     }
 
-    /**
-     * @When I add :product with :productOption :productOptionValue to the cart
-     */
+    #[When('I add :product with :productOption :productOptionValue to the cart')]
     public function iAddThisProductWithToTheCart(
         ProductInterface $product,
         string $productOption,
@@ -196,14 +181,12 @@ final class CartContext implements Context
         $this->shopClient->executeCustomRequest($request);
     }
 
-    /**
-     * @Given /^I change (product "[^"]+") quantity to (\d+)$/
-     * @Given I change :product quantity to :quantity
-     * @When /^I change (product "[^"]+") quantity to (\d+) in my (cart)$/
-     * @When /^the (?:visitor|customer) change (product "[^"]+") quantity to (\d+) in his (cart)$/
-     * @When /^the visitor try to change (product "[^"]+") quantity to (\d+) in the customer (cart)$/
-     * @When /^I try to change (product "[^"]+") quantity to (\d+) in my (cart)$/
-     */
+    #[Given('/^I change (product "[^"]+") quantity to (\d+)$/')]
+    #[Given('I change :product quantity to :quantity')]
+    #[When('/^I change (product "[^"]+") quantity to (\d+) in my (cart)$/')]
+    #[When('/^the (?:visitor|customer) change (product "[^"]+") quantity to (\d+) in his (cart)$/')]
+    #[When('/^the visitor try to change (product "[^"]+") quantity to (\d+) in the customer (cart)$/')]
+    #[When('/^I try to change (product "[^"]+") quantity to (\d+) in my (cart)$/')]
     public function iChangeQuantityToInMyCart(ProductInterface $product, int $quantity, ?string $tokenValue = null): void
     {
         if (null === $tokenValue && $this->sharedStorage->has('cart_token')) {
@@ -221,29 +204,23 @@ final class CartContext implements Context
         $this->removeOrderItemFromCart((string) $itemResponse['id'], $tokenValue);
     }
 
-    /**
-     * @When /^I remove ("[^"]+" variant) from the (cart)$/
-     */
+    #[When('/^I remove ("[^"]+" variant) from the (cart)$/')]
     public function iRemoveVariantFromTheCart(ProductVariantInterface $variant, string $tokenValue): void
     {
         $itemResponse = $this->getOrderItemResponseFromProductVariantInCart($variant, $tokenValue);
         $this->removeOrderItemFromCart((string) $itemResponse['id'], $tokenValue);
     }
 
-    /**
-     * @When I pick up (my )cart (again)
-     * @When I pick up cart in the :localeCode locale
-     * @When I pick up cart without specifying locale
-     * @When the visitor picks up the cart
-     */
+    #[When('I pick up (my )cart (again)')]
+    #[When('I pick up cart in the :localeCode locale')]
+    #[When('I pick up cart without specifying locale')]
+    #[When('the visitor picks up the cart')]
     public function iPickUpMyCart(?string $localeCode = null): void
     {
         $this->pickupCart($localeCode);
     }
 
-    /**
-     * @When I pick up cart using wrong locale
-     */
+    #[When('I pick up cart using wrong locale')]
     public function iPickUpMyCartUsingWrongLocale(): void
     {
         $this->pickupCart('not_valid');
@@ -258,21 +235,17 @@ final class CartContext implements Context
         $this->shopClient->show(Resources::ORDERS, $tokenValue);
     }
 
-    /**
-     * @When I update my cart
-     * @Then I should still be on product :product page
-     * @Then I should be on :product product detailed page
-     */
+    #[When('I update my cart')]
+    #[Then('I should still be on product :product page')]
+    #[Then('I should be on :product product detailed page')]
     public function intentionallyLeftBlank(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then /^I should be notified that (this product) does not have sufficient stock$/
-     * @Then /^I should be notified that (this product) has insufficient stock$/
-     * @Then /^I should be notified that (this product) cannot be updated$/
-     */
+    #[Then('/^I should be notified that (this product) does not have sufficient stock$/')]
+    #[Then('/^I should be notified that (this product) has insufficient stock$/')]
+    #[Then('/^I should be notified that (this product) cannot be updated$/')]
     public function iShouldBeNotifiedThatThisProductDoesNotHaveSufficientStock(ProductInterface $product): void
     {
         Assert::true($this->responseChecker->hasViolationWithMessage(
@@ -281,10 +254,8 @@ final class CartContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should not be notified that (this product) does not have sufficient stock$/
-     * @Then /^I should not be notified that (this product) cannot be updated$/
-     */
+    #[Then('/^I should not be notified that (this product) does not have sufficient stock$/')]
+    #[Then('/^I should not be notified that (this product) cannot be updated$/')]
     public function iShouldNotBeNotifiedThatThisProductDoesNotHaveSufficientStock(ProductInterface $product): void
     {
         Assert::false($this->responseChecker->hasViolationWithMessage(
@@ -303,9 +274,7 @@ final class CartContext implements Context
         ));
     }
 
-    /**
-     * @Then my cart's locale should be :locale
-     */
+    #[Then('my cart\'s locale should be :locale')]
     public function myCartLocaleShouldBe(LocaleInterface $locale): void
     {
         Assert::same(
@@ -317,9 +286,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should not have access to the summary of my (previous cart)$/
-     */
+    #[Then('/^I should not have access to the summary of my (previous cart)$/')]
     public function iShouldNotHaveAccessToTheSummaryOfMyCart(OrderInterface $order): void
     {
         Assert::same(
@@ -329,9 +296,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then my cart should be cleared
-     */
+    #[Then('my cart should be cleared')]
     public function myCartShouldBeCleared(): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -356,9 +321,7 @@ final class CartContext implements Context
         Assert::same($total, (int) $responseTotal, 'Expected totals are not the same. Received message:' . $response->getContent());
     }
 
-    /**
-     * @Then /^my (cart) items total should be ("[^"]+")$/
-     */
+    #[Then('/^my (cart) items total should be ("[^"]+")$/')]
     public function myCartItemsTotalShouldBe(string $tokenValue, int $total): void
     {
         $response = $this->shopClient->show(Resources::ORDERS, $tokenValue);
@@ -370,9 +333,7 @@ final class CartContext implements Context
         Assert::same($total, (int) $responseTotal, 'Expected items totals are not the same. Received message:' . $response->getContent());
     }
 
-    /**
-     * @Then /^my included in price taxes should be ("[^"]+")$/
-     */
+    #[Then('/^my included in price taxes should be ("[^"]+")$/')]
     public function myIncludedInPriceTaxesShouldBe(int $taxTotal): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -384,9 +345,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then my cart should be empty
-     */
+    #[Then('my cart should be empty')]
     public function myCartShouldBeEmpty(): void
     {
         $tokenValue = $this->sharedStorage->get('cart_token');
@@ -397,9 +356,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^the visitor has no access to (customer's cart)$/
-     */
+    #[Then('/^the visitor has no access to (customer\'s cart)$/')]
     public function theVisitorHasNoAccessToCustomer(?string $tokenValue): void
     {
         $response = $this->shopClient->show(Resources::ORDERS, $tokenValue);
@@ -410,17 +367,13 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then I should be on my cart summary page
-     */
+    #[Then('I should be on my cart summary page')]
     public function iShouldBeOnMyCartSummaryPage(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then I should be notified that the product has been successfully added
-     */
+    #[Then('I should be notified that the product has been successfully added')]
     public function iShouldBeNotifiedThatTheProductHasBeenSuccessfullyAdded(): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -430,9 +383,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that quantity of added product cannot be lower that 1
-     */
+    #[Then('I should be notified that quantity of added product cannot be lower that 1')]
     public function iShouldBeNotifiedThatQuantityOfAddedProductCannotBeLowerThan1(): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -442,9 +393,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see(?:| also) "([^"]+)" with unit price ("[^"]+") in my cart$/
-     */
+    #[Then('/^I should see(?:| also) "([^"]+)" with unit price ("[^"]+") in my cart$/')]
     public function iShouldSeeProductWithUnitPriceInMyCart(string $productName, int $unitPrice): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -460,10 +409,8 @@ final class CartContext implements Context
         throw new \InvalidArgumentException(sprintf('The product %s does not exist', $productName));
     }
 
-    /**
-     * @Then /^I should see(?:| also) "([^"]+)" with discounted unit price ("[^"]+") in my cart$/
-     * @Then /^the product "([^"]+)" should have discounted unit price ("[^"]+") in the cart$/
-     */
+    #[Then('/^I should see(?:| also) "([^"]+)" with discounted unit price ("[^"]+") in my cart$/')]
+    #[Then('/^the product "([^"]+)" should have discounted unit price ("[^"]+") in the cart$/')]
     public function iShouldSeeProductWithDiscountedUnitPriceInMyCart(string $productName, int $discountedUnitPrice): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -479,10 +426,8 @@ final class CartContext implements Context
         throw new \InvalidArgumentException(sprintf('The product %s does not exist', $productName));
     }
 
-    /**
-     * @Then /^the product "([^"]+)" should have total price ("[^"]+") in the cart$/
-     * @Then /^total price of "([^"]+)" item should be ("[^"]+")$/
-     */
+    #[Then('/^the product "([^"]+)" should have total price ("[^"]+") in the cart$/')]
+    #[Then('/^total price of "([^"]+)" item should be ("[^"]+")$/')]
     public function theProductShouldHaveTotalPriceInTheCart(string $productName, int $totalPrice): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -498,10 +443,8 @@ final class CartContext implements Context
         throw new \InvalidArgumentException(sprintf('The product %s does not exist', $productName));
     }
 
-    /**
-     * @Then there should be one item in my cart
-     * @Then there should be one item named :productName in my cart
-     */
+    #[Then('there should be one item in my cart')]
+    #[Then('there should be one item named :productName in my cart')]
     public function thereShouldBeOneItemInMyCart(?string $productName = null): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -516,9 +459,7 @@ final class CartContext implements Context
         $this->sharedStorage->set('item', $items[0]);
     }
 
-    /**
-     * @Then /^there should be (\d+) item in my (cart)$/
-     */
+    #[Then('/^there should be (\d+) item in my (cart)$/')]
     public function thereShouldCountItemsInMyCart(int $count, string $cartToken): void
     {
         $response = $this->shopClient->show(Resources::ORDERS, $cartToken);
@@ -527,9 +468,7 @@ final class CartContext implements Context
         Assert::count($items, $count);
     }
 
-    /**
-     * @Then /^(this item) should have name "([^"]+)"$/
-     */
+    #[Then('/^(this item) should have name "([^"]+)"$/')]
     public function thisItemShouldHaveName(array $item, string $productName): void
     {
         $response = $this->getProductForItem($item);
@@ -540,9 +479,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this item) should have variant "([^"]+)"$/
-     */
+    #[Then('/^(this item) should have variant "([^"]+)"$/')]
     public function thisItemShouldHaveVariant(array $item, string $variantName): void
     {
         $response = $this->getProductVariantForItem($item);
@@ -553,9 +490,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this item) should have code "([^"]+)"$/
-     */
+    #[Then('/^(this item) should have code "([^"]+)"$/')]
     public function thisItemShouldHaveCode(array $item, string $variantCode): void
     {
         $response = $this->getProductVariantForItem($item);
@@ -576,9 +511,7 @@ final class CartContext implements Context
         $this->compareItemPrice($product->getName(), $pricing - $amount);
     }
 
-    /**
-     * @Then /^(product "[^"]+") price should be discounted by ("[^"]+")$/
-     */
+    #[Then('/^(product "[^"]+") price should be discounted by ("[^"]+")$/')]
     public function itsPriceShouldBeDiscountedBy(ProductInterface $product, int $amount): void
     {
         $pricing = $this->getExpectedPriceOfProductTimesQuantity($product);
@@ -586,9 +519,7 @@ final class CartContext implements Context
         $this->compareItemPrice($product->getName(), $pricing - $amount, 'discountedUnitPrice');
     }
 
-    /**
-     * @Then /^(its|theirs) subtotal price should be decreased by ("[^"]+")$/
-     */
+    #[Then('/^(its|theirs) subtotal price should be decreased by ("[^"]+")$/')]
     public function itsSubtotalPriceShouldBeDecreasedBy(ProductInterface $product, int $amount): void
     {
         $pricing = $this->getExpectedPriceOfProductTimesQuantity($product);
@@ -602,18 +533,14 @@ final class CartContext implements Context
         $this->compareItemPrice($product->getName(), $this->getExpectedPriceOfProductTimesQuantity($product));
     }
 
-    /**
-     * @Then I should see :productName with quantity :quantity in my cart
-     * @Then /^the (?:customer|visitor) should see product "([^"]+)" with quantity (\d+) in his cart$/
-     */
+    #[Then('I should see :productName with quantity :quantity in my cart')]
+    #[Then('/^the (?:customer|visitor) should see product "([^"]+)" with quantity (\d+) in his cart$/')]
     public function iShouldSeeWithQuantityInMyCart(string $productName, int $quantity): void
     {
         $this->checkProductQuantityByCustomer($this->shopClient->getLastResponse(), $productName, $quantity);
     }
 
-    /**
-     * @Then I should be informed that cart items are no longer available
-     */
+    #[Then('I should be informed that cart items are no longer available')]
     public function iShouldBeInformedThatCartItemsAreNoLongerAvailable(): void
     {
         $response = $this->sharedStorage->get('response') ?? $this->shopClient->getLastResponse();
@@ -623,9 +550,7 @@ final class CartContext implements Context
         Assert::same($this->responseChecker->getResponseContent($response)['hydra:description'], 'Not Found');
     }
 
-    /**
-     * @Then I should be informed that I cannot change the cart items after the checkout is completed
-     */
+    #[Then('I should be informed that I cannot change the cart items after the checkout is completed')]
     public function iShouldBeInformedThatICannotChangeTheCartItemsAfterTheCheckoutIsCompleted(): void
     {
         Assert::same(
@@ -635,17 +560,13 @@ final class CartContext implements Context
         Assert::same($this->shopClient->getLastResponse()->getStatusCode(), 422);
     }
 
-    /**
-     * @Then /^the administrator should see "([^"]+)" product with quantity (\d+) in the (?:customer|visitor) cart$/
-     */
+    #[Then('/^the administrator should see "([^"]+)" product with quantity (\d+) in the (?:customer|visitor) cart$/')]
     public function theAdministratorShouldSeeProductWithQuantityInTheCart(string $productName, int $quantity): void
     {
         $this->checkProductQuantityByAdmin($this->adminClient->getLastResponse(), $productName, $quantity);
     }
 
-    /**
-     * @Then /^the (?:visitor|customer) should see ("[^"]+" product) in the (cart)$/
-     */
+    #[Then('/^the (?:visitor|customer) should see ("[^"]+" product) in the (cart)$/')]
     public function theVisitorShouldSeeProductInTheCart(
         ProductInterface $product,
         string $tokenValue,
@@ -656,9 +577,7 @@ final class CartContext implements Context
         $this->iShouldSeeWithQuantityInMyCart($product->getName(), $quantity);
     }
 
-    /**
-     * @When /^I check items in my (cart)$/
-     */
+    #[When('/^I check items in my (cart)$/')]
     public function iCheckItemsOfMyCart(string $tokenValue): void
     {
         $request = $this->requestFactory->customItemAction(
@@ -671,9 +590,7 @@ final class CartContext implements Context
         $this->shopClient->executeCustomRequest($request);
     }
 
-    /**
-     * @Then /^my cart should have ("[^"]+") items total$/
-     */
+    #[Then('/^my cart should have ("[^"]+") items total$/')]
     public function myCartShouldHaveItemsTotal(int $itemsTotal): void
     {
         Assert::same(
@@ -682,9 +599,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^my cart taxes should be ("[^"]+")$/
-     */
+    #[Then('/^my cart taxes should be ("[^"]+")$/')]
     public function myCartTaxesShouldBe(int $taxTotal): void
     {
         Assert::same(
@@ -693,9 +608,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^my cart included in price taxes should be ("[^"]+")$/
-     */
+    #[Then('/^my cart included in price taxes should be ("[^"]+")$/')]
     public function myCartTaxesIncludedInPriceShouldBe(int $taxTotal): void
     {
         Assert::same(
@@ -704,10 +617,8 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^my cart should have (\d+) items of (product "([^"]+)")$/
-     * @Then /^my cart should have quantity of (\d+) items of (product "([^"]+)")$/
-     */
+    #[Then('/^my cart should have (\d+) items of (product "([^"]+)")$/')]
+    #[Then('/^my cart should have quantity of (\d+) items of (product "([^"]+)")$/')]
     public function myCartShouldHaveItems(int $quantity, ProductInterface $product): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -736,9 +647,7 @@ final class CartContext implements Context
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @Then /^I should have empty (cart)$/
-     */
+    #[Then('/^I should have empty (cart)$/')]
     public function iShouldHaveEmptyCart(string $tokenValue): void
     {
         $items = $this->responseChecker->getValue($this->shopClient->show(Resources::ORDERS, $tokenValue), 'items');
@@ -746,9 +655,7 @@ final class CartContext implements Context
         Assert::same(count($items), 0, 'There should be an empty cart');
     }
 
-    /**
-     * @Then I should be unable to add it to the cart
-     */
+    #[Then('I should be unable to add it to the cart')]
     public function iShouldBeUnableToAddItToTheCart(): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -761,9 +668,7 @@ final class CartContext implements Context
         Assert::same($response->getStatusCode(), 422);
     }
 
-    /**
-     * @Then /^this product should have ([^"]+) "([^"]+)"$/
-     */
+    #[Then('/^this product should have ([^"]+) "([^"]+)"$/')]
     public function thisItemShouldHaveOptionValue(string $expectedOptionName, string $expectedOptionValueValue): void
     {
         $item = $this->sharedStorage->get('item');
@@ -789,9 +694,7 @@ final class CartContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see "([^"]+)" with original price ("[^"]+") in my cart$/
-     */
+    #[Then('/^I should see "([^"]+)" with original price ("[^"]+") in my cart$/')]
     public function iShouldSeeWithOriginalPriceInMyCart(string $productName, int $originalPrice): void
     {
         $response = $this->shopClient->getLastResponse();
@@ -807,9 +710,7 @@ final class CartContext implements Context
         throw new \InvalidArgumentException(sprintf('The product %s does not exist', $productName));
     }
 
-    /**
-     * @Then /^I should see "([^"]+)" only with unit price ("[^"]+") in my cart$/
-     */
+    #[Then('/^I should see "([^"]+)" only with unit price ("[^"]+") in my cart$/')]
     public function iShouldSeeOnlyWithUnitPriceInMyCart(string $productName, int $unitPrice): void
     {
         $response = $this->shopClient->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ChannelContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,11 +33,9 @@ final class ChannelContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I (?:am browsing|start browsing|try to browse|browse) (?:|the )("[^"]+" channel)$/
-     * @When /^I (?:start browsing|try to browse|browse) (that channel)$/
-     * @When /^I (?:am browsing|start browsing|try to browse|browse) (?:|the )(channel "[^"]+")$/
-     */
+    #[When('/^I (?:am browsing|start browsing|try to browse|browse) (?:|the )("[^"]+" channel)$/')]
+    #[When('/^I (?:start browsing|try to browse|browse) (that channel)$/')]
+    #[When('/^I (?:am browsing|start browsing|try to browse|browse) (?:|the )(channel "[^"]+")$/')]
     public function iAmBrowsingChannel(ChannelInterface $channel): void
     {
         $this->sharedStorage->set('hostname', $channel->getHostname());
@@ -44,9 +44,7 @@ final class ChannelContext implements Context
         $this->client->show(Resources::CHANNELS, $channel->getCode());
     }
 
-    /**
-     * @Then I should (still) shop using the :currencyCode currency
-     */
+    #[Then('I should (still) shop using the :currencyCode currency')]
     public function iShouldShopUsingTheCurrency(string $currencyCode): void
     {
         Assert::same(
@@ -58,9 +56,7 @@ final class ChannelContext implements Context
         );
     }
 
-    /**
-     * @Then I should be able to shop using the :currencyCode currency
-     */
+    #[Then('I should be able to shop using the :currencyCode currency')]
     public function iShouldBeAbleToShopUsingTheCurrency(string $currencyCode): void
     {
         $this->client->index(Resources::CURRENCIES);
@@ -74,9 +70,7 @@ final class ChannelContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to shop using the :currencyCode currency
-     */
+    #[Then('I should not be able to shop using the :currencyCode currency')]
     public function iShouldNotBeAbleToShopUsingTheCurrency(string $currencyCode): void
     {
         $this->client->index(Resources::CURRENCIES);

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutCompleteContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop\Checkout;
 
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -38,10 +40,8 @@ final readonly class CheckoutCompleteContext implements Context
         $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
     }
 
-    /**
-     * @Given I have confirmed order
-     */
     #[When('I try to complete checkout')]
+    #[Given('I have confirmed order')]
     public function iConfirmMyOrder(): void
     {
         $request = $this->requestFactory->customItemAction(
@@ -55,9 +55,7 @@ final readonly class CheckoutCompleteContext implements Context
         $this->client->executeCustomRequest($request);
     }
 
-    /**
-     * @Then /^I should be informed that (this variant) has been disabled$/
-     */
+    #[Then('/^I should be informed that (this variant) has been disabled$/')]
     public function iShouldBeInformedThatThisVariantHasBeenDisabled(ProductVariantInterface $productVariant): void
     {
         $lastResponseContent = $this->client->getLastResponse()->getContent();
@@ -66,9 +64,7 @@ final readonly class CheckoutCompleteContext implements Context
         Assert::contains($lastResponseContent, sprintf('The product %s is no longer available.', $productVariant->getName()));
     }
 
-    /**
-     * @Then my order should not be placed due to changed order total
-     */
+    #[Then('my order should not be placed due to changed order total')]
     public function myOrderShouldNotBePlacedDueToChangedOrderTotal(): void
     {
         $lastResponseContent = $this->client->getLastResponse()->getContent();

--- a/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/Checkout/CheckoutOrderDetailsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop\Checkout;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -32,9 +34,7 @@ final class CheckoutOrderDetailsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I want to browse order details for (this order)$/
-     */
+    #[When('/^I want to browse order details for (this order)$/')]
     public function iWantToBrowseOrderDetailsForThisOrder(OrderInterface $order): void
     {
         $this->sharedStorage->set('cart_token', $order->getTokenValue());
@@ -42,28 +42,22 @@ final class CheckoutOrderDetailsContext implements Context
         $this->client->show(Resources::ORDERS, $order->getTokenValue());
     }
 
-    /**
-     * @Then I should be able to pay (again)
-     */
+    #[Then('I should be able to pay (again)')]
     public function iShouldBeAbleToPay(): void
     {
         $state = $this->getLatestPaymentState();
         Assert::eq($state, PaymentInterface::STATE_NEW);
     }
 
-    /**
-     * @Then I should not be able to pay (again)
-     */
+    #[Then('I should not be able to pay (again)')]
     public function iShouldNotBeAbleToPay(): void
     {
         $state = $this->getLatestPaymentState();
         Assert::notEq($state, PaymentInterface::STATE_NEW);
     }
 
-    /**
-     * @When I want to pay for my order
-     * @When I go to the change payment method page
-     */
+    #[When('I want to pay for my order')]
+    #[When('I go to the change payment method page')]
     public function iWantToPayForMyOrder(): void
     {
         $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -76,9 +76,7 @@ final class CheckoutContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^(my) billing address is fulfilled automatically through default address$/
-     */
+    #[Given('/^(my) billing address is fulfilled automatically through default address$/')]
     public function myBillingAddressIsFulfilledAutomaticallyThroughDefaultAddress(ShopUserInterface $user): void
     {
         /** @var CustomerInterface|null $customer */
@@ -91,9 +89,7 @@ final class CheckoutContext implements Context
         $this->iSpecifyTheBillingAddressAs($defaultAddress);
     }
 
-    /**
-     * @When I try to complete the shipping step
-     */
+    #[When('I try to complete the shipping step')]
     public function iTryToCompleteTheShippingStep(): void
     {
         $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
@@ -133,18 +129,14 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @When I specified the billing address
-     */
+    #[When('I specified the billing address')]
     public function iSpecifiedTheBillingAddress(): void
     {
         $this->addressOrder($this->getArrayWithDefaultAddress());
     }
 
-    /**
-     * @When I proceed with :shippingMethod shipping method and :paymentMethod payment
-     * @When I have proceeded order with :shippingMethod shipping method and :paymentMethod payment
-     */
+    #[When('I proceed with :shippingMethod shipping method and :paymentMethod payment')]
+    #[When('I have proceeded order with :shippingMethod shipping method and :paymentMethod payment')]
     public function iProceedOrderWithShippingMethodAndPayment(
         ShippingMethodInterface $shippingMethod,
         PaymentMethodInterface $paymentMethod,
@@ -153,23 +145,19 @@ final class CheckoutContext implements Context
         $this->iChoosePaymentMethod($paymentMethod);
     }
 
-    /**
-     * @Given I am at the checkout addressing step
-     * @When I complete the payment step
-     * @When I complete the shipping step
-     * @When I go to the checkout addressing step
-     * @Then there should be information about no available shipping methods
-     * @Then I should be informed that my order cannot be shipped to this address
-     * @Then I should not be able to address an order with an empty cart
-     */
+    #[Given('I am at the checkout addressing step')]
+    #[When('I complete the payment step')]
+    #[When('I complete the shipping step')]
+    #[When('I go to the checkout addressing step')]
+    #[Then('there should be information about no available shipping methods')]
+    #[Then('I should be informed that my order cannot be shipped to this address')]
+    #[Then('I should not be able to address an order with an empty cart')]
     public function iAmAtTheCheckoutAddressingStep(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then I should see that there is no shipment assigned
-     */
+    #[Then('I should see that there is no shipment assigned')]
     public function iShouldSeeThatThereIsNoShipmentAssigned(): void
     {
         $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
@@ -177,9 +165,7 @@ final class CheckoutContext implements Context
         Assert::isEmpty($this->responseChecker->getValue($response, 'shipments'));
     }
 
-    /**
-     * @Then I should see that no payment method is assigned
-     */
+    #[Then('I should see that no payment method is assigned')]
     public function iShouldSeeThatNoPaymentMethodIsAssigned(): void
     {
         $response = $this->client->requestGet(sprintf('orders/%s', $this->sharedStorage->get('cart_token')));
@@ -187,9 +173,7 @@ final class CheckoutContext implements Context
         Assert::isEmpty($this->responseChecker->getValue($response, 'payments'));
     }
 
-    /**
-     * @Then there should not be any payment methods available for selection
-     */
+    #[Then('there should not be any payment methods available for selection')]
     public function thereShouldNotBeAnyPaymentMethodsAvailableForSelection(): void
     {
         $response = $this->client->requestGet('payment-methods');
@@ -197,9 +181,7 @@ final class CheckoutContext implements Context
         Assert::isEmpty($this->responseChecker->getCollection($response));
     }
 
-    /**
-     * @When /^I choose "([^"]+)" street for (billing|shipping) address$/
-     */
+    #[When('/^I choose "([^"]+)" street for (billing|shipping) address$/')]
     public function iChooseForBillingAddress(string $street, string $addressType): void
     {
         $addressBook = $this->responseChecker->getCollection($this->client->index(Resources::ADDRESSES));
@@ -217,33 +199,27 @@ final class CheckoutContext implements Context
         $this->addressOrder($this->content);
     }
 
-    /**
-     * @Given /^the (?:customer|visitor) has specified the email as "([^"]+)"$/
-     * @When I specify the email as :email
-     * @When /^the (?:customer|visitor) specify the email as "([^"]+)"$/
-     */
+    #[Given('/^the (?:customer|visitor) has specified the email as "([^"]+)"$/')]
+    #[When('I specify the email as :email')]
+    #[When('/^the (?:customer|visitor) specify the email as "([^"]+)"$/')]
     public function iSpecifyTheEmailAs(?string $email): void
     {
         $this->content['email'] = $email;
     }
 
-    /**
-     * @Given /^the (?:visitor|customer) has specified (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^I specify(?: the| different) billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^the visitor changes the billing (address to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^the (?:customer|visitor) specify the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^I specify the billing (address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
-     */
     #[Given('the customer specify the billing address')]
     #[Given('the visitor specify the billing address')]
+    #[Given('/^the (?:visitor|customer) has specified (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^I specify(?: the| different) billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^the visitor changes the billing (address to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^the (?:customer|visitor) specify the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^I specify the billing (address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/')]
     public function iSpecifyTheBillingAddressAs(?AddressInterface $address = null): void
     {
         $this->fillAddress('billingAddress', $address ?? $this->addressFactory->createDefault());
     }
 
-    /**
-     * @When /^the visitor try to specify the incorrect billing address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/
-     */
+    #[When('/^the visitor try to specify the incorrect billing address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/')]
     public function iTryToSpecifyTheIncorrectBillingAddressAs(
         string $city,
         string $street,
@@ -256,9 +232,7 @@ final class CheckoutContext implements Context
         $this->addAddress($addressType, $city, $street, $postcode, $customerName, $countryName);
     }
 
-    /**
-     * @When /^the visitor try to specify the billing address without country as "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/
-     */
+    #[When('/^the visitor try to specify the billing address without country as "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/')]
     public function iTryToSpecifyTheBillingAddressWithoutCountryAs(
         string $city,
         string $street,
@@ -268,37 +242,29 @@ final class CheckoutContext implements Context
         $this->addAddress('billingAddress', $city, $street, $postcode, $customerName);
     }
 
-    /**
-     * @When /^I specify the(?:| required) shipping (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^I specify the shipping (address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/
-     */
+    #[When('/^I specify the(?:| required) shipping (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^I specify the shipping (address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)")$/')]
     public function iSpecifyTheShippingAddressAs(AddressInterface $address): void
     {
         $this->fillAddress('shippingAddress', $address);
     }
 
-    /**
-     * @When /^I (do not specify any shipping address) information$/
-     */
+    #[When('/^I (do not specify any shipping address) information$/')]
     public function iDoNotSpecifyAnyShippingAddressInformation(AddressInterface $address): void
     {
         $this->fillAddress('billingAddress', $address);
         $this->fillAddress('shippingAddress', $address);
     }
 
-    /**
-     * @When /^I (do not specify any billing address) information$/
-     */
+    #[When('/^I (do not specify any billing address) information$/')]
     public function iDoNotSpecifyAnyBillingAddressInformation(AddressInterface $address): void
     {
         $this->fillAddress('billingAddress', $address);
     }
 
-    /**
-     * @When /^I specified the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^I define the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     * @When /^I try to change the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     */
+    #[When('/^I specified the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^I define the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
+    #[When('/^I try to change the billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
     public function iSpecifiedTheBillingAddressAs(AddressInterface $address): void
     {
         $this->fillAddress('billingAddress', $address);
@@ -306,25 +272,19 @@ final class CheckoutContext implements Context
         $this->content = [];
     }
 
-    /**
-     * @When /^I specify (billing|shipping) country (province as "[^"]+")$/
-     */
+    #[When('/^I specify (billing|shipping) country (province as "[^"]+")$/')]
     public function iSpecifyCountryProvinceAs(string $addressType, ProvinceInterface $province): void
     {
         $this->content[$addressType . 'Address']['provinceCode'] = $province->getCode();
     }
 
-    /**
-     * @When /^I specify the province name manually as "([^"]+)" for (billing|shipping) address$/
-     */
+    #[When('/^I specify the province name manually as "([^"]+)" for (billing|shipping) address$/')]
     public function iSpecifyTheProvinceNameManuallyAsForAddress(string $provinceName, string $addressType): void
     {
         $this->content[$addressType . 'Address']['provinceName'] = $provinceName;
     }
 
-    /**
-     * @When I specify the first and last name as :fullName for billing address
-     */
+    #[When('I specify the first and last name as :fullName for billing address')]
     public function iSpecifyTheFirstAndLastNameAsForBillingAddress(string $fullName): void
     {
         $names = explode(' ', $fullName);
@@ -333,10 +293,8 @@ final class CheckoutContext implements Context
         $this->content['billingAddress']['lastName'] = $names[1];
     }
 
-    /**
-     * @Given /^I have completed addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/
-     * @When /^I complete addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/
-     */
+    #[Given('/^I have completed addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/')]
+    #[When('/^I complete addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/')]
     public function iCompleteAddressingStepWithEmail(string $email, AddressInterface $address): void
     {
         $this->addressOrder([
@@ -352,9 +310,7 @@ final class CheckoutContext implements Context
         ]);
     }
 
-    /**
-     * @When /^I complete addressing step with ("[^"]+" based billing address)$/
-     */
+    #[When('/^I complete addressing step with ("[^"]+" based billing address)$/')]
     public function iCompleteAddressingStepWithAddress(AddressInterface $address): void
     {
         $this->addressOrder([
@@ -369,13 +325,11 @@ final class CheckoutContext implements Context
         ]);
     }
 
-    /**
-     * @Given /^the (?:customer|visitor) has completed the addressing step$/
-     * @When I complete the addressing step
-     * @When I try to complete the addressing step
-     * @When /^the (?:customer|visitor) completes the addressing step$/
-     * @When the visitor try to complete the addressing step in the customer cart
-     */
+    #[Given('/^the (?:customer|visitor) has completed the addressing step$/')]
+    #[When('I complete the addressing step')]
+    #[When('I try to complete the addressing step')]
+    #[When('/^the (?:customer|visitor) completes the addressing step$/')]
+    #[When('the visitor try to complete the addressing step in the customer cart')]
     public function iCompleteTheAddressingStep(): void
     {
         $this->addressOrder($this->content);
@@ -383,25 +337,19 @@ final class CheckoutContext implements Context
         $this->content = [];
     }
 
-    /**
-     * @When I proceed as guest :email with :country as billing country
-     */
+    #[When('I proceed as guest :email with :country as billing country')]
     public function iProceedLoggingAsGuestWithAsBillingCountry(string $email, CountryInterface $country): void
     {
         $this->addressOrderWithCountryAndEmail($country, $email);
     }
 
-    /**
-     * @When I proceed with selecting :country as billing country
-     */
+    #[When('I proceed with selecting :country as billing country')]
     public function iProceedWithSelectingCountryAsBillingCountry(CountryInterface $country): void
     {
         $this->addressOrderWithCountryAndEmail($country);
     }
 
-    /**
-     * @When I provide additional note like :notes
-     */
+    #[When('I provide additional note like :notes')]
     public function iProvideAdditionalNotesLike(string $notes): void
     {
         $this->content['additionalNote'] = $notes;
@@ -409,9 +357,7 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('additional_note', $notes);
     }
 
-    /**
-     * @When I want to complete checkout
-     */
+    #[When('I want to complete checkout')]
     public function iWantToCompleteCheckout(): void
     {
         $response = $this->completeOrder();
@@ -421,12 +367,10 @@ final class CheckoutContext implements Context
         $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
     }
 
-    /**
-     * @Given I confirmed my order
-     * @Given the customer confirmed the order
-     * @When /^the (?:visitor|customer) confirm his order$/
-     */
     #[When('I confirm my order')]
+    #[Given('I confirmed my order')]
+    #[Given('the customer confirmed the order')]
+    #[When('/^the (?:visitor|customer) confirm his order$/')]
     public function iConfirmMyOrder(): void
     {
         $response = $this->completeOrder();
@@ -443,9 +387,7 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('order', $this->orderRepository->findOneByNumber($this->sharedStorage->get('order_number')));
     }
 
-    /**
-     * @When I try to confirm my order
-     */
+    #[When('I try to confirm my order')]
     public function iTryToConfirmMyOrder(): void
     {
         $response = $this->completeOrder();
@@ -460,9 +402,7 @@ final class CheckoutContext implements Context
         // This step is relevant only for the UI
     }
 
-    /**
-     * @When I try to select :shippingMethodCode shipping method
-     */
+    #[When('I try to select :shippingMethodCode shipping method')]
     public function iTryToSelectShippingMethod(string $shippingMethodCode): void
     {
         $request = $this->requestFactory->customItemAction(
@@ -482,9 +422,7 @@ final class CheckoutContext implements Context
         $this->client->executeCustomRequest($request);
     }
 
-    /**
-     * @When I try to select :paymentMethodCode payment method
-     */
+    #[When('I try to select :paymentMethodCode payment method')]
     public function iTryToSelectPaymentMethod(string $paymentMethodCode): void
     {
         $cart = $this->getCart();
@@ -512,9 +450,7 @@ final class CheckoutContext implements Context
         // This step is relevant only for the UI
     }
 
-    /**
-     * @Then I should be notified that the order should be addressed first
-     */
+    #[Then('I should be notified that the order should be addressed first')]
     public function iShouldBeNotifiedThatTheOrderShouldBeAddressedFirst(): void
     {
         Assert::true($this->responseChecker->isViolationWithMessageInResponse(
@@ -523,12 +459,10 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then the visitor has no access to proceed with :shippingMethod shipping method in the customer cart
-     * @Then the visitor has no access to proceed with :paymentMethod payment in the customer cart
-     * @Then the visitor has no access to confirm the customer order
-     * @Then the visitor has no access to change product :product quantity to :quantity in the customer cart
-     */
+    #[Then('the visitor has no access to proceed with :shippingMethod shipping method in the customer cart')]
+    #[Then('the visitor has no access to proceed with :paymentMethod payment in the customer cart')]
+    #[Then('the visitor has no access to confirm the customer order')]
+    #[Then('the visitor has no access to change product :product quantity to :quantity in the customer cart')]
     public function theVisitorHasNoProceedWithShippingMethodInTheCustomerCart(): void
     {
         $response = $this->client->getLastResponse();
@@ -537,18 +471,16 @@ final class CheckoutContext implements Context
         Assert::same($this->responseChecker->getResponseContent($response)['hydra:description'], 'Not Found');
     }
 
-    /**
-     * @Given I completed the payment step with :paymentMethod payment method
-     * @Given /^the (?:customer|visitor) has proceeded ("[^"]+" payment)$/
-     * @When I choose :paymentMethod payment method
-     * @When I select :paymentMethod payment method
-     * @When /^the (?:customer|visitor) proceed with ("[^"]+" payment)$/
-     * @When I try to change payment method to :paymentMethod payment
-     * @When I change payment method to :paymentMethod after checkout
-     * @When I retry the payment with :paymentMethod payment method
-     */
     #[When('the visitor proceeds with :paymentMethod payment method')]
     #[When('the customer proceeds with :paymentMethod payment method')]
+    #[Given('I completed the payment step with :paymentMethod payment method')]
+    #[Given('/^the (?:customer|visitor) has proceeded ("[^"]+" payment)$/')]
+    #[When('I choose :paymentMethod payment method')]
+    #[When('I select :paymentMethod payment method')]
+    #[When('/^the (?:customer|visitor) proceed with ("[^"]+" payment)$/')]
+    #[When('I try to change payment method to :paymentMethod payment')]
+    #[When('I change payment method to :paymentMethod after checkout')]
+    #[When('I retry the payment with :paymentMethod payment method')]
     public function iChoosePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $request = $this->requestFactory->customItemAction(
@@ -563,9 +495,7 @@ final class CheckoutContext implements Context
         $this->client->executeCustomRequest($request);
     }
 
-    /**
-     * @When I proceed through checkout process
-     */
+    #[When('I proceed through checkout process')]
     public function iProceedThroughCheckoutProcess(): void
     {
         $this->addressOrder($this->getArrayWithDefaultAddress());
@@ -577,10 +507,8 @@ final class CheckoutContext implements Context
         $this->iChoosePaymentMethod($paymentMethod);
     }
 
-    /**
-     * @When I proceed with selecting :paymentMethod payment method
-     * @When I have proceeded selecting :paymentMethod payment method
-     */
+    #[When('I proceed with selecting :paymentMethod payment method')]
+    #[When('I have proceeded selecting :paymentMethod payment method')]
     public function iHaveProceededSelectingPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->addressOrder($this->getArrayWithDefaultAddress());
@@ -588,28 +516,22 @@ final class CheckoutContext implements Context
         $this->iChoosePaymentMethod($paymentMethod);
     }
 
-    /**
-     * @Then /^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+") should be filled as (billing) address$/
-     * @Then /^the visitor should has ("[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+" specified as) (billing) address$/
-     */
+    #[Then('/^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+") should be filled as (billing) address$/')]
+    #[Then('/^the visitor should has ("[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+" specified as) (billing) address$/')]
     public function addressShouldBeFilledAsBillingAddress(AddressInterface $address, string $addressType): void
     {
         $this->addressShouldBeFilledAs($address, $addressType);
     }
 
-    /**
-     * @Then /^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+") should be filled as (shipping) address$/
-     * @Then /^the visitor should has ("[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+" specified as) (shipping) address$/
-     */
+    #[Then('/^(address "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+") should be filled as (shipping) address$/')]
+    #[Then('/^the visitor should has ("[^"]+", "[^"]+", "[^"]+", "[^"]+", "[^"]+" specified as) (shipping) address$/')]
     public function addressShouldBeFilledAsShippingAddress(AddressInterface $address, string $addressType): void
     {
         $this->addressShouldBeFilledAs($address, $addressType);
     }
 
-    /**
-     * @Then I should be on the checkout complete step
-     * @Then I should be on the checkout summary step
-     */
+    #[Then('I should be on the checkout complete step')]
+    #[Then('I should be on the checkout summary step')]
     public function iShouldBeOnTheCheckoutCompleteStep(): void
     {
         Assert::inArray(
@@ -618,9 +540,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed with :paymentMethod payment method instructions
-     */
+    #[Then('I should be informed with :paymentMethod payment method instructions')]
     public function iShouldBeInformedWithPaymentMethodInstructions(PaymentMethodInterface $paymentMethod): void
     {
         $response = $this->client->getLastResponse();
@@ -666,9 +586,7 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not be able to select :paymentMethod payment method
-     */
+    #[Then('I should not be able to select :paymentMethod payment method')]
     public function iShouldNotBeAbleToSelectPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->iChoosePaymentMethod($paymentMethod);
@@ -684,9 +602,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that payment method with code :code does not exist
-     */
+    #[Then('I should be informed that payment method with code :code does not exist')]
     public function iShouldBeInformedThatPaymentMethodWithCodeDoesNotExist(string $code): void
     {
         Assert::true(
@@ -697,9 +613,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should be able to select :paymentMethodName payment method
-     */
+    #[Then('I should be able to select :paymentMethodName payment method')]
     public function iShouldBeAbleToSelectPaymentMethod(string $paymentMethodName): void
     {
         $paymentMethods = $this->getPossiblePaymentMethods();
@@ -707,9 +621,7 @@ final class CheckoutContext implements Context
         Assert::notFalse(array_search($paymentMethodName, array_column($paymentMethods, 'name'), true));
     }
 
-    /**
-     * @Then I should see :firstPaymentMethodName and :secondPaymentMethodName payment methods
-     */
+    #[Then('I should see :firstPaymentMethodName and :secondPaymentMethodName payment methods')]
     public function iShouldSeePaymentMethods(string ...$paymentMethodsNames): void
     {
         $paymentMethods = $this->getPossiblePaymentMethods();
@@ -719,9 +631,7 @@ final class CheckoutContext implements Context
         }
     }
 
-    /**
-     * @Then I should not see :firstPaymentMethodName and :secondPaymentMethodName payment methods
-     */
+    #[Then('I should not see :firstPaymentMethodName and :secondPaymentMethodName payment methods')]
     public function iShouldNotSeePaymentMethods(string ...$paymentMethodsNames): void
     {
         $paymentMethods = $this->getPossiblePaymentMethods();
@@ -731,9 +641,7 @@ final class CheckoutContext implements Context
         }
     }
 
-    /**
-     * @Then I should have :paymentMethodName payment method available as the :choice choice
-     */
+    #[Then('I should have :paymentMethodName payment method available as the :choice choice')]
     public function iShouldHavePaymentMethodAvailableAsTheChoice(string $paymentMethodName, string $choice): void
     {
         $paymentMethods = $this->getPossiblePaymentMethods();
@@ -747,17 +655,13 @@ final class CheckoutContext implements Context
         }
     }
 
-    /**
-     * @Then I should still be on the checkout addressing step
-     */
+    #[Then('I should still be on the checkout addressing step')]
     public function iShouldStillBeOnTheCheckoutAddressingStep(): void
     {
         Assert::same($this->getCart()['checkoutState'], OrderCheckoutStates::STATE_CART);
     }
 
-    /**
-     * @Then I should be on the checkout payment step
-     */
+    #[Then('I should be on the checkout payment step')]
     public function iShouldBeOnTheCheckoutPaymentStep(): void
     {
         Assert::inArray(
@@ -766,9 +670,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see any information about payment method
-     */
+    #[Then('I should not see any information about payment method')]
     public function iShouldNotSeeAnyInformationAboutPaymentMethod(): void
     {
         $response = $this->client->getLastResponse();
@@ -776,25 +678,19 @@ final class CheckoutContext implements Context
         Assert::true(empty($this->responseChecker->getResponseContent($response)['payments']));
     }
 
-    /**
-     * @Then I should see :shippingMethod shipping method
-     */
+    #[Then('I should see :shippingMethod shipping method')]
     public function iShouldSeeShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         Assert::true($this->hasShippingMethod($shippingMethod));
     }
 
-    /**
-     * @Then /^I should see (shipping method "[^"]+") with fee ("[^"]+")/
-     */
+    #[Then('/^I should see (shipping method "[^"]+") with fee ("[^"]+")/')]
     public function iShouldSeeShippingFee(ShippingMethodInterface $shippingMethod, int $fee): void
     {
         Assert::true($this->hasShippingMethodWithFee($shippingMethod, $fee));
     }
 
-    /**
-     * @Then my order's payment method should be :paymentMethod
-     */
+    #[Then('my order\'s payment method should be :paymentMethod')]
     public function myOrdersPaymentMethodShouldBe(PaymentMethodInterface $paymentMethod): void
     {
         $paymentMethods = $this->getPossiblePaymentMethods();
@@ -809,9 +705,7 @@ final class CheckoutContext implements Context
         throw new \InvalidArgumentException('Couldn\'t find given payment method for this order');
     }
 
-    /**
-     * @Then my order's shipping method should be :shippingMethod
-     */
+    #[Then('my order\'s shipping method should be :shippingMethod')]
     public function myOrdersShippingMethodShouldBe(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethods = $this->getCartShippingMethods($this->getCart());
@@ -826,9 +720,7 @@ final class CheckoutContext implements Context
         throw new \InvalidArgumentException('Couldn\'t find given shipping method for this order');
     }
 
-    /**
-     * @Then I should be on the checkout shipping step
-     */
+    #[Then('I should be on the checkout shipping step')]
     public function iShouldBeOnTheCheckoutShippingStep(): void
     {
         Assert::same($this->getCheckoutState(), OrderCheckoutStates::STATE_ADDRESSED);
@@ -841,18 +733,14 @@ final class CheckoutContext implements Context
         Assert::isEmpty($this->getCart()['shipments']);
     }
 
-    /**
-     * @Then I should not be able to proceed checkout payment step
-     */
+    #[Then('I should not be able to proceed checkout payment step')]
     public function iShouldNotBeAbleToProceedCheckoutPaymentStep(): void
     {
         $this->iShouldBeOnTheCheckoutPaymentStep();
         Assert::isEmpty($this->getCart()['payments']);
     }
 
-    /**
-     * @Then I should not be able to proceed checkout complete step
-     */
+    #[Then('I should not be able to proceed checkout complete step')]
     public function iShouldNotBeAbleToProceedCheckoutCompleteStep(): void
     {
         $this->iShouldBeOnTheCheckoutCompleteStep();
@@ -862,18 +750,14 @@ final class CheckoutContext implements Context
         Assert::same($this->responseChecker->getError($response), 'An empty order cannot be processed.');
     }
 
-    /**
-     * @Then /^the (?:visitor|customer) should have checkout (address|shipping method|payment) step completed$/
-     */
+    #[Then('/^the (?:visitor|customer) should have checkout (address|shipping method|payment) step completed$/')]
     public function theVisitorShouldHaveCheckoutAddressStepCompleted(string $stepType): void
     {
         Assert::same($this->getCheckoutState(), $this::CHECKOUT_STATE_TYPES[$stepType]);
     }
 
-    /**
-     * @Then I should be notified that :countryName country does not exist
-     * @Then they should be notified that :countryName country does not exist
-     */
+    #[Then('I should be notified that :countryName country does not exist')]
+    #[Then('they should be notified that :countryName country does not exist')]
     public function iShouldBeNotifiedThatCountryDoesNotExist(string $countryName): void
     {
         $this->responseChecker->hasViolationWithMessage(
@@ -882,10 +766,8 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that address without country cannot exist
-     * @Then they should be notified that address without country cannot exist
-     */
+    #[Then('I should be notified that address without country cannot exist')]
+    #[Then('they should be notified that address without country cannot exist')]
     public function iShouldBeNotifiedThatAddressWithoutCountryCannotExist(): void
     {
         $this->responseChecker->hasViolationWithMessage(
@@ -894,9 +776,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then they should be notified that they cannot address an empty cart
-     */
+    #[Then('they should be notified that they cannot address an empty cart')]
     public function theyShouldBeNotifiedThatTheyCannotAddressAnEmptyCart(): void
     {
         $response = $this->client->getLastResponse();
@@ -905,35 +785,27 @@ final class CheckoutContext implements Context
         $this->responseChecker->hasViolationWithMessage($response, 'The empty cart cannot be addressed');
     }
 
-    /**
-     * @Then I should see the thank you page
-     * @Then /^the (?:visitor|customer) should see the thank you page$/
-     */
     #[Then('my order should be completed successfully')]
+    #[Then('I should see the thank you page')]
+    #[Then('/^the (?:visitor|customer) should see the thank you page$/')]
     public function iShouldSeeTheThankYouPage(): void
     {
         Assert::same($this->getCheckoutState(), OrderCheckoutStates::STATE_COMPLETED);
     }
 
-    /**
-     * @Then I should see selected :shippingMethod shipping method
-     */
+    #[Then('I should see selected :shippingMethod shipping method')]
     public function iShouldSeeSelectedShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         Assert::true($this->hasShippingMethod($shippingMethod));
     }
 
-    /**
-     * @Then I should not see :shippingMethod shipping method
-     */
+    #[Then('I should not see :shippingMethod shipping method')]
     public function iShouldNotSeeShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         Assert::false($this->hasShippingMethod($shippingMethod));
     }
 
-    /**
-     * @Then I should have :shippingMethod shipping method available as the first choice
-     */
+    #[Then('I should have :shippingMethod shipping method available as the first choice')]
     public function iShouldHaveShippingMethodAvailableAsFirstChoice(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethods = $this->getCartShippingMethods($this->getCart());
@@ -941,9 +813,7 @@ final class CheckoutContext implements Context
         Assert::true($shippingMethods[0]['code'] === $shippingMethod->getCode());
     }
 
-    /**
-     * @Then I should have :shippingMethod shipping method available as the last choice
-     */
+    #[Then('I should have :shippingMethod shipping method available as the last choice')]
     public function iShouldHaveShippingMethodAvailableAsLastChoice(ShippingMethodInterface $shippingMethod): void
     {
         $shippingMethods = $this->getCartShippingMethods($this->getCart());
@@ -951,17 +821,13 @@ final class CheckoutContext implements Context
         Assert::true(end($shippingMethods)['code'] === $shippingMethod->getCode());
     }
 
-    /**
-     * @Then /^my order total should be ("[^"]+")$/
-     */
+    #[Then('/^my order total should be ("[^"]+")$/')]
     public function myOrderTotalShouldBe(int $total): void
     {
         Assert::same($total, (int) $this->getCart()['total']);
     }
 
-    /**
-     * @Then /^my order promotion total should be ("[^"]+")$/
-     */
+    #[Then('/^my order promotion total should be ("[^"]+")$/')]
     public function myOrderPromotionTotalShouldBe(int $promotionTotal): void
     {
         $responsePromotionTotal = $this->responseChecker->getValue($this->client->getLastResponse(), 'orderPromotionTotal');
@@ -969,9 +835,7 @@ final class CheckoutContext implements Context
         Assert::same($promotionTotal, $responsePromotionTotal);
     }
 
-    /**
-     * @Then /^my tax total should be ("[^"]+")$/
-     */
+    #[Then('/^my tax total should be ("[^"]+")$/')]
     public function myTaxTotalShouldBe(int $taxTotal): void
     {
         $responseTaxTotal = $this->responseChecker->getValue($this->client->getLastResponse(), 'taxTotal');
@@ -979,9 +843,7 @@ final class CheckoutContext implements Context
         Assert::same($taxTotal, $responseTaxTotal);
     }
 
-    /**
-     * @Then I should have :quantity :productName products in the cart
-     */
+    #[Then('I should have :quantity :productName products in the cart')]
     public function iShouldHaveProductsInTheCart(int $quantity, string $productName): void
     {
         Assert::true(
@@ -1008,9 +870,7 @@ final class CheckoutContext implements Context
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'orderPromotionTotal'), $discount);
     }
 
-    /**
-     * @Then there should be no taxes charged
-     */
+    #[Then('there should be no taxes charged')]
     public function thereShouldBeNoTaxesCharged(): void
     {
         $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
@@ -1018,33 +878,25 @@ final class CheckoutContext implements Context
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'taxTotal'), 0);
     }
 
-    /**
-     * @Then my order's locale should be :localeCode
-     */
+    #[Then('my order\'s locale should be :localeCode')]
     public function myOrderLocaleShouldBe(string $localeCode): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'localeCode'), $localeCode);
     }
 
-    /**
-     * @Then /^my order shipping should be ("(?:\£|\$)\d+(?:\.\d+)?")$/
-     */
+    #[Then('/^my order shipping should be ("(?:\£|\$)\d+(?:\.\d+)?")$/')]
     public function myOrderShippingShouldBe(int $price): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'shippingTotal'), $price);
     }
 
-    /**
-     * @Then I should not see shipping total
-     */
+    #[Then('I should not see shipping total')]
     public function iShouldNotSeeShippingTotal(): void
     {
         Assert::same($this->responseChecker->getValue($this->client->getLastResponse(), 'shippingTotal'), 0);
     }
 
-    /**
-     * @Then /^I should(?:| also) be notified that the "([^"]+)" and the "([^"]+)" in (shipping|billing) details are required$/
-     */
+    #[Then('/^I should(?:| also) be notified that the "([^"]+)" and the "([^"]+)" in (shipping|billing) details are required$/')]
     public function iShouldBeNotifiedThatTheAndTheInShippingDetailsAreRequired(string $firstElement, string $secondElement, string $detailType): void
     {
         $response = $this->client->getLastResponse();
@@ -1065,9 +917,7 @@ final class CheckoutContext implements Context
         }
     }
 
-    /**
-     * @Then /^I should(?:| also) be notified that the "([^"]+)" in (shipping|billing) details is required$/
-     */
+    #[Then('/^I should(?:| also) be notified that the "([^"]+)" in (shipping|billing) details is required$/')]
     public function iShouldBeNotifiedThatTheInShippingDetailsIsRequired(string $element, string $type): void
     {
         /** @var array|null $violations */
@@ -1081,10 +931,8 @@ final class CheckoutContext implements Context
         Assert::same($violation['message'], sprintf('Please enter %s.', $element));
     }
 
-    /**
-     * @Then /^I should be informed that (this product) has been disabled$/
-     * @Then /^I should be informed that (product "[^"]+") is disabled$/
-     */
+    #[Then('/^I should be informed that (this product) has been disabled$/')]
+    #[Then('/^I should be informed that (product "[^"]+") is disabled$/')]
     public function iShouldBeInformedThatThisProductHasBeenDisabled(ProductInterface $product): void
     {
         Assert::true($this->responseChecker->isViolationWithMessageInResponse(
@@ -1093,9 +941,7 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should be informed that (product "[^"]+") does not exist$/
-     */
+    #[Then('/^I should be informed that (product "[^"]+") does not exist$/')]
     public function iShouldBeInformedThatThisProductDoesNotExist(ProductInterface $product): void
     {
         Assert::true($this->responseChecker->isViolationWithMessageInResponse(
@@ -1104,9 +950,7 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should be informed that ("([^"]*)" product variant) does not exist$/
-     */
+    #[Then('/^I should be informed that ("([^"]*)" product variant) does not exist$/')]
     public function iShouldBeInformedThatProductVariantDoesNotExist(ProductVariantInterface $productVariant): void
     {
         Assert::true($this->responseChecker->isViolationWithMessageInResponse(
@@ -1115,9 +959,7 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be informed that product variant with code :code does not exist
-     */
+    #[Then('I should be informed that product variant with code :code does not exist')]
     public function iShouldBeInformedThatProductVariantWithCodeDoesNotExist(string $code): void
     {
         Assert::true($this->responseChecker->isViolationWithMessageInResponse(
@@ -1132,10 +974,8 @@ final class CheckoutContext implements Context
         Assert::same($this->client->getLastResponse()->getStatusCode(), 422);
     }
 
-    /**
-     * @Then address to :fullName should be used for both :addressType1 and :addressType2 of my order
-     * @Then my order's :addressType address should be to :fullName
-     */
+    #[Then('address to :fullName should be used for both :addressType1 and :addressType2 of my order')]
+    #[Then('my order\'s :addressType address should be to :fullName')]
     public function iShouldSeeThisShippingAddressAsShippingAndBillingAddress(string $fullName, string ...$addressTypes): void
     {
         foreach ($addressTypes as $addressType) {
@@ -1143,17 +983,13 @@ final class CheckoutContext implements Context
         }
     }
 
-    /**
-     * @Then I should see :provinceName in the :addressType address
-     */
+    #[Then('I should see :provinceName in the :addressType address')]
     public function iShouldSeeInTheBillingAddress(string $provinceName, string $addressType): void
     {
         $this->hasProvinceNameInAddress($provinceName, $addressType);
     }
 
-    /**
-     * @Then /^I should be informed that (this payment method) has been disabled$/
-     */
+    #[Then('/^I should be informed that (this payment method) has been disabled$/')]
     public function iShouldBeInformedThatThisPaymentMethodHasBeenDisabled(PaymentMethodInterface $paymentMethod): void
     {
         $response = $this->client->getLastResponse();
@@ -1169,27 +1005,21 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @When /^I try to add (product "[^"]+") to the cart$/
-     */
+    #[When('/^I try to add (product "[^"]+") to the cart$/')]
     public function iTryToAddProductToCart(ProductInterface $product): void
     {
         $this->putProductToCart($product, $this->sharedStorage->get('cart_token'));
     }
 
-    /**
-     * @When /^I try to add ("([^"]+)" product variant)$/
-     * @When /^I try to add ("([^"]+)" variant of product "([^"]+)")$/
-     */
+    #[When('/^I try to add ("([^"]+)" product variant)$/')]
+    #[When('/^I try to add ("([^"]+)" variant of product "([^"]+)")$/')]
     public function iTryToAddProductVariant(ProductVariantInterface $productVariant): void
     {
         $tokenValue = $this->getCartTokenValue();
         $this->putVariantToCart($productVariant, $tokenValue);
     }
 
-    /**
-     * @When /^I try to add (product "[^"]+") with variant code "([^"]+)"$/
-     */
+    #[When('/^I try to add (product "[^"]+") with variant code "([^"]+)"$/')]
     public function iTryToAddProductVariantWithCode(ProductInterface $product, string $code): void
     {
         $tokenValue = $this->getCartTokenValue();
@@ -1214,25 +1044,19 @@ final class CheckoutContext implements Context
         $this->sharedStorage->set('response', $this->client->executeCustomRequest($request));
     }
 
-    /**
-     * @When /^I try to remove (product "[^"]+") from the cart$/
-     */
+    #[When('/^I try to remove (product "[^"]+") from the cart$/')]
     public function iTryToRemoveProductFromTheCart(ProductInterface $product): void
     {
         $this->removeOrderItemFromCart($product->getId(), $this->sharedStorage->get('cart_token'));
     }
 
-    /**
-     * @When /^I try to change quantity to (\d+) of (product "[^"]+") from the (cart)$/
-     */
+    #[When('/^I try to change quantity to (\d+) of (product "[^"]+") from the (cart)$/')]
     public function iTryToChangeQuantityToOfProductFromTheCart(int $quantity, ProductInterface $product, ?string $tokenValue): void
     {
         $this->putProductToCart($product, $tokenValue, $quantity);
     }
 
-    /**
-     * @Then I should be informed that cart is no longer available
-     */
+    #[Then('I should be informed that cart is no longer available')]
     public function iShouldBeInformedThatCartIsNoLongerAvailable(): void
     {
         $response = $this->client->getLastResponse();
@@ -1242,10 +1066,8 @@ final class CheckoutContext implements Context
         Assert::same($this->responseChecker->getResponseContent($response)['hydra:description'], 'Not Found');
     }
 
-    /**
-     * @Then /^I should not be able to specify province name manually for (billing address|shipping address)$/
-     * @Then /^I should be notified that selected province is invalid for (billing address|shipping address)$/
-     */
+    #[Then('/^I should not be able to specify province name manually for (billing address|shipping address)$/')]
+    #[Then('/^I should be notified that selected province is invalid for (billing address|shipping address)$/')]
     public function iShouldNotBeAbleToSpecifyProvinceNameManuallyForAddress(string $addressType): void
     {
         $response = $this->client->getLastResponse();
@@ -1264,9 +1086,7 @@ final class CheckoutContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should be informed that (this promotion) is no longer applied$/
-     */
+    #[Then('/^I should be informed that (this promotion) is no longer applied$/')]
     public function iShouldBeInformedThatMyPromotionIsNoLongerApplied(PromotionInterface $promotion): void
     {
         Assert::contains(
@@ -1275,9 +1095,7 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to confirm order because the :shippingMethodName shipping method is not available
-     */
+    #[Then('I should not be able to confirm order because the :shippingMethodName shipping method is not available')]
     public function iShouldNotBeAbleToConfirmOrderBecauseTheShippingMethodIsNotAvailable(string $shippingMethodName): void
     {
         Assert::same(
@@ -1289,17 +1107,13 @@ final class CheckoutContext implements Context
         );
     }
 
-    /**
-     * @When /^I should see (product "[^"]+") with unit price ("[^"]+")$/
-     */
+    #[When('/^I should see (product "[^"]+") with unit price ("[^"]+")$/')]
     public function iShouldSeeWithUnitPrice(ProductInterface $product, int $unitPrice): void
     {
         Assert::true($this->hasProductWithUnitPrice($product->getName(), $unitPrice));
     }
 
-    /**
-     * @Then I should be checking out as :email
-     */
+    #[Then('I should be checking out as :email')]
     public function iShouldBeCheckingOutAs(string $email): void
     {
         $cart = $this->getCart();
@@ -1308,9 +1122,7 @@ final class CheckoutContext implements Context
         Assert::same($cart['customer']['email'], $email);
     }
 
-    /**
-     * @Then I should not be able to change email
-     */
+    #[Then('I should not be able to change email')]
     public function iShouldNotBeAbleToChangeEmail(): void
     {
         $response = $this->client

--- a/src/Sylius/Behat/Context/Api/Shop/ContactContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ContactContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -31,35 +33,27 @@ final class ContactContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to request contact
-     * @When I do not specify the email
-     * @When I do not specify the message
-     */
+    #[When('I want to request contact')]
+    #[When('I do not specify the email')]
+    #[When('I do not specify the message')]
     public function iWantToRequestContact(): void
     {
         //intentionally left empty
     }
 
-    /**
-     * @When I specify the message as :message
-     */
+    #[When('I specify the message as :message')]
     public function iSpecifyTheMessage(string $message): void
     {
         $this->content['message'] = $message;
     }
 
-    /**
-     * @When I specify the email as :email
-     */
+    #[When('I specify the email as :email')]
     public function iSpecifyTheEmail($email): void
     {
         $this->content['email'] = $email;
     }
 
-    /**
-     * @When I( try to) send it
-     */
+    #[When('I( try to) send it')]
     public function iSendIt(): void
     {
         $request = $this->requestFactory->create(
@@ -74,9 +68,7 @@ final class ContactContext implements Context
         $this->client->request($request);
     }
 
-    /**
-     * @Then I should be notified that the contact request has been submitted successfully
-     */
+    #[Then('I should be notified that the contact request has been submitted successfully')]
     public function iShouldBeNotifiedThatTheContactRequestHasBeenSubmittedSuccessfully(): void
     {
         $response = $this->client->getLastResponse();
@@ -84,9 +76,7 @@ final class ContactContext implements Context
         Assert::same($response->getStatusCode(), 202);
     }
 
-    /**
-     * @Then I should be notified that the email is invalid
-     */
+    #[Then('I should be notified that the email is invalid')]
     public function iShouldBeNotifiedThatEmailIsInvalid(): void
     {
         $response = $this->client->getLastResponse();
@@ -97,9 +87,7 @@ final class ContactContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that the (email|message) is required$/
-     */
+    #[Then('/^I should be notified that the (email|message) is required$/')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CurrencyContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -26,19 +28,15 @@ final readonly class CurrencyContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I (?:start browsing|try to browse|browse) currencies$/
-     */
+    #[When('/^I (?:start browsing|try to browse|browse) currencies$/')]
     public function iBrowseCurrencies(): void
     {
         $this->client->index(Resources::CURRENCIES);
     }
 
-    /**
-     * @Then I should see :firstCurrency in the list
-     * @Then I should see :firstCurrency and :secondCurrency in the list
-     * @Then I should see :firstCurrency, :secondCurrency and :thirdCurrency in the list
-     */
+    #[Then('I should see :firstCurrency in the list')]
+    #[Then('I should see :firstCurrency and :secondCurrency in the list')]
+    #[Then('I should see :firstCurrency, :secondCurrency and :thirdCurrency in the list')]
     public function iShouldSeeCurrenciesInTheList(string ...$currenciesCodes): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -45,9 +47,7 @@ final class CustomerContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to modify my profile
-     */
+    #[When('I want to modify my profile')]
     public function iWantToModifyMyProfile(): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -57,9 +57,7 @@ final class CustomerContext implements Context
         $this->client->buildUpdateRequest(Resources::CUSTOMERS, (string) $customer->getId());
     }
 
-    /**
-     * @When I want to change my password
-     */
+    #[When('I want to change my password')]
     public function iWantToChangeMyPassword(): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -70,84 +68,64 @@ final class CustomerContext implements Context
         $this->client->buildCustomUpdateRequest(sprintf('customers/%s/password', $customer->getId()));
     }
 
-    /**
-     * @When I specify the first name as :firstName
-     * @When I remove the first name
-     */
+    #[When('I specify the first name as :firstName')]
+    #[When('I remove the first name')]
     public function iSpecifyTheFirstName(string $firstName = ''): void
     {
         $this->client->addRequestData('firstName', $firstName);
     }
 
-    /**
-     * @When I specify the :firstOrLast name as null value
-     */
+    #[When('I specify the :firstOrLast name as null value')]
     public function iSpecifyTheFirstOrLastNameAsNull(string $firstOrLast): void
     {
         $this->client->addRequestData($firstOrLast . 'Name', null);
     }
 
-    /**
-     * @When I specify the gender as a wrong value
-     */
+    #[When('I specify the gender as a wrong value')]
     public function iSpecifyTheFirstNameAsWrongValue(): void
     {
         $this->client->addRequestData('gender', 'wrong_value');
     }
 
-    /**
-     * @When I specify the phone number as huge value
-     */
+    #[When('I specify the phone number as huge value')]
     public function iSpecifyThePhoneNumberAsHugeValue(): void
     {
         $this->client->addRequestData('phoneNumber', str_repeat('1', 256));
     }
 
-    /**
-     * @When I specify the last name as :lastName
-     * @When I remove the last name
-     */
+    #[When('I specify the last name as :lastName')]
+    #[When('I remove the last name')]
     public function iSpecifyTheLastName(string $lastName = ''): void
     {
         $this->client->addRequestData('lastName', $lastName);
     }
 
-    /**
-     * @When I specify the customer email as :email
-     * @When I remove the customer email
-     */
+    #[When('I specify the customer email as :email')]
+    #[When('I remove the customer email')]
     public function iSpecifyCustomerTheEmail(string $email = ''): void
     {
         $this->client->addRequestData('email', $email);
     }
 
-    /**
-     * @When I specify the current password as :password
-     */
+    #[When('I specify the current password as :password')]
     public function iSpecifyTheCurrentPasswordAs(string $password): void
     {
         $this->client->addRequestData('currentPassword', $password);
     }
 
-    /**
-     * @When I specify the new password as :password
-     */
+    #[When('I specify the new password as :password')]
     public function iSpecifyTheNewPasswordAs(string $password): void
     {
         $this->client->addRequestData('newPassword', $password);
     }
 
-    /**
-     * @When I confirm this password as :password
-     */
+    #[When('I confirm this password as :password')]
     public function iSpecifyTheConfirmationPasswordAs(string $password): void
     {
         $this->client->addRequestData('confirmNewPassword', $password);
     }
 
-    /**
-     * @When I change password from :oldPassword to :newPassword
-     */
+    #[When('I change password from :oldPassword to :newPassword')]
     public function iChangePasswordTo(string $oldPassword, string $newPassword): void
     {
         $this->client->setRequestData([
@@ -157,17 +135,13 @@ final class CustomerContext implements Context
         ]);
     }
 
-    /**
-     * @When I subscribe to the newsletter
-     */
+    #[When('I subscribe to the newsletter')]
     public function iSubscribeToTheNewsletter(): void
     {
         $this->client->addRequestData('subscribedToNewsletter', true);
     }
 
-    /**
-     * @Then I should be subscribed to the newsletter
-     */
+    #[Then('I should be subscribed to the newsletter')]
     public function iShouldBeSubscribedToTheNewsletter(): void
     {
         $response = $this->client->getLastResponse();
@@ -175,27 +149,21 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->getValue($response, 'subscribedToNewsletter'));
     }
 
-    /**
-     * @When /^(I) try to verify my account using the link from this email$/
-     */
+    #[When('/^(I) try to verify my account using the link from this email$/')]
     public function iTryToVerifyMyAccountUsingTheLinkFromEmail(ShopUserInterface $user): void
     {
         $this->verificationToken = $user->getEmailVerificationToken();
         $this->verifyAccount($this->verificationToken);
     }
 
-    /**
-     * @When I (try to )verify using :token token
-     */
+    #[When('I (try to )verify using :token token')]
     public function iTryToVerifyUsing(string $token): void
     {
         $this->verificationToken = $token;
         $this->verifyAccount($token);
     }
 
-    /**
-     * @When I resend the verification email
-     */
+    #[When('I resend the verification email')]
     public function iResendVerificationEmail(): void
     {
         /** @var ShopUserInterface $user */
@@ -204,9 +172,7 @@ final class CustomerContext implements Context
         $this->resendVerificationEmail($user->getEmail());
     }
 
-    /**
-     * @When I use the verification link from the first email to verify
-     */
+    #[When('I use the verification link from the first email to verify')]
     public function iUseVerificationLinkFromFirstEmailToVerify(): void
     {
         $token = $this->sharedStorage->get('verification_token');
@@ -214,27 +180,21 @@ final class CustomerContext implements Context
         $this->verifyAccount($token);
     }
 
-    /**
-     * @When I register with email :email and password :password
-     */
+    #[When('I register with email :email and password :password')]
     public function iRegisterWithEmailAndPassword(string $email, string $password): void
     {
         $this->registerAccount($email, $password);
         $this->loginContext->iLogInAsWithPassword($email, $password);
     }
 
-    /**
-     * @Then I should be notified that the verification email has been sent
-     */
+    #[Then('I should be notified that the verification email has been sent')]
     public function iShouldBeNotifiedThatTheVerificationEmailHasBeenSent(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), 202);
     }
 
-    /**
-     * @Then my email should be :email
-     * @Then my email should still be :email
-     */
+    #[Then('my email should be :email')]
+    #[Then('my email should still be :email')]
     public function myEmailShouldBe(string $email): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -247,10 +207,8 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'email', $email));
     }
 
-    /**
-     * @Then my name should be :name
-     * @Then my name should still be :name
-     */
+    #[Then('my name should be :name')]
+    #[Then('my name should still be :name')]
     public function myNameShouldBe(string $name): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -261,9 +219,7 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'fullName', $name));
     }
 
-    /**
-     * @Then my gender should still be :gender
-     */
+    #[Then('my gender should still be :gender')]
     public function myGenderShouldBe(string $gender): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -274,9 +230,7 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'gender', $gender));
     }
 
-    /**
-     * @Then my phone number should still be :phoneNumber
-     */
+    #[Then('my phone number should still be :phoneNumber')]
     public function myPhoneNumberShouldBe(string $phoneNumber): void
     {
         /** @var ShopUserInterface $shopUser */
@@ -287,9 +241,7 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'phoneNumber', $phoneNumber));
     }
 
-    /**
-     * @Then I should be notified that the first name is required
-     */
+    #[Then('I should be notified that the first name is required')]
     public function iShouldBeNotifiedThatFirstNameIsRequired(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -298,9 +250,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be (also) notified that the :firstOrLast name needs to be provided
-     */
+    #[Then('I should be (also) notified that the :firstOrLast name needs to be provided')]
     public function iShouldBeNotifiedThatFirstOrLastNameNeedsToBeProvided(string $firstOrLast): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -309,9 +259,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that my gender is invalid
-     */
+    #[Then('I should be notified that my gender is invalid')]
     public function iShouldBeNotifiedThatGenderIsInvalid(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -320,9 +268,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the phone number is too long
-     */
+    #[Then('I should be notified that the phone number is too long')]
     public function iShouldBeNotifiedThatThePhoneNumberIsTooLong(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -331,9 +277,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the last name is required
-     */
+    #[Then('I should be notified that the last name is required')]
     public function iShouldBeNotifiedThatLastNameIsRequired(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -342,9 +286,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the email is required
-     */
+    #[Then('I should be notified that the email is required')]
     public function iShouldBeNotifiedThatEmailIsRequired(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -353,9 +295,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the email is already used
-     */
+    #[Then('I should be notified that the email is already used')]
     public function iShouldBeNotifiedThatTheEmailIsAlreadyUsed(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -364,9 +304,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the email is invalid
-     */
+    #[Then('I should be notified that the email is invalid')]
     public function iShouldBeNotifiedThatEmailIsInvalid(): void
     {
         Assert::true($this->isViolationWithMessageInResponse(
@@ -375,9 +313,7 @@ final class CustomerContext implements Context
         ));
     }
 
-    /**
-     * @Then I should be notified that the verification token is invalid
-     */
+    #[Then('I should be notified that the verification token is invalid')]
     public function iShouldBeNotifiedThatTheVerificationTokenIsInvalid(): void
     {
         $response = $this->client->getLastResponse();
@@ -387,17 +323,13 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @When I (try to) browse my orders
-     */
+    #[When('I (try to) browse my orders')]
     public function iBrowseMyOrders(): void
     {
         $this->client->index(Resources::ORDERS);
     }
 
-    /**
-     * @When I register with previously used :email email and :password password
-     */
+    #[When('I register with previously used :email email and :password password')]
     public function iRegisterWithPreviouslyUsedEmailAndPassword(string $email, string $password): void
     {
         $this->registrationContext->iWantToRegisterNewAccount();
@@ -408,17 +340,13 @@ final class CustomerContext implements Context
         $this->loginContext->iLogInAsWithPassword($email, $password);
     }
 
-    /**
-     * @Then I should see a single order in the list
-     */
+    #[Then('I should see a single order in the list')]
     public function iShouldSeeASingleOrderInTheList(): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->index(Resources::ORDERS)), 1);
     }
 
-    /**
-     * @Then this order should have :orderNumber number
-     */
+    #[Then('this order should have :orderNumber number')]
     public function thisOrderShouldHaveNumber(string $orderNumber): void
     {
         Assert::true(
@@ -430,19 +358,15 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the verification was successful
-     */
+    #[Then('I should be notified that the verification was successful')]
     public function iShouldBeNotifiedThatTheVerificationWasSuccessful(): void
     {
         $this->responseChecker->isCreationSuccessful($this->client->getLastResponse());
     }
 
-    /**
-     * @Then I should be notified that my password has been successfully changed
-     * @Then I should be notified that new account has been successfully created
-     * @Then I should be notified that my account has been created and the verification email has been sent
-     */
+    #[Then('I should be notified that my password has been successfully changed')]
+    #[Then('I should be notified that new account has been successfully created')]
+    #[Then('I should be notified that my account has been created and the verification email has been sent')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyChanged(): void
     {
         $response = $this->client->getLastResponse();
@@ -454,9 +378,7 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that provided password is different than the current one
-     */
+    #[Then('I should be notified that provided password is different than the current one')]
     public function iShouldBeNotifiedThatProvidedPasswordIsDifferentThanTheCurrentOne(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), 422);
@@ -467,9 +389,7 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the entered passwords do not match
-     */
+    #[Then('I should be notified that the entered passwords do not match')]
     public function iShouldBeNotifiedThatTheEnteredPasswordsDoNotMatch(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), 422);
@@ -480,9 +400,7 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that the ([^"]+) should be ([^"]+)$/
-     */
+    #[Then('/^I should be notified that the ([^"]+) should be ([^"]+)$/')]
     public function iShouldBeNotifiedThatTheElementShouldBe(string $elementName, string $validationMessage): void
     {
         Assert::contains(
@@ -491,9 +409,7 @@ final class CustomerContext implements Context
         );
     }
 
-    /**
-     * @Then my account should be verified
-     */
+    #[Then('my account should be verified')]
     public function myAccountShouldBeVerified(): void
     {
         $response = $this->getResponseWithAccountData();
@@ -501,9 +417,7 @@ final class CustomerContext implements Context
         Assert::true($this->responseChecker->getResponseContent($response)['user']['verified']);
     }
 
-    /**
-     * @Then /^(?:my|his|her) account should not be verified$/
-     */
+    #[Then('/^(?:my|his|her) account should not be verified$/')]
     public function myAccountShouldNotBeVerified(): void
     {
         $response = $this->getResponseWithAccountData();
@@ -511,9 +425,7 @@ final class CustomerContext implements Context
         Assert::false($this->responseChecker->getResponseContent($response)['user']['verified']);
     }
 
-    /**
-     * @Then I should not be able to resend the verification email
-     */
+    #[Then('I should not be able to resend the verification email')]
     public function iShouldBeUnableToResendVerificationEmail(): void
     {
         /** @var ShopUserInterface $user */

--- a/src/Sylius/Behat/Context/Api/Shop/ExchangeRateContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ExchangeRateContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -27,25 +29,19 @@ final readonly class ExchangeRateContext implements Context
     ) {
     }
 
-    /**
-     * @When I get exchange rates of the store
-     */
+    #[When('I get exchange rates of the store')]
     public function iGetExchangeRatesOfTheStore(): void
     {
         $this->client->index(Resources::EXCHANGE_RATES);
     }
 
-    /**
-     * @Then I should see :count exchange rates on the list
-     */
+    #[Then('I should see :count exchange rates on the list')]
     public function iShouldSeeExchangeRatesOnTheList(int $count): void
     {
         Assert::count($this->responseChecker->getCollection($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see that the exchange rate of :sourceCurrency to :targetCurrency is :ratio
-     */
+    #[Then('I should see that the exchange rate of :sourceCurrency to :targetCurrency is :ratio')]
     public function iShouldSeeThatExchangeRateOfSourceCurrencyToTargetCurrencyIs(string $sourceCurrency, string $targetCurrency, float $ratio): void
     {
         $exchangeRate = $this->getExchangeRateByTargetCurrency($sourceCurrency, $targetCurrency);
@@ -53,9 +49,7 @@ final readonly class ExchangeRateContext implements Context
         Assert::same($exchangeRate['ratio'], $ratio);
     }
 
-    /**
-     * @Then I should not see :sourceCurrency to :targetCurrency exchange rate
-     */
+    #[Then('I should not see :sourceCurrency to :targetCurrency exchange rate')]
     public function iShouldNotSeeSourceCurrencyToTargetCurrencyExchangeRate(string $sourceCurrency, string $targetCurrency): void
     {
         Assert::throws(

--- a/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/HomepageContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
@@ -33,9 +35,7 @@ final class HomepageContext implements Context
     ) {
     }
 
-    /**
-     * @When I check latest products
-     */
+    #[When('I check latest products')]
     public function iCheckLatestProducts(): void
     {
         $this->client->customAction(
@@ -44,9 +44,7 @@ final class HomepageContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :productName product
-     */
+    #[Then('I should see :productName product')]
     public function iShouldSeeProduct(string $productName): void
     {
         Assert::true(
@@ -58,9 +56,7 @@ final class HomepageContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see :productName product
-     */
+    #[Then('I should not see :productName product')]
     public function iShouldNotSeeProduct(string $productName): void
     {
         Assert::false(
@@ -72,27 +68,21 @@ final class HomepageContext implements Context
         );
     }
 
-    /**
-     * @When I check available taxons
-     */
+    #[When('I check available taxons')]
     public function iCheckAvailableTaxons(): void
     {
         $this->objectManager->clear(); // avoiding doctrine cache
         $this->client->customAction(sprintf('%s/shop/taxons', $this->apiUrlPrefix), HttpRequest::METHOD_GET);
     }
 
-    /**
-     * @Then I should see :count products in the list
-     */
+    #[Then('I should see :count products in the list')]
     public function iShouldSeeProductsInTheList(int $count): void
     {
         Assert::eq($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then I should see :firstMenuItem in the menu
-     * @Then I should see :firstMenuItem and :secondMenuItem in the menu
-     */
+    #[Then('I should see :firstMenuItem in the menu')]
+    #[Then('I should see :firstMenuItem and :secondMenuItem in the menu')]
     public function iShouldSeeAndInTheMenu(string ...$expectedMenuItems): void
     {
         $menuItems = $this->getAvailableTaxonMenuItemsFromTaxonCollection($this->client->getLastResponse());
@@ -103,11 +93,9 @@ final class HomepageContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see :firstMenuItem and :secondMenuItem in the menu
-     * @Then I should not see :firstMenuItem, :secondMenuItem and :thirdMenuItem in the menu
-     * @Then I should not see :firstMenuItem, :secondMenuItem, :thirdMenuItem and :fourthMenuItem in the menu
-     */
+    #[Then('I should not see :firstMenuItem and :secondMenuItem in the menu')]
+    #[Then('I should not see :firstMenuItem, :secondMenuItem and :thirdMenuItem in the menu')]
+    #[Then('I should not see :firstMenuItem, :secondMenuItem, :thirdMenuItem and :fourthMenuItem in the menu')]
     public function iShouldNotSeeAndInTheMenu(string ...$unexpectedMenuItems): void
     {
         $menuItems = $this->getAvailableTaxonMenuItemsFromTaxonCollection($this->client->getLastResponse());

--- a/src/Sylius/Behat/Context/Api/Shop/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LocaleContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -30,34 +32,26 @@ final class LocaleContext implements Context
     ) {
     }
 
-    /**
-     * @When I get available locales
-     */
+    #[When('I get available locales')]
     public function iGetAvailableLocales(): void
     {
         $this->client->index(Resources::LOCALES);
     }
 
-    /**
-     * @When I get :locale locale
-     */
+    #[When('I get :locale locale')]
     public function iGetLocale(LocaleInterface $locale): void
     {
         $this->client->show(Resources::LOCALES, $locale->getCode());
     }
 
-    /**
-     * @When I switch to the :localeCode locale
-     * @When I use the locale :localeCode
-     */
+    #[When('I switch to the :localeCode locale')]
+    #[When('I use the locale :localeCode')]
     public function iSwitchToTheLocale(string $localeCode): void
     {
         $this->sharedStorage->set('current_locale_code', $localeCode);
     }
 
-    /**
-     * @Then I should have :count locales
-     */
+    #[Then('I should have :count locales')]
     public function iShouldHaveLocales(int $count): void
     {
         Assert::same(
@@ -66,9 +60,7 @@ final class LocaleContext implements Context
         );
     }
 
-    /**
-     * @Then the :name locale with code :code should be available
-     */
+    #[Then('the :name locale with code :code should be available')]
     public function theLocaleWithCodeShouldBeAvailable(string $name, string $code): void
     {
         Assert::true(
@@ -76,9 +68,7 @@ final class LocaleContext implements Context
         );
     }
 
-    /**
-     * @Then the :name locale with code :code should not be available
-     */
+    #[Then('the :name locale with code :code should not be available')]
     public function theLocaleWithCodeShouldNotBeAvailable(string $name, string $code): void
     {
         Assert::false(
@@ -86,9 +76,7 @@ final class LocaleContext implements Context
         );
     }
 
-    /**
-     * @Then I should have :name with code :code
-     */
+    #[Then('I should have :name with code :code')]
     public function iShouldHaveWithCode(string $name, string $code): void
     {
         $response = $this->client->getLastResponse();
@@ -97,9 +85,7 @@ final class LocaleContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'code', $code));
     }
 
-    /**
-     * @Then I should( still) shop using the :localeCode locale
-     */
+    #[Then('I should( still) shop using the :localeCode locale')]
     public function iShouldShopUsingTheLocale(string $localeCode): void
     {
         $this->client->buildCreateRequest(Resources::ORDERS);
@@ -107,9 +93,7 @@ final class LocaleContext implements Context
         Assert::same($this->responseChecker->getValue($this->client->create(), 'localeCode'), $localeCode);
     }
 
-    /**
-     * @Then I should be able to shop using the :localeCode locale
-     */
+    #[Then('I should be able to shop using the :localeCode locale')]
     public function iShouldBeAbleToShopUsingTheLocale(string $localeCode): void
     {
         $this->iGetAvailableLocales();
@@ -119,9 +103,7 @@ final class LocaleContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to shop using the :localeCode locale
-     */
+    #[Then('I should not be able to shop using the :localeCode locale')]
     public function iShouldNotBeAbleToShopUsingTheLocale(string $localeCode): void
     {
         $this->iGetAvailableLocales();

--- a/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/LoginContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -50,17 +53,13 @@ final class LoginContext implements Context
     ) {
     }
 
-    /**
-     * @Given there is the visitor
-     */
+    #[Given('there is the visitor')]
     public function iAmAVisitor(): void
     {
         // Intentionally left blank;
     }
 
-    /**
-     * @When I log in with the email :email
-     */
+    #[When('I log in with the email :email')]
     public function iLogInWithTheEmail(string $email): void
     {
         $this->shopAuthenticationTokenClient->request(
@@ -78,25 +77,19 @@ final class LoginContext implements Context
         Assert::keyExists($content, 'token', 'Token not found.');
     }
 
-    /**
-     * @When I want to log in
-     */
+    #[When('I want to log in')]
     public function iWantToLogIn(): void
     {
         $this->apiSecurityClient->prepareLoginRequest();
     }
 
-    /**
-     * @When I want to reset password
-     */
+    #[When('I want to reset password')]
     public function iWantToResetPassword(): void
     {
         $this->request = $this->requestFactory->create('shop', 'customers/reset-password', 'Bearer');
     }
 
-    /**
-     * @When I reset password for email :email in :locale locale
-     */
+    #[When('I reset password for email :email in :locale locale')]
     public function iResetPasswordForEmailInLocale(string $email, LocaleInterface $locale): void
     {
         $this->iWantToResetPassword();
@@ -105,9 +98,7 @@ final class LoginContext implements Context
         $this->iResetIt();
     }
 
-    /**
-     * @When /^I follow link on (my) email to reset my password$/
-     */
+    #[When('/^I follow link on (my) email to reset my password$/')]
     public function iFollowLinkOnMyEmailToResetPassword(ShopUserInterface $user): void
     {
         $this->request = $this->requestFactory->custom(
@@ -116,70 +107,54 @@ final class LoginContext implements Context
         );
     }
 
-    /**
-     * @When I reset it
-     * @When I try to reset it
-     */
+    #[When('I reset it')]
+    #[When('I try to reset it')]
     public function iResetIt(): void
     {
         $this->client->executeCustomRequest($this->request);
     }
 
-    /**
-     * @When I specify the username as :username
-     */
+    #[When('I specify the username as :username')]
     public function iSpecifyTheUsername(string $username): void
     {
         $this->apiSecurityClient->setEmail($username);
     }
 
-    /**
-     * @When I specify customer email as :email
-     * @When I do not specify the email
-     */
+    #[When('I specify customer email as :email')]
+    #[When('I do not specify the email')]
     public function iSpecifyTheEmail(string $email = ''): void
     {
         $this->request->updateContent(['email' => $email]);
     }
 
-    /**
-     * @When I specify my new password as :password
-     * @When I do not specify my new password
-     */
+    #[When('I specify my new password as :password')]
+    #[When('I do not specify my new password')]
     public function iSpecifyMyNewPassword(?string $password = null): void
     {
         $this->request->updateContent(['newPassword' => $this->replaceWithSecurePassword($password)]);
     }
 
-    /**
-     * @When I confirm my new password as :password
-     * @When I do not confirm my new password
-     */
+    #[When('I confirm my new password as :password')]
+    #[When('I do not confirm my new password')]
     public function iConfirmMyNewPassword(?string $password = null): void
     {
         $this->request->updateContent(['confirmNewPassword' => $this->confirmSecurePassword($password)]);
     }
 
-    /**
-     * @When I specify the password as :password
-     */
+    #[When('I specify the password as :password')]
     public function iSpecifyThePasswordAs(string $password): void
     {
         $this->apiSecurityClient->setPassword($password);
     }
 
-    /**
-     * @When I log in
-     * @When I try to log in
-     */
+    #[When('I log in')]
+    #[When('I try to log in')]
     public function iLogIn(): void
     {
         $this->apiSecurityClient->call();
     }
 
-    /**
-     * @When I log in as :email with :password password
-     */
+    #[When('I log in as :email with :password password')]
     public function iLogInAsWithPassword(string $email, string $password): void
     {
         $this->apiSecurityClient->prepareLoginRequest();
@@ -188,26 +163,20 @@ final class LoginContext implements Context
         $this->apiSecurityClient->call();
     }
 
-    /**
-     * @When I log out
-     * @When the customer logged out
-     */
+    #[When('I log out')]
+    #[When('the customer logged out')]
     public function iLogOut()
     {
         $this->apiSecurityClient->logOut();
     }
 
-    /**
-     * @Then I should be logged in
-     */
+    #[Then('I should be logged in')]
     public function iShouldBeLoggedIn(): void
     {
         Assert::true($this->apiSecurityClient->isLoggedIn(), 'Shop user should be logged in, but they are not.');
     }
 
-    /**
-     * @Then I should not be logged in
-     */
+    #[Then('I should not be logged in')]
     public function iShouldNotBeLoggedIn(): void
     {
         try {
@@ -223,27 +192,21 @@ final class LoginContext implements Context
         Assert::false($isLoggedIn, 'Shop user should not be logged in, but they are.');
     }
 
-    /**
-     * @Then I should be notified about bad credentials
-     */
+    #[Then('I should be notified about bad credentials')]
     public function iShouldBeNotifiedAboutBadCredentials(): void
     {
         Assert::same($this->apiSecurityClient->getErrorMessage(), 'Invalid credentials.');
     }
 
-    /**
-     * @Then I should be notified that email with reset instruction has been sent
-     * @Then I should be notified that my password has been successfully reset
-     */
+    #[Then('I should be notified that email with reset instruction has been sent')]
+    #[Then('I should be notified that my password has been successfully reset')]
     public function iShouldBeNotifiedThatEmailWithResetInstructionWasSent(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), 202);
     }
 
-    /**
-     * @Then I should be able to log in as :email with :password password
-     * @Then the customer should be able to log in as :email with :password password
-     */
+    #[Then('I should be able to log in as :email with :password password')]
+    #[Then('the customer should be able to log in as :email with :password password')]
     public function iShouldBeAbleToLogInAsWithPassword(string $email, string $password): void
     {
         $this->iLogInAsWithPassword($email, $password);
@@ -251,9 +214,7 @@ final class LoginContext implements Context
         $this->iShouldBeLoggedIn();
     }
 
-    /**
-     * @Then I should not be able to log in as :email with :password password
-     */
+    #[Then('I should not be able to log in as :email with :password password')]
     public function iShouldNotBeAbleToLogInAsWithPassword(string $email, string $password): void
     {
         $this->iLogInAsWithPassword($email, $password);
@@ -261,9 +222,7 @@ final class LoginContext implements Context
         $this->iShouldNotBeLoggedIn();
     }
 
-    /**
-     * @Then I should see who I am
-     */
+    #[Then('I should see who I am')]
     public function iShouldSeeWhoIAm(): void
     {
         /** @var CustomerInterface $customer */
@@ -278,9 +237,7 @@ final class LoginContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to change my password again with the same token
-     */
+    #[Then('I should not be able to change my password again with the same token')]
     public function iShouldNotBeAbleToChangeMyPasswordAgainWithTheSameToken(): void
     {
         $response = $this->client->executeCustomRequest($this->request);
@@ -288,9 +245,7 @@ final class LoginContext implements Context
         Assert::same($this->responseChecker->getError($response), 'token: Password reset token itotallyforgotmypassword is invalid.');
     }
 
-    /**
-     * @Then I should not be able to change my password with this token
-     */
+    #[Then('I should not be able to change my password with this token')]
     public function iShouldNotBeAbleToChangeMyPasswordWithThisToken(): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -48,10 +50,8 @@ final readonly class OrderContext implements Context
     ) {
     }
 
-    /**
-     * @When I change my payment method to :paymentMethod
-     * @When I try to change my payment method to :paymentMethod
-     */
+    #[When('I change my payment method to :paymentMethod')]
+    #[When('I try to change my payment method to :paymentMethod')]
     public function iChangeMyPaymentMethodTo(PaymentMethodInterface $paymentMethod): void
     {
         /** @var OrderInterface $order */
@@ -73,9 +73,7 @@ final readonly class OrderContext implements Context
         $this->shopClient->executeCustomRequest($request);
     }
 
-    /**
-     * @When I view the summary of my order :order
-     */
+    #[When('I view the summary of my order :order')]
     public function iViewTheSummaryOfMyOrder(OrderInterface $order): void
     {
         $this->shopClient->show(Resources::ORDERS, $order->getTokenValue());
@@ -84,9 +82,7 @@ final readonly class OrderContext implements Context
         $this->sharedStorage->set('cart_token', $order->getTokenValue());
     }
 
-    /**
-     * @When I try to see the order placed by a customer :customer
-     */
+    #[When('I try to see the order placed by a customer :customer')]
     public function iTryToSeeTheOrderPlacedByACustomer(CustomerInterface $customer): void
     {
         /** @var OrderInterface $order */
@@ -96,9 +92,7 @@ final readonly class OrderContext implements Context
         $this->iViewTheSummaryOfMyOrder($order);
     }
 
-    /**
-     * @Then I should be able to access this order's details
-     */
+    #[Then('I should be able to access this order\'s details')]
     public function iShouldBeAbleToAccessThisOrderDetails(): void
     {
         $response = $this->shopClient->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
@@ -114,17 +108,13 @@ final readonly class OrderContext implements Context
         );
     }
 
-    /**
-     * @Then it should have the number :orderNumber
-     */
+    #[Then('it should have the number :orderNumber')]
     public function itShouldHaveTheNumber(string $orderNumber): void
     {
         Assert::same($this->responseChecker->getValue($this->shopClient->getLastResponse(), 'number'), $orderNumber);
     }
 
-    /**
-     * @Then I should see :customerName, :street, :postcode, :city, :country as :addressType address
-     */
+    #[Then('I should see :customerName, :street, :postcode, :city, :country as :addressType address')]
     public function iShouldSeeAsShippingAddress(
         string $customerName,
         string $street,
@@ -145,17 +135,13 @@ final readonly class OrderContext implements Context
         Assert::same($address['countryCode'], $country->getCode());
     }
 
-    /**
-     * @Then I should see :amount items in the list
-     */
+    #[Then('I should see :amount items in the list')]
     public function iShouldSeeItemsInTheList(int $amount): void
     {
         Assert::same(count($this->responseChecker->getValue($this->shopClient->getLastResponse(), 'items')), $amount);
     }
 
-    /**
-     * @Then the product named :productName should be in the items list
-     */
+    #[Then('the product named :productName should be in the items list')]
     public function theProductShouldBeInTheItemsList(string $productName): void
     {
         $items = $this->responseChecker->getValue($this->shopClient->getLastResponse(), 'items');
@@ -169,10 +155,8 @@ final readonly class OrderContext implements Context
         throw new \InvalidArgumentException('There is no product with given name.');
     }
 
-    /**
-     * @Then /^the order's (shipment) status should be "([^"]+)"$/
-     * @Then /^I should see its order's (payment) status as "([^"]+)"$/
-     */
+    #[Then('/^the order\'s (shipment) status should be "([^"]+)"$/')]
+    #[Then('/^I should see its order\'s (payment) status as "([^"]+)"$/')]
     public function iShouldSeeItsOrderSStatusAs(string $elementType, string $orderElementState): void
     {
         if ($elementType === 'shipment') {
@@ -190,9 +174,7 @@ final readonly class OrderContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :provinceName as province in the :addressType address
-     */
+    #[Then('I should see :provinceName as province in the :addressType address')]
     public function iShouldSeeAsProvinceInTheShippingAddress(string $provinceName, string $addressType): void
     {
         $address = $this->responseChecker->getValue($this->shopClient->getLastResponse(), ($addressType . 'Address'));
@@ -200,9 +182,7 @@ final readonly class OrderContext implements Context
         Assert::same($address['provinceName'], $provinceName);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+") as order's subtotal$/
-     */
+    #[Then('/^I should see ("[^"]+") as order\'s subtotal$/')]
     public function iShouldSeeAsOrderSSubtotal(int $expectedSubtotal): void
     {
         $items = $this->responseChecker->getValue($this->shopClient->getLastResponse(), 'items');
@@ -216,17 +196,13 @@ final readonly class OrderContext implements Context
         Assert::same($subtotal, $expectedSubtotal);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+") as order's total$/
-     */
+    #[Then('/^I should see ("[^"]+") as order\'s total$/')]
     public function iShouldSeeAsOrderSTotal(int $total): void
     {
         Assert::same($this->responseChecker->getValue($this->shopClient->getLastResponse(), 'total'), $total);
     }
 
-    /**
-     * @Then /^I should see that I have to pay ("[^"]+") for this order$/
-     */
+    #[Then('/^I should see that I have to pay ("[^"]+") for this order$/')]
     public function iShouldSeeIHaveToPayForThisOrder(int $paymentAmount): void
     {
         $response = $this->shopClient->showByIri(
@@ -236,18 +212,14 @@ final readonly class OrderContext implements Context
         Assert::same($this->responseChecker->getValue($response, 'amount'), $paymentAmount);
     }
 
-    /**
-     * @Then :promotionName should be applied to my order
-     * @Then :promotionName should be applied to my order shipping
-     */
+    #[Then(':promotionName should be applied to my order')]
+    #[Then(':promotionName should be applied to my order shipping')]
     public function shouldBeAppliedToMyOrder(string $promotionName): void
     {
         Assert::true($this->hasAdjustmentWithLabel($promotionName));
     }
 
-    /**
-     * @Then /^(this promotion) should give ("[^"]+") discount on shipping$/
-     */
+    #[Then('/^(this promotion) should give ("[^"]+") discount on shipping$/')]
     public function thisPromotionShouldGiveDiscountOnShipping(PromotionInterface $promotion, int $discount): void
     {
         $adjustment = $this->getAdjustmentWithLabel($promotion->getName());
@@ -255,9 +227,7 @@ final readonly class OrderContext implements Context
         Assert::same($discount, $adjustment['amount']);
     }
 
-    /**
-     * @Then /^the ("[^"]+" product) should have unit price discounted by ("[^"]+")$/
-     */
+    #[Then('/^the ("[^"]+" product) should have unit price discounted by ("[^"]+")$/')]
     public function theShouldHaveUnitPriceDiscountedFor(ProductInterface $product, int $amount): void
     {
         $discount = 0;
@@ -270,25 +240,19 @@ final readonly class OrderContext implements Context
         Assert::same(-$discount, $amount);
     }
 
-    /**
-     * @Then /^the ("[^"]+" product) should have unit prices discounted by ("[^"]+"), ("[^"]+") and ("[^"]+")$/
-     */
+    #[Then('/^the ("[^"]+" product) should have unit prices discounted by ("[^"]+"), ("[^"]+") and ("[^"]+")$/')]
     public function theShouldHaveUnitPricesDiscountedFor(ProductInterface $product, int $amountOne, int $amountTwo, int $amountThree): void
     {
         Assert::true($this->hasCorrectAmountsDistributedOnAdjustments([$amountOne, $amountTwo, $amountThree], $product));
     }
 
-    /**
-     * @Then /^the ("[^"]+" product) should have unit prices discounted by ("[^"]+") and ("[^"]+")$/
-     */
+    #[Then('/^the ("[^"]+" product) should have unit prices discounted by ("[^"]+") and ("[^"]+")$/')]
     public function theShouldHaveUnitPricesDiscountedForAnd(ProductInterface $product, int $amountOne, int $amountTwo): void
     {
         Assert::true($this->hasCorrectAmountsDistributedOnAdjustments([$amountOne, $amountTwo], $product));
     }
 
-    /**
-     * @Then I should have chosen :paymentMethod payment method
-     */
+    #[Then('I should have chosen :paymentMethod payment method')]
     public function iShouldHaveChosenPaymentMethodForMyOrder(PaymentMethodInterface $paymentMethod): void
     {
         $payment = $this
@@ -299,25 +263,19 @@ final readonly class OrderContext implements Context
         Assert::same($this->iriConverter->getIriFromResource($paymentMethod), $payment['method']);
     }
 
-    /**
-     * @Then I should not be able to see that order
-     */
+    #[Then('I should not be able to see that order')]
     public function iShouldNotBeAbleToSeeThatOrder(): void
     {
         Assert::false($this->responseChecker->isShowSuccessful($this->shopClient->getLastResponse()));
     }
 
-    /**
-     * @Then I should be denied an access to order list
-     */
+    #[Then('I should be denied an access to order list')]
     public function iShouldDeniedAnAccessToOrderList(): void
     {
         Assert::true($this->responseChecker->hasAccessDenied($this->shopClient->getLastResponse()));
     }
 
-    /**
-     * @Then I should have :paymentMethod payment method on my order
-     */
+    #[Then('I should have :paymentMethod payment method on my order')]
     public function iShouldHavePaymentMethodOnMyOrder(PaymentMethodInterface $paymentMethod): void
     {
         $paymentMethodIri = $this
@@ -328,9 +286,7 @@ final readonly class OrderContext implements Context
         Assert::same($this->iriConverter->getResourceFromIri($paymentMethodIri)->getCode(), $paymentMethod->getCode());
     }
 
-    /**
-     * @Then /^(the administrator) should know about (this additional note) for (this order made by "[^"]+")$/
-     */
+    #[Then('/^(the administrator) should know about (this additional note) for (this order made by "[^"]+")$/')]
     public function theCustomerServiceShouldKnowAboutThisAdditionalNotes(
         AdminUserInterface $user,
         string $notes,
@@ -344,9 +300,7 @@ final readonly class OrderContext implements Context
         );
     }
 
-    /**
-     * @Then /^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/
-     */
+    #[Then('/^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/')]
     public function theAdministratorShouldSeeThatThisOrderHasBeenPlacedIn(
         AdminUserInterface $user,
         OrderInterface $order,

--- a/src/Sylius/Behat/Context/Api/Shop/OrderItemContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderItemContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -33,9 +35,7 @@ final class OrderItemContext implements Context
     ) {
     }
 
-    /**
-     * @When I try to see one of the items from the order placed by a customer :customer
-     */
+    #[When('I try to see one of the items from the order placed by a customer :customer')]
     public function iTryToSeeOneOfTheItemsFromTheOrderPlacedByACustomer(CustomerInterface $customer): void
     {
         /** @var OrderInterface $order */
@@ -48,9 +48,7 @@ final class OrderItemContext implements Context
         $this->client->show(Resources::ORDER_ITEMS, (string) $orderItem->getId());
     }
 
-    /**
-     * @When I try to see one of the units from the order placed by a customer :customer
-     */
+    #[When('I try to see one of the units from the order placed by a customer :customer')]
     public function iTryToSeeOneOfTheUnitsFromTheOrderPlacedByACustomer(CustomerInterface $customer): void
     {
         /** @var OrderInterface $order */
@@ -63,17 +61,13 @@ final class OrderItemContext implements Context
         $this->client->show(Resources::ORDER_ITEM_UNITS, (string) $orderItemUnit->getId());
     }
 
-    /**
-     * @Then I should not be able to see that item
-     */
+    #[Then('I should not be able to see that item')]
     public function iShouldNotBeAbleToSeeThatItem(): void
     {
         Assert::false($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should not be able to see that unit
-     */
+    #[Then('I should not be able to see that unit')]
     public function iShouldNotBeAbleToSeeThatUnit(): void
     {
         Assert::false($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));

--- a/src/Sylius/Behat/Context/Api/Shop/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PaymentContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,9 +33,7 @@ final readonly class PaymentContext implements Context
     ) {
     }
 
-    /**
-     * @When I try to see the payment of the order placed by a customer :customer
-     */
+    #[When('I try to see the payment of the order placed by a customer :customer')]
     public function iTryToSeeThePaymentOfTheOrderPlacedByACustomer(CustomerInterface $customer): void
     {
         /** @var OrderInterface $order */
@@ -48,17 +48,13 @@ final readonly class PaymentContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to see that payment
-     */
+    #[Then('I should not be able to see that payment')]
     public function iShouldNotBeAbleToSeeThatPayment(): void
     {
         Assert::false($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));
     }
 
-    /**
-     * @Then I should see its payment state as :state
-     */
+    #[Then('I should see its payment state as :state')]
     public function iShouldSeeItsPaymentStateAs(string $state): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/PaymentRequestContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PaymentRequestContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\Request;
@@ -36,9 +38,7 @@ final readonly class PaymentRequestContext implements Context
     ) {
     }
 
-    /**
-     * @When I try to pay for my order
-     */
+    #[When('I try to pay for my order')]
     public function iTryToPayForMyOrder(array $payload = []): void
     {
         $this->client->show(Resources::ORDERS, $this->sharedStorage->get('cart_token'));
@@ -51,17 +51,13 @@ final readonly class PaymentRequestContext implements Context
         $this->sharedStorage->set('payment_request_uri', $uri);
     }
 
-    /**
-     * @When I try to update my payment request
-     */
+    #[When('I try to update my payment request')]
     public function iTryToUpdateMyPaymentRequest(array $payload = []): void
     {
         $this->putPaymentRequest($this->sharedStorage->get('payment_request_uri'), $payload);
     }
 
-    /**
-     * @Then a payment request with action :action for payment method :paymentMethod should have state :state
-     */
+    #[Then('a payment request with action :action for payment method :paymentMethod should have state :state')]
     public function aPaymentRequestWithActionForPaymentMethodShouldHaveState(string $action, PaymentMethodInterface $paymentMethod, string $state): void
     {
         $request = $this->getRequestForPaymentRequestWithAction($action);

--- a/src/Sylius/Behat/Context/Api/Shop/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductAttributeContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,9 +32,7 @@ final class ProductAttributeContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should (also) see the product attribute :attributeName with value :expectedAttribute
-     */
+    #[Then('I should (also) see the product attribute :attributeName with value :expectedAttribute')]
     public function iShouldSeeTheProductAttributeWithValue(string $attributeName, string $expectedAttribute): void
     {
         $attribute = $this->getAttributeByName($attributeName);
@@ -48,9 +47,7 @@ final class ProductAttributeContext implements Context
         Assert::same($attributeValue, $expectedAttribute);
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product attribute "([^"]+)" with (positive|negative) value$/
-     */
+    #[Then('/^I should(?:| also) see the product attribute "([^"]+)" with (positive|negative) value$/')]
     public function iShouldSeeTheProductAttributeWithBoolean(string $attributeName, string $expectedAttribute): void
     {
         $attribute = $this->getAttributeByName($attributeName);
@@ -58,9 +55,7 @@ final class ProductAttributeContext implements Context
         Assert::same($attribute['value'], 'positive' === $expectedAttribute);
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product attribute "([^"]+)" with value ([^"]+)%$/
-     */
+    #[Then('/^I should(?:| also) see the product attribute "([^"]+)" with value ([^"]+)%$/')]
     public function iShouldSeeTheProductAttributeWithPercentage(string $attributeName, int $expectedAttribute): void
     {
         $attribute = $this->getAttributeByName($attributeName);
@@ -68,9 +63,7 @@ final class ProductAttributeContext implements Context
         Assert::same($attribute['value'], $expectedAttribute / 100);
     }
 
-    /**
-     * @Then I should (also) see the product attribute :attributeName with value :expectedAttribute on the list
-     */
+    #[Then('I should (also) see the product attribute :attributeName with value :expectedAttribute on the list')]
     public function iShouldSeeTheProductAttributeWithValueOnTheList(string $attributeName, string $expectedAttribute): void
     {
         $attribute = $this->getAttributeByName($attributeName);
@@ -78,17 +71,13 @@ final class ProductAttributeContext implements Context
         Assert::inArray($expectedAttribute, $attribute['value']);
     }
 
-    /**
-     * @Then I should not see the product attribute :attributeName
-     */
+    #[Then('I should not see the product attribute :attributeName')]
     public function iShouldNotSeeTheProductAttribute(string $attributeName): void
     {
         Assert::false($this->hasAttributeByName($attributeName));
     }
 
-    /**
-     * @Then I should (also) see the product attribute :attributeName with date :expectedAttribute
-     */
+    #[Then('I should (also) see the product attribute :attributeName with date :expectedAttribute')]
     public function iShouldSeeTheProductAttributeWithDate(string $attributeName, string $expectedAttribute): void
     {
         $attribute = $this->getAttributeByName($attributeName);
@@ -96,17 +85,13 @@ final class ProductAttributeContext implements Context
         Assert::true(new \DateTime($attribute['value']) == new \DateTime($expectedAttribute));
     }
 
-    /**
-     * @Then I should see :count attributes
-     */
+    #[Then('I should see :count attributes')]
     public function iShouldSeeAttributes(int $count): void
     {
         Assert::count($this->getAttributes(), $count);
     }
 
-    /**
-     * @Then the first attribute should be :name
-     */
+    #[Then('the first attribute should be :name')]
     public function theFirstAttributeShouldBe(string $name): void
     {
         $attributes = $this->getAttributes();
@@ -116,9 +101,7 @@ final class ProductAttributeContext implements Context
         Assert::same($attribute['name'], $name);
     }
 
-    /**
-     * @Then the last attribute should be :name
-     */
+    #[Then('the last attribute should be :name')]
     public function theLastAttributeShouldBe(string $name): void
     {
         $attributes = $this->getAttributes();

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -49,11 +51,9 @@ final class ProductContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I check (this product)'s details$/
-     * @When I view product :product
-     * @When customer view product :product
-     */
+    #[When('/^I check (this product)\'s details$/')]
+    #[When('I view product :product')]
+    #[When('customer view product :product')]
     public function iViewProduct(ProductInterface $product): void
     {
         $this->objectManager->clear(); // it's needed to clear the entity manager to receive the product images in correct order, as the images are using fallback order when added programmatically
@@ -67,19 +67,15 @@ final class ProductContext implements Context
         $this->sharedStorage->remove('product_attributes');
     }
 
-    /**
-     * @When I try to reach nonexistent product
-     */
+    #[When('I try to reach nonexistent product')]
     public function iTryToReachNonexistentProduct(): void
     {
         $this->client->show(Resources::PRODUCTS, 'nonexistent');
     }
 
-    /**
-     * @When I view product :product in the :localeCode locale
-     * @When /^I check (this product)'s details in the ("([^"]+)" locale)$/
-     * @When /^I try to check (this product)'s details in the ("([^"]+)" locale)$/
-     */
+    #[When('I view product :product in the :localeCode locale')]
+    #[When('/^I check (this product)\'s details in the ("([^"]+)" locale)$/')]
+    #[When('/^I try to check (this product)\'s details in the ("([^"]+)" locale)$/')]
     public function iViewProductInTheLocale(ProductInterface $product, string $localeCode): void
     {
         $this->sharedStorage->set('current_locale_code', $localeCode);
@@ -89,9 +85,7 @@ final class ProductContext implements Context
         $this->sharedStorage->remove('current_locale_code');
     }
 
-    /**
-     * @When I view product :product using slug
-     */
+    #[When('I view product :product using slug')]
     public function iViewProductUsingSlug(ProductInterface $product): void
     {
         $this->client->showByIri(sprintf('%s/shop/products-by-slug/%s', $this->apiUrlPrefix, $product->getSlug()));
@@ -99,9 +93,7 @@ final class ProductContext implements Context
         $this->sharedStorage->set('product', $product);
     }
 
-    /**
-     * @Then I should be redirected to :product product
-     */
+    #[Then('I should be redirected to :product product')]
     public function iShouldBeRedirectedToProduct(ProductInterface $product): void
     {
         $response = $this->client->getLastResponse();
@@ -109,10 +101,8 @@ final class ProductContext implements Context
         Assert::eq($response->headers->get('Location'), sprintf('%s/shop/products/%s', $this->apiUrlPrefix, $product->getCode()));
     }
 
-    /**
-     * @When I browse products from taxon :taxon
-     * @When I browse products
-     */
+    #[When('I browse products from taxon :taxon')]
+    #[When('I browse products')]
     public function iBrowseProductsFromTaxon(?TaxonInterface $taxon = null): void
     {
         $this->client->index(Resources::PRODUCTS);
@@ -123,9 +113,7 @@ final class ProductContext implements Context
         }
     }
 
-    /**
-     * @When I browse products from product taxon code :taxon
-     */
+    #[When('I browse products from product taxon code :taxon')]
     public function iBrowseProductsFromProductTaxonCode(TaxonInterface $taxon): void
     {
         $this->client->index(Resources::PRODUCTS);
@@ -133,9 +121,7 @@ final class ProductContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When /^I browse products from ("([^"]+)" and "([^"]+)" taxons)$/
-     */
+    #[When('/^I browse products from ("([^"]+)" and "([^"]+)" taxons)$/')]
     public function iBrowseProductsFromProductTaxonCodes(iterable $taxons): void
     {
         $this->client->index(Resources::PRODUCTS);
@@ -147,9 +133,7 @@ final class ProductContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I browse products from non existing taxon
-     */
+    #[When('I browse products from non existing taxon')]
     public function iBrowseProductsFromNonExistingTaxon(): void
     {
         $this->client->index(Resources::PRODUCTS);
@@ -158,9 +142,7 @@ final class ProductContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When /^I sort products by the (oldest|newest) date first$/
-     */
+    #[When('/^I sort products by the (oldest|newest) date first$/')]
     public function iSortProductsByTheDateFirst(string $sortDirection): void
     {
         $sortDirection = 'oldest' === $sortDirection ? 'asc' : 'desc';
@@ -168,67 +150,51 @@ final class ProductContext implements Context
         $this->client->sort(['createdAt' => $sortDirection]);
     }
 
-    /**
-     * @When I sort products by the lowest price first
-     */
+    #[When('I sort products by the lowest price first')]
     public function iSortProductsByTheLowestPriceFirst(): void
     {
         $this->client->sort(['price' => 'asc']);
     }
 
-    /**
-     * @When I sort products by the highest price first
-     */
+    #[When('I sort products by the highest price first')]
     public function iSortProductsByTheHighestPriceFirst(): void
     {
         $this->client->sort(['price' => 'desc']);
     }
 
-    /**
-     * @When I sort products alphabetically from a to z
-     */
+    #[When('I sort products alphabetically from a to z')]
     public function iSortProductsAlphabeticallyFromAToZ(): void
     {
         $this->client->sort(['translation.name' => 'asc']);
     }
 
-    /**
-     * @When I sort products alphabetically from z to a
-     */
+    #[When('I sort products alphabetically from z to a')]
     public function iSortProductsAlphabeticallyFromZToA(): void
     {
         $this->client->sort(['translation.name' => 'desc']);
     }
 
-    /**
-     * @When I clear filter
-     */
+    #[When('I clear filter')]
     public function iClearFilter(): void
     {
         $this->client->clearParameters();
         $this->client->filter();
     }
 
-    /**
-     * @When I search for products with name :name
-     */
+    #[When('I search for products with name :name')]
     public function iSearchForProductsWithName(string $name): void
     {
         $this->client->addFilter('translations.name', $name);
         $this->client->filter();
     }
 
-    /**
-     * @Then I should see :rating as its average rating
-     */
+    #[Then('I should see :rating as its average rating')]
     public function iShouldSeeAsItsAverageRating(float $rating): void
     {
         Assert::same(round($this->responseChecker->getValue($this->client->getLastResponse(), 'averageRating'), 2), $rating);
     }
 
-    /**
-     * @Then I should see the product :name
-     */
+    #[Then('I should see the product :name')]
     public function iShouldSeeTheProduct(string $name): void
     {
         Assert::true($this->hasProductWithName(
@@ -237,17 +203,13 @@ final class ProductContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see a product with code :code
-     */
+    #[Then('I should see a product with code :code')]
     public function iShouldSeeAProductWithCode(string $code): void
     {
         Assert::true($this->responseChecker->hasItemWithValue($this->client->getLastResponse(), 'code', $code));
     }
 
-    /**
-     * @Then I should see a product with name :name
-     */
+    #[Then('I should see a product with name :name')]
     public function iShouldSeeAProductWithName(string $name): void
     {
         Assert::true(
@@ -255,9 +217,7 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then I should see that it is out of stock
-     */
+    #[Then('I should see that it is out of stock')]
     public function iShouldSeeItIsOutOfStock(): void
     {
         /** @var ProductVariantInterface $productVariant */
@@ -268,9 +228,7 @@ final class ProductContext implements Context
         Assert::false($this->responseChecker->getValue($variantResponse, 'inStock'));
     }
 
-    /**
-     * @Then I should not see the product :name
-     */
+    #[Then('I should not see the product :name')]
     public function iShouldNotSeeTheProduct(string $name): void
     {
         Assert::false($this->hasProductWithName(
@@ -279,10 +237,8 @@ final class ProductContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should see the product price ("[^"]+")$/
-     * @Then /^customer should see the product price ("[^"]+")$/
-     */
+    #[Then('/^I should see the product price ("[^"]+")$/')]
+    #[Then('/^customer should see the product price ("[^"]+")$/')]
     public function iShouldSeeTheProductPrice(int $price): void
     {
         /** @var ProductVariantInterface $checkedVariant */
@@ -293,10 +249,8 @@ final class ProductContext implements Context
         Assert::same($variant['code'], $checkedVariant->getCode());
     }
 
-    /**
-     * @Then /^I should see the product original price ("[^"]+")$/
-     * @Then /^customer should see the product original price ("[^"]+")$/
-     */
+    #[Then('/^I should see the product original price ("[^"]+")$/')]
+    #[Then('/^customer should see the product original price ("[^"]+")$/')]
     public function iShouldSeeTheProductOriginalPrice(int $originalPrice): void
     {
         /** @var ProductVariantInterface $checkedVariant */
@@ -307,9 +261,7 @@ final class ProductContext implements Context
         Assert::same($variant['code'], $checkedVariant->getCode());
     }
 
-    /**
-     * @Then I should see this product has no catalog promotion applied
-     */
+    #[Then('I should see this product has no catalog promotion applied')]
     public function iShouldSeeThisProductHasNoCatalogPromotionApplied(): void
     {
         $variant = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -318,9 +270,7 @@ final class ProductContext implements Context
         Assert::keyNotExists($variant, 'appliedPromotions');
     }
 
-    /**
-     * @Then I should not see any original price
-     */
+    #[Then('I should not see any original price')]
     public function iShouldNotSeeAnyOriginalPrice(): void
     {
         $product = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -328,9 +278,7 @@ final class ProductContext implements Context
         Assert::same($product['defaultVariantData']['originalPrice'], $product['defaultVariantData']['price']);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+" product) discounted from ("[^"]+") to ("[^"]+")$/
-     */
+    #[Then('/^I should see ("[^"]+" product) discounted from ("[^"]+") to ("[^"]+")$/')]
     public function iShouldSeeProductDiscountedFromTo(ProductInterface $product, int $originalPrice, int $price): void
     {
         $lastResponse = $this->client->getLastResponse();
@@ -347,9 +295,7 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see the (product "[^"]+") with price ("[^"]+")$/
-     */
+    #[Then('/^I should see the (product "[^"]+") with price ("[^"]+")$/')]
     public function iShouldSeeTheProductWithPrice(ProductInterface $product, int $price): void
     {
         Assert::true(
@@ -362,9 +308,7 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the product :product with short description :shortDescription
-     */
+    #[Then('I should see the product :product with short description :shortDescription')]
     public function iShouldSeeTheProductWithShortDescription(ProductInterface $product, string $shortDescription): void
     {
         Assert::true(
@@ -377,9 +321,7 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then the first product on the list should have code :code
-     */
+    #[Then('the first product on the list should have code :code')]
     public function theFirstProductOnTheListShouldHaveCode(string $code): void
     {
         $products = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -387,9 +329,7 @@ final class ProductContext implements Context
         Assert::same($products[0]['code'], $code);
     }
 
-    /**
-     * @Then the last product on the list should have code :value
-     */
+    #[Then('the last product on the list should have code :value')]
     public function theLastProductOnTheListShouldHaveCode(string $code): void
     {
         $products = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -397,9 +337,7 @@ final class ProductContext implements Context
         Assert::same(end($products)['code'], $code);
     }
 
-    /**
-     * @Then the first product on the list should have name :name
-     */
+    #[Then('the first product on the list should have name :name')]
     public function theFirstProductOnTheListShouldHaveName(string $name): void
     {
         $products = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -407,9 +345,7 @@ final class ProductContext implements Context
         Assert::same($products[0]['name'], $name);
     }
 
-    /**
-     * @Then /^the first product on the list should have name "([^"]+)" and price ("[^"]+")$/
-     */
+    #[Then('/^the first product on the list should have name "([^"]+)" and price ("[^"]+")$/')]
     public function theFirstProductOnTheListShouldHaveNameAndPrice(string $name, int $price): void
     {
         $product = $this->responseChecker->getCollection($this->client->resend())[0];
@@ -418,9 +354,7 @@ final class ProductContext implements Context
         Assert::same($product['defaultVariantData']['price'], $price);
     }
 
-    /**
-     * @Then the last product on the list should have name :name
-     */
+    #[Then('the last product on the list should have name :name')]
     public function theLastProductOnTheListShouldHaveName(string $name): void
     {
         $products = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -428,9 +362,7 @@ final class ProductContext implements Context
         Assert::same(end($products)['name'], $name);
     }
 
-    /**
-     * @Then /^the last product on the list should have name "([^"]+)" and price ("[^"]+")$/
-     */
+    #[Then('/^the last product on the list should have name "([^"]+)" and price ("[^"]+")$/')]
     public function theLastProductOnTheListShouldHaveNameAndPrice(string $name, int $price): void
     {
         $products = $this->responseChecker->getCollection($this->client->resend());
@@ -440,9 +372,7 @@ final class ProductContext implements Context
         Assert::same($product['defaultVariantData']['price'], $price);
     }
 
-    /**
-     * @When /^I should see only (\d+) product(s)$/
-     */
+    #[When('/^I should see only (\d+) product(s)$/')]
     public function iShouldSeeOnlyProducts(int $count): void
     {
         Assert::same(
@@ -452,27 +382,21 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the product with name :name
-     */
+    #[Then('I should not see the product with name :name')]
     public function iShouldNotSeeProductWithName(string $name): void
     {
         Assert::false($this->responseChecker->hasItemWithValue($this->client->getLastResponse(), 'name', $name));
     }
 
-    /**
-     * @Then I should see the product name :name
-     */
+    #[Then('I should see the product name :name')]
     public function iShouldSeeProductName(string $name): void
     {
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'name', $name));
     }
 
-    /**
-     * @Then the main image should be of type :type
-     * @Then I should be able to see a main image of type :type
-     * @Then the first thumbnail image should be of type :type
-     */
+    #[Then('the main image should be of type :type')]
+    #[Then('I should be able to see a main image of type :type')]
+    #[Then('the first thumbnail image should be of type :type')]
     public function theImageShouldBeOfType(string $type): void
     {
         $images = $this->responseChecker->getValue($this->client->getLastResponse(), 'images');
@@ -480,9 +404,7 @@ final class ProductContext implements Context
         Assert::same($images[0]['type'], $type);
     }
 
-    /**
-     * @Then the second thumbnail image should be of type :type
-     */
+    #[Then('the second thumbnail image should be of type :type')]
     public function theSecondThumbnailImageShouldBeOfType(string $type): void
     {
         $images = $this->responseChecker->getValue($this->client->getLastResponse(), 'images');
@@ -490,9 +412,7 @@ final class ProductContext implements Context
         Assert::same($images[1]['type'], $type);
     }
 
-    /**
-     * @Then /^I should not be able to view (this product) in the ("([^"]+)" locale)$/
-     */
+    #[Then('/^I should not be able to view (this product) in the ("([^"]+)" locale)$/')]
     public function iShouldNotBeAbleToViewThisProductInLocale(ProductInterface $product, string $localeCode): void
     {
         Assert::false($this->responseChecker->hasValue(
@@ -502,9 +422,7 @@ final class ProductContext implements Context
         ));
     }
 
-    /**
-     * @Then its current variant should be named :variantName
-     */
+    #[Then('its current variant should be named :variantName')]
     public function itsCurrentVariantShouldBeNamed(string $variantName): void
     {
         $response = $this->client->getLastResponse();
@@ -516,25 +434,19 @@ final class ProductContext implements Context
         Assert::true($this->responseChecker->hasValue($this->client->getLastResponse(), 'name', $variantName));
     }
 
-    /**
-     * @Then I should see empty list of products
-     */
+    #[Then('I should see empty list of products')]
     public function iShouldSeeEmptyListOfProducts(): void
     {
         Assert::same($this->responseChecker->countTotalCollectionItems($this->client->getLastResponse()), 0);
     }
 
-    /**
-     * @Then I should see :count products in the list
-     */
+    #[Then('I should see :count products in the list')]
     public function iShouldSeeProductsInTheList(int $count): void
     {
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $count);
     }
 
-    /**
-     * @Then they should have order like :firstProductName, :secondProductName and :thirdProductName
-     */
+    #[Then('they should have order like :firstProductName, :secondProductName and :thirdProductName')]
     public function theyShouldHaveOrderLikeAnd(string ...$productNames): void
     {
         $productNamesFromResponse = new ArrayCollection();
@@ -548,9 +460,7 @@ final class ProductContext implements Context
         }
     }
 
-    /**
-     * @Then /^the product price should be ("[^"]+")$/
-     */
+    #[Then('/^the product price should be ("[^"]+")$/')]
     public function theProductPriceShouldBe(int $price): void
     {
         $defaultVariant = $this->responseChecker->getValue($this->client->getLastResponse(), 'defaultVariantData');
@@ -558,9 +468,7 @@ final class ProductContext implements Context
         Assert::same($defaultVariant['price'], $price);
     }
 
-    /**
-     * @Then I should see the product description :description
-     */
+    #[Then('I should see the product description :description')]
     public function iShouldSeeTheProductDescription(string $description): void
     {
         Assert::same(
@@ -569,9 +477,7 @@ final class ProductContext implements Context
         );
     }
 
-    /**
-     * @Then /^the visitor should(?:| still) see ("[^"]+") as the (price|original price) of the ("[^"]+" product) in the ("[^"]+" channel)$/
-     */
+    #[Then('/^the visitor should(?:| still) see ("[^"]+") as the (price|original price) of the ("[^"]+" product) in the ("[^"]+" channel)$/')]
     public function theVisitorShouldSeeAsThePriceOfTheProductInTheChannel(
         int $price,
         string $priceType,
@@ -590,25 +496,19 @@ final class ProductContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see a main image
-     */
+    #[Then('I should see a main image')]
     public function iShouldSeeAMainImage(): void
     {
         Assert::true($this->hasProductWithMainImage());
     }
 
-    /**
-     * @Then /^I should not be able to select the "([^"]+)" ([^\s]+) option value$/
-     */
+    #[Then('/^I should not be able to select the "([^"]+)" ([^\s]+) option value$/')]
     public function iShouldNotBeAbleToSelectTheOptionValue(string $optionValueValue, string $optionName): void
     {
         Assert::false($this->hasProductOptionWithNameAndValue($optionName, $optionValueValue));
     }
 
-    /**
-     * @Then /^I should be able to select the "([^"]+)" and "([^"]+)" ([^\s]+) option values$/
-     */
+    #[Then('/^I should be able to select the "([^"]+)" and "([^"]+)" ([^\s]+) option values$/')]
     public function iShouldBeAbleToSelectTheAndColorOptionValues(
         string $optionValueValue1,
         string $optionValueValue2,
@@ -618,9 +518,7 @@ final class ProductContext implements Context
         Assert::true($this->hasProductOptionWithNameAndValue($optionName, $optionValueValue2));
     }
 
-    /**
-     * @Then I should be able to select between :count variants
-     */
+    #[Then('I should be able to select between :count variants')]
     public function iShouldBeAbleToSelectBetweenVariants(int $count): void
     {
         $response = $this->client->getLastResponse();
@@ -629,9 +527,7 @@ final class ProductContext implements Context
         Assert::count($variants, $count);
     }
 
-    /**
-     * @Then I should not be able to select the :productVariantName variant
-     */
+    #[Then('I should not be able to select the :productVariantName variant')]
     public function iShouldNotBeAbleToSelectTheVariant(string $productVariantName): void
     {
         $response = $this->client->getLastResponse();
@@ -640,33 +536,25 @@ final class ProductContext implements Context
         Assert::false($this->productHasProductVariantWithName($variants, $productVariantName));
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product association "([^"]+)" with (products "[^"]+" and "[^"]+")$/
-     */
+    #[Then('/^I should(?:| also) see the product association "([^"]+)" with (products "[^"]+" and "[^"]+")$/')]
     public function iShouldSeeTheProductAssociationWithProductsAnd(string $productAssociationName, array $products): void
     {
         Assert::true($this->isProductAssociationWithProductsAvailable($productAssociationName, $products));
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product association "([^"]+)" with (product "[^"]+")$/
-     */
+    #[Then('/^I should(?:| also) see the product association "([^"]+)" with (product "[^"]+")$/')]
     public function iShouldSeeTheProductAssociationWithProduct(string $productAssociationName, ProductInterface $product): void
     {
         Assert::true($this->isProductAssociationWithProductsAvailable($productAssociationName, [$product]));
     }
 
-    /**
-     * @Then /^I should(?:| also) not see the product association "([^"]+)" with (product "[^"]+")$/
-     */
+    #[Then('/^I should(?:| also) not see the product association "([^"]+)" with (product "[^"]+")$/')]
     public function iShouldNotSeeTheProductAssociationWithProduct(string $productAssociationName, ProductInterface $product): void
     {
         Assert::false($this->isProductAssociationWithProductsAvailable($productAssociationName, [$product]));
     }
 
-    /**
-     * @Then /^I should not see the product (association "([^"]+)")$/
-     */
+    #[Then('/^I should not see the product (association "([^"]+)")$/')]
     public function iShouldNotSeeTheProductAssociation(ProductAssociationTypeInterface $productAssociationType): void
     {
         $productAssociationTypeIri = $this->iriConverter->getIriFromResource($productAssociationType);
@@ -685,9 +573,7 @@ final class ProductContext implements Context
         }
     }
 
-    /**
-     * @Then I should not see information about its lowest price
-     */
+    #[Then('I should not see information about its lowest price')]
     public function iShouldNotSeeInformationAboutItsLowestPrice(): void
     {
         $product = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -697,9 +583,7 @@ final class ProductContext implements Context
         Assert::same($variant['lowestPriceBeforeDiscount'], null);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+") as its lowest price before the discount$/
-     */
+    #[Then('/^I should see ("[^"]+") as its lowest price before the discount$/')]
     public function iShouldSeeAsItsLowestPriceBeforeTheDiscount(int $lowestPriceBeforeDiscount): void
     {
         $product = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -709,17 +593,13 @@ final class ProductContext implements Context
         Assert::same($variant['lowestPriceBeforeDiscount'], $lowestPriceBeforeDiscount);
     }
 
-    /**
-     * @Then I should be informed that the product does not exist
-     */
+    #[Then('I should be informed that the product does not exist')]
     public function iShouldBeInformedThatTheProductDoesNotExist(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_NOT_FOUND);
     }
 
-    /**
-     * @Then /^I should be informed that the taxon does not exist$/
-     */
+    #[Then('/^I should be informed that the taxon does not exist$/')]
     public function iShouldBeInformedThatTheTaxonDoesNotExist(): void
     {
         Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_NOT_FOUND);

--- a/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -33,9 +35,7 @@ final class ProductReviewContext implements Context
     ) {
     }
 
-    /**
-     * @When I check this product's reviews
-     */
+    #[When('I check this product\'s reviews')]
     public function iCheckThisProductsReviews(): void
     {
         /** @var ProductInterface $product */
@@ -46,30 +46,24 @@ final class ProductReviewContext implements Context
         $this->client->filter();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->client->create();
     }
 
-    /**
-     * @When I want to review product :product
-     */
+    #[When('I want to review product :product')]
     public function iWantToReviewProduct(ProductInterface $product): void
     {
         $this->client->buildCreateRequest(Resources::PRODUCT_REVIEWS);
         $this->client->addRequestData('product', $this->iriConverter->getIriFromResource($product));
     }
 
-    /**
-     * @When I leave a comment :comment as :email
-     * @When I leave a comment :comment, titled :title as :email
-     * @When I leave a comment :comment, titled :title
-     * @When I leave a review titled :title as :email
-     */
+    #[When('I leave a comment :comment as :email')]
+    #[When('I leave a comment :comment, titled :title as :email')]
+    #[When('I leave a comment :comment, titled :title')]
+    #[When('I leave a review titled :title as :email')]
     public function iLeaveACommentTitled(?string $comment = null, ?string $title = null, ?string $email = null): void
     {
         $this->client->addRequestData('title', $title);
@@ -80,26 +74,20 @@ final class ProductReviewContext implements Context
         }
     }
 
-    /**
-     * @When I rate it with :rating point(s)
-     * @When I do not rate it
-     */
+    #[When('I rate it with :rating point(s)')]
+    #[When('I do not rate it')]
     public function iRateItWithPoints(?int $rating = null): void
     {
         $this->client->addRequestData('rating', $rating);
     }
 
-    /**
-     * @When I title it with very long title
-     */
+    #[When('I title it with very long title')]
     public function iTitleItWithVeryLongTitle(): void
     {
         $this->client->addRequestData('title', 'Exegi monumentum aere perennius regalique situ pyramidum altius, quod non imber edax, non Aquilo inpotens possit diruere aut innumerabilis annorum series et fuga temporum. Non omnis moriar multaque pars mei vitabit Libitinam; usque ego postera crescam laude recens, dum Capitoliumscandet cum tacita virgine pontifex.Dicar, qua violens obstrepit Aufiduset qua pauper aquae Daunus agrestiumregnavit populorum, ex humili potensprinceps Aeolium carmen ad Italosdeduxisse modos. Sume superbiamquaesitam meritis et mihi Delphicalauro cinge volens, Melpomene, comam.');
     }
 
-    /**
-     * @Then I should see :amount product reviews
-     */
+    #[Then('I should see :amount product reviews')]
     public function iShouldSeeProductReviews(int $amount = 0): void
     {
         /** @var ProductInterface $product */
@@ -114,34 +102,26 @@ final class ProductReviewContext implements Context
         Assert::same($this->responseChecker->countCollectionItems($this->client->getLastResponse()), $amount);
     }
 
-    /**
-     * @Then I should see reviews titled :titleOne, :titleTwo and :titleThree
-     */
+    #[Then('I should see reviews titled :titleOne, :titleTwo and :titleThree')]
     public function iShouldSeeReviewsTitledAnd(string ...$titles): void
     {
         Assert::true($this->hasReviewsWithTitles($titles));
     }
 
-    /**
-     * @Then I should not see review titled :title
-     */
+    #[Then('I should not see review titled :title')]
     public function iShouldNotSeeReviewTitled(string $title): void
     {
         Assert::false($this->hasReviewsWithTitles([$title]));
     }
 
-    /**
-     * @Then I should be notified that my review is waiting for the acceptation
-     */
+    #[Then('I should be notified that my review is waiting for the acceptation')]
     public function iShouldBeNotifiedThatMyReviewIsWaitingForTheAcceptation(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then I should see :amount product reviews in the list
-     * @Then I should be notified that there are no reviews
-     */
+    #[Then('I should see :amount product reviews in the list')]
+    #[Then('I should be notified that there are no reviews')]
     public function iShouldSeeProductReviewsInTheList(int $amount = 0): void
     {
         $productReviews = $this->responseChecker->getCollection($this->client->getLastResponse());
@@ -149,81 +129,61 @@ final class ProductReviewContext implements Context
         Assert::count($productReviews, $amount);
     }
 
-    /**
-     * @Then I should not see review titled :title in the list
-     */
+    #[Then('I should not see review titled :title in the list')]
     public function iShouldNotSeeReviewTitledInTheList(string $title): void
     {
         Assert::isEmpty($this->responseChecker->getCollectionItemsWithValue($this->client->getLastResponse(), 'title', $title));
     }
 
-    /**
-     * @Then I should be notified that I must check review rating
-     */
+    #[Then('I should be notified that I must check review rating')]
     public function iShouldBeNotifiedThatIMustCheckReviewRating(): void
     {
         $this->assertError('Request field "rating" should be of type "int".');
     }
 
-    /**
-     * @Then I should be notified that title is required
-     */
+    #[Then('I should be notified that title is required')]
     public function iShouldBeNotifiedThatTitleIsRequired(): void
     {
         $this->assertError('Request field "title" should be of type "string".');
     }
 
-    /**
-     * @Then I should be notified that title must have at least 2 characters
-     */
+    #[Then('I should be notified that title must have at least 2 characters')]
     public function iShouldBeNotifiedThatTitleMustHaveAtLeast2Characters(): void
     {
         $this->assertViolation('Review title must have at least 2 characters.', 'title');
     }
 
-    /**
-     * @Then I should be notified that title must have at most 255 characters
-     */
+    #[Then('I should be notified that title must have at most 255 characters')]
     public function iShouldBeNotifiedThatTitleMustHaveAtMost255Characters(): void
     {
         $this->assertViolation('Review title must have at most 255 characters.', 'title');
     }
 
-    /**
-     * @Then I should be notified that comment is required
-     */
+    #[Then('I should be notified that comment is required')]
     public function iShouldBeNotifiedThatCommentIsRequired(): void
     {
         $this->assertError('Request field "comment" should be of type "string".');
     }
 
-    /**
-     * @Then I should be notified that I must enter my email
-     */
+    #[Then('I should be notified that I must enter my email')]
     public function iShouldBeNotifiedThatIMustEnterMyEmail(): void
     {
         $this->assertViolation('Please enter your email.', 'email');
     }
 
-    /**
-     * @Then I should be notified that this email is already registered
-     */
+    #[Then('I should be notified that this email is already registered')]
     public function iShouldBeNotifiedThatThisEmailIsAlreadyRegistered(): void
     {
         $this->assertViolation('This email is already registered, please login or use forgotten password.', 'email');
     }
 
-    /**
-     * @Then I should be notified that rating must be between 1 and 5
-     */
+    #[Then('I should be notified that rating must be between 1 and 5')]
     public function iShouldBeNotifiedThatRatingMustBeBetween1And5(): void
     {
         $this->assertViolation('Review rating must be between 1 and 5.', 'rating');
     }
 
-    /**
-     * @Then the :productReview product review of :product product should not be visible for customers
-     */
+    #[Then('the :productReview product review of :product product should not be visible for customers')]
     public function thisProductReviewOfProductShouldNotBeVisibleForCustomers(
         ReviewInterface $productReview,
         ProductInterface $product,

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -35,29 +37,23 @@ final class ProductVariantContext implements Context
     ) {
     }
 
-    /**
-     * @When I select :variant variant
-     * @When I view :variant variant
-     * @When I view :variant variant of the :product product
-     */
+    #[When('I select :variant variant')]
+    #[When('I view :variant variant')]
+    #[When('I view :variant variant of the :product product')]
     public function iSelectVariant(ProductVariantInterface $variant): void
     {
         $this->sharedStorage->set('variant', $variant);
         $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
     }
 
-    /**
-     * @When the visitor view :variant variant
-     */
+    #[When('the visitor view :variant variant')]
     public function visitorViewVariant(ProductVariantInterface $variant): void
     {
         $this->sharedStorage->set('token', null);
         $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
     }
 
-    /**
-     * @When I view variants
-     */
+    #[When('I view variants')]
     public function iViewVariants(): void
     {
         $response = $this->client->index(Resources::PRODUCT_VARIANTS);
@@ -65,9 +61,7 @@ final class ProductVariantContext implements Context
         $this->sharedStorage->set('response', $response);
     }
 
-    /**
-     * @When /^I view variants of the ("[^"]+" product)$/
-     */
+    #[When('/^I view variants of the ("[^"]+" product)$/')]
     public function iViewVariantsOfTheProduct(ProductInterface $product): void
     {
         $response = $this->client->index(Resources::PRODUCT_VARIANTS, ['product' => $this->iriConverter->getIriFromResource($product)]);
@@ -75,9 +69,7 @@ final class ProductVariantContext implements Context
         $this->sharedStorage->set('product_variant_collection', $this->responseChecker->getCollection($response));
     }
 
-    /**
-     * @When /^I filter (?:them|variants) by ("[^"]+" option value)$/
-     */
+    #[When('/^I filter (?:them|variants) by ("[^"]+" option value)$/')]
     public function iFilterVariantsByOption(ProductOptionValueInterface $optionValue): void
     {
         $this->client->addFilter('optionValues[]', $this->iriConverter->getIriFromResource($optionValue));
@@ -86,10 +78,8 @@ final class ProductVariantContext implements Context
         $this->sharedStorage->set('product_variant_collection', $this->responseChecker->getCollection($response));
     }
 
-    /**
-     * @Then /^(?:the|this) product variant price should be ("[^"]+")$/
-     * @Then /^I should see the variant price ("[^"]+")$/
-     */
+    #[Then('/^(?:the|this) product variant price should be ("[^"]+")$/')]
+    #[Then('/^I should see the variant price ("[^"]+")$/')]
     public function theProductVariantPriceShouldBe(int $price): void
     {
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -97,9 +87,7 @@ final class ProductVariantContext implements Context
         Assert::same($response['price'], $price);
     }
 
-    /**
-     * @Then /^(?:the|this) product original price should be ("[^"]+")$/
-     */
+    #[Then('/^(?:the|this) product original price should be ("[^"]+")$/')]
     public function theProductOriginalPriceShouldBe(int $originalPrice): void
     {
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
@@ -107,13 +95,11 @@ final class ProductVariantContext implements Context
         Assert::same($response['originalPrice'], $originalPrice);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" and "([^"]+)" promotions$/
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/
-     */
+    #[Then('/^I should see ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/')]
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/')]
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" and "([^"]+)" promotions$/')]
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/')]
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" promotions$/')]
     public function iShouldSeeVariantIsDiscountedFromToWithPromotions(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -132,9 +118,7 @@ final class ProductVariantContext implements Context
         }
     }
 
-    /**
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with ([^"]+) promotions$/
-     */
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with ([^"]+) promotions$/')]
     public function iShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -148,9 +132,7 @@ final class ProductVariantContext implements Context
         Assert::count($content['appliedPromotions'], $numberOfPromotions);
     }
 
-    /**
-     * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with only "([^"]+)" promotion$/
-     */
+    #[Then('/^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with only "([^"]+)" promotion$/')]
     public function iShouldSeeVariantIsDiscountedFromToWithOnlyPromotion(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -167,9 +149,7 @@ final class ProductVariantContext implements Context
         Assert::same($catalogPromotionContent['label'], $promotionName);
     }
 
-    /**
-     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
-     */
+    #[Then('/^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/')]
     public function theVisitorShouldSeeThatTheVariantIsDiscountedWithPromotion(
         ProductVariantInterface $productVariant,
         int $originalPrice,
@@ -182,9 +162,7 @@ final class ProductVariantContext implements Context
         $this->iShouldSeeVariantIsDiscountedFromToWithPromotions($productVariant, $originalPrice, $price, $promotionName);
     }
 
-    /**
-     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with ([^"]+) promotions$/
-     */
+    #[Then('/^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with ([^"]+) promotions$/')]
     public function theVisitorShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -197,9 +175,7 @@ final class ProductVariantContext implements Context
         $this->iShouldSeeVariantIsDiscountedFromToWithNumberOfPromotions($variant, $originalPrice, $price, $numberOfPromotions);
     }
 
-    /**
-     * @Then /^I should see ("[^"]+" variant) is not discounted$/
-     */
+    #[Then('/^I should see ("[^"]+" variant) is not discounted$/')]
     public function iShouldSeeVariantIsNotDiscounted(ProductVariantInterface $variant): void
     {
         $response = $this->sharedStorage->has('response') ? $this->sharedStorage->get('response') : $this->client->getLastResponse();
@@ -209,10 +185,8 @@ final class ProductVariantContext implements Context
         Assert::keyNotExists($item, 'appliedPromotions');
     }
 
-    /**
-     * @Then /^the visitor should see (this variant) is not discounted$/
-     * @Then /^the visitor should see that the ("[^"]+" variant) is not discounted$/
-     */
+    #[Then('/^the visitor should see (this variant) is not discounted$/')]
+    #[Then('/^the visitor should see that the ("[^"]+" variant) is not discounted$/')]
     public function theVisitorShouldSeeThatTheVariantIsNotDiscounted(ProductVariantInterface $variant): void
     {
         $this->sharedStorage->set('token', null);
@@ -220,9 +194,7 @@ final class ProductVariantContext implements Context
         $this->iShouldSeeThisVariantIsNotDiscounted($variant);
     }
 
-    /**
-     * @Then /^I should see (this variant) is not discounted$/
-     */
+    #[Then('/^I should see (this variant) is not discounted$/')]
     public function iShouldSeeThisVariantIsNotDiscounted(ProductVariantInterface $variant): void
     {
         $content = $this->responseChecker->getResponseContent($this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode()));
@@ -230,10 +202,8 @@ final class ProductVariantContext implements Context
         Assert::keyNotExists($content, 'appliedPromotions');
     }
 
-    /**
-     * @Then /^("[^"]+" variant) and ("[^"]+" variant) should be discounted$/
-     * @Then /^("[^"]+" variant) should be discounted$/
-     */
+    #[Then('/^("[^"]+" variant) and ("[^"]+" variant) should be discounted$/')]
+    #[Then('/^("[^"]+" variant) should be discounted$/')]
     public function variantAndVariantShouldBeDiscounted(ProductVariantInterface ...$variants): void
     {
         $this->sharedStorage->set('token', null);
@@ -249,10 +219,8 @@ final class ProductVariantContext implements Context
         }
     }
 
-    /**
-     * @Then /^("[^"]+" variant) and ("[^"]+" variant) should not be discounted$/
-     * @Then /^("[^"]+" variant) should not be discounted$/
-     */
+    #[Then('/^("[^"]+" variant) and ("[^"]+" variant) should not be discounted$/')]
+    #[Then('/^("[^"]+" variant) should not be discounted$/')]
     public function variantAndVariantShouldNotBeDiscounted(ProductVariantInterface ...$variants): void
     {
         $this->sharedStorage->set('token', null);
@@ -268,9 +236,7 @@ final class ProductVariantContext implements Context
         }
     }
 
-    /**
-     * @Then I should not see :variant variant
-     */
+    #[Then('I should not see :variant variant')]
     public function iShouldNotSeeVariant(ProductVariantInterface $variant): void
     {
         $response = $this->client->show(Resources::PRODUCT_VARIANTS, $variant->getCode());
@@ -282,9 +248,7 @@ final class ProductVariantContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see ("([^"]+)", "([^"]+)" and "([^"]+)" variants)$/
-     */
+    #[Then('/^I should see ("([^"]+)", "([^"]+)" and "([^"]+)" variants)$/')]
     public function variantAndVariantShouldBeVisible(array $variants): void
     {
         $this->sharedStorage->set('token', null);
@@ -300,9 +264,7 @@ final class ProductVariantContext implements Context
         }
     }
 
-    /**
-     * @Then /^I should see variant with ("[^"]+" option) and ("[^"]+" option value) priced at ("[^"]+") at (\d)(?:st|nd|rd|th) position$/
-     */
+    #[Then('/^I should see variant with ("[^"]+" option) and ("[^"]+" option value) priced at ("[^"]+") at (\d)(?:st|nd|rd|th) position$/')]
     public function iShouldSeeVariantWithOptionPricedAtAtPosition(
         string $expectedOptionName,
         string $expectedOptionValueValue,
@@ -325,9 +287,7 @@ final class ProductVariantContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should not see variant with "([^"]+)" option "([^"]+)"$/
-     */
+    #[Then('/^I should not see variant with "([^"]+)" option "([^"]+)"$/')]
     public function iShouldNotSeeVariantWithOptionPricedAt(string $expectedOptionName, string $expectedOptionValueValue): void
     {
         $variants = $this->sharedStorage->get('product_variant_collection');
@@ -344,9 +304,7 @@ final class ProductVariantContext implements Context
         }
     }
 
-    /**
-     * @Then I should not see any variants
-     */
+    #[Then('I should not see any variants')]
     public function iShouldNotSeeAnyVariants(): void
     {
         Assert::same(

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Client\ApiClientInterface;
@@ -37,9 +38,7 @@ final class PromotionContext implements Context
         $this->useCouponCode($couponCode);
     }
 
-    /**
-     * @Then I should be notified that the coupon is invalid
-     */
+    #[Then('I should be notified that the coupon is invalid')]
     public function iShouldBeNotifiedThatCouponIsInvalid(): void
     {
         $response = $this->client->getLastResponse();

--- a/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/RegistrationContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\RequestFactoryInterface;
@@ -41,78 +43,60 @@ final class RegistrationContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to register a new account
-     * @When I want to again register a new account
-     */
+    #[When('I want to register a new account')]
+    #[When('I want to again register a new account')]
     public function iWantToRegisterNewAccount(): void
     {
         $this->fillContent();
     }
 
-    /**
-     * @When I specify the first name as :firstName
-     * @When I do not specify the first name
-     */
+    #[When('I specify the first name as :firstName')]
+    #[When('I do not specify the first name')]
     public function iSpecifyTheFirstNameAs(string $firstName = ''): void
     {
         $this->content['firstName'] = $firstName;
     }
 
-    /**
-     * @When I specify the :firstOrLast name as too long value
-     */
+    #[When('I specify the :firstOrLast name as too long value')]
     public function iSpecifyTheFirstOrLastNameAsTooLongValue(string $firstOrLast): void
     {
         $this->content[$firstOrLast . 'Name'] = str_repeat('a', 256);
     }
 
-    /**
-     * @When I specify the last name as :lastName
-     * @When I do not specify the last name
-     */
+    #[When('I specify the last name as :lastName')]
+    #[When('I do not specify the last name')]
     public function iSpecifyTheLastNameAs(string $lastName = ''): void
     {
         $this->content['lastName'] = $lastName;
     }
 
-    /**
-     * @When I specify the email as :email
-     * @When I do not specify the email
-     */
+    #[When('I specify the email as :email')]
+    #[When('I do not specify the email')]
     public function iSpecifyTheEmailAs(string $email = ''): void
     {
         $this->content['email'] = $email;
     }
 
-    /**
-     * @When I specify the password as :password
-     * @When I do not specify the password
-     */
+    #[When('I specify the password as :password')]
+    #[When('I do not specify the password')]
     public function iSpecifyThePasswordAs(string $password = ''): void
     {
         $this->content['password'] = $this->replaceWithSecurePassword($password);
     }
 
-    /**
-     * @When I specify the phone number as :phoneNumber
-     */
+    #[When('I specify the phone number as :phoneNumber')]
     public function iSpecifyThePhoneNumberAs(string $phoneNumber): void
     {
         $this->content['phoneNumber'] = $phoneNumber;
     }
 
-    /**
-     * @When I subscribe to the newsletter
-     */
+    #[When('I subscribe to the newsletter')]
     public function iSubscribeToTheNewsletter(): void
     {
         $this->content['subscribedToNewsletter'] = true;
     }
 
-    /**
-     * @When I verify my account using link sent to :customer
-     */
+    #[When('I verify my account using link sent to :customer')]
     public function iVerifyMyAccountUsingLink(CustomerInterface $customer): void
     {
         $this->sharedStorage->set('customer', $customer);
@@ -126,18 +110,14 @@ final class RegistrationContext implements Context
         $this->shopClient->executeCustomRequest($request);
     }
 
-    /**
-     * @When I confirm this password
-     */
+    #[When('I confirm this password')]
     public function iConfirmThisPassword(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @When I register with email :email and password :password
-     * @When I register with email :email and password :password in the :localeCode locale
-     */
+    #[When('I register with email :email and password :password')]
+    #[When('I register with email :email and password :password in the :localeCode locale')]
     public function iRegisterWithEmailAndPassword(string $email, string $password, string $localeCode = 'en_US'): void
     {
         $this->sharedStorage->set('current_locale_code', $localeCode);
@@ -149,10 +129,8 @@ final class RegistrationContext implements Context
         $this->loginContext->iLogInAsWithPassword($email, $password);
     }
 
-    /**
-     * @When I register this account
-     * @When I try to register this account
-     */
+    #[When('I register this account')]
+    #[When('I try to register this account')]
     public function iRegisterThisAccount(): void
     {
         $request = $this->requestFactory->create('shop', Resources::CUSTOMERS, '');
@@ -163,41 +141,31 @@ final class RegistrationContext implements Context
         $this->content = [];
     }
 
-    /**
-     * @When I log in as :email with :password password
-     */
+    #[When('I log in as :email with :password password')]
     public function iLogInAsWithPassword(string $email, string $password): void
     {
         $this->loginContext->iLogInAsWithPassword($email, $password);
     }
 
-    /**
-     * @When I log out
-     */
+    #[When('I log out')]
     public function iLogOut(): void
     {
         $this->loginContext->iLogOut();
     }
 
-    /**
-     * @Then I should be notified that new account has been successfully created
-     */
+    #[Then('I should be notified that new account has been successfully created')]
     public function iShouldBeNotifiedThatNewAccountHasBeenSuccessfullyCreated(): void
     {
         Assert::same($this->shopClient->getLastResponse()->getStatusCode(), 204);
     }
 
-    /**
-     * @Then I should be notified that the first name is required
-     */
+    #[Then('I should be notified that the first name is required')]
     public function iShouldBeNotifiedThatTheFirstNameIsRequired(): void
     {
         $this->assertFieldValidationMessage('firstName', 'Please enter your first name.');
     }
 
-    /**
-     * @Then /^I should be notified that the "([^"]+)" and "([^"]+)" have to be provided$/
-     */
+    #[Then('/^I should be notified that the "([^"]+)" and "([^"]+)" have to be provided$/')]
     public function iShouldBeNotifiedThatFieldHaveToBeProvided(string ...$fields): void
     {
         $fields = $this->convertElementsToCamelCase($fields);
@@ -210,58 +178,44 @@ final class RegistrationContext implements Context
         Assert::same($this->shopClient->getLastResponse()->getStatusCode(), Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 
-    /**
-     * @Then I should be notified that the last name is required
-     */
+    #[Then('I should be notified that the last name is required')]
     public function iShouldBeNotifiedThatTheLastNameIsRequired(): void
     {
         $this->assertFieldValidationMessage('lastName', 'Please enter your last name.');
     }
 
-    /**
-     * @Then I should be notified that the password is required
-     */
+    #[Then('I should be notified that the password is required')]
     public function iShouldBeNotifiedThatThePasswordIsRequired(): void
     {
         $this->assertFieldValidationMessage('password', 'Please enter your password.');
     }
 
-    /**
-     * @Then I should be notified that the :firstOrLast name is too long
-     */
+    #[Then('I should be notified that the :firstOrLast name is too long')]
     public function iShouldBeNotifiedThatTheFirstOrLastNameIsTooLong(string $firstOrLast): void
     {
         $this->assertFieldValidationMessage($firstOrLast . 'Name', sprintf('%s name must not be longer than 255 characters.', ucfirst($firstOrLast)));
     }
 
-    /**
-     * @Then I should be notified that the email is required
-     */
+    #[Then('I should be notified that the email is required')]
     public function iShouldBeNotifiedThatTheEmailIsRequired(): void
     {
         $this->assertFieldValidationMessage('email', 'Please enter your email.');
     }
 
-    /**
-     * @Then I should be notified that the email is already used
-     */
+    #[Then('I should be notified that the email is already used')]
     public function iShouldBeNotifiedThatTheEmailIsAlreadyUsed(): void
     {
         $this->assertFieldValidationMessage('email', 'This email is already used.');
     }
 
-    /**
-     * @Then I should not be logged in
-     * @Then I should be logged in
-     */
+    #[Then('I should not be logged in')]
+    #[Then('I should be logged in')]
     public function iShouldNotBeLoggedIn(): void
     {
         // Intentionally left blank
     }
 
-    /**
-     * @Then I should be subscribed to the newsletter
-     */
+    #[Then('I should be subscribed to the newsletter')]
     public function iShouldBeSubscribedToTheNewsletter(): void
     {
         $customer = $this->sharedStorage->get('customer');
@@ -271,10 +225,8 @@ final class RegistrationContext implements Context
         Assert::true($this->responseChecker->getResponseContent($response)['subscribedToNewsletter']);
     }
 
-    /**
-     * @Then I should be on my account dashboard
-     * @Then I should be on registration thank you page
-     */
+    #[Then('I should be on my account dashboard')]
+    #[Then('I should be on registration thank you page')]
     public function intentionallyLeftBlank(): void
     {
     }

--- a/src/Sylius/Behat/Context/Api/Shop/ShipmentContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ShipmentContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -31,9 +33,7 @@ final readonly class ShipmentContext implements Context
     ) {
     }
 
-    /**
-     * @When I try to see the shipment of the order placed by a customer :customer
-     */
+    #[When('I try to see the shipment of the order placed by a customer :customer')]
     public function iTryToSeeTheShipmentOfTheOrderPlacedByACustomer(CustomerInterface $customer): void
     {
         /** @var OrderInterface $order */
@@ -48,10 +48,8 @@ final readonly class ShipmentContext implements Context
         );
     }
 
-    /**
-     * @Then the shipment state should be :state
-     * @Then the order's shipment state should be :state
-     */
+    #[Then('the shipment state should be :state')]
+    #[Then('the order\'s shipment state should be :state')]
     public function theShipmentStateShouldBe(string $state): void
     {
         $response = $this->client->getLastResponse();
@@ -63,9 +61,7 @@ final readonly class ShipmentContext implements Context
         Assert::true($this->responseChecker->hasValue($response, 'state', $state, isCaseSensitive: false));
     }
 
-    /**
-     * @Then I should not be able to see that shipment
-     */
+    #[Then('I should not be able to see that shipment')]
     public function iShouldNotBeAbleToSeeThatShipment(): void
     {
         Assert::false($this->responseChecker->isShowSuccessful($this->client->getLastResponse()));

--- a/src/Sylius/Behat/Context/Api/Shop/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/TaxonContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Shop;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
@@ -32,19 +34,15 @@ final readonly class TaxonContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I try to browse products from (taxon "([^"]+)")$/
-     * @When /^I check the ("[^"]+" taxon)'s details$/
-     */
+    #[When('/^I try to browse products from (taxon "([^"]+)")$/')]
+    #[When('/^I check the ("[^"]+" taxon)\'s details$/')]
     public function iTryToBrowseProductsFrom(TaxonInterface $taxon): void
     {
         $this->objectManager->clear(); // avoiding doctrine cache
         $this->client->show(Resources::TAXONS, $taxon->getCode());
     }
 
-    /**
-     * @Then I should not see :taxon in the vertical menu
-     */
+    #[Then('I should not see :taxon in the vertical menu')]
     public function iShouldNotSeeInTheVerticalMenu(TaxonInterface $taxon): void
     {
         Assert::false(
@@ -53,9 +51,7 @@ final readonly class TaxonContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the taxon name :name
-     */
+    #[Then('I should see the taxon name :name')]
     public function iShouldSeeTaxonName(string $name): void
     {
         Assert::true(
@@ -64,9 +60,7 @@ final readonly class TaxonContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see ("([^"]+)" and "([^"]+)" in the vertical menu)$/
-     */
+    #[Then('/^I should see ("([^"]+)" and "([^"]+)" in the vertical menu)$/')]
     public function iShouldSeeInTheVerticalMenu(iterable $taxons): void
     {
         foreach ($taxons as $taxon) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18822
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated test step declarations to PHP 8 attribute syntax for consistency and clearer test mapping.

* **Tests**
  * Updated numerous API test scenarios (addresses, cart, checkout, auth, registration, products, etc.) to use the new step wiring and adjusted flows where needed.

* **Bug Fix**
  * Fixed default-address handling so marking an address as default correctly updates the customer record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->