### PR TITLE
Convert Behat annotations to PHP attributes in UI Admin contexts

### DIFF
--- a/src/Sylius/Behat/Context/Ui/Admin/BrowsingCatalogPromotionProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/BrowsingCatalogPromotionProductVariantsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\CatalogPromotion\ProductVariant\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Product\ShowPageInterface;
@@ -29,44 +32,34 @@ final readonly class BrowsingCatalogPromotionProductVariantsContext implements C
     ) {
     }
 
-    /**
-     * @Given I am browsing variants affected by catalog promotion :catalogPromotion
-     * @When I browse variants affected by catalog promotion :catalogPromotion
-     */
+    #[Given('I am browsing variants affected by catalog promotion :catalogPromotion')]
+    #[When('I browse variants affected by catalog promotion :catalogPromotion')]
     public function iBrowseVariantsAffectedByCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->catalogPromotionProductVariantIndexPage->open(['id' => $catalogPromotion->getId()]);
     }
 
-    /**
-     * @When I want to view the product of variant :variant
-     */
+    #[When('I want to view the product of variant :variant')]
     public function iWantToViewTheProductOfVariant(ProductVariantInterface $variant): void
     {
         $this->catalogPromotionProductVariantIndexPage->showProductOf($variant->getId());
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->catalogPromotionProductVariantIndexPage->filterByCode($phrase);
         $this->catalogPromotionProductVariantIndexPage->filter();
     }
 
-    /**
-     * @When I filter by name containing :phrase
-     */
+    #[When('I filter by name containing :phrase')]
     public function iFilterByNameContaining(string $phrase): void
     {
         $this->catalogPromotionProductVariantIndexPage->filterByName($phrase);
         $this->catalogPromotionProductVariantIndexPage->filter();
     }
 
-    /**
-     * @Then /^there should be (\d+) product variants? on the list$/
-     */
+    #[Then('/^there should be (\d+) product variants? on the list$/')]
     public function thereShouldBeProductVariantsOnTheList(int $count): void
     {
         Assert::same(
@@ -75,10 +68,8 @@ final readonly class BrowsingCatalogPromotionProductVariantsContext implements C
         );
     }
 
-    /**
-     * @Then it should be the :variantName product variant
-     * @Then it should be :firstVariant and :secondVariant product variants
-     */
+    #[Then('it should be the :variantName product variant')]
+    #[Then('it should be :firstVariant and :secondVariant product variants')]
     public function theProductVariantShouldBeInTheRegistry(string ...$variantsNames): void
     {
         foreach ($variantsNames as $variantName) {
@@ -88,9 +79,7 @@ final readonly class BrowsingCatalogPromotionProductVariantsContext implements C
         }
     }
 
-    /**
-     * @Then I should be viewing the details of product :product
-     */
+    #[Then('I should be viewing the details of product :product')]
     public function iShouldBeViewingTheDetailsOfProduct(ProductInterface $product): void
     {
         Assert::true($this->productShowPage->isOpen(['id' => $product->getId()]));

--- a/src/Sylius/Behat/Context/Ui/Admin/BrowsingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/BrowsingProductVariantsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\ProductVariant\IndexPageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -28,17 +30,13 @@ final class BrowsingProductVariantsContext implements Context
     ) {
     }
 
-    /**
-     * @When I start sorting variants by :field
-     */
+    #[When('I start sorting variants by :field')]
     public function iSortProductsBy($field)
     {
         $this->indexPage->sortBy($field);
     }
 
-    /**
-     * @Then the :productVariantCode variant of the :product product should appear in the store
-     */
+    #[Then('the :productVariantCode variant of the :product product should appear in the store')]
     public function theProductVariantShouldAppearInTheShop($productVariantCode, ProductInterface $product)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -46,17 +44,13 @@ final class BrowsingProductVariantsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
     }
 
-    /**
-     * @Then I should see the product variant :productVariantName in the list
-     */
+    #[Then('I should see the product variant :productVariantName in the list')]
     public function iShouldSeeTheProductVariantInTheList(string $productVariantName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productVariantName]));
     }
 
-    /**
-     * @Then the :productVariantCode variant of the :product product should not appear in the store
-     */
+    #[Then('the :productVariantCode variant of the :product product should not appear in the store')]
     public function theProductVariantShouldNotAppearInTheShop($productVariantCode, ProductInterface $product)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -64,9 +58,7 @@ final class BrowsingProductVariantsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
     }
 
-    /**
-     * @Then the :product product should have no variants
-     */
+    #[Then('the :product product should have no variants')]
     public function theProductShouldHaveNoVariants(ProductInterface $product)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -74,9 +66,7 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertNumberOfVariantsOnProductPage(0);
     }
 
-    /**
-     * @Then the :product product should have only one variant
-     */
+    #[Then('the :product product should have only one variant')]
     public function theProductShouldHaveOnlyOneVariant(ProductInterface $product)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -84,37 +74,29 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertNumberOfVariantsOnProductPage(1);
     }
 
-    /**
-     * @When /^I browse variants of (this product)$/
-     * @When /^I (?:|want to )view all variants of (this product)$/
-     * @When /^I view(?:| all) variants of the (product "[^"]+")(?:| again)$/
-     */
+    #[When('/^I browse variants of (this product)$/')]
+    #[When('/^I (?:|want to )view all variants of (this product)$/')]
+    #[When('/^I view(?:| all) variants of the (product "[^"]+")(?:| again)$/')]
     public function iWantToViewAllVariantsOfThisProduct(ProductInterface $product)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
     }
 
-    /**
-     * @Then I should see :numberOfProductVariants variants in the list
-     * @Then I should see :numberOfProductVariants variant in the list
-     * @Then I should not see any variants in the list
-     */
+    #[Then('I should see :numberOfProductVariants variants in the list')]
+    #[Then('I should see :numberOfProductVariants variant in the list')]
+    #[Then('I should not see any variants in the list')]
     public function iShouldSeeProductVariantsInTheList($numberOfProductVariants = 0)
     {
         Assert::same($this->indexPage->countItems(), (int) $numberOfProductVariants);
     }
 
-    /**
-     * @Then I should see a single product variant in the list
-     */
+    #[Then('I should see a single product variant in the list')]
     public function iShouldSeeASingleProductVariantInTheList(): void
     {
         $this->iShouldSeeProductVariantsInTheList(1);
     }
 
-    /**
-     * @Then /^(this variant) should not exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should not exist in the product catalog$/')]
     public function productVariantShouldNotExist(ProductVariantInterface $productVariant)
     {
         $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
@@ -122,17 +104,13 @@ final class BrowsingProductVariantsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName()]));
     }
 
-    /**
-     * @Then /^(this variant) should still exist in the product catalog$/
-     */
+    #[Then('/^(this variant) should still exist in the product catalog$/')]
     public function productShouldExistInTheProductCatalog(ProductVariantInterface $productVariant)
     {
         $this->theProductVariantShouldAppearInTheShop($productVariant->getCode(), $productVariant->getProduct());
     }
 
-    /**
-     * @Then /^the variant "([^"]+)" should have (\d+) items on hand$/
-     */
+    #[Then('/^the variant "([^"]+)" should have (\d+) items on hand$/')]
     public function thisVariantShouldHaveItemsOnHand($productVariantName, $quantity): void
     {
         Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
@@ -141,9 +119,7 @@ final class BrowsingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^the "([^"]+)" variant of ("[^"]+" product) should have (\d+) items on hand$/
-     */
+    #[Then('/^the "([^"]+)" variant of ("[^"]+" product) should have (\d+) items on hand$/')]
     public function theVariantOfProductShouldHaveItemsOnHand($productVariantName, ProductInterface $product, $quantity): void
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -154,9 +130,7 @@ final class BrowsingProductVariantsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^I should see that the ("([^"]+)" variant) is not tracked$/
-     */
+    #[Then('/^I should see that the ("([^"]+)" variant) is not tracked$/')]
     public function iShouldSeeThatIsNotTracked(ProductVariantInterface $productVariant)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([
@@ -165,9 +139,7 @@ final class BrowsingProductVariantsContext implements Context
         ]));
     }
 
-    /**
-     * @Then /^I should see that the ("[^"]+" variant) has zero on hand quantity$/
-     */
+    #[Then('/^I should see that the ("[^"]+" variant) has zero on hand quantity$/')]
     public function iShouldSeeThatTheVariantHasZeroOnHandQuantity(ProductVariantInterface $productVariant)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([
@@ -176,9 +148,7 @@ final class BrowsingProductVariantsContext implements Context
         ]));
     }
 
-    /**
-     * @Then /^(\d+) units of (this product) should be on hold$/
-     */
+    #[Then('/^(\d+) units of (this product) should be on hold$/')]
     public function unitsOfThisProductShouldBeOnHold($quantity, ProductInterface $product)
     {
         /** @var ProductVariantInterface $variant */
@@ -187,9 +157,7 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertOnHoldQuantityOfVariant($quantity, $variant);
     }
 
-    /**
-     * @Then /^(\d+) units of (this product) should be on hand$/
-     */
+    #[Then('/^(\d+) units of (this product) should be on hand$/')]
     public function unitsOfThisProductShouldBeOnHand($quantity, ProductInterface $product)
     {
         /** @var ProductVariantInterface $variant */
@@ -198,9 +166,7 @@ final class BrowsingProductVariantsContext implements Context
         Assert::same($this->indexPage->getOnHandQuantityFor($variant), (int) $quantity);
     }
 
-    /**
-     * @Then /^there should be no units of (this product) on hold$/
-     */
+    #[Then('/^there should be no units of (this product) on hold$/')]
     public function thereShouldBeNoUnitsOfThisProductOnHold(ProductInterface $product)
     {
         /** @var ProductVariantInterface $variant */
@@ -209,17 +175,13 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertOnHoldQuantityOfVariant(0, $variant);
     }
 
-    /**
-     * @Then the :variant variant should have :amount items on hold
-     */
+    #[Then('the :variant variant should have :amount items on hold')]
     public function thisVariantShouldHaveItemsOnHold(ProductVariantInterface $variant, $amount)
     {
         $this->assertOnHoldQuantityOfVariant((int) $amount, $variant);
     }
 
-    /**
-     * @Then the :variant variant of :product product should have :amount items on hold
-     */
+    #[Then('the :variant variant of :product product should have :amount items on hold')]
     public function theVariantOfProductShouldHaveItemsOnHold(ProductVariantInterface $variant, ProductInterface $product, $amount)
     {
         $this->indexPage->open(['productId' => $product->getId()]);
@@ -227,17 +189,13 @@ final class BrowsingProductVariantsContext implements Context
         $this->assertOnHoldQuantityOfVariant((int) $amount, $variant);
     }
 
-    /**
-     * @Then the first variant in the list should have :field :value
-     */
+    #[Then('the first variant in the list should have :field :value')]
     public function theFirstVariantInTheListShouldHave($field, $value)
     {
         Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
-    /**
-     * @Then the last variant in the list should have :field :value
-     */
+    #[Then('the last variant in the list should have :field :value')]
     public function theLastVariantInTheListShouldHave($field, $value)
     {
         $values = $this->indexPage->getColumnFields($field);
@@ -245,9 +203,7 @@ final class BrowsingProductVariantsContext implements Context
         Assert::same(end($values), $value);
     }
 
-    /**
-     * @Then /^(this variant) should have a (\d+) item currently in stock$/
-     */
+    #[Then('/^(this variant) should have a (\d+) item currently in stock$/')]
     public function thisVariantShouldHaveAItemCurrentlyInStock(ProductVariantInterface $productVariant, $amountInStock)
     {
         $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
@@ -255,17 +211,13 @@ final class BrowsingProductVariantsContext implements Context
         Assert::same($this->indexPage->getOnHandQuantityFor($productVariant), (int) $amountInStock);
     }
 
-    /**
-     * @Then /^I should be on the list of (this product)'s variants$/
-     */
+    #[Then('/^I should be on the list of (this product)\'s variants$/')]
     public function iShouldBeOnTheListOfThisProductVariants(ProductInterface $product): void
     {
         Assert::true($this->indexPage->isOpen(['productId' => $product->getId()]));
     }
 
-    /**
-     * @Then /^I should see that the ("([^"]*)" variant) is enabled$/
-     */
+    #[Then('/^I should see that the ("([^"]*)" variant) is enabled$/')]
     public function iShouldSeeThatTheVariantIsEnabled(ProductVariantInterface $productVariant): void
     {
         Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(

--- a/src/Sylius/Behat/Context/Ui/Admin/ChannelPricingLogEntryContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ChannelPricingLogEntryContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\ChannelPricingLogEntry\IndexPageInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -24,9 +26,7 @@ final class ChannelPricingLogEntryContext implements Context
     {
     }
 
-    /**
-     * @When /^I go to the price history of a (variant with code "[^"]+")$/
-     */
+    #[When('/^I go to the price history of a (variant with code "[^"]+")$/')]
     public function iGoToThePriceHistoryOfAVariant(ProductVariantInterface $productVariant): void
     {
         $channelPricing = $productVariant->getChannelPricings()->first();
@@ -39,19 +39,15 @@ final class ChannelPricingLogEntryContext implements Context
         ]);
     }
 
-    /**
-     * @Then I should see :count log entries in the catalog price history
-     * @Then I should see a single log entry in the catalog price history
-     */
+    #[Then('I should see :count log entries in the catalog price history')]
+    #[Then('I should see a single log entry in the catalog price history')]
     public function iShouldSeeLogEntriesInTheCatalogPriceHistoryForTheVariant(int $count = 1): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then /^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the "([^"]+)" selling price, "([^"]+)" original price and datetime of the price change$/
-     * @Then /^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the "([^"]+)" selling price, no original price and datetime of the price change$/
-     */
+    #[Then('/^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the "([^"]+)" selling price, "([^"]+)" original price and datetime of the price change$/')]
+    #[Then('/^there should be a log entry on the (\d+)(?:|st|nd|rd|th) position with the "([^"]+)" selling price, no original price and datetime of the price change$/')]
     public function thereShouldBeALogEntryOnThePositionWithTheSellingPriceOriginalPriceAndDatetimeOfThePriceChange(
         int $position,
         string $price,
@@ -60,10 +56,8 @@ final class ChannelPricingLogEntryContext implements Context
         Assert::true($this->indexPage->isLogEntryWithPriceAndOriginalPriceOnPosition($price, $originalPrice, $position));
     }
 
-    /**
-     * @Then /^there should be a log entry with the "([^"]+)" selling price, "([^"]+)" original price and datetime of the price change$/
-     * @Then /^there should be a log entry with the "([^"]+)" selling price, no original price and datetime of the price change$/
-     */
+    #[Then('/^there should be a log entry with the "([^"]+)" selling price, "([^"]+)" original price and datetime of the price change$/')]
+    #[Then('/^there should be a log entry with the "([^"]+)" selling price, no original price and datetime of the price change$/')]
     public function thereShouldBeALogEntryWithTheSellingPriceOriginalPriceAndDatetimeOfThePriceChange(
         string $price,
         string $originalPrice = '-',

--- a/src/Sylius/Behat/Context/Ui/Admin/DashboardContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/DashboardContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
@@ -27,11 +29,9 @@ final class DashboardContext implements Context
     {
     }
 
-    /**
-     * @Given I am on the administration dashboard
-     * @When I (try to )open administration dashboard
-     * @When I (try to )view statistics
-     */
+    #[Given('I am on the administration dashboard')]
+    #[When('I (try to )open administration dashboard')]
+    #[When('I (try to )view statistics')]
     public function iViewStatistics(): void
     {
         try {
@@ -41,20 +41,18 @@ final class DashboardContext implements Context
     }
 
     /**
-     * @When I view statistics for :channel channel
-     *
      * @throws UnexpectedPageException
      */
+    #[When('I view statistics for :channel channel')]
     public function iViewStatisticsForChannel(ChannelInterface $channel): void
     {
         $this->dashboardPage->open(['channel' => $channel->getCode()]);
     }
 
     /**
-     * @When /^I view statistics for ("[^"]+" channel) and (current|previous|next) year split by (month|day)$/
-     *
      * @throws UnexpectedPageException
      */
+    #[When('/^I view statistics for ("[^"]+" channel) and (current|previous|next) year split by (month|day)$/')]
     public function iViewStatisticsForChannelAndYear(
         ChannelInterface $channel,
         string $period,
@@ -78,10 +76,9 @@ final class DashboardContext implements Context
     }
 
     /**
-     * @When /^I view statistics for ("[^"]+" channel) and (previous|next) year$/
-     *
      * @throws UnexpectedPageException
      */
+    #[When('/^I view statistics for ("[^"]+" channel) and (previous|next) year$/')]
     public function iViewStatisticsForPreviousPeriod(
         ChannelInterface $channel,
         string $period,
@@ -97,57 +94,43 @@ final class DashboardContext implements Context
         };
     }
 
-    /**
-     * @When I choose :channelName channel
-     */
+    #[When('I choose :channelName channel')]
     public function iChooseChannel(string $channelName): void
     {
         $this->dashboardPage->chooseChannel($channelName);
     }
 
-    /**
-     * @When I search for product :product via the navbar
-     */
+    #[When('I search for product :product via the navbar')]
     public function iSearchForProductViaTheNavbar(ProductInterface $product): void
     {
         $this->dashboardPage->searchForProductViaNavbar($product);
     }
 
-    /**
-     * @When I log out
-     */
+    #[When('I log out')]
     public function iLogOut(): void
     {
         $this->dashboardPage->logOut();
     }
 
-    /**
-     * @Then I should see :number paid orders
-     */
+    #[Then('I should see :number paid orders')]
     public function iShouldSeePaidOrders(int $number): void
     {
         Assert::same($this->dashboardPage->getNumberOfPaidOrders(), $number);
     }
 
-    /**
-     * @Then I should see :number new customers
-     */
+    #[Then('I should see :number new customers')]
     public function iShouldSeeNewCustomers(int $number): void
     {
         Assert::same($this->dashboardPage->getNumberOfNewCustomers(), $number);
     }
 
-    /**
-     * @Then there should be total sales of :total
-     */
+    #[Then('there should be total sales of :total')]
     public function thereShouldBeTotalSalesOf(string $total): void
     {
         Assert::same($this->dashboardPage->getTotalSales(), $total);
     }
 
-    /**
-     * @Then the average order value should be :value
-     */
+    #[Then('the average order value should be :value')]
     public function myAverageOrderValueShouldBe(string $value): void
     {
         Assert::same(
@@ -157,25 +140,19 @@ final class DashboardContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :number new customers in the list
-     */
+    #[Then('I should see :number new customers in the list')]
     public function iShouldSeeNewCustomersInTheList(int $number): void
     {
         Assert::same($this->dashboardPage->getNumberOfNewCustomersInTheList(), $number);
     }
 
-    /**
-     * @Then I should see :number new orders in the list
-     */
+    #[Then('I should see :number new orders in the list')]
     public function iShouldSeeNewOrdersInTheList(int $number): void
     {
         Assert::same($this->dashboardPage->getNumberOfNewOrdersInTheList(), $number);
     }
 
-    /**
-     * @Then I should not see the administration dashboard
-     */
+    #[Then('I should not see the administration dashboard')]
     public function iShouldNotSeeTheAdministrationDashboard(): void
     {
         Assert::false($this->dashboardPage->isOpen());

--- a/src/Sylius/Behat/Context/Ui/Admin/ErrorPageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ErrorPageContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\ErrorPageInterface;
 use Webmozart\Assert\Assert;
@@ -23,9 +24,7 @@ final readonly class ErrorPageContext implements Context
     {
     }
 
-    /**
-     * @Then I should see the not found page with the link to the dashboard
-     */
+    #[Then('I should see the not found page with the link to the dashboard')]
     public function iShouldSeeTheNotFoundPageWithTheLinkToTheDashboard(): void
     {
         Assert::true($this->errorPage->isItAdminNotFoundPage(), 'This test might require to be run without debug mode enabled.');

--- a/src/Sylius/Behat/Context/Ui/Admin/Helper/ValidationTrait.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/Helper/ValidationTrait.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin\Helper;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Sylius\Behat\Behaviour\SpecifiesItsField;
 use Sylius\Behat\Page\SyliusPageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -20,18 +22,14 @@ use Webmozart\Assert\Assert;
 
 trait ValidationTrait
 {
-    /**
-     * @When I specify a too long :field
-     */
+    #[When('I specify a too long :field')]
     public function iSpecifyATooLong(string $field): void
     {
         $this->resolveCurrentPage()->specifyField(ucwords($field), str_repeat('a', 256));
     }
 
-    /**
-     * @Then I should be notified that :field is too long
-     * @Then I should be notified that :field should be no longer than :maxLength characters
-     */
+    #[Then('I should be notified that :field is too long')]
+    #[Then('I should be notified that :field should be no longer than :maxLength characters')]
     public function iShouldBeNotifiedThatFieldValueIsTooLong(string $field, int $maxLength = 255): void
     {
         try {

--- a/src/Sylius/Behat/Context/Ui/Admin/ImpersonatingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ImpersonatingCustomersContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Administrator\ImpersonateUserPageInterface;
@@ -34,9 +37,7 @@ final class ImpersonatingCustomersContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am impersonating the customer :customer
-     */
+    #[Given('I am impersonating the customer :customer')]
     public function iAmImpersonatingCustomer(CustomerInterface $customer)
     {
         $this->customerShowPage->open(['id' => $customer->getId()]);
@@ -44,66 +45,50 @@ final class ImpersonatingCustomersContext implements Context
         $this->homePage->open();
     }
 
-    /**
-     * @When I visit the store
-     */
+    #[When('I visit the store')]
     public function iVisitTheStore()
     {
         $this->homePage->open();
     }
 
-    /**
-     * @When I log out from the store
-     */
+    #[When('I log out from the store')]
     public function iLogOut()
     {
         $this->homePage->logOut();
     }
 
-    /**
-     * @When I log out from my admin account
-     */
+    #[When('I log out from my admin account')]
     public function iLogOutFromMyAdminAccount()
     {
         $this->dashboardPage->open();
         $this->dashboardPage->logOut();
     }
 
-    /**
-     * @When I impersonate them
-     */
+    #[When('I impersonate them')]
     public function iTryToImpersonateThem()
     {
         $this->customerShowPage->impersonate();
     }
 
-    /**
-     * @When I impersonate the customer :customer
-     */
+    #[When('I impersonate the customer :customer')]
     public function iImpersonateCustomer(CustomerInterface $customer)
     {
         $this->impersonateUserPage->tryToOpen(['username' => $customer->getEmail()]);
     }
 
-    /**
-     * @Then I should be unable to impersonate them
-     */
+    #[Then('I should be unable to impersonate them')]
     public function iShouldBeUnableToImpersonateThem()
     {
         Assert::false($this->customerShowPage->hasImpersonateButton());
     }
 
-    /**
-     * @Then I should still be able to access the administration dashboard
-     */
+    #[Then('I should still be able to access the administration dashboard')]
     public function iShouldBeAbleToAccessAdministrationDashboard()
     {
         $this->dashboardPage->open();
     }
 
-    /**
-     * @Then I should be logged in as :fullName
-     */
+    #[Then('I should be logged in as :fullName')]
     public function iShouldBeLoggedInAs(string $fullName): void
     {
         [$firstName, $lastName] = explode(' ', $fullName);
@@ -112,9 +97,7 @@ final class ImpersonatingCustomersContext implements Context
         Assert::contains($this->homePage->getFullName(), $firstName);
     }
 
-    /**
-     * @Then I should not be logged in as :fullName
-     */
+    #[Then('I should not be logged in as :fullName')]
     public function iShouldNotBeLoggedInAs($fullName)
     {
         $this->homePage->open();
@@ -123,9 +106,7 @@ final class ImpersonatingCustomersContext implements Context
         Assert::false(strpos($this->homePage->getFullName(), $fullName));
     }
 
-    /**
-     * @Then I should see that impersonating :email was successful
-     */
+    #[Then('I should see that impersonating :email was successful')]
     public function iShouldSeeThatImpersonatingWasSuccessful($email)
     {
         $this->notificationChecker->checkNotification($email, NotificationType::success());

--- a/src/Sylius/Behat/Context/Ui/Admin/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/LocaleContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Administrator\CreatePageInterface;
 use Sylius\Behat\Page\Admin\DashboardPageInterface;
@@ -28,11 +29,9 @@ final readonly class LocaleContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should be viewing the administration panel in :localeCode locale
-     * @Then I should still be viewing the administration panel in :localeCode locale
-     * @Then they should be viewing the administration panel in :localeCode locale
-     */
+    #[Then('I should be viewing the administration panel in :localeCode locale')]
+    #[Then('I should still be viewing the administration panel in :localeCode locale')]
+    #[Then('they should be viewing the administration panel in :localeCode locale')]
     public function iShouldBeViewingTheAdministrationPanelIn(string $localeCode): void
     {
         if (!$this->dashboardPage->isOpen()) {
@@ -42,9 +41,7 @@ final readonly class LocaleContext implements Context
         Assert::same($this->dashboardPage->getDashboardHeader(), $this->translate('sylius.ui.dashboard', $localeCode));
     }
 
-    /**
-     * @Then I should be notified that this email is not valid in :localeCode locale
-     */
+    #[Then('I should be notified that this email is not valid in :localeCode locale')]
     public function iShouldBeNotifiedThatThisEmailIsNotValidInLocale(string $localeCode): void
     {
         Assert::same($this->createPage->getValidationMessage('field_email'), $this->translate('sylius.contact.email.invalid', $localeCode, 'validators'));

--- a/src/Sylius/Behat/Context/Ui/Admin/LoginContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/LoginContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Account\LoginPageInterface;
 use Sylius\Behat\Page\Admin\DashboardPageInterface;
@@ -27,91 +30,69 @@ final class LoginContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to log in
-     */
+    #[When('I want to log in')]
     public function iWantToLogIn()
     {
         $this->loginPage->open();
     }
 
-    /**
-     * @When I specify the username as :username
-     */
+    #[When('I specify the username as :username')]
     public function iSpecifyTheUsername($username = null)
     {
         $this->loginPage->specifyUsername($username);
     }
 
-    /**
-     * @When I specify the password as :password
-     * @When I do not specify the password
-     */
+    #[When('I specify the password as :password')]
+    #[When('I do not specify the password')]
     public function iSpecifyThePasswordAs($password = null)
     {
         $this->loginPage->specifyPassword($password);
     }
 
-    /**
-     * @When /^(this administrator) logs in using "([^"]+)" password$/
-     */
+    #[When('/^(this administrator) logs in using "([^"]+)" password$/')]
     public function theyLogIn(AdminUserInterface $adminUser, $password)
     {
         $this->logInAgain($adminUser->getUsername(), $password);
     }
 
-    /**
-     * @When I log in
-     */
+    #[When('I log in')]
     public function iLogIn()
     {
         $this->loginPage->logIn();
     }
 
-    /**
-     * @Then I should be logged in
-     */
+    #[Then('I should be logged in')]
     public function iShouldBeLoggedIn()
     {
         $this->dashboardPage->verify();
     }
 
-    /**
-     * @Then I should not be logged in
-     */
+    #[Then('I should not be logged in')]
     public function iShouldNotBeLoggedIn()
     {
         Assert::false($this->dashboardPage->isOpen());
     }
 
-    /**
-     * @Given I should be on login page
-     */
+    #[Given('I should be on login page')]
     public function iShouldBeOnLoginPage()
     {
         Assert::true($this->loginPage->isOpen());
     }
 
-    /**
-     * @Then I should be notified about bad credentials
-     */
+    #[Then('I should be notified about bad credentials')]
     public function iShouldBeNotifiedAboutBadCredentials()
     {
         Assert::true($this->loginPage->hasValidationErrorWith('Invalid credentials.'));
     }
 
-    /**
-     * @Then I should be able to log in as :username authenticated by :password password
-     */
+    #[Then('I should be able to log in as :username authenticated by :password password')]
     public function iShouldBeAbleToLogInAsAuthenticatedByPassword($username, $password)
     {
         $this->logInAgain($username, $password);
         $this->iShouldBeLoggedIn();
     }
 
-    /**
-     * @Then I should not be able to log in as :username authenticated by :password password
-     */
+    #[Then('I should not be able to log in as :username authenticated by :password password')]
     public function iShouldNotBeAbleToLogInAsAuthenticatedByPassword($username, $password)
     {
         $this->logInAgain($username, $password);
@@ -120,9 +101,7 @@ final class LoginContext implements Context
         Assert::false($this->dashboardPage->isOpen());
     }
 
-    /**
-     * @Then I should be on the login page
-     */
+    #[Then('I should be on the login page')]
     public function iShouldBeOnTheLoginPage(): void
     {
         Assert::true($this->loginPage->isOpen());

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorLocalesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorLocalesContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Administrator\UpdatePageInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -26,9 +27,7 @@ final class ManagingAdministratorLocalesContext implements Context
     ) {
     }
 
-    /**
-     * @When I change my locale to :localeCode
-     */
+    #[When('I change my locale to :localeCode')]
     public function iChangeMyLocaleTo(string $localeCode): void
     {
         /** @var AdminUserInterface $adminUser */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\TopBarElementInterface;
 use Sylius\Behat\NotificationType;
@@ -38,53 +41,41 @@ final class ManagingAdministratorsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new administrator
-     */
+    #[When('I want to create a new administrator')]
     public function iWantToCreateANewAdministrator()
     {
         $this->createPage->open();
     }
 
-    /**
-     * @Given /^I am editing (my) details$/
-     * @When /^I want to edit (this administrator)$/
-     */
+    #[Given('/^I am editing (my) details$/')]
+    #[When('/^I want to edit (this administrator)$/')]
     public function iWantToEditThisAdministrator(AdminUserInterface $adminUser)
     {
         $this->updatePage->open(['id' => $adminUser->getId()]);
     }
 
-    /**
-     * @When I browse administrators
-     * @When I want to browse administrators
-     */
+    #[When('I browse administrators')]
+    #[When('I want to browse administrators')]
     public function iWantToBrowseAdministrators()
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I try to browse administrators
-     */
+    #[When('I try to browse administrators')]
     public function iTryToBrowseAdministrators(): void
     {
         $this->indexPage->tryToOpen();
     }
 
-    /**
-     * @When I specify its name as :username
-     * @When I do not specify its name
-     * @When I change its name to :username
-     */
+    #[When('I specify its name as :username')]
+    #[When('I do not specify its name')]
+    #[When('I change its name to :username')]
     public function iSpecifyItsNameAs($username = null): void
     {
         $this->createPage->setUsername($username ?? '');
     }
 
-    /**
-     * @When I specify its :field as too long string
-     */
+    #[When('I specify its :field as too long string')]
     public function iSpecifyItsFieldAsTooLongString(string $field): void
     {
         match ($field) {
@@ -94,95 +85,73 @@ final class ManagingAdministratorsContext implements Context
         };
     }
 
-    /**
-     * @When I specify its email as :email
-     * @When I do not specify its email
-     * @When I change its email to :email
-     */
+    #[When('I specify its email as :email')]
+    #[When('I do not specify its email')]
+    #[When('I change its email to :email')]
     public function iSpecifyItsEmailAs($email = null)
     {
         $this->createPage->setEmail($email ?? '');
     }
 
-    /**
-     * @When I specify its locale as :localeCode
-     */
+    #[When('I specify its locale as :localeCode')]
     public function iSpecifyItsLocaleAs($localeCode)
     {
         $this->createPage->setLocale($localeCode);
     }
 
-    /**
-     * @When I set my locale to :localeCode
-     */
+    #[When('I set my locale to :localeCode')]
     public function iSetMyLocaleTo($localeCode)
     {
         $this->updatePage->setLocale($localeCode);
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When I specify its password as :password
-     * @When I do not specify its password
-     * @When I change its password to :password
-     */
+    #[When('I specify its password as :password')]
+    #[When('I do not specify its password')]
+    #[When('I change its password to :password')]
     public function iSpecifyItsPasswordAs($password = null)
     {
         $this->createPage->setPassword($password ?? '');
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt()
     {
         $this->createPage->enable();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I delete administrator with email :email
-     */
+    #[When('I delete administrator with email :email')]
     public function iDeleteAdministratorWithEmail($email)
     {
         $this->indexPage->deleteResourceOnPage(['email' => $email]);
     }
 
-    /**
-     * @When I check (also) the :email administrator
-     */
+    #[When('I check (also) the :email administrator')]
     public function iCheckTheAdministrator(string $email): void
     {
         $this->indexPage->checkResourceOnPage(['email' => $email]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I upload the :avatar image as the avatar
-     */
+    #[When('I upload the :avatar image as the avatar')]
     public function iUploadTheImageAsTheAvatar(string $avatar): void
     {
         $this->createPage->attachAvatar($avatar);
     }
 
-    /**
-     * @When /^I (?:upload|update) the "([^"]+)" image as (my) avatar$/
-     */
+    #[When('/^I (?:upload|update) the "([^"]+)" image as (my) avatar$/')]
     public function iUploadTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
         $path = $this->updateAvatar($avatar, $administrator);
@@ -190,11 +159,9 @@ final class ManagingAdministratorsContext implements Context
         $this->sharedStorage->set($avatar, $path);
     }
 
-    /**
-     * @Then the administrator :email should appear in the store
-     * @Then I should see the administrator :email in the list
-     * @Then there should still be only one administrator with an email :email
-     */
+    #[Then('the administrator :email should appear in the store')]
+    #[Then('I should see the administrator :email in the list')]
+    #[Then('there should still be only one administrator with an email :email')]
     public function theAdministratorShouldAppearInTheStore($email)
     {
         $this->indexPage->open();
@@ -202,10 +169,8 @@ final class ManagingAdministratorsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
-    /**
-     * @Then this administrator with name :username should appear in the store
-     * @Then there should still be only one administrator with name :username
-     */
+    #[Then('this administrator with name :username should appear in the store')]
+    #[Then('there should still be only one administrator with name :username')]
     public function thisAdministratorWithNameShouldAppearInTheStore($username)
     {
         $this->indexPage->open();
@@ -213,58 +178,44 @@ final class ManagingAdministratorsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['username' => $username]));
     }
 
-    /**
-     * @Then I should see a single administrator in the list
-     * @Then /^there should be (\d+) administrators in the list$/
-     */
+    #[Then('I should see a single administrator in the list')]
+    #[Then('/^there should be (\d+) administrators in the list$/')]
     public function iShouldSeeAdministratorsInTheList(int $number = 1): void
     {
         Assert::same($this->indexPage->countItems(), (int) $number);
     }
 
-    /**
-     * @When I remove the avatar
-     */
+    #[When('I remove the avatar')]
     public function iRemoveTheAvatarImage(): void
     {
         $this->updatePage->removeAvatar();
     }
 
-    /**
-     * @Then I should be notified that email must be unique
-     */
+    #[Then('I should be notified that email must be unique')]
     public function iShouldBeNotifiedThatEmailMustBeUnique()
     {
         Assert::same($this->createPage->getValidationMessage('field_email'), 'This email is already used.');
     }
 
-    /**
-     * @Then I should be notified that name must be unique
-     */
+    #[Then('I should be notified that name must be unique')]
     public function iShouldBeNotifiedThatNameMustBeUnique()
     {
         Assert::same($this->createPage->getValidationMessage('field_username'), 'This username is already used.');
     }
 
-    /**
-     * @Then I should be notified that the :elementName is required
-     */
+    #[Then('I should be notified that the :elementName is required')]
     public function iShouldBeNotifiedThatFirstNameIsRequired($elementName)
     {
         Assert::same($this->createPage->getValidationMessage(sprintf('%s_%s', 'field', $elementName)), sprintf('Please enter your %s.', $elementName));
     }
 
-    /**
-     * @Then I should be notified that this email is not valid
-     */
+    #[Then('I should be notified that this email is not valid')]
     public function iShouldBeNotifiedThatEmailIsNotValid()
     {
         Assert::same($this->createPage->getValidationMessage('field_email'), 'This email is invalid.');
     }
 
-    /**
-     * @Then I should be notified that this :field is too long
-     */
+    #[Then('I should be notified that this :field is too long')]
     public function iShouldBeNotifiedThatThisFieldIsTooLong(string $field): void
     {
         match ($field) {
@@ -274,17 +225,13 @@ final class ManagingAdministratorsContext implements Context
         };
     }
 
-    /**
-     * @Then there should not be :email administrator anymore
-     */
+    #[Then('there should not be :email administrator anymore')]
     public function thereShouldBeNoAnymore($email)
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
-    /**
-     * @Then I should be notified that it cannot be deleted
-     */
+    #[Then('I should be notified that it cannot be deleted')]
     public function iShouldBeNotifiedThatItCannotBeDeleted()
     {
         $this->notificationChecker->checkNotification(
@@ -293,9 +240,7 @@ final class ManagingAdministratorsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should see the "([^"]*)" image as (my) avatar$/
-     */
+    #[Then('/^I should see the "([^"]*)" image as (my) avatar$/')]
     public function iShouldSeeTheImageAsMyAvatar(string $avatar, AdminUserInterface $administrator): void
     {
         /** @var AdminUserInterface $administrator */
@@ -306,17 +251,13 @@ final class ManagingAdministratorsContext implements Context
         Assert::same($this->sharedStorage->get($avatar), $administrator->getAvatar()->getPath());
     }
 
-    /**
-     * @Then /^I should see the "([^"]*)" avatar image in the top bar next to my name$/
-     */
+    #[Then('/^I should see the "([^"]*)" avatar image in the top bar next to my name$/')]
     public function iShouldSeeTheAvatarImageInTheTopBarNextToMyName(string $avatar): void
     {
         Assert::true($this->topBarElement->hasAvatarInMainBar($avatar));
     }
 
-    /**
-     * @Then I should not see the :avatar avatar image in the additional information section of my account
-     */
+    #[Then('I should not see the :avatar avatar image in the additional information section of my account')]
     public function iShouldNotSeeTheAvatarImageInTheAdditionalInformationSectionOfMyAccount(string $avatar): void
     {
         $avatarPath = $this->sharedStorage->get($avatar);
@@ -324,9 +265,7 @@ final class ManagingAdministratorsContext implements Context
         Assert::false($this->updatePage->hasAvatar($avatarPath));
     }
 
-    /**
-     * @Then I should not see the :avatar avatar image in the top bar next to my name
-     */
+    #[Then('I should not see the :avatar avatar image in the top bar next to my name')]
     public function iShouldNotSeeTheAvatarImageInTheTopBarNextToMyName(string $avatar): void
     {
         $avatarPath = $this->sharedStorage->get($avatar);
@@ -335,9 +274,7 @@ final class ManagingAdministratorsContext implements Context
         Assert::true($this->topBarElement->hasDefaultAvatarInMainBar(), 'Default avatar should be present in the top bar');
     }
 
-    /**
-     * @Then I should not see any image as the avatar
-     */
+    #[Then('I should not see any image as the avatar')]
     public function iShouldNotSeeAnyImageAsTheAvatar(): void
     {
         Assert::false($this->createPage->isAvatarAttached());

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\CatalogPromotion\FilterElementInterface;
@@ -54,26 +57,20 @@ final class ManagingCatalogPromotionsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing catalog promotions
-     * @When I browse catalog promotions
-     */
+    #[Given('I am browsing catalog promotions')]
+    #[When('I browse catalog promotions')]
     public function iBrowseCatalogPromotions(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I want to create a new catalog promotion
-     */
+    #[When('I want to create a new catalog promotion')]
     public function iWantToCreateNewCatalogPromotion(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I create a new catalog promotion with :code code and :name name
-     */
+    #[When('I create a new catalog promotion with :code code and :name name')]
     public function iCreateANewCatalogPromotionWithCodeAndName(string $code, string $name): void
     {
         $this->createPage->open();
@@ -82,9 +79,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->createPage->create();
     }
 
-    /**
-     * @When I create a new catalog promotion with :code code and :name name and :priority priority
-     */
+    #[When('I create a new catalog promotion with :code code and :name name and :priority priority')]
     public function iCreateANewCatalogPromotionWithCodeAndNameAndPriority(string $code, string $name, int $priority): void
     {
         $this->createPage->open();
@@ -94,134 +89,102 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->createPage->create();
     }
 
-    /**
-     * @When I create a new catalog promotion without specifying its code and name
-     */
+    #[When('I create a new catalog promotion without specifying its code and name')]
     public function iCreateANewCatalogPromotionWithoutSpecifyingItsCodeAndName(): void
     {
         $this->createPage->open();
         $this->createPage->create();
     }
 
-    /**
-     * @When I specify its code as :code
-     */
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :name
-     */
+    #[When('I name it :name')]
     public function iNameIt(string $name): void
     {
         $this->formElement->nameIt($name);
     }
 
-    /**
-     * @When I set its priority to :priority
-     */
+    #[When('I set its priority to :priority')]
     public function iSetItsPriorityTo(int $priority): void
     {
         $this->formElement->prioritizeIt($priority);
     }
 
-    /**
-     * @When I specify its label as :label in :localeCode
-     */
+    #[When('I specify its label as :label in :localeCode')]
     public function iSpecifyItsLabelAsIn(string $label, string $localeCode): void
     {
         $this->formElement->labelIt($label, $localeCode);
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
     public function iDescribeItAsIn(string $description, string $localeCode): void
     {
         $this->formElement->describeIt($description, $localeCode);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->formElement->changeEnableTo(true);
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->formElement->changeEnableTo(false);
     }
 
-    /**
-     * @When I make it available in channel :channelName
-     */
+    #[When('I make it available in channel :channelName')]
     public function iMakeItAvailableInChannel(string $channelName): void
     {
         $this->formElement->checkChannel($channelName);
     }
 
-    /**
-     * @When I make it start at :startDate and ends at :endDate
-     */
+    #[When('I make it start at :startDate and ends at :endDate')]
     public function iMakeItOperateBetweenDates(string $startDate, string $endDate): void
     {
         $this->formElement->specifyStartDate(new \DateTime($startDate));
         $this->formElement->specifyEndDate(new \DateTime($endDate));
     }
 
-    /**
-     * @When I make it start yesterday and ends tomorrow
-     */
+    #[When('I make it start yesterday and ends tomorrow')]
     public function iMakeItOperateBetweenYesterdayAndTomorrow(): void
     {
         $this->formElement->specifyStartDate(new \DateTime('yesterday'));
         $this->formElement->specifyEndDate(new \DateTime('tomorrow'));
     }
 
-    /**
-     * @When I make it start at :startDate
-     */
+    #[When('I make it start at :startDate')]
     public function iMakeItOperateFromDate(string $startDate): void
     {
         $this->formElement->specifyStartDate(new \DateTime($startDate));
     }
 
-    /**
-     * @When I make it unavailable in channel :channelName
-     */
+    #[When('I make it unavailable in channel :channelName')]
     public function iMakeItUnavailableInChannel(string $channelName): void
     {
         $this->formElement->uncheckChannel($channelName);
     }
 
-    /**
-     * @When I( try to) change its end date to :endDate
-     */
+    #[When('I( try to) change its end date to :endDate')]
     public function iChangeItsEndDateTo(string $endDate): void
     {
         $this->formElement->specifyEndDate(new \DateTime($endDate));
     }
 
-    /**
-     * @When I add a new catalog promotion scope
-     */
+    #[When('I add a new catalog promotion scope')]
     public function iAddANewCatalogPromotionScope(): void
     {
         $this->formElement->addScope(InForProductScopeVariantChecker::TYPE);
     }
 
-    /**
-     * @When /^I add(?:| another) scope that applies on ("[^"]+" variant)$/
-     * @When /^I add scope that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
-     * @When /^I add scope that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
-     */
+    #[When('/^I add(?:| another) scope that applies on ("[^"]+" variant)$/')]
+    #[When('/^I add scope that applies on ("[^"]+" variant) and ("[^"]+" variant)$/')]
+    #[When('/^I add scope that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/')]
     public function iAddScopeThatAppliesOnVariants(ProductVariantInterface ...$variants): void
     {
         $variantNames = array_map(fn (ProductVariantInterface $variant) => $variant->getName(), $variants);
@@ -230,9 +193,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->formElement->selectScopeOption($variantNames);
     }
 
-    /**
-     * @When /^I add scope that applies on ("[^"]+" taxon)$/
-     */
+    #[When('/^I add scope that applies on ("[^"]+" taxon)$/')]
     public function iAddScopeThatAppliesOnTaxons(TaxonInterface ...$taxons): void
     {
         $taxonNames = array_map(fn (TaxonInterface $taxon) => $taxon->getName(), $taxons);
@@ -241,69 +202,53 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->formElement->selectScopeOption($taxonNames);
     }
 
-    /**
-     * @When /^I add scope that applies on ("[^"]+" product)$/
-     */
+    #[When('/^I add scope that applies on ("[^"]+" product)$/')]
     public function iAddScopeThatAppliesOnProduct(ProductInterface $product): void
     {
         $this->formElement->addScope(InForProductScopeVariantChecker::TYPE);
         $this->formElement->selectScopeOption([$product->getName()]);
     }
 
-    /**
-     * @When I add :productVariant variant to its scope
-     */
+    #[When('I add :productVariant variant to its scope')]
     public function iAddVariantToItsScope(ProductVariantInterface $productVariant): void
     {
         $this->formElement->selectScopeOption([$productVariant->getName()]);
     }
 
-    /**
-     * @When I remove :productVariant variant from its scope
-     */
+    #[When('I remove :productVariant variant from its scope')]
     public function iRemoveVariantFromItsScope(ProductVariantInterface $productVariant): void
     {
         $this->formElement->removeScopeOption([$productVariant->getName()]);
     }
 
-    /**
-     * @When I remove its last action
-     */
+    #[When('I remove its last action')]
     public function iRemoveItsLastAction(): void
     {
         $this->formElement->removeLastAction();
     }
 
-    /**
-     * @When I add a new catalog promotion action
-     */
+    #[When('I add a new catalog promotion action')]
     public function iAddANewCatalogPromotionAction(): void
     {
         $this->formElement->addAction(FixedDiscountPriceCalculator::TYPE);
     }
 
-    /**
-     * @When I add another action that gives ":discount%" percentage discount
-     * @When I add action that gives ":discount%" percentage discount
-     */
+    #[When('I add another action that gives ":discount%" percentage discount')]
+    #[When('I add action that gives ":discount%" percentage discount')]
     public function iAddActionThatGivesPercentageDiscount(string $discount): void
     {
         $this->formElement->addAction(PercentageDiscountPriceCalculator::TYPE);
         $this->formElement->fillActionOption('Amount', $discount);
     }
 
-    /**
-     * @When /^I add action that gives "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/
-     */
+    #[When('/^I add action that gives "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/')]
     public function iAddActionThatGivesFixedDiscount(string $discount, ChannelInterface $channel): void
     {
         $this->formElement->addAction(FixedDiscountPriceCalculator::TYPE);
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', $discount);
     }
 
-    /**
-     * @When /^I create an exclusive "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by "((?:\d+\.)?\d+)%" in ("[^"]+" channel)$/
-     */
+    #[When('/^I create an exclusive "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by "((?:\d+\.)?\d+)%" in ("[^"]+" channel)$/')]
     public function iCreateAnExclusiveCatalogPromotionWithCodeAndPriorityThatReducesPriceByInTheChannelAndAppliesOnProduct(
         string $name,
         int $priority,
@@ -314,9 +259,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->createCatalogPromotion($name, $priority, true, $product, $discount, $channel);
     }
 
-    /**
-     * @When /^I create a "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by "((?:\d+\.)?\d+)%" in ("[^"]+" channel)$/
-     */
+    #[When('/^I create a "([^"]+)" catalog promotion with ([^"]+) priority that applies on ("[^"]+" product) and reduces price by "((?:\d+\.)?\d+)%" in ("[^"]+" channel)$/')]
     public function iCreateACatalogPromotionWithCodeAndNameAndPriorityThatAppliesOnProductAndReducesPriceByInChannel(
         string $name,
         int $priority,
@@ -327,18 +270,14 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->createCatalogPromotion($name, $priority, false, $product, $discount, $channel);
     }
 
-    /**
-     * @When I (try to) add it
-     */
+    #[When('I (try to) add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I rename the :catalogPromotion catalog promotion to :name
-     * @When I try to rename the :catalogPromotion catalog promotion to :name
-     */
+    #[When('I rename the :catalogPromotion catalog promotion to :name')]
+    #[When('I try to rename the :catalogPromotion catalog promotion to :name')]
     public function iRenameTheCatalogPromotionTo(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
@@ -346,26 +285,20 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When I modify a catalog promotion :catalogPromotion
-     * @When I want to modify a catalog promotion :catalogPromotion
-     */
+    #[When('I modify a catalog promotion :catalogPromotion')]
+    #[When('I want to modify a catalog promotion :catalogPromotion')]
     public function iWantToModifyACatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
     }
 
-    /**
-     * @When I remove its last scope
-     */
+    #[When('I remove its last scope')]
     public function iRemoveItsLastScope(): void
     {
         $this->formElement->removeLastScope();
     }
 
-    /**
-     * @When I disable :catalogPromotion catalog promotion
-     */
+    #[When('I disable :catalogPromotion catalog promotion')]
     public function iDisableCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
@@ -375,9 +308,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @When I enable :catalogPromotion catalog promotion
-     */
+    #[When('I enable :catalogPromotion catalog promotion')]
     public function iEnableThisCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->updatePage->open(['id' => $catalogPromotion->getId()]);
@@ -385,66 +316,50 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When I edit its action so that it reduces price by ":discount%"
-     */
+    #[When('I edit its action so that it reduces price by ":discount%"')]
     public function iEditItsActionSoThatItReducesPriceBy(string $discount): void
     {
         $this->formElement->fillActionOption('Amount', $discount);
     }
 
-    /**
-     * @When I add for variants scope without variants configured
-     */
+    #[When('I add for variants scope without variants configured')]
     public function iAddForVariantsScopeWithoutVariantsConfigured(): void
     {
         $this->formElement->addScope(InForVariantsScopeVariantChecker::TYPE);
     }
 
-    /**
-     * @When I add catalog promotion scope for taxon without taxons
-     */
+    #[When('I add catalog promotion scope for taxon without taxons')]
     public function iAddForTaxonScopeWithoutTaxonsConfigured(): void
     {
         $this->formElement->addScope(InForTaxonsScopeVariantChecker::TYPE);
     }
 
-    /**
-     * @When I add catalog promotion scope for product without products
-     */
+    #[When('I add catalog promotion scope for product without products')]
     public function iAddCatalogPromotionScopeForProductWithoutProducts(): void
     {
         $this->formElement->addScope(InForProductScopeVariantChecker::TYPE);
     }
 
-    /**
-     * @When I add percentage discount action without amount configured
-     */
+    #[When('I add percentage discount action without amount configured')]
     public function iAddPercentageDiscountActionWithoutAmountConfigured(): void
     {
         $this->formElement->addAction(PercentageDiscountPriceCalculator::TYPE);
     }
 
-    /**
-     * @When I add fixed discount action without amount configured for the :channel channel
-     */
+    #[When('I add fixed discount action without amount configured for the :channel channel')]
     public function iAddFixedDiscountActionWithoutAmountConfigured(): void
     {
         $this->formElement->addAction(FixedDiscountPriceCalculator::TYPE);
     }
 
-    /**
-     * @When I add invalid percentage discount action with non number in amount
-     */
+    #[When('I add invalid percentage discount action with non number in amount')]
     public function iAddInvalidPercentageDiscountActionWithNonNumberInAmount(): void
     {
         $this->formElement->addAction(PercentageDiscountPriceCalculator::TYPE);
         $this->formElement->fillActionOption('Amount', 'alot');
     }
 
-    /**
-     * @When I add invalid fixed discount action with non number in amount for the :channel channel
-     */
+    #[When('I add invalid fixed discount action with non number in amount for the :channel channel')]
     public function iAddInvalidFixedDiscountActionWithNonNumberInAmountForTheChannel(
         ChannelInterface $channel,
     ): void {
@@ -452,10 +367,8 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', 'wrong value');
     }
 
-    /**
-     * @When /^I make (this catalog promotion) unavailable in the ("[^"]+" channel)$/
-     * @When /^I make the ("[^"]+" catalog promotion) unavailable in the ("[^"]+" channel)$/
-     */
+    #[When('/^I make (this catalog promotion) unavailable in the ("[^"]+" channel)$/')]
+    #[When('/^I make the ("[^"]+" catalog promotion) unavailable in the ("[^"]+" channel)$/')]
     public function iMakeThisCatalogPromotionUnavailableInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -467,10 +380,8 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When /^I make (this catalog promotion) available in the ("[^"]+" channel)$/
-     * @When /^I make ("[^"]+" catalog promotion) available in the ("[^"]+" channel)$/
-     */
+    #[When('/^I make (this catalog promotion) available in the ("[^"]+" channel)$/')]
+    #[When('/^I make ("[^"]+" catalog promotion) available in the ("[^"]+" channel)$/')]
     public function iMakeThisCatalogPromotionAvailableInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -482,10 +393,8 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When /^I switch (this catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/
-     * @When /^I switch ("[^"]+" catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/
-     */
+    #[When('/^I switch (this catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/')]
+    #[When('/^I switch ("[^"]+" catalog promotion) availability from the ("[^"]+" channel) to the ("[^"]+" channel)$/')]
     public function iSwitchThisCatalogPromotionAvailabilityFromTheChannelToTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $removedChannel,
@@ -499,60 +408,46 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When I view details of the catalog promotion :catalogPromotion
-     */
+    #[When('I view details of the catalog promotion :catalogPromotion')]
     public function iViewDetailsOfTheCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->showPage->open(['id' => $catalogPromotion->getId()]);
     }
 
-    /**
-     * @When I edit it to have empty amount of percentage discount
-     */
+    #[When('I edit it to have empty amount of percentage discount')]
     public function iEditItToHaveEmptyPercentageDiscount(): void
     {
         $this->formElement->fillActionOption('Amount', '');
     }
 
-    /**
-     * @When I edit it to have empty amount of fixed discount in the :channel channel
-     */
+    #[When('I edit it to have empty amount of fixed discount in the :channel channel')]
     public function iEditItToHaveEmptyFixedDiscountInChannel(ChannelInterface $channel): void
     {
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', '');
     }
 
-    /**
-     * @When I filter by :channel channel
-     */
+    #[When('I filter by :channel channel')]
     public function iFilterByChannel(ChannelInterface $channel): void
     {
         $this->filterElement->chooseChannel($channel);
         $this->filterElement->filter();
     }
 
-    /**
-     * @When I filter enabled catalog promotions
-     */
+    #[When('I filter enabled catalog promotions')]
     public function iFilterEnabledCatalogPromotions(): void
     {
         $this->filterElement->chooseEnabled();
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter by (active|failed|inactive|processing) state$/
-     */
+    #[When('/^I filter by (active|failed|inactive|processing) state$/')]
     public function iFilterByState(string $state): void
     {
         $this->filterElement->chooseState(ucfirst($state));
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterByDateUpTo(string $dateType, string $date): void
     {
         if ('start' === $dateType) {
@@ -564,9 +459,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterByDateFrom(string $dateType, string $date): void
     {
         if ('start' === $dateType) {
@@ -578,9 +471,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterByDateFromDateToDate(string $dateType, string $fromDate, string $toDate): void
     {
         if ('start' === $dateType) {
@@ -594,18 +485,14 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->filterElement->filter();
     }
 
-    /**
-     * @When I request the removal of :catalogPromotion catalog promotion
-     */
+    #[When('I request the removal of :catalogPromotion catalog promotion')]
     public function iRequestTheRemovalOfCatalogPromotion(CatalogPromotionInterface $catalogPromotion): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['name' => $catalogPromotion->getName()]);
     }
 
-    /**
-     * @When I sort catalog promotions by :order :field
-     */
+    #[When('I sort catalog promotions by :order :field')]
     public function iSortCatalogPromotionByOrderField(string $order, string $field): void
     {
         $this->indexPage->sortBy(
@@ -614,9 +501,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a discount amount should be between 0% and 100%
-     */
+    #[Then('I should be notified that a discount amount should be between 0% and 100%')]
     public function iShouldBeNotifiedThatADiscountAmountShouldBeBetween0And100Percent(): void
     {
         Assert::same(
@@ -625,9 +510,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the percentage amount should be a number and cannot be empty
-     */
+    #[Then('I should be notified that the percentage amount should be a number and cannot be empty')]
     public function iShouldBeNotifiedThatThePercentageAmountShouldBeANumber(): void
     {
         Assert::same(
@@ -636,9 +519,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the fixed amount cannot be empty
-     */
+    #[Then('I should be notified that the fixed amount cannot be empty')]
     public function iShouldBeNotifiedThatTheFixedAmountShouldCannotBeEmpty(): void
     {
         Assert::same(
@@ -647,9 +528,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the fixed amount should be a number
-     */
+    #[Then('I should be notified that the fixed amount should be a number')]
     public function iShouldBeNotifiedThatTheFixedAmountShouldBeANumber(): void
     {
         Assert::same(
@@ -658,11 +537,9 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then there should be :amount catalog promotions on the list
-     * @Then there should be :amount new catalog promotion on the list
-     * @Then there should be an empty list of catalog promotions
-     */
+    #[Then('there should be :amount catalog promotions on the list')]
+    #[Then('there should be :amount new catalog promotion on the list')]
+    #[Then('there should be an empty list of catalog promotions')]
     public function thereShouldBeCatalogPromotionsOnTheList(int $amount = 0): void
     {
         $this->indexPage->open();
@@ -670,18 +547,14 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->iShouldSeeCountCatalogPromotionsOnTheList($amount);
     }
 
-    /**
-     * @Then I should see :count catalog promotions on the list
-     */
+    #[Then('I should see :count catalog promotions on the list')]
     public function iShouldSeeCountCatalogPromotionsOnTheList(int $count): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then the catalog promotions named :firstName and :secondName should be in the registry
-     * @Then I should see a catalog promotion with name :name
-     */
+    #[Then('the catalog promotions named :firstName and :secondName should be in the registry')]
+    #[Then('I should see a catalog promotion with name :name')]
     public function theCatalogPromotionsNamedShouldBeInTheRegistry(string ...$names): void
     {
         foreach ($names as $name) {
@@ -692,9 +565,7 @@ final class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then the catalog promotion named :name should operate between :startDate and :endDate
-     */
+    #[Then('the catalog promotion named :name should operate between :startDate and :endDate')]
     public function theCatalogPromotionNamedShouldOperateBetweenDates(string $name, string $startDate, string $endDate): void
     {
         Assert::true(
@@ -708,9 +579,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the catalog promotion named :name should have priority :priority
-     */
+    #[Then('the catalog promotion named :name should have priority :priority')]
     public function theCatalogPromotionNamedShouldHavePriority(string $name, int $priority): void
     {
         Assert::true(
@@ -723,9 +592,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then it should have :code code and :name name
-     */
+    #[Then('it should have :code code and :name name')]
     public function itShouldHaveCodeAndName(string $code, string $name): void
     {
         Assert::true(
@@ -734,9 +601,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then it should have priority equal to :priority
-     */
+    #[Then('it should have priority equal to :priority')]
     public function itShouldHavePriorityEqualTo(int $priority): void
     {
         Assert::true(
@@ -745,9 +610,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^("[^"]+" catalog promotion) should apply to ("[^"]+" variant) and ("[^"]+" variant)$/
-     */
+    #[Then('/^("[^"]+" catalog promotion) should apply to ("[^"]+" variant) and ("[^"]+" variant)$/')]
     public function itShouldHaveVariantBasedScope(
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface ...$variants,
@@ -763,9 +626,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @Then /^("[^"]+" catalog promotion) should apply to all products from ("[^"]+" taxon)$/
-     */
+    #[Then('/^("[^"]+" catalog promotion) should apply to all products from ("[^"]+" taxon)$/')]
     public function itShouldHaveTaxonsBasedScope(
         CatalogPromotionInterface $catalogPromotion,
         TaxonInterface ...$taxons,
@@ -779,9 +640,7 @@ final class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then /^this catalog promotion should be applied on ("[^"]+" taxon)$/
-     */
+    #[Then('/^this catalog promotion should be applied on ("[^"]+" taxon)$/')]
     public function thisCatalogPromotionShouldBeAppliedOnTaxon(TaxonInterface $taxon): void
     {
         $selectedTaxons = $this->formElement->getLastScopeNames();
@@ -789,9 +648,7 @@ final class ManagingCatalogPromotionsContext implements Context
         Assert::inArray($taxon->getName(), $selectedTaxons);
     }
 
-    /**
-     * @Then /^the ("[^"]+" catalog promotion) should apply to all variants of ("[^"]+" product)$/
-     */
+    #[Then('/^the ("[^"]+" catalog promotion) should apply to all variants of ("[^"]+" product)$/')]
     public function theCatalogPromotionShouldApplyToAllVariantsOfProduct(
         CatalogPromotionInterface $catalogPromotion,
         ProductInterface $product,
@@ -801,19 +658,15 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->thisCatalogPromotionShouldBeAppliedOnProduct($product);
     }
 
-    /**
-     * @Then /^this catalog promotion should be applied on ("[^"]+" product)$/
-     */
+    #[Then('/^this catalog promotion should be applied on ("[^"]+" product)$/')]
     public function thisCatalogPromotionShouldBeAppliedOnProduct(ProductInterface $product): void
     {
         $selectedProducts = $this->formElement->getLastScopeNames();
         Assert::inArray($product->getName(), $selectedProducts);
     }
 
-    /**
-     * @Then /^it should apply to ("[^"]+" variant) and ("[^"]+" variant)$/
-     * @Then /^this catalog promotion should be applied on ("[^"]+" variant)$/
-     */
+    #[Then('/^it should apply to ("[^"]+" variant) and ("[^"]+" variant)$/')]
+    #[Then('/^this catalog promotion should be applied on ("[^"]+" variant)$/')]
     public function itShouldApplyToVariants(ProductVariantInterface ...$variants): void
     {
         $selectedVariants = $this->formElement->getLastScopeNames();
@@ -823,9 +676,7 @@ final class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then /^this catalog promotion should not be applied on ("[^"]+" variant)$/
-     */
+    #[Then('/^this catalog promotion should not be applied on ("[^"]+" variant)$/')]
     public function itShouldNotApplyToVariants(ProductVariantInterface ...$variants): void
     {
         $selectedVariants = $this->formElement->getLastScopeNames();
@@ -835,19 +686,15 @@ final class ManagingCatalogPromotionsContext implements Context
         }
     }
 
-    /**
-     * @Then /^it should have "([^"]+)%" discount$/
-     * @Then /^this catalog promotion should have "([^"]+)%" percentage discount$/
-     */
+    #[Then('/^it should have "([^"]+)%" discount$/')]
+    #[Then('/^this catalog promotion should have "([^"]+)%" percentage discount$/')]
     public function itShouldHaveDiscount(string $amount): void
     {
         Assert::same($this->formElement->getLastActionOption('Amount'), $amount);
     }
 
-    /**
-     * @Then /^the ("[^"]+" catalog promotion) should have "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/
-     * @Then /^(this catalog promotion) should have "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/
-     */
+    #[Then('/^the ("[^"]+" catalog promotion) should have "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/')]
+    #[Then('/^(this catalog promotion) should have "(?:€|£|\$)([^"]+)" of fixed discount in the ("[^"]+" channel)$/')]
     public function theCatalogPromotionShouldHaveFixedDiscountInTheChannel(
         CatalogPromotionInterface $catalogPromotion,
         string $amount,
@@ -858,9 +705,7 @@ final class ManagingCatalogPromotionsContext implements Context
         Assert::same($this->formElement->getLastActionOptionForChannel($channel->getCode(), 'Amount'), $amount);
     }
 
-    /**
-     * @Then there should still be only one catalog promotion with code :code
-     */
+    #[Then('there should still be only one catalog promotion with code :code')]
     public function thereShouldStillBeOnlyOneCatalogPromotionWithCode(string $code): void
     {
         $this->indexPage->open();
@@ -868,19 +713,15 @@ final class ManagingCatalogPromotionsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    /**
-     * @Then the catalog promotion :catalogPromotionName should be available in channel :channelName
-     */
+    #[Then('the catalog promotion :catalogPromotionName should be available in channel :channelName')]
     public function theCatalogPromotionShouldBeAvailableInChannel(string $catalogPromotionName, string $channelName): void
     {
         $this->indexPage->open();
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $catalogPromotionName, 'channels' => $channelName]));
     }
 
-    /**
-     * @Then /^(it) should operate between "([^"]+)" and "([^"]+)"$/
-     * @Then /^(this catalog promotion) should operate between "([^"]+)" and "([^"]+)"$/
-     */
+    #[Then('/^(it) should operate between "([^"]+)" and "([^"]+)"$/')]
+    #[Then('/^(this catalog promotion) should operate between "([^"]+)" and "([^"]+)"$/')]
     public function theCatalogPromotionShouldOperateBetweenDates(
         CatalogPromotionInterface $catalogPromotion,
         string $startDate,
@@ -894,9 +735,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @Then /^(it) should operate between yesterday and tomorrow$/
-     */
+    #[Then('/^(it) should operate between yesterday and tomorrow$/')]
     public function theCatalogPromotionShouldOperateBetweenYesterdayAndTomorrow(
         CatalogPromotionInterface $catalogPromotion,
     ): void {
@@ -910,10 +749,8 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->sharedStorage->set('catalog_promotion', $catalogPromotion);
     }
 
-    /**
-     * @Then /^(it) should be (inactive|active)$/
-     * @Then /^(this catalog promotion) should(?:| still) be (inactive|active)$/
-     */
+    #[Then('/^(it) should be (inactive|active)$/')]
+    #[Then('/^(this catalog promotion) should(?:| still) be (inactive|active)$/')]
     public function itShouldBeInactive(CatalogPromotionInterface $catalogPromotion, string $state): void
     {
         $this->indexPage->open();
@@ -923,9 +760,7 @@ final class ManagingCatalogPromotionsContext implements Context
         ));
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be available in channel "([^"]+)"$/
-     */
+    #[Then('/^(this catalog promotion) should be available in channel "([^"]+)"$/')]
     public function thisCatalogPromotionShouldBeAvailableInChannel(
         CatalogPromotionInterface $catalogPromotion,
         string $channelName,
@@ -935,9 +770,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $this->theCatalogPromotionShouldBeAvailableInChannel($catalogPromotion->getName(), $channelName);
     }
 
-    /**
-     * @Then /^(this catalog promotion) should not be available in channel "([^"]+)"$/
-     */
+    #[Then('/^(this catalog promotion) should not be available in channel "([^"]+)"$/')]
     public function thisCatalogPromotionShouldNotBeAvailableInChannel(
         CatalogPromotionInterface $catalogPromotion,
         string $channelName,
@@ -947,9 +780,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that catalog promotion has been successfully created
-     */
+    #[Then('I should be notified that catalog promotion has been successfully created')]
     public function iShouldBeNotifiedThatCatalogPromotionHasBeenSuccessfullyCreated(): void
     {
         $this->notificationChecker->checkNotification(
@@ -958,26 +789,20 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code and name are required
-     */
+    #[Then('I should be notified that code and name are required')]
     public function iShouldBeNotifiedThatCodeAndNameAreRequired(): void
     {
         Assert::same($this->createPage->getValidationMessage('code'), 'Please enter catalog promotion code.');
         Assert::same($this->createPage->getValidationMessage('name'), 'Please enter catalog promotion name.');
     }
 
-    /**
-     * @Then I should be notified that catalog promotion with this code already exists
-     */
+    #[Then('I should be notified that catalog promotion with this code already exists')]
     public function iShouldBeNotifiedThatCatalogPromotionWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->createPage->getValidationMessage('code'), 'The catalog promotion with given code already exists.');
     }
 
-    /**
-     * @Then /^(this catalog promotion) name should(?:| still) be "([^"]+)"$/
-     */
+    #[Then('/^(this catalog promotion) name should(?:| still) be "([^"]+)"$/')]
     public function thisCatalogPromotionNameShouldBe(CatalogPromotionInterface $catalogPromotion, string $name): void
     {
         $this->iBrowseCatalogPromotions();
@@ -987,9 +812,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this catalog promotion) should be (labelled|described) as "([^"]+)" in ("[^"]+" locale)$/
-     */
+    #[Then('/^(this catalog promotion) should be (labelled|described) as "([^"]+)" in ("[^"]+" locale)$/')]
     public function thisCatalogPromotionLabelInLocaleShouldBe(
         CatalogPromotionInterface $catalogPromotion,
         string $field,
@@ -1004,25 +827,19 @@ final class ManagingCatalogPromotionsContext implements Context
         Assert::same($this->formElement->getFieldValueInLocale($fieldsMapping[$field], $localeCode), $value);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @Then I should be notified that at least 1 variant is required
-     */
+    #[Then('I should be notified that at least 1 variant is required')]
     public function iShouldBeNotifiedThatAtLeast1VariantIsRequired(): void
     {
         Assert::same($this->formElement->getValidationMessage('last_scope'), 'Please add at least 1 variant.');
     }
 
-    /**
-     * @Then /^I should be notified that I must add at least one (product|taxon)$/
-     */
+    #[Then('/^I should be notified that I must add at least one (product|taxon)$/')]
     public function iShouldBeNotifiedThatIMustAddAtLeastOne(string $entity): void
     {
         Assert::same(
@@ -1031,9 +848,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to edit it due to wrong state
-     */
+    #[Then('I should not be able to edit it due to wrong state')]
     public function iShouldNotBeAbleToEditItDueToWrongState(): void
     {
         Assert::inArray(
@@ -1042,82 +857,62 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then its name should be :name
-     */
+    #[Then('its name should be :name')]
     public function itsNameShouldBe(string $name): void
     {
         Assert::same($this->showPage->getName(), $name);
     }
 
-    /**
-     * @Then it should reduce price by :amount
-     */
+    #[Then('it should reduce price by :amount')]
     public function thisCatalogPromotionShouldHavePercentageDiscount(string $amount): void
     {
         Assert::true($this->showPage->hasActionWithPercentageDiscount($amount));
     }
 
-    /**
-     * @Then it should reduce price by :amount in the :channel channel
-     */
+    #[Then('it should reduce price by :amount in the :channel channel')]
     public function itShouldReducePriceByInTheChannel(string $amount, ChannelInterface $channel): void
     {
         Assert::true($this->showPage->hasActionWithFixedDiscount($amount, $channel));
     }
 
-    /**
-     * @Then it should apply on :variant variant
-     */
+    #[Then('it should apply on :variant variant')]
     public function itShouldApplyOnVariant(ProductVariantInterface $variant): void
     {
         Assert::true($this->showPage->hasScopeWithVariant($variant));
     }
 
-    /**
-     * @Then it should apply on :product product
-     */
+    #[Then('it should apply on :product product')]
     public function itShouldApplyOnProduct(ProductInterface $product): void
     {
         Assert::true($this->showPage->hasScopeWithProduct($product));
     }
 
-    /**
-     * @Given it should be exclusive
-     */
+    #[Given('it should be exclusive')]
     public function itShouldBeExclusive(): void
     {
         Assert::true($this->showPage->isExclusive());
     }
 
-    /**
-     * @Given it should not be exclusive
-     */
+    #[Given('it should not be exclusive')]
     public function itShouldNotBeExclusive(): void
     {
         Assert::false($this->showPage->isExclusive());
     }
 
-    /**
-     * @Then it should start at :startDate and end at :endDate
-     */
+    #[Then('it should start at :startDate and end at :endDate')]
     public function itShouldStartAtAndEndAt(string $startDate, string $endDate): void
     {
         Assert::contains($this->showPage->getStartDate(), $startDate);
         Assert::contains($this->showPage->getEndDate(), $endDate);
     }
 
-    /**
-     * @Then I should get information that the end date cannot be set before start date
-     */
+    #[Then('I should get information that the end date cannot be set before start date')]
     public function iShouldGetInformationThatTheEndDateCannotBeSetBeforeStartDate(): void
     {
         Assert::same($this->formElement->getValidationMessage('end_date_date'), 'End date cannot be set before start date.');
     }
 
-    /**
-     * @Then I should be notified that not all channels are filled
-     */
+    #[Then('I should be notified that not all channels are filled')]
     public function iShouldBeNotifiedThatNotAllChannelsAreFilled(): void
     {
         Assert::contains(
@@ -1126,17 +921,13 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then its priority should be :priority
-     */
+    #[Then('its priority should be :priority')]
     public function itsPriorityShouldBe(int $priority): void
     {
         Assert::same($this->showPage->getPriority(), $priority);
     }
 
-    /**
-     * @Then I should see the catalog promotion scope configuration form
-     */
+    #[Then('I should see the catalog promotion scope configuration form')]
     public function iShouldSeeTheCatalogPromotionScopeConfigurationForm(): void
     {
         Assert::true(
@@ -1145,9 +936,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the catalog promotion action configuration form
-     */
+    #[Then('I should see the catalog promotion action configuration form')]
     public function iShouldSeeTheCatalogPromotionActionConfigurationForm(): void
     {
         Assert::true(
@@ -1156,9 +945,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see a catalog promotion with name :name
-     */
+    #[Then('I should not see a catalog promotion with name :name')]
     public function iShouldNotSeeACatalogPromotionWithName(string $name): void
     {
         Assert::false(
@@ -1167,9 +954,7 @@ final class ManagingCatalogPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the first catalog promotion should have code :code
-     */
+    #[Then('the first catalog promotion should have code :code')]
     public function theFirstCatalogPromotionShouldHaveCode(string $code): void
     {
         Assert::same($this->indexPage->getColumnFields('code')[0], $code);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Channel\ShopBillingDataElementInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
@@ -24,9 +26,7 @@ final class ManagingChannelsBillingDataContext implements Context
     {
     }
 
-    /**
-     * @When I specify shop billing data for this channel as :company, :street, :postcode, :city, :taxId tax ID and :country country
-     */
+    #[When('I specify shop billing data for this channel as :company, :street, :postcode, :city, :taxId tax ID and :country country')]
     public function iSpecifyNewShopBillingDataForChannelAs(
         string $company,
         string $street,
@@ -40,25 +40,19 @@ final class ManagingChannelsBillingDataContext implements Context
         $this->shopBillingDataElement->specifyBillingAddress($street, $postcode, $city, $country->getCode());
     }
 
-    /**
-     * @When I specify company as :company
-     */
+    #[When('I specify company as :company')]
     public function specifyCompanyAs(string $company): void
     {
         $this->shopBillingDataElement->specifyCompany($company);
     }
 
-    /**
-     * @When I specify tax ID as :taxId
-     */
+    #[When('I specify tax ID as :taxId')]
     public function specifyTaxIdAs(string $taxId): void
     {
         $this->shopBillingDataElement->specifyTaxId($taxId);
     }
 
-    /**
-     * @When I specify shop billing address as :street, :postcode :city, :country
-     */
+    #[When('I specify shop billing address as :street, :postcode :city, :country')]
     public function specifyShopBillingAddressAs(
         string $street,
         string $postcode,
@@ -68,26 +62,20 @@ final class ManagingChannelsBillingDataContext implements Context
         $this->shopBillingDataElement->specifyBillingAddress($street, $postcode, $city, $country->getCode());
     }
 
-    /**
-     * @Then this channel company should be :company
-     */
+    #[Then('this channel company should be :company')]
     public function thisChannelCompanyShouldBe(string $company): void
     {
         Assert::true($this->shopBillingDataElement->hasCompany($company));
     }
 
-    /**
-     * @Then this channel tax ID should be :taxId
-     */
+    #[Then('this channel tax ID should be :taxId')]
     public function thisChanneTaxIdShouldBe(string $taxId): void
     {
         Assert::true($this->shopBillingDataElement->hasTaxId($taxId));
     }
 
-    /**
-     * @Then this channel shop billing address should be :street, :postcode :city and :country country
-     * @Then this channel shop billing address should be :street, :postcode :city, :country
-     */
+    #[Then('this channel shop billing address should be :street, :postcode :city and :country country')]
+    #[Then('this channel shop billing address should be :street, :postcode :city, :country')]
     public function thisChannelShopBillingAddressShouldBe(
         string $street,
         string $postcode,

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\Channel\DiscountedProductsCheckingPeriodInputElementInterface;
@@ -49,46 +52,36 @@ final class ManagingChannelsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new channel
-     */
+    #[When('I want to create a new channel')]
     public function iWantToCreateANewChannel(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iNameIt(?string $name = null): void
     {
         $this->createPage->nameIt($name ?? '');
     }
 
-    /**
-     * @When I specify its name as a too long string
-     */
+    #[When('I specify its name as a too long string')]
     public function iSpecifyItsNameAsATooLongString(): void
     {
         $this->createPage->nameIt($this->getTooLongString());
     }
 
-    /**
-     * @When I choose :currency as the base currency
-     * @When I do not choose base currency
-     */
+    #[When('I choose :currency as the base currency')]
+    #[When('I do not choose base currency')]
     public function iChooseAsABaseCurrency(?CurrencyInterface $currency = null): void
     {
         if (null !== $currency) {
@@ -96,10 +89,8 @@ final class ManagingChannelsContext implements Context
         }
     }
 
-    /**
-     * @When I choose :defaultLocaleName as a default locale
-     * @When I do not choose default locale
-     */
+    #[When('I choose :defaultLocaleName as a default locale')]
+    #[When('I do not choose default locale')]
     public function iChooseAsADefaultLocale(?string $defaultLocaleName = null): void
     {
         if (null !== $defaultLocaleName) {
@@ -107,61 +98,47 @@ final class ManagingChannelsContext implements Context
         }
     }
 
-    /**
-     * @When I choose :firstCountry and :secondCountry as operating countries
-     */
+    #[When('I choose :firstCountry and :secondCountry as operating countries')]
     public function iChooseOperatingCountries(string ...$countries): void
     {
         $this->createPage->chooseOperatingCountries($countries);
     }
 
-    /**
-     * @When I specify menu taxon as :menuTaxon
-     * @When I change its menu taxon to :menuTaxon
-     */
+    #[When('I specify menu taxon as :menuTaxon')]
+    #[When('I change its menu taxon to :menuTaxon')]
     public function iSpecifyMenuTaxonAs(string $menuTaxon): void
     {
         $this->resolveCurrentPage()->specifyMenuTaxon($menuTaxon);
     }
 
-    /**
-     * @When I allow to skip shipping step if only one shipping method is available
-     */
+    #[When('I allow to skip shipping step if only one shipping method is available')]
     public function iAllowToSkipShippingStepIfOnlyOneShippingMethodIsAvailable(): void
     {
         $this->createPage->allowToSkipShippingStep();
     }
 
-    /**
-     * @When I allow to skip payment step if only one payment method is available
-     */
+    #[When('I allow to skip payment step if only one payment method is available')]
     public function iAllowToSkipPaymentStepIfOnlyOnePaymentMethodIsAvailable(): void
     {
         $this->createPage->allowToSkipPaymentStep();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When /^I choose (billing|shipping) address as a required address in the checkout$/
-     */
+    #[When('/^I choose (billing|shipping) address as a required address in the checkout$/')]
     public function iChooseAddressAsARequiredAddressInTheCheckout(string $type): void
     {
         $this->shippingAddressInCheckoutRequiredElement->requireAddressTypeInCheckout($type);
     }
 
-    /**
-     * @Then I should see the channel :channelName in the list
-     * @Then the channel :channelName should appear in the registry
-     * @Then the channel :channelName should be in the registry
-     */
+    #[Then('I should see the channel :channelName in the list')]
+    #[Then('the channel :channelName should appear in the registry')]
+    #[Then('the channel :channelName should be in the registry')]
     public function theChannelShouldAppearInTheRegistry(string $channelName): void
     {
         $this->iWantToBrowseChannels();
@@ -169,97 +146,73 @@ final class ManagingChannelsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $channelName]));
     }
 
-    /**
-     * @Then /^(this channel) should still be in the registry$/
-     */
+    #[Then('/^(this channel) should still be in the registry$/')]
     public function thisChannelShouldAppearInTheRegistry(ChannelInterface $channel): void
     {
         $this->theChannelShouldAppearInTheRegistry($channel->getName());
     }
 
-    /**
-     * @When I describe it as :description
-     */
+    #[When('I describe it as :description')]
     public function iDescribeItAs(string $description): void
     {
         $this->createPage->describeItAs($description);
     }
 
-    /**
-     * @When I set its hostname as :hostname
-     */
+    #[When('I set its hostname as :hostname')]
     public function iSetItsHostnameAs(string $hostname): void
     {
         $this->createPage->setHostname($hostname);
     }
 
-    /**
-     * @When I specify its hostname as a too long string
-     */
+    #[When('I specify its hostname as a too long string')]
     public function iSpecifyItsHostnameAsATooLongString(): void
     {
         $this->createPage->setHostname($this->getTooLongString());
     }
 
-    /**
-     * @When I set its contact email as :contactEmail
-     */
+    #[When('I set its contact email as :contactEmail')]
     public function iSetItsContactEmailAs(string $contactEmail): void
     {
         $this->createPage->setContactEmail($contactEmail);
     }
 
-    /**
-     * @When I specify its contact email as a too long string
-     */
+    #[When('I specify its contact email as a too long string')]
     public function iSpecifyItsContactEmailAsATooLongString(): void
     {
         $this->createPage->setContactEmail($this->getTooLongString());
     }
 
-    /**
-     * @When I set its contact phone number as :contactPhoneNumber
-     */
+    #[When('I set its contact phone number as :contactPhoneNumber')]
     public function iSetItsContactPhoneNumberAs(string $contactPhoneNumber): void
     {
         $this->createPage->setContactPhoneNumber($contactPhoneNumber);
     }
 
-    /**
-     * @When I specify its contact phone number as a too long string
-     */
+    #[When('I specify its contact phone number as a too long string')]
     public function iSpecifyItsContactPhoneNumberAsATooLongString(): void
     {
         $this->createPage->setContactPhoneNumber($this->getTooLongString());
     }
 
-    /**
-     * @When I define its color as :color
-     */
+    #[When('I define its color as :color')]
     public function iDefineItsColorAs(string $color): void
     {
         $this->createPage->defineColor($color);
     }
 
-    /**
-     * @When I specify its color as a too long string
-     */
+    #[When('I specify its color as a too long string')]
     public function iSpecifyItsColorAsATooLongString(): void
     {
         $this->createPage->defineColor($this->getTooLongString());
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->updatePage->enable();
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -268,17 +221,13 @@ final class ManagingChannelsContext implements Context
         $currentPage->disable();
     }
 
-    /**
-     * @When I exclude the :taxon taxon from showing the lowest price of discounted products
-     */
+    #[When('I exclude the :taxon taxon from showing the lowest price of discounted products')]
     public function iExcludeTheTaxonFromShowingTheLowestPriceOfDiscountedProducts(TaxonInterface $taxon): void
     {
         $this->excludeTaxonsFromShowingLowestPriceInputElement->excludeTaxon($taxon);
     }
 
-    /**
-     * @When /^I exclude the ("([^"]+)" and "([^"]+)" taxons) from showing the lowest price of discounted products$/
-     */
+    #[When('/^I exclude the ("([^"]+)" and "([^"]+)" taxons) from showing the lowest price of discounted products$/')]
     public function iExcludeTheTaxonsFromShowingTheLowestPriceOfDiscountedProducts(iterable $taxons): void
     {
         foreach ($taxons as $taxon) {
@@ -286,17 +235,13 @@ final class ManagingChannelsContext implements Context
         }
     }
 
-    /**
-     * @When I remove the :taxon taxon from excluded taxons from showing the lowest price of discounted products
-     */
+    #[When('I remove the :taxon taxon from excluded taxons from showing the lowest price of discounted products')]
     public function iRemoveTheTaxonFromExcludedTaxonsFromShowingTheLowestPriceOfDiscountedProducts(TaxonInterface $taxon): void
     {
         $this->excludeTaxonsFromShowingLowestPriceInputElement->removeExcludedTaxon($taxon);
     }
 
-    /**
-     * @Then I should be notified that at least one channel has to be defined
-     */
+    #[Then('I should be notified that at least one channel has to be defined')]
     public function iShouldBeNotifiedThatAtLeastOneChannelHasToBeDefinedIsRequired(): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -305,9 +250,7 @@ final class ManagingChannelsContext implements Context
         Assert::same($currentPage->getValidationMessage('enabled'), 'Must have at least one enabled entity');
     }
 
-    /**
-     * @Then channel with :element :value should not be added
-     */
+    #[Then('channel with :element :value should not be added')]
     public function channelWithShouldNotBeAdded(string $element, string $value): void
     {
         $this->iWantToBrowseChannels();
@@ -315,9 +258,7 @@ final class ManagingChannelsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then /^I should be notified that ([^"]+) is required$/
-     */
+    #[Then('/^I should be notified that ([^"]+) is required$/')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -329,21 +270,17 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Given I am modifying a channel :channel
-     * @When I want to modify a channel :channel
-     * @When /^I want to modify (this channel)$/
-     * @When I want to modify a billing data of channel :channel
-     */
+    #[Given('I am modifying a channel :channel')]
+    #[When('I want to modify a channel :channel')]
+    #[When('/^I want to modify (this channel)$/')]
+    #[When('I want to modify a billing data of channel :channel')]
     public function iWantToModifyChannel(ChannelInterface $channel): void
     {
         $this->updatePage->open(['id' => $channel->getId()]);
     }
 
-    /**
-     * @Then /^(this channel) name should be "([^"]+)"$/
-     * @Then /^(this channel) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this channel) name should be "([^"]+)"$/')]
+    #[Then('/^(this channel) should still be named "([^"]+)"$/')]
     public function thisChannelNameShouldBe(ChannelInterface $channel, string $channelName): void
     {
         $this->iWantToBrowseChannels();
@@ -354,17 +291,13 @@ final class ManagingChannelsContext implements Context
         ]));
     }
 
-    /**
-     * @Then I should be notified that channel with this code already exists
-     */
+    #[Then('I should be notified that channel with this code already exists')]
     public function iShouldBeNotifiedThatChannelWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->createPage->getValidationMessage('code'), 'Channel code has to be unique.');
     }
 
-    /**
-     * @Then there should still be only one channel with :element :value
-     */
+    #[Then('there should still be only one channel with :element :value')]
     public function thereShouldStillBeOnlyOneChannelWithCode(string $element, string $value): void
     {
         $this->iWantToBrowseChannels();
@@ -372,86 +305,66 @@ final class ManagingChannelsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @When I browse channels
-     * @When I want to browse channels
-     */
+    #[When('I browse channels')]
+    #[When('I want to browse channels')]
     public function iWantToBrowseChannels(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I check (also) the :channelName channel
-     */
+    #[When('I check (also) the :channelName channel')]
     public function iCheckTheChannel(string $channelName): void
     {
         $this->indexPage->checkResourceOnPage(['nameAndDescription' => $channelName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see a single channel in the list
-     * @Then I should see :numberOfChannels channels in the list
-     */
+    #[Then('I should see a single channel in the list')]
+    #[Then('I should see :numberOfChannels channels in the list')]
     public function iShouldSeeChannelsInTheList(int $numberOfChannels = 1): void
     {
         Assert::same($this->indexPage->countItems(), $numberOfChannels);
     }
 
-    /**
-     * @Then the code field should be disabled
-     * @Then I should not be able to edit its code
-     */
+    #[Then('the code field should be disabled')]
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @Then /^(this channel) should be disabled$/
-     */
+    #[Then('/^(this channel) should be disabled$/')]
     public function thisChannelShouldBeDisabled(ChannelInterface $channel): void
     {
         $this->assertChannelState($channel, false);
     }
 
-    /**
-     * @Then /^(this channel) should be enabled$/
-     * @Then channel with name :channel should still be enabled
-     */
+    #[Then('/^(this channel) should be enabled$/')]
+    #[Then('channel with name :channel should still be enabled')]
     public function thisChannelShouldBeEnabled(ChannelInterface $channel): void
     {
         $this->assertChannelState($channel, true);
     }
 
-    /**
-     * @When I delete channel :channel
-     */
+    #[When('I delete channel :channel')]
     public function iDeleteChannel(ChannelInterface $channel): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['nameAndDescription' => $channel->getName()]);
     }
 
-    /**
-     * @Then the :channelName channel should no longer exist in the registry
-     */
+    #[Then('the :channelName channel should no longer exist in the registry')]
     public function thisChannelShouldNoLongerExistInTheRegistry(string $channelName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $channelName]));
     }
 
-    /**
-     * @Then I should be notified that it cannot be deleted
-     */
+    #[Then('I should be notified that it cannot be deleted')]
     public function iShouldBeNotifiedThatItCannotBeDeleted(): void
     {
         $this->notificationChecker->checkNotification(
@@ -460,9 +373,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @When I make it available (only) in :nameOfLocale
-     */
+    #[When('I make it available (only) in :nameOfLocale')]
     public function iMakeItAvailableIn(string $nameOfLocale): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -471,9 +382,7 @@ final class ManagingChannelsContext implements Context
         $currentPage->chooseLocale($nameOfLocale);
     }
 
-    /**
-     * @Then the channel :channel should be available in :nameOfLocale
-     */
+    #[Then('the channel :channel should be available in :nameOfLocale')]
     public function theChannelShouldBeAvailableIn(ChannelInterface $channel, string $nameOfLocale): void
     {
         $this->updatePage->open(['id' => $channel->getId()]);
@@ -481,9 +390,7 @@ final class ManagingChannelsContext implements Context
         Assert::inArray($nameOfLocale, $this->updatePage->getLocales());
     }
 
-    /**
-     * @When I allow for paying in :currencyCode
-     */
+    #[When('I allow for paying in :currencyCode')]
     public function iAllowToPayingForThisChannel(string $currencyCode): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -492,9 +399,7 @@ final class ManagingChannelsContext implements Context
         $currentPage->chooseCurrency($currencyCode);
     }
 
-    /**
-     * @Then paying in :currency should be possible for the :channel channel
-     */
+    #[Then('paying in :currency should be possible for the :channel channel')]
     public function payingInCurrencyShouldBePossibleForTheChannel(CurrencyInterface $currency, ChannelInterface $channel): void
     {
         $this->updatePage->open(['id' => $channel->getId()]);
@@ -502,9 +407,7 @@ final class ManagingChannelsContext implements Context
         Assert::inArray($currency->getName(), $this->updatePage->getCurrencies());
     }
 
-    /**
-     * @When I select the :taxZone as default tax zone
-     */
+    #[When('I select the :taxZone as default tax zone')]
     public function iSelectDefaultTaxZone(string $taxZone): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -513,17 +416,13 @@ final class ManagingChannelsContext implements Context
         $currentPage->chooseDefaultTaxZone($taxZone);
     }
 
-    /**
-     * @Given I remove its default tax zone
-     */
+    #[Given('I remove its default tax zone')]
     public function iRemoveItsDefaultTaxZone(): void
     {
         $this->updatePage->chooseDefaultTaxZone('');
     }
 
-    /**
-     * @When I select the :taxCalculationStrategy as tax calculation strategy
-     */
+    #[When('I select the :taxCalculationStrategy as tax calculation strategy')]
     public function iSelectTaxCalculationStrategy(string $taxCalculationStrategy): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -532,18 +431,14 @@ final class ManagingChannelsContext implements Context
         $currentPage->chooseTaxCalculationStrategy($taxCalculationStrategy);
     }
 
-    /**
-     * @When /^I specify (-?\d+) days as the lowest price for discounted products checking period$/
-     */
+    #[When('/^I specify (-?\d+) days as the lowest price for discounted products checking period$/')]
     public function iSpecifyDaysAsTheLowestPriceForDiscountedProductsCheckingPeriod(int $days): void
     {
         $this->discountedProductsCheckingPeriodInputElement->specifyPeriod($days);
     }
 
-    /**
-     * @Then /^the "[^"]+" channel should have the lowest price for discounted products checking period set to (\d+) days$/
-     * @Then its lowest price for discounted products checking period should be set to :days days
-     */
+    #[Then('/^the "[^"]+" channel should have the lowest price for discounted products checking period set to (\d+) days$/')]
+    #[Then('its lowest price for discounted products checking period should be set to :days days')]
     public function theChannelShouldHaveTheLowestPriceForDiscountedProductsCheckingPeriodSetToDays(int $days): void
     {
         $lowestPriceForDiscountedProductsCheckingPeriod = $this->discountedProductsCheckingPeriodInputElement->getPeriod();
@@ -551,9 +446,7 @@ final class ManagingChannelsContext implements Context
         Assert::same($days, $lowestPriceForDiscountedProductsCheckingPeriod);
     }
 
-    /**
-     * @Then I should be notified that the lowest price for discounted products checking period must be lower
-     */
+    #[Then('I should be notified that the lowest price for discounted products checking period must be lower')]
     public function iShouldBeNotifiedThatTheLowestPriceForDiscountedProductsCheckingPeriodMustBeLower(): void
     {
         Assert::same(
@@ -562,17 +455,13 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @When /^I (enable|disable) showing the lowest price of discounted products$/
-     */
+    #[When('/^I (enable|disable) showing the lowest price of discounted products$/')]
     public function iEnableShowingTheLowestPriceOfDiscountedProducts(string $visible): void
     {
         $this->lowestPriceFlagElement->$visible();
     }
 
-    /**
-     * @Then I should be notified that the lowest price for discounted products checking period must be greater than 0
-     */
+    #[Then('I should be notified that the lowest price for discounted products checking period must be greater than 0')]
     public function iShouldBeNotifiedThatTheLowestPriceForDiscountedProductsCheckingPeriodMustBeGreaterThanZero(): void
     {
         Assert::same(
@@ -581,9 +470,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the ("[^"]+" channel) should have the lowest price of discounted products prior to the current discount (enabled|disabled)$/
-     */
+    #[Then('/^the ("[^"]+" channel) should have the lowest price of discounted products prior to the current discount (enabled|disabled)$/')]
     public function theChannelShouldHaveTheLowestPriceOfDiscountedProductsPriorToTheCurrentDiscountEnabledOrDisabled(
         ChannelInterface $channel,
         string $visible,
@@ -594,9 +481,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then /^this channel should have ("([^"]+)" and "([^"]+)" taxons) excluded from displaying the lowest price of discounted products$/
-     */
+    #[Then('/^this channel should have ("([^"]+)" and "([^"]+)" taxons) excluded from displaying the lowest price of discounted products$/')]
     public function thisChannelShouldHaveTaxonsExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(iterable $taxons): void
     {
         foreach ($taxons as $taxon) {
@@ -607,9 +492,7 @@ final class ManagingChannelsContext implements Context
         }
     }
 
-    /**
-     * @Then the default tax zone for the :channel channel should be :taxZone
-     */
+    #[Then('the default tax zone for the :channel channel should be :taxZone')]
     public function theDefaultTaxZoneForTheChannelShouldBe(ChannelInterface $channel, string $taxZone): void
     {
         $this->updatePage->open(['id' => $channel->getId()]);
@@ -617,9 +500,7 @@ final class ManagingChannelsContext implements Context
         Assert::same($this->updatePage->getDefaultTaxZone(), $taxZone);
     }
 
-    /**
-     * @Then channel :channel should not have default tax zone
-     */
+    #[Then('channel :channel should not have default tax zone')]
     public function channelShouldNotHaveDefaultTaxZone(ChannelInterface $channel): void
     {
         $this->updatePage->open(['id' => $channel->getId()]);
@@ -627,9 +508,7 @@ final class ManagingChannelsContext implements Context
         Assert::isEmpty($this->updatePage->getDefaultTaxZone());
     }
 
-    /**
-     * @Then the tax calculation strategy for the :channel channel should be :taxCalculationStrategy
-     */
+    #[Then('the tax calculation strategy for the :channel channel should be :taxCalculationStrategy')]
     public function theTaxCalculationStrategyForTheChannelShouldBe(
         ChannelInterface $channel,
         string $taxCalculationStrategy,
@@ -642,18 +521,14 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then the base currency field should be disabled
-     * @Then I should not be able to edit its base currency
-     */
+    #[Then('the base currency field should be disabled')]
+    #[Then('I should not be able to edit its base currency')]
     public function theBaseCurrencyFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isBaseCurrencyDisabled());
     }
 
-    /**
-     * @Then I should be notified that the default locale has to be enabled
-     */
+    #[Then('I should be notified that the default locale has to be enabled')]
     public function iShouldBeNotifiedThatTheDefaultLocaleHasToBeEnabled(): void
     {
         Assert::same(
@@ -662,10 +537,8 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Given /^(this channel) menu taxon should be "([^"]+)"$/
-     * @Given the channel :channel should have :menuTaxon as a menu taxon
-     */
+    #[Given('/^(this channel) menu taxon should be "([^"]+)"$/')]
+    #[Given('the channel :channel should have :menuTaxon as a menu taxon')]
     public function thisChannelMenuTaxonShouldBe(ChannelInterface $channel, string $menuTaxon): void
     {
         if (!$this->updatePage->isOpen(['id' => $channel->getId()])) {
@@ -675,9 +548,7 @@ final class ManagingChannelsContext implements Context
         Assert::same($this->updatePage->getMenuTaxon(), $menuTaxon);
     }
 
-    /**
-     * @Then this channel should have :taxon taxon excluded from displaying the lowest price of discounted products
-     */
+    #[Then('this channel should have :taxon taxon excluded from displaying the lowest price of discounted products')]
     public function thisChannelShouldHaveTaxonExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(
         TaxonInterface $taxon,
     ): void {
@@ -687,9 +558,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then this channel should not have :taxon taxon excluded from displaying the lowest price of discounted products
-     */
+    #[Then('this channel should not have :taxon taxon excluded from displaying the lowest price of discounted products')]
     public function thisChannelShouldNotHaveTaxonExcludedFromDisplayingTheLowestPriceOfDiscountedProducts(
         TaxonInterface $taxon,
     ): void {
@@ -699,9 +568,7 @@ final class ManagingChannelsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the required address in the checkout for this channel should be (billing|shipping)$/
-     */
+    #[Then('/^the required address in the checkout for this channel should be (billing|shipping)$/')]
     public function theRequiredAddressInTheCheckoutForThisChannelShouldBe(string $type): void
     {
         Assert::same($this->shippingAddressInCheckoutRequiredElement->getRequiredAddressTypeInCheckout(), $type);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\NotificationType;
@@ -37,35 +39,27 @@ final class ManagingCountriesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to add a new country
-     */
+    #[When('I want to add a new country')]
     public function iWantToAddNewCountry()
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When /^I want to edit (this country)$/
-     * @When /^I am editing (this country)$/
-     */
+    #[When('/^I want to edit (this country)$/')]
+    #[When('/^I am editing (this country)$/')]
     public function iWantToEditThisCountry(CountryInterface $country)
     {
         $this->updatePage->open(['id' => $country->getId()]);
     }
 
-    /**
-     * @When I choose :countryName
-     */
+    #[When('I choose :countryName')]
     public function iChoose(string $countryName): void
     {
         $this->createPage->selectCountry($countryName);
     }
 
-    /**
-     * @When I add the :provinceName province with :provinceCode code
-     * @When I add the :provinceName province with :provinceCode code and :provinceAbbreviation abbreviation
-     */
+    #[When('I add the :provinceName province with :provinceCode code')]
+    #[When('I add the :provinceName province with :provinceCode code and :provinceAbbreviation abbreviation')]
     public function iAddProvinceWithCode(string $provinceName, string $provinceCode, ?string $provinceAbbreviation = null): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -79,34 +73,26 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt()
     {
         $this->updatePage->enable();
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->updatePage->disable();
     }
 
-    /**
-     * @Then /^the (country "([^"]+)") should appear in the store$/
-     */
+    #[Then('/^the (country "([^"]+)") should appear in the store$/')]
     public function countryShouldAppearInTheStore(CountryInterface $country)
     {
         $this->indexPage->open();
@@ -114,9 +100,7 @@ final class ManagingCountriesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $country->getCode()]));
     }
 
-    /**
-     * @Then /^(this country) should be enabled$/
-     */
+    #[Then('/^(this country) should be enabled$/')]
     public function thisCountryShouldBeEnabled(CountryInterface $country)
     {
         $this->indexPage->open();
@@ -124,9 +108,7 @@ final class ManagingCountriesContext implements Context
         Assert::true($this->indexPage->isCountryEnabled($country));
     }
 
-    /**
-     * @Then /^(this country) should be disabled$/
-     */
+    #[Then('/^(this country) should be disabled$/')]
     public function thisCountryShouldBeDisabled(CountryInterface $country): void
     {
         $this->indexPage->open();
@@ -134,9 +116,7 @@ final class ManagingCountriesContext implements Context
         Assert::true($this->indexPage->isCountryDisabled($country));
     }
 
-    /**
-     * @Then I should not be able to choose :name
-     */
+    #[Then('I should not be able to choose :name')]
     public function iShouldNotBeAbleToChoose(string $name): void
     {
         try {
@@ -148,19 +128,15 @@ final class ManagingCountriesContext implements Context
         throw new \DomainException('Choose name should throw an exception!');
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isCodeFieldDisabled());
     }
 
-    /**
-     * @Then /^(this country) should(?:| still) have the "([^"]*)" province$/
-     * @Then /^(this country) should(?:| still) have the "([^"]*)" and "([^"]*)" provinces$/
-     * @Then /^the (country "[^"]*") should(?:| still) have the "([^"]*)" province$/
-     */
+    #[Then('/^(this country) should(?:| still) have the "([^"]*)" province$/')]
+    #[Then('/^(this country) should(?:| still) have the "([^"]*)" and "([^"]*)" provinces$/')]
+    #[Then('/^the (country "[^"]*") should(?:| still) have the "([^"]*)" province$/')]
     public function countryShouldHaveProvince(CountryInterface $country, string ...$provinceNames)
     {
         $this->iWantToEditThisCountry($country);
@@ -170,9 +146,7 @@ final class ManagingCountriesContext implements Context
         }
     }
 
-    /**
-     * @Then /^(this country) should not have the "([^"]*)" province$/
-     */
+    #[Then('/^(this country) should not have the "([^"]*)" province$/')]
     public function thisCountryShouldNotHaveTheProvince(CountryInterface $country, $provinceName)
     {
         $this->iWantToEditThisCountry($country);
@@ -180,9 +154,7 @@ final class ManagingCountriesContext implements Context
         Assert::false($this->updatePage->isThereProvince($provinceName));
     }
 
-    /**
-     * @Then /^the province should still be named "([^"]*)" in (this country)$/
-     */
+    #[Then('/^the province should still be named "([^"]*)" in (this country)$/')]
     public function thisProvinceShouldStillBeNamed($provinceName, CountryInterface $country)
     {
         $this->updatePage->open(['id' => $country->getId()]);
@@ -190,9 +162,7 @@ final class ManagingCountriesContext implements Context
         Assert::true($this->updatePage->isThereProvince($provinceName));
     }
 
-    /**
-     * @Then /^province with name "([^"]*)" should not be added in (this country)$/
-     */
+    #[Then('/^province with name "([^"]*)" should not be added in (this country)$/')]
     public function provinceWithNameShouldNotBeAdded($provinceName, CountryInterface $country)
     {
         $this->updatePage->open(['id' => $country->getId()]);
@@ -200,9 +170,7 @@ final class ManagingCountriesContext implements Context
         Assert::false($this->updatePage->isThereProvince($provinceName));
     }
 
-    /**
-     * @Then /^province with code "([^"]*)" should not be added in (this country)$/
-     */
+    #[Then('/^province with code "([^"]*)" should not be added in (this country)$/')]
     public function provinceWithCodeShouldNotBeAdded($provinceCode, CountryInterface $country)
     {
         $this->updatePage->open(['id' => $country->getId()]);
@@ -210,17 +178,13 @@ final class ManagingCountriesContext implements Context
         Assert::false($this->updatePage->isThereProvinceWithCode($provinceCode));
     }
 
-    /**
-     * @When /^I(?:| also) delete the "([^"]*)" province of this country$/
-     */
+    #[When('/^I(?:| also) delete the "([^"]*)" province of this country$/')]
     public function iDeleteTheProvinceOfCountry($provinceName): void
     {
         $this->updatePage->removeProvince($provinceName);
     }
 
-    /**
-     * @When /^I want to create a new province in (country "([^"]*)")$/
-     */
+    #[When('/^I want to create a new province in (country "([^"]*)")$/')]
     public function iWantToCreateANewProvinceInCountry(CountryInterface $country): void
     {
         $this->updatePage->open(['id' => $country->getId()]);
@@ -228,60 +192,46 @@ final class ManagingCountriesContext implements Context
         $this->updatePage->addProvince();
     }
 
-    /**
-     * @When I name the province :provinceName
-     * @When I do not name the province
-     */
+    #[When('I name the province :provinceName')]
+    #[When('I do not name the province')]
     public function iNameTheProvince($provinceName = null): void
     {
         $this->updatePage->specifyProvinceName($provinceName ?? '');
     }
 
-    /**
-     * @When I do not specify the province code
-     * @When I specify the province code as :provinceCode
-     */
+    #[When('I do not specify the province code')]
+    #[When('I specify the province code as :provinceCode')]
     public function iSpecifyTheProvinceCode($provinceCode = null): void
     {
         $this->updatePage->specifyProvinceCode($provinceCode ?? '');
     }
 
-    /**
-     * @When I provide a too long province code
-     */
+    #[When('I provide a too long province code')]
     public function iProvideTooLongProvinceCode(): void
     {
         $this->iSpecifyTheProvinceCode(sprintf('US-%s', str_repeat('A', self::MAX_PROVINCE_CODE_LENGTH)));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired($element)
     {
         Assert::same($this->updatePage->getValidationMessage($element), sprintf('Please enter province %s.', $element));
     }
 
-    /**
-     * @When I remove :provinceName province name
-     */
+    #[When('I remove :provinceName province name')]
     public function iRemoveProvinceName(string $provinceName): void
     {
         $this->updatePage->removeProvinceName($provinceName);
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @Then /^I should be notified that province (code|name) must be unique$/
-     */
+    #[Then('/^I should be notified that province (code|name) must be unique$/')]
     public function iShouldBeNotifiedThatProvinceCodeMustBeUnique(string $field): void
     {
         Assert::same($this->updatePage->getValidationMessage($field), sprintf('Province %s must be unique.', $field));
     }
 
-    /**
-     * @Then I should be notified that all province codes and names within this country need to be unique
-     */
+    #[Then('I should be notified that all province codes and names within this country need to be unique')]
     public function iShouldBeNotifiedThatAllProvinceCodesAndNamesWithinThisCountryNeedToBeUnique(): void
     {
         Assert::inArray(
@@ -290,25 +240,19 @@ final class ManagingCountriesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that name of the province is required
-     */
+    #[Then('I should be notified that name of the province is required')]
     public function iShouldBeNotifiedThatNameOfTheProvinceIsRequired(): void
     {
         Assert::same($this->updatePage->getValidationMessage('name'), 'Please enter province name.');
     }
 
-    /**
-     * @Then I should be informed that the provided province code is too long
-     */
+    #[Then('I should be informed that the provided province code is too long')]
     public function iShouldBeInformedThatTheCodeIsTooLong(): void
     {
         Assert::contains($this->updatePage->getValidationMessage('code'), 'The code must not be longer than');
     }
 
-    /**
-     * @Then I should be notified that provinces that are in use cannot be deleted
-     */
+    #[Then('I should be notified that provinces that are in use cannot be deleted')]
     public function iShouldBeNotifiedThatProvincesThatAreInUseCannotBeDeleted(): void
     {
         $this->notificationChecker->checkNotification(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Currency\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -29,35 +31,27 @@ final readonly class ManagingCurrenciesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to add a new currency
-     */
+    #[When('I want to add a new currency')]
     public function iWantToAddNewCurrency(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I choose :currencyName
-     */
+    #[When('I choose :currencyName')]
     public function iChoose($currencyName): void
     {
         $this->formElement->chooseCurrency($currencyName);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @Then the currency :currency should appear in the store
-     * @Then I should see the currency :currency on the list
-     */
+    #[Then('the currency :currency should appear in the store')]
+    #[Then('I should see the currency :currency on the list')]
     public function currencyShouldAppearInTheStore(CurrencyInterface $currency): void
     {
         $this->indexPage->open();
@@ -65,25 +59,19 @@ final readonly class ManagingCurrenciesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $currency->getCode()]));
     }
 
-    /**
-     * @When I want to browse currencies of the store
-     */
+    #[When('I want to browse currencies of the store')]
     public function iWantToSeeAllCurrenciesInStore(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Then /^I should see (\d+) currencies on the list$/
-     */
+    #[Then('/^I should see (\d+) currencies on the list$/')]
     public function iShouldSeeCurrenciesInTheList(int $amountOfCurrencies): void
     {
         Assert::same($this->indexPage->countItems(), $amountOfCurrencies);
     }
 
-    /**
-     * @Then I should not be able to choose :name
-     */
+    #[Then('I should not be able to choose :name')]
     public function iShouldNotBeAbleToChoose(string $name): void
     {
         Assert::false($this->formElement->isCurrencyAvailable($name));

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\CustomerGroup\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -31,93 +33,71 @@ final readonly class ManagingCustomerGroupsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new customer group
-     */
+    #[When('I want to create a new customer group')]
     public function iWantToCreateANewCustomerGroup(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->fillElement($code ?? '', 'code');
     }
 
-    /**
-     * @When I specify a too long code
-     */
+    #[When('I specify a too long code')]
     public function iSpecifyATooLongCode(): void
     {
         $this->formElement->fillElement(str_repeat('a', 256), 'code');
     }
 
-    /**
-     * @When I specify its name as :name
-     * @When I remove its name
-     */
+    #[When('I specify its name as :name')]
+    #[When('I remove its name')]
     public function iSpecifyItsNameAs(?string $name = null): void
     {
         $this->formElement->fillElement($name ?? '', 'name');
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When /^I want to edit (this customer group)$/
-     */
+    #[When('/^I want to edit (this customer group)$/')]
     public function iWantToEditThisCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->updatePage->open(['id' => $customerGroup->getId()]);
     }
 
-    /**
-     * @When I check (also) the :customerGroupName customer group
-     */
+    #[When('I check (also) the :customerGroupName customer group')]
     public function iCheckTheCustomerGroup(string $customerGroupName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $customerGroupName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I browse customer groups
-     * @When I want to browse customer groups
-     */
+    #[When('I browse customer groups')]
+    #[When('I want to browse customer groups')]
     public function iWantToBrowseCustomerGroups(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I sort them by the (code|name) in (asc|desc)ending order$/
-     */
+    #[When('/^I sort them by the (code|name) in (asc|desc)ending order$/')]
     public function iSortThemByTheField(string $field, string $order): void
     {
         $this->indexPage->sortBy($field, $order);
     }
 
-    /**
-     * @Then the customer group :customerGroup should appear in the store
-     */
+    #[Then('the customer group :customerGroup should appear in the store')]
     public function theCustomerGroupShouldAppearInTheStore(CustomerGroupInterface $customerGroup): void
     {
         $this->indexPage->open();
@@ -125,10 +105,8 @@ final readonly class ManagingCustomerGroupsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $customerGroup->getName()]));
     }
 
-    /**
-     * @Then this customer group with name :name should appear in the store
-     * @Then I should see the customer group :name in the list
-     */
+    #[Then('this customer group with name :name should appear in the store')]
+    #[Then('I should see the customer group :name in the list')]
     public function thisCustomerGroupWithNameShouldAppearInTheStore(string $name): void
     {
         $this->indexPage->open();
@@ -136,20 +114,17 @@ final readonly class ManagingCustomerGroupsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
-    /**
-     * @Then there should be :amountOfCustomerGroups customer groups in the list
-     */
+    #[Then('there should be :amountOfCustomerGroups customer groups in the list')]
     public function thereShouldBeCustomerGroupsInTheList(int $amountOfCustomerGroups = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amountOfCustomerGroups);
     }
 
     /**
-     * @Then I should see a single customer group in the list
-     * @Then I should see :amountOfCustomerGroups customer groups in the list
-     *
      * This step is a duplicate of the above because some scenarios require to open the index page before checking anything
      */
+    #[Then('I should see a single customer group in the list')]
+    #[Then('I should see :amountOfCustomerGroups customer groups in the list')]
     public function iShouldSeeCustomerGroupsInTheList(int $amountOfCustomerGroups = 1): void
     {
         $this->indexPage->open();
@@ -157,9 +132,7 @@ final readonly class ManagingCustomerGroupsContext implements Context
         Assert::same($this->indexPage->countItems(), $amountOfCustomerGroups);
     }
 
-    /**
-     * @Then /^the (\d+)(?:|st|nd|rd|th) customer group on the list should have (name|code) "([^"]+)" and (name|code) "([^"]+)"$/
-     */
+    #[Then('/^the (\d+)(?:|st|nd|rd|th) customer group on the list should have (name|code) "([^"]+)" and (name|code) "([^"]+)"$/')]
     public function theFirstCustomerGroupOnTheListShouldHave(
         int $position,
         string $firstField,
@@ -176,9 +149,7 @@ final readonly class ManagingCustomerGroupsContext implements Context
         Assert::same($fields[$position - 1], $secondValue);
     }
 
-    /**
-     * @Then /^(this customer group) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this customer group) should still be named "([^"]+)"$/')]
     public function thisCustomerGroupShouldStillBeNamed(CustomerGroupInterface $customerGroup, string $customerGroupName): void
     {
         $this->iWantToBrowseCustomerGroups();
@@ -187,9 +158,7 @@ final readonly class ManagingCustomerGroupsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $customerGroupName]));
     }
 
-    /**
-     * @Then I should be notified that name is required
-     */
+    #[Then('I should be notified that name is required')]
     public function iShouldBeNotifiedThatNameIsRequired(): void
     {
         Assert::same(
@@ -198,17 +167,13 @@ final readonly class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that customer group with this code already exists
-     */
+    #[Then('I should be notified that customer group with this code already exists')]
     public function iShouldBeNotifiedThatCustomerGroupWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'Customer group code has to be unique.');
     }
 
-    /**
-     * @Then I should be notified that code is too long
-     */
+    #[Then('I should be notified that code is too long')]
     public function iShouldBeNotifiedThatCodeIsTooLong(): void
     {
         Assert::contains(
@@ -217,25 +182,19 @@ final readonly class ManagingCustomerGroupsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be informed that this form contains errors
-     */
+    #[Then('I should be informed that this form contains errors')]
     public function iShouldBeInformedThatThisFormContainsErrors(): void
     {
         Assert::true($this->formElement->hasFormErrorAlert());
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @When I delete the :customerGroup customer group
-     */
+    #[When('I delete the :customerGroup customer group')]
     public function iDeleteTheCustomerGroup(CustomerGroupInterface $customerGroup): void
     {
         $this->iWantToBrowseCustomerGroups();
@@ -243,9 +202,7 @@ final readonly class ManagingCustomerGroupsContext implements Context
         $this->indexPage->deleteResourceOnPage(['name' => $customerGroup->getName()]);
     }
 
-    /**
-     * @Then /^(this customer group) should no longer exist in the registry$/
-     */
+    #[Then('/^(this customer group) should no longer exist in the registry$/')]
     public function thisCustomerGroupShouldNoLongerExistInTheRegistry(CustomerGroupInterface $customerGroup): void
     {
         Assert::false(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Element\Admin\Customer\FormElementInterface;
@@ -43,62 +44,48 @@ final class ManagingCustomersContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new customer
-     * @When I want to create a new customer account
-     */
+    #[When('I want to create a new customer')]
+    #[When('I want to create a new customer account')]
     public function iWantToCreateANewCustomer()
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When /^I specify (?:their|his) first name as "([^"]*)"$/
-     */
+    #[When('/^I specify (?:their|his) first name as "([^"]*)"$/')]
     public function iSpecifyItsFirstNameAs($name): void
     {
         $this->formElement->specifyFirstName($name);
     }
 
-    /**
-     * @When /^I specify (?:their|his) last name as "([^"]*)"$/
-     */
+    #[When('/^I specify (?:their|his) last name as "([^"]*)"$/')]
     public function iSpecifyItsLastNameAs($name)
     {
         $this->formElement->specifyLastName($name);
     }
 
-    /**
-     * @When I specify their email as :name
-     * @When I do not specify their email
-     */
+    #[When('I specify their email as :name')]
+    #[When('I do not specify their email')]
     public function iSpecifyItsEmailAs($email = null)
     {
         $this->formElement->specifyEmail($email ?? '');
     }
 
-    /**
-     * @When I change their email to :email
-     * @When I remove its email
-     */
+    #[When('I change their email to :email')]
+    #[When('I remove its email')]
     public function iChangeTheirEmailTo($email = null): void
     {
         $this->formElement->specifyEmail($email ?? '');
     }
 
-    /**
-     * @When I add them
-     * @When I try to add them
-     */
+    #[When('I add them')]
+    #[When('I try to add them')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I filter by group :groupName
-     * @When I filter by groups :firstGroup and :secondGroup
-     */
+    #[When('I filter by group :groupName')]
+    #[When('I filter by groups :firstGroup and :secondGroup')]
     public function iFilterByGroup(string ...$groupsNames): void
     {
         foreach ($groupsNames as $groupName) {
@@ -108,10 +95,8 @@ final class ManagingCustomersContext implements Context
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then the customer :customer should appear in the store
-     * @Then the customer :customer should still have this email
-     */
+    #[Then('the customer :customer should appear in the store')]
+    #[Then('the customer :customer should still have this email')]
     public function theCustomerShould(CustomerInterface $customer)
     {
         $this->indexPage->open();
@@ -119,49 +104,37 @@ final class ManagingCustomersContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $customer->getEmail()]));
     }
 
-    /**
-     * @When I select :gender as its gender
-     */
+    #[When('I select :gender as its gender')]
     public function iSelectGender($gender)
     {
         $this->formElement->chooseGender($gender);
     }
 
-    /**
-     * @When I select :group as their group
-     */
+    #[When('I select :group as their group')]
     public function iSelectGroup($group)
     {
         $this->formElement->chooseGroup($group);
     }
 
-    /**
-     * @When I specify its birthday as :birthday
-     */
+    #[When('I specify its birthday as :birthday')]
     public function iSpecifyItsBirthdayAs($birthday)
     {
         $this->formElement->specifyBirthday($birthday);
     }
 
-    /**
-     * @When /^I want to edit (this customer)$/
-     */
+    #[When('/^I want to edit (this customer)$/')]
     public function iWantToEditThisCustomer(CustomerInterface $customer)
     {
         $this->updatePage->open(['id' => $customer->getId()]);
     }
 
-    /**
-     * @When I verify it
-     */
+    #[When('I verify it')]
     public function iTryToVerifyIt(): void
     {
         $this->formElement->verifyUser();
     }
 
-    /**
-     * @Then /^(this customer) should be verified$/
-     */
+    #[Then('/^(this customer) should be verified$/')]
     public function thisCustomerShouldBeVerified(CustomerInterface $customer): void
     {
         $this->indexPage->open();
@@ -169,9 +142,7 @@ final class ManagingCustomersContext implements Context
         Assert::true($this->indexPage->isCustomerVerified($customer));
     }
 
-    /**
-     * @Then /^(this customer) with name "([^"]*)" should appear in the store$/
-     */
+    #[Then('/^(this customer) with name "([^"]*)" should appear in the store$/')]
     public function theCustomerWithNameShouldAppearInTheRegistry(CustomerInterface $customer, $name)
     {
         $this->updatePage->open(['id' => $customer->getId()]);
@@ -179,51 +150,39 @@ final class ManagingCustomersContext implements Context
         Assert::same($this->formElement->getFullName(), $name);
     }
 
-    /**
-     * @When I want to see all customers in store
-     */
+    #[When('I want to see all customers in store')]
     public function iWantToSeeAllCustomersInStore()
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I sort customers by (ascending|descending) registration date$/
-     */
+    #[When('/^I sort customers by (ascending|descending) registration date$/')]
     public function iSortCustomersByRegistrationDate(string $order): void
     {
         $this->sortBy($order, 'createdAt');
     }
 
-    /**
-     * @When /^I sort customers by (ascending|descending) (email|first name|last name)$/
-     */
+    #[When('/^I sort customers by (ascending|descending) (email|first name|last name)$/')]
     public function iSortCustomersByField(string $order, string $field): void
     {
         $this->sortBy($order, StringInflector::nameToCamelCase($field));
     }
 
-    /**
-     * @Then /^I should see (\d+) customers (?:in|on) the list$/
-     * @Then /^I should see a single customer on the list$/
-     */
+    #[Then('/^I should see (\d+) customers (?:in|on) the list$/')]
+    #[Then('/^I should see a single customer on the list$/')]
     public function iShouldSeeCustomersInTheList($amountOfCustomers = 1)
     {
         Assert::same($this->indexPage->countItems(), (int) $amountOfCustomers);
     }
 
-    /**
-     * @Then I should see the customer :email in the list
-     * @Then I should see the customer :email on the list
-     */
+    #[Then('I should see the customer :email in the list')]
+    #[Then('I should see the customer :email on the list')]
     public function iShouldSeeTheCustomerInTheList($email)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
-    /**
-     * @Then /^the (first|last) customer should be "([^"]+)"$/
-     */
+    #[Then('/^the (first|last) customer should be "([^"]+)"$/')]
     public function theFirstLastCustomerShouldBe(string $placement, string $email): void
     {
         $index = 'first' === $placement ? 0 : $this->indexPage->countItems() - 1;
@@ -234,9 +193,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that ([^"]+) is required$/
-     */
+    #[Then('/^I should be notified that ([^"]+) is required$/')]
     public function iShouldBeNotifiedThatFirstNameIsRequired(string $elementName): void
     {
         Assert::same(
@@ -245,9 +202,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that ([^"]+) should be ([^"]+)$/
-     */
+    #[Then('/^I should be notified that ([^"]+) should be ([^"]+)$/')]
     public function iShouldBeNotifiedThatTheElementShouldBe($elementName, $validationMessage)
     {
         Assert::same(
@@ -256,9 +211,7 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then the customer with email :email should not appear in the store
-     */
+    #[Then('the customer with email :email should not appear in the store')]
     public function theCustomerShouldNotAppearInTheStore($email)
     {
         $this->indexPage->open();
@@ -266,18 +219,14 @@ final class ManagingCustomersContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
-    /**
-     * @When I remove its first name
-     */
+    #[When('I remove its first name')]
     public function iRemoveItsFirstName()
     {
         $this->formElement->specifyFirstName('');
     }
 
-    /**
-     * @Then /^(this customer) should have an empty first name$/
-     * @Then the customer :customer should still have an empty first name
-     */
+    #[Then('/^(this customer) should have an empty first name$/')]
+    #[Then('the customer :customer should still have an empty first name')]
     public function theCustomerShouldStillHaveAnEmptyFirstName(CustomerInterface $customer)
     {
         $this->updatePage->open(['id' => $customer->getId()]);
@@ -285,18 +234,14 @@ final class ManagingCustomersContext implements Context
         Assert::eq($this->formElement->getFirstName(), '');
     }
 
-    /**
-     * @When I remove its last name
-     */
+    #[When('I remove its last name')]
     public function iRemoveItsLastName()
     {
         $this->formElement->specifyLastName('');
     }
 
-    /**
-     * @Then /^(this customer) should have an empty last name$/
-     * @Then the customer :customer should still have an empty last name
-     */
+    #[Then('/^(this customer) should have an empty last name$/')]
+    #[Then('the customer :customer should still have an empty last name')]
     public function theCustomerShouldStillHaveAnEmptyLastName(CustomerInterface $customer)
     {
         $this->updatePage->open(['id' => $customer->getId()]);
@@ -304,25 +249,19 @@ final class ManagingCustomersContext implements Context
         Assert::eq($this->formElement->getLastName(), '');
     }
 
-    /**
-     * @Then I should be notified that email is not valid
-     */
+    #[Then('I should be notified that email is not valid')]
     public function iShouldBeNotifiedThatEmailIsNotValid()
     {
         Assert::same($this->formElement->getValidationMessage('email'), 'This email is invalid.');
     }
 
-    /**
-     * @Then I should be notified that email must be unique
-     */
+    #[Then('I should be notified that email must be unique')]
     public function iShouldBeNotifiedThatEmailMustBeUnique()
     {
         Assert::same($this->formElement->getValidationMessage('email'), 'This email is already used.');
     }
 
-    /**
-     * @Then there should still be only one customer with email :email
-     */
+    #[Then('there should still be only one customer with email :email')]
     public function thereShouldStillBeOnlyOneCustomerWithEmail($email)
     {
         $this->indexPage->open();
@@ -330,35 +269,27 @@ final class ManagingCustomersContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
-    /**
-     * @When I want to enable :customer
-     * @When I want to disable :customer
-     * @When I want to verify :customer
-     */
+    #[When('I want to enable :customer')]
+    #[When('I want to disable :customer')]
+    #[When('I want to verify :customer')]
     public function iWantToChangeStatusOf(CustomerInterface $customer): void
     {
         $this->updatePage->open(['id' => $customer->getId()]);
     }
 
-    /**
-     * @When I enable their account
-     */
+    #[When('I enable their account')]
     public function iEnableIt()
     {
         $this->formElement->enable();
     }
 
-    /**
-     * @When I disable their account
-     */
+    #[When('I disable their account')]
     public function iDisableIt()
     {
         $this->formElement->disable();
     }
 
-    /**
-     * @Then /^(this customer) should be enabled$/
-     */
+    #[Then('/^(this customer) should be enabled$/')]
     public function thisCustomerShouldBeEnabled(CustomerInterface $customer): void
     {
         $this->indexPage->open();
@@ -366,9 +297,7 @@ final class ManagingCustomersContext implements Context
         Assert::true($this->indexPage->isCustomerEnabled($customer), true);
     }
 
-    /**
-     * @Then /^(this customer) should be disabled$/
-     */
+    #[Then('/^(this customer) should be disabled$/')]
     public function thisCustomerShouldBeDisabled(CustomerInterface $customer): void
     {
         $this->indexPage->open();
@@ -382,26 +311,20 @@ final class ManagingCustomersContext implements Context
         $this->formElement->specifyPassword($password);
     }
 
-    /**
-     * @When I browse orders of a customer :customer
-     */
+    #[When('I browse orders of a customer :customer')]
     public function iBrowseOrdersOfACustomer(CustomerInterface $customer): void
     {
         $this->ordersIndexPage->open(['id' => $customer->getId()]);
     }
 
-    /**
-     * @When I sort the orders :sortType by :field
-     */
+    #[When('I sort the orders :sortType by :field')]
     public function iSortTheOrderByField(string $field): void
     {
         $this->ordersIndexPage->sort(ucfirst($field));
     }
 
-    /**
-     * @Then the customer :customer should have an account created
-     * @Then /^(this customer) should have an account created$/
-     */
+    #[Then('the customer :customer should have an account created')]
+    #[Then('/^(this customer) should have an account created$/')]
     public function theyShouldHaveAnAccountCreated(CustomerInterface $customer): void
     {
         Assert::notNull(
@@ -410,50 +333,38 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @When I view details of the customer :customer
-     * @When /^I view (their) details$/
-     */
+    #[When('I view details of the customer :customer')]
+    #[When('/^I view (their) details$/')]
     public function iViewDetailsOfTheCustomer(CustomerInterface $customer)
     {
         $this->showPage->open(['id' => $customer->getId()]);
     }
 
-    /**
-     * @Then /^(?:their|his) name should be "([^"]+)"$/
-     */
+    #[Then('/^(?:their|his) name should be "([^"]+)"$/')]
     public function hisNameShouldBe(string $name): void
     {
         Assert::same($this->showPage->getCustomerName(), $name);
     }
 
-    /**
-     * @Then he should be registered since :registrationDate
-     */
+    #[Then('he should be registered since :registrationDate')]
     public function hisRegistrationDateShouldBe($registrationDate)
     {
         Assert::eq($this->showPage->getRegistrationDate(), new \DateTime($registrationDate));
     }
 
-    /**
-     * @Then /^(?:their|his) email should be "([^"]+)"$/
-     */
+    #[Then('/^(?:their|his) email should be "([^"]+)"$/')]
     public function hisEmailShouldBe(string $email): void
     {
         Assert::same($this->showPage->getCustomerEmail(), $email);
     }
 
-    /**
-     * @Then /^(?:their|his) phone number should be "([^"]+)"$/
-     */
+    #[Then('/^(?:their|his) phone number should be "([^"]+)"$/')]
     public function hisPhoneNumberShouldBe(string $phoneNumber): void
     {
         Assert::same($this->showPage->getCustomerPhoneNumber(), $phoneNumber);
     }
 
-    /**
-     * @Then their default address should be :firstName :lastName, :street, :postcode :city, :country
-     */
+    #[Then('their default address should be :firstName :lastName, :street, :postcode :city, :country')]
     public function theirSDefaultAddressShouldBe(
         string $firstName,
         string $lastName,
@@ -468,41 +379,31 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see information about no existing account for this customer
-     */
+    #[Then('I should see information about no existing account for this customer')]
     public function iShouldSeeInformationAboutNoExistingAccountForThisCustomer()
     {
         Assert::false($this->showPage->hasAccount());
     }
 
-    /**
-     * @Then I should see that this customer is subscribed to the newsletter
-     */
+    #[Then('I should see that this customer is subscribed to the newsletter')]
     public function iShouldSeeThatThisCustomerIsSubscribedToTheNewsletter()
     {
         Assert::true($this->showPage->isSubscribedToNewsletter());
     }
 
-    /**
-     * @Then I should not see information about email verification
-     */
+    #[Then('I should not see information about email verification')]
     public function iShouldSeeInformationAboutEmailVerification()
     {
         Assert::true($this->showPage->hasEmailVerificationInformation());
     }
 
-    /**
-     * @When I make them subscribed to the newsletter
-     */
+    #[When('I make them subscribed to the newsletter')]
     public function iMakeThemSubscribedToTheNewsletter()
     {
         $this->formElement->subscribeToTheNewsletter();
     }
 
-    /**
-     * @When I change the password of user :customer to :newPassword
-     */
+    #[When('I change the password of user :customer to :newPassword')]
     public function iChangeThePasswordOfUserTo(CustomerInterface $customer, $newPassword)
     {
         $this->updatePage->open(['id' => $customer->getId()]);
@@ -510,25 +411,19 @@ final class ManagingCustomersContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @Then this customer should be subscribed to the newsletter
-     */
+    #[Then('this customer should be subscribed to the newsletter')]
     public function thisCustomerShouldBeSubscribedToTheNewsletter()
     {
         Assert::true($this->formElement->isSubscribedToTheNewsletter());
     }
 
-    /**
-     * @Then the province in the default address should be :provinceName
-     */
+    #[Then('the province in the default address should be :provinceName')]
     public function theProvinceInTheDefaultAddressShouldBe($provinceName)
     {
         Assert::true($this->showPage->hasDefaultAddressProvinceName($provinceName));
     }
 
-    /**
-     * @Then this customer should have :groupName as their group
-     */
+    #[Then('this customer should have :groupName as their group')]
     public function thisCustomerShouldHaveAsTheirGroup($groupName)
     {
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->updatePage, $this->showPage]);
@@ -540,65 +435,49 @@ final class ManagingCustomersContext implements Context
         }
     }
 
-    /**
-     * @Then I should see that this customer has verified the email
-     */
+    #[Then('I should see that this customer has verified the email')]
     public function iShouldSeeThatThisCustomerHasVerifiedTheEmail()
     {
         Assert::true($this->showPage->hasVerifiedEmail());
     }
 
-    /**
-     * @Then I should see a single order in the list
-     */
+    #[Then('I should see a single order in the list')]
     public function iShouldSeeASingleOrderInTheList()
     {
         Assert::same($this->ordersIndexPage->countItems(), 1);
     }
 
-    /**
-     * @Then I should see the order with number :orderNumber in the list
-     */
+    #[Then('I should see the order with number :orderNumber in the list')]
     public function iShouldSeeASingleOrderFromCustomer($orderNumber)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @Then I should not see the order with number :orderNumber in the list
-     */
+    #[Then('I should not see the order with number :orderNumber in the list')]
     public function iShouldNotSeeASingleOrderFromCustomer($orderNumber)
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @When I do not specify any information
-     */
+    #[When('I do not specify any information')]
     public function iDoNotSpecifyAnyInformation()
     {
         // Intentionally left blank.
     }
 
-    /**
-     * @Then I should still be on the customer creation page
-     */
+    #[Then('I should still be on the customer creation page')]
     public function iShouldBeOnTheCustomerCreationPage()
     {
         $this->createPage->verify();
     }
 
-    /**
-     * @When I do not choose create account option
-     */
+    #[When('I do not choose create account option')]
     public function iDoNotChooseCreateAccountOption()
     {
         // Intentionally left blank.
     }
 
-    /**
-     * @Then /^I should be notified that the password must be at least (\d+) characters long$/
-     */
+    #[Then('/^I should be notified that the password must be at least (\d+) characters long$/')]
     public function iShouldBeNotifiedThatThePasswordMustBeAtLeastCharactersLong($amountOfCharacters)
     {
         Assert::same(
@@ -607,33 +486,25 @@ final class ManagingCustomersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the customer has not placed any orders yet
-     */
+    #[Then('I should see the customer has not placed any orders yet')]
     public function iShouldSeeTheCustomerHasNotYetPlacedAnyOrders()
     {
         Assert::false($this->showPage->hasCustomerPlacedAnyOrders());
     }
 
-    /**
-     * @Then /^I should see that they have placed (\d+) orders? in the ("[^"]+" channel)$/
-     */
+    #[Then('/^I should see that they have placed (\d+) orders? in the ("[^"]+" channel)$/')]
     public function iShouldSeeThatTheyHavePlacedOrdersInTheChannel($ordersCount, ChannelInterface $channel)
     {
         Assert::same($this->showPage->getOrdersCountInChannel($channel->getCode()), (int) $ordersCount);
     }
 
-    /**
-     * @Then /^I should see that the overall total value of all their orders in the ("[^"]+" channel) is "([^"]+)"$/
-     */
+    #[Then('/^I should see that the overall total value of all their orders in the ("[^"]+" channel) is "([^"]+)"$/')]
     public function iShouldSeeThatTheOverallTotalValueOfAllTheirOrdersInTheChannelIs(ChannelInterface $channel, $ordersValue)
     {
         Assert::same($this->showPage->getOrdersTotalInChannel($channel->getCode()), $ordersValue);
     }
 
-    /**
-     * @Then /^I should see that the average total value of their order in the ("[^"]+" channel) is "([^"]+)"$/
-     */
+    #[Then('/^I should see that the average total value of their order in the ("[^"]+" channel) is "([^"]+)"$/')]
     public function iShouldSeeThatTheAverageTotalValueOfTheirOrderInTheChannelIs(ChannelInterface $channel, $ordersValue)
     {
         Assert::same($this->showPage->getAverageTotalInChannel($channel->getCode()), $ordersValue);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\ExchangeRate\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -32,77 +35,59 @@ final readonly class ManagingExchangeRatesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to add a new exchange rate
-     */
+    #[When('I want to add a new exchange rate')]
     public function iWantToAddNewExchangeRate(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When /^I want to edit (this exchange rate)$/
-     * @When /^I am editing (this exchange rate)$/
-     */
+    #[When('/^I want to edit (this exchange rate)$/')]
+    #[When('/^I am editing (this exchange rate)$/')]
     public function iWantToEditThisExchangeRate(ExchangeRateInterface $exchangeRate): void
     {
         $this->updatePage->open(['id' => $exchangeRate->getId()]);
     }
 
-    /**
-     * @Given I am browsing exchange rates of the store
-     * @When I browse exchange rates
-     * @When I browse exchange rates of the store
-     */
+    #[Given('I am browsing exchange rates of the store')]
+    #[When('I browse exchange rates')]
+    #[When('I browse exchange rates of the store')]
     public function iWantToBrowseExchangeRatesOfTheStore(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I specify its ratio as (-?[0-9\.]+)$/
-     * @When I don't specify its ratio
-     */
+    #[When('/^I specify its ratio as (-?[0-9\.]+)$/')]
+    #[When('I don\'t specify its ratio')]
     public function iSpecifyItsRatioAs(?string $ratio = null): void
     {
         $this->formElement->specifyRatio($ratio ?? '');
     }
 
-    /**
-     * @When I choose :currencyCode as the source currency
-     */
+    #[When('I choose :currencyCode as the source currency')]
     public function iChooseAsSourceCurrency(string $currencyCode): void
     {
         $this->formElement->specifySourceCurrency($currencyCode);
     }
 
-    /**
-     * @When I choose :currencyCode as the target currency
-     */
+    #[When('I choose :currencyCode as the target currency')]
     public function iChooseAsTargetCurrency(string $currencyCode): void
     {
         $this->formElement->specifyTargetCurrency($currencyCode);
     }
 
-    /**
-     * @When I( try to) add it
-     */
+    #[When('I( try to) add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I change ratio to :ratio
-     */
+    #[When('I change ratio to :ratio')]
     public function iChangeRatioTo(string $ratio): void
     {
         $this->formElement->specifyRatio($ratio);
     }
 
-    /**
-     * @When I delete the exchange rate between :sourceCurrencyName and :targetCurrencyName
-     */
+    #[When('I delete the exchange rate between :sourceCurrencyName and :targetCurrencyName')]
     public function iDeleteTheExchangeRateBetweenAnd(string $sourceCurrencyName, string $targetCurrencyName): void
     {
         $this->indexPage->open();
@@ -113,25 +98,19 @@ final readonly class ManagingExchangeRatesContext implements Context
         ]);
     }
 
-    /**
-     * @When I choose :currencyName as a currency filter
-     */
+    #[When('I choose :currencyName as a currency filter')]
     public function iChooseCurrencyAsACurrencyFilter(string $currencyName): void
     {
         $this->indexPage->chooseCurrencyFilter($currencyName);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I check (also) the exchange rate between :sourceCurrencyName and :targetCurrencyName
-     */
+    #[When('I check (also) the exchange rate between :sourceCurrencyName and :targetCurrencyName')]
     public function iCheckTheExchangeRateBetweenAnd(string $sourceCurrencyName, string $targetCurrencyName): void
     {
         $this->indexPage->checkResourceOnPage([
@@ -140,26 +119,20 @@ final readonly class ManagingExchangeRatesContext implements Context
         ]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see :count exchange rates on the list
-     */
+    #[Then('I should see :count exchange rates on the list')]
     public function iShouldSeeExchangeRatesOnTheList(int $count): void
     {
         $this->assertCountOfExchangeRatesOnTheList($count);
     }
 
-    /**
-     * @Then I should see a single exchange rate in the list
-     * @Then I should( still) see one exchange rate on the list
-     */
+    #[Then('I should see a single exchange rate in the list')]
+    #[Then('I should( still) see one exchange rate on the list')]
     public function iShouldSeeOneExchangeRateOnTheList(): void
     {
         $this->indexPage->open();
@@ -167,9 +140,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         $this->assertCountOfExchangeRatesOnTheList(1);
     }
 
-    /**
-     * @Then the exchange rate with ratio :ratio between :sourceCurrency and :targetCurrency should appear in the store
-     */
+    #[Then('the exchange rate with ratio :ratio between :sourceCurrency and :targetCurrency should appear in the store')]
     public function theExchangeRateBetweenAndShouldAppearInTheStore(
         string $ratio,
         CurrencyInterface $sourceCurrency,
@@ -180,10 +151,8 @@ final readonly class ManagingExchangeRatesContext implements Context
         $this->assertExchangeRateWithRatioIsOnTheList($ratio, $sourceCurrency->getName(), $targetCurrency->getName());
     }
 
-    /**
-     * @Then I should see the exchange rate between :sourceCurrencyName and :targetCurrencyName in the list
-     * @Then I should (also) see an exchange rate between :sourceCurrencyName and :targetCurrencyName on the list
-     */
+    #[Then('I should see the exchange rate between :sourceCurrencyName and :targetCurrencyName in the list')]
+    #[Then('I should (also) see an exchange rate between :sourceCurrencyName and :targetCurrencyName on the list')]
     public function iShouldSeeAnExchangeRateBetweenAndOnTheList(
         string $sourceCurrencyName,
         string $targetCurrencyName,
@@ -194,17 +163,13 @@ final readonly class ManagingExchangeRatesContext implements Context
         ]));
     }
 
-    /**
-     * @Then it should have a ratio of :ratio
-     */
+    #[Then('it should have a ratio of :ratio')]
     public function thisExchangeRateShouldHaveRatioOf(string $ratio): void
     {
         Assert::eq($this->formElement->getRatio(), $ratio);
     }
 
-    /**
-     * @Then /^(this exchange rate) should no longer be on the list$/
-     */
+    #[Then('/^(this exchange rate) should no longer be on the list$/')]
     public function thisExchangeRateShouldNoLongerBeOnTheList(ExchangeRateInterface $exchangeRate): void
     {
         $this->assertExchangeRateIsNotOnTheList(
@@ -213,9 +178,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then the exchange rate between :sourceCurrencyName and :targetCurrencyName should not be added
-     */
+    #[Then('the exchange rate between :sourceCurrencyName and :targetCurrencyName should not be added')]
     public function theExchangeRateBetweenAndShouldNotBeAdded(string $sourceCurrencyName, string $targetCurrencyName): void
     {
         $this->indexPage->open();
@@ -223,9 +186,7 @@ final readonly class ManagingExchangeRatesContext implements Context
         $this->assertExchangeRateIsNotOnTheList($sourceCurrencyName, $targetCurrencyName);
     }
 
-    /**
-     * @Then /^(this exchange rate) should have a ratio of ([0-9\.]+)$/
-     */
+    #[Then('/^(this exchange rate) should have a ratio of ([0-9\.]+)$/')]
     public function thisExchangeRateShouldHaveARatioOf(ExchangeRateInterface $exchangeRate, string $ratio): void
     {
         $sourceCurrencyName = $exchangeRate->getSourceCurrency()->getName();
@@ -234,25 +195,19 @@ final readonly class ManagingExchangeRatesContext implements Context
         $this->assertExchangeRateWithRatioIsOnTheList($ratio, $sourceCurrencyName, $targetCurrencyName);
     }
 
-    /**
-     * @Then I should not be able to edit its source currency
-     */
+    #[Then('I should not be able to edit its source currency')]
     public function iShouldNotBeAbleToEditItsSourceCurrency(): void
     {
         Assert::true($this->formElement->isFieldDisabled('source_currency'));
     }
 
-    /**
-     * @Then I should not be able to edit its target currency
-     */
+    #[Then('I should not be able to edit its target currency')]
     public function iShouldNotBeAbleToEditItsTargetCurrency(): void
     {
         Assert::true($this->formElement->isFieldDisabled('target_currency'));
     }
 
-    /**
-     * @Then /^I should be notified that ([^"]+) is required$/
-     */
+    #[Then('/^I should be notified that ([^"]+) is required$/')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::same(
@@ -261,33 +216,25 @@ final readonly class ManagingExchangeRatesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the ratio must be greater than zero
-     */
+    #[Then('I should be notified that the ratio must be greater than zero')]
     public function iShouldBeNotifiedThatRatioMustBeGreaterThanZero(): void
     {
         Assert::same($this->formElement->getValidationMessage('ratio'), 'The ratio must be greater than 0.');
     }
 
-    /**
-     * @Then I should be notified that the ratio must be less than :value
-     */
+    #[Then('I should be notified that the ratio must be less than :value')]
     public function iShouldBeNotifiedThatRatioMustBeLessThan(string $value): void
     {
         Assert::same($this->formElement->getValidationMessage('ratio'), sprintf('The ratio must be less than %s.', $value));
     }
 
-    /**
-     * @Then I should be notified that source and target currencies must differ
-     */
+    #[Then('I should be notified that source and target currencies must differ')]
     public function iShouldBeNotifiedThatSourceAndTargetCurrenciesMustDiffer(): void
     {
         $this->assertFormHasValidationMessage('The source and target currencies must differ.');
     }
 
-    /**
-     * @Then I should be notified that the currency pair must be unique
-     */
+    #[Then('I should be notified that the currency pair must be unique')]
     public function iShouldBeNotifiedThatTheCurrencyPairMustBeUnique(): void
     {
         $this->assertFormHasValidationMessage('The currency pair must be unique.');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingInventoryContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingInventoryContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Inventory\IndexPageInterface;
 use Webmozart\Assert\Assert;
@@ -23,18 +26,14 @@ final class ManagingInventoryContext implements Context
     {
     }
 
-    /**
-     * @Given I am browsing inventory
-     * @When I want to browse inventory
-     */
+    #[Given('I am browsing inventory')]
+    #[When('I want to browse inventory')]
     public function iWantToBrowseInventory(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I filter tracked variants with (code|name) containing "([^"]+)"/
-     */
+    #[When('/^I filter tracked variants with (code|name) containing "([^"]+)"/')]
     public function iFilterTrackedVariantsWithCodeContaining($field, $value)
     {
         $this->indexPage->specifyFilterType($field, 'Contains');
@@ -43,35 +42,27 @@ final class ManagingInventoryContext implements Context
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter tracked variants by :productName product
-     */
+    #[When('I filter tracked variants by :productName product')]
     public function iFilterTrackedVariantsByProduct(string $productName): void
     {
         $this->indexPage->filterByProduct($productName);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I sort the tracked variants :sortingOrder by :field
-     */
+    #[When('I sort the tracked variants :sortingOrder by :field')]
     public function iSortTrackedVariantsBy(string $sortingOrder, string $field): void
     {
         $this->indexPage->sortBy($field, $sortingOrder === 'descending' ? 'desc' : 'asc');
     }
 
-    /**
-     * @Then I should see only one tracked variant in the list
-     * @Then I should see :count tracked variants in the list
-     */
+    #[Then('I should see only one tracked variant in the list')]
+    #[Then('I should see :count tracked variants in the list')]
     public function iShouldSeeTrackedVariantsInTheList(int $count = 1): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then I should see that the :productVariantName variant has :quantity quantity on hand
-     */
+    #[Then('I should see that the :productVariantName variant has :quantity quantity on hand')]
     public function iShouldSeeThatTheProductVariantHasQuantityOnHand($productVariantName, $quantity)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([
@@ -80,9 +71,7 @@ final class ManagingInventoryContext implements Context
         ]));
     }
 
-    /**
-     * @Then the first variant on the list should have :field :name
-     */
+    #[Then('the first variant on the list should have :field :name')]
     public function theFirstVariantOnTheListShouldHave(string $field, string $variantName): void
     {
         $names = $this->indexPage->getColumnFields($field);
@@ -90,9 +79,7 @@ final class ManagingInventoryContext implements Context
         Assert::contains(reset($names), $variantName);
     }
 
-    /**
-     * @Then the last variant on the list should have :field :name
-     */
+    #[Then('the last variant on the list should have :field :name')]
     public function theLastVariantOnTheListShouldHave(string $field, string $variantName): void
     {
         $names = $this->indexPage->getColumnFields($field);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingLocalesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingLocalesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Locale\FormElementInterface;
 use Sylius\Behat\NotificationType;
@@ -31,60 +34,46 @@ final readonly class ManagingLocalesContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing locales
-     */
+    #[Given('I am browsing locales')]
     public function iAmBrowsingLocales(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I want to create a new locale
-     * @When I want to add a new locale
-     */
+    #[When('I want to create a new locale')]
+    #[When('I want to add a new locale')]
     public function iWantToCreateNewLocale(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I choose :name
-     */
+    #[When('I choose :name')]
     public function iChoose(string $name): void
     {
         $this->formElement->chooseLocale($name);
     }
 
-    /**
-     * @When I add it
-     */
+    #[When('I add it')]
     public function iAdd(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I remove :localeCode locale
-     */
+    #[When('I remove :localeCode locale')]
     public function iRemoveLocale(string $localeCode): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['code' => $localeCode]);
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->indexPage->filterByCode($phrase);
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then the store should be available in the :name language
-     */
+    #[Then('the store should be available in the :name language')]
     public function storeShouldBeAvailableInLanguage(string $name): void
     {
         $doesLocaleExist = $this->indexPage->isSingleResourceOnPage(['name' => $name]);
@@ -92,17 +81,13 @@ final readonly class ManagingLocalesContext implements Context
         Assert::true($doesLocaleExist);
     }
 
-    /**
-     * @Then I should not be able to choose :name
-     */
+    #[Then('I should not be able to choose :name')]
     public function iShouldNotBeAbleToChoose(string $name): void
     {
         Assert::false($this->formElement->isLocaleAvailable($name));
     }
 
-    /**
-     * @Then I should be informed that locale :localeCode has been deleted
-     */
+    #[Then('I should be informed that locale :localeCode has been deleted')]
     public function iShouldBeInformedThatLocaleHasBeenDeleted(string $localeCode): void
     {
         $this->notificationChecker->checkNotification(
@@ -111,18 +96,14 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then only the :localeCode locale should be present in the system
-     */
+    #[Then('only the :localeCode locale should be present in the system')]
     public function onlyTheLocaleShouldBePresentInTheSystem(string $localeCode): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $localeCode]));
         Assert::true($this->indexPage->countItems() === 1);
     }
 
-    /**
-     * @Then I should be informed that locale :localeCode is in use and cannot be deleted
-     */
+    #[Then('I should be informed that locale :localeCode is in use and cannot be deleted')]
     public function iShouldBeInformedThatLocaleIsInUseAndCannotBeDeleted(string $localeCode): void
     {
         $this->notificationChecker->checkNotification(
@@ -131,25 +112,19 @@ final readonly class ManagingLocalesContext implements Context
         );
     }
 
-    /**
-     * @Then the :localeCode locale should be still present in the system
-     */
+    #[Then('the :localeCode locale should be still present in the system')]
     public function theLocaleShouldBeStillPresentInTheSystem(string $localeCode): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $localeCode]));
     }
 
-    /**
-     * @Then I should see a single locale in the list
-     */
+    #[Then('I should see a single locale in the list')]
     public function iShouldSeeLocaleInTheList(): void
     {
         Assert::same($this->indexPage->countItems(), 1);
     }
 
-    /**
-     * @Then I should see the locale :localeName
-     */
+    #[Then('I should see the locale :localeName')]
     public function iShouldSeeTheLocale(string $localeName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $localeName]));

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Behat\Step\Then;
 use Behat\Step\When;
@@ -44,21 +45,17 @@ final readonly class ManagingOrdersContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing orders
-     */
     #[When('I browse orders')]
+    #[Given('I am browsing orders')]
     public function iBrowseOrders(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Given /^I am viewing the summary of (this order)$/
-     * @Given I am viewing the summary of the order :order
-     * @When I view the summary of the order :order
-     * @When /^I view the summary of the (order placed by "[^"]+")$/
-     */
+    #[Given('/^I am viewing the summary of (this order)$/')]
+    #[Given('I am viewing the summary of the order :order')]
+    #[When('I view the summary of the order :order')]
+    #[When('/^I view the summary of the (order placed by "[^"]+")$/')]
     public function iViewTheSummaryOfTheOrder(OrderInterface $order): void
     {
         $this->showPage->open(['id' => $order->getId()]);
@@ -70,123 +67,93 @@ final readonly class ManagingOrdersContext implements Context
         $this->showPage->open(['id' => $order->getId()]);
     }
 
-    /**
-     * @When /^I try to view the summary of the (customer's latest cart)$/
-     */
+    #[When('/^I try to view the summary of the (customer\'s latest cart)$/')]
     public function iTryToViewTheSummaryOfTheCustomersLatestCart(OrderInterface $cart): void
     {
         $this->showPage->tryToOpen(['id' => $cart->getId()]);
     }
 
-    /**
-     * @When /^I mark (this order) as paid$/
-     */
+    #[When('/^I mark (this order) as paid$/')]
     public function iMarkThisOrderAsAPaid(OrderInterface $order): void
     {
         $this->showPage->completeOrderLastPayment($order);
     }
 
-    /**
-     * @When /^I mark (this order)'s payment as refunded$/
-     */
+    #[When('/^I mark (this order)\'s payment as refunded$/')]
     public function iMarkThisOrderSPaymentAsRefunded(OrderInterface $order): void
     {
         $this->showPage->refundOrderLastPayment($order);
     }
 
-    /**
-     * @When specify its tracking code as :trackingCode
-     */
+    #[When('specify its tracking code as :trackingCode')]
     public function specifyItsTrackingCodeAs(string $trackingCode): void
     {
         $this->showPage->specifyTrackingCode($trackingCode);
         $this->sharedStorage->set('tracking_code', $trackingCode);
     }
 
-    /**
-     * @When /^I ship (this order)$/
-     */
+    #[When('/^I ship (this order)$/')]
     public function iShipThisOrder(OrderInterface $order): void
     {
         $this->showPage->shipOrder($order);
     }
 
-    /**
-     * @When I switch the way orders are sorted by :fieldName
-     */
+    #[When('I switch the way orders are sorted by :fieldName')]
     public function iSwitchSortingBy(string $fieldName): void
     {
         $this->indexPage->sortBy($fieldName);
     }
 
-    /**
-     * @When I specify filter date from as :dateTime
-     */
+    #[When('I specify filter date from as :dateTime')]
     public function iSpecifyFilterDateFromAs(string $dateTime): void
     {
         $this->indexPage->specifyFilterDateFrom($dateTime);
     }
 
-    /**
-     * @When I specify filter date to as :dateTime
-     */
+    #[When('I specify filter date to as :dateTime')]
     public function iSpecifyFilterDateToAs(string $dateTime): void
     {
         $this->indexPage->specifyFilterDateTo($dateTime);
     }
 
-    /**
-     * @When I choose :channelName as a channel filter
-     */
+    #[When('I choose :channelName as a channel filter')]
     public function iChooseChannelAsAChannelFilter(string $channelName): void
     {
         $this->indexPage->specifyFilterChannel($channelName);
     }
 
-    /**
-     * @When I choose :methodName as a shipping method filter
-     */
+    #[When('I choose :methodName as a shipping method filter')]
     public function iChooseMethodAsAShippingMethodFilter(string $methodName): void
     {
         $this->indexPage->specifyFilterShippingMethod($methodName);
     }
 
-    /**
-     * @When I choose :currencyName as the filter currency
-     */
+    #[When('I choose :currencyName as the filter currency')]
     public function iChooseCurrencyAsTheFilterCurrency(string $currencyName): void
     {
         $this->indexPage->chooseFilterCurrency($currencyName);
     }
 
-    /**
-     * @When I specify filter total being greater than :total
-     */
+    #[When('I specify filter total being greater than :total')]
     public function iSpecifyFilterTotalBeingGreaterThan(string $total): void
     {
         $this->indexPage->specifyFilterTotalGreaterThan($total);
     }
 
-    /**
-     * @When I specify filter total being less than :total
-     */
+    #[When('I specify filter total being less than :total')]
     public function iSpecifyFilterTotalBeingLessThan(string $total): void
     {
         $this->indexPage->specifyFilterTotalLessThan($total);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter by product :productName
-     * @When I filter by products :firstProduct and :secondProduct
-     */
+    #[When('I filter by product :productName')]
+    #[When('I filter by products :firstProduct and :secondProduct')]
     public function iFilterByProduct(string ...$productsNames): void
     {
         foreach ($productsNames as $productName) {
@@ -196,10 +163,8 @@ final readonly class ManagingOrdersContext implements Context
         $this->iFilter();
     }
 
-    /**
-     * @When I filter by variant :variantName
-     * @When I filter by variants :firstVariant and :secondVariant
-     */
+    #[When('I filter by variant :variantName')]
+    #[When('I filter by variants :firstVariant and :secondVariant')]
     public function iFilterByVariant(string ...$variantsNames): void
     {
         foreach ($variantsNames as $variantName) {
@@ -209,34 +174,26 @@ final readonly class ManagingOrdersContext implements Context
         $this->iFilter();
     }
 
-    /**
-     * @When I filter by customer :customer
-     */
+    #[When('I filter by customer :customer')]
     public function iFilterByCustomer(CustomerInterface $customer): void
     {
         $this->indexPage->specifyFilterCustomer($customer->getFullName());
         $this->iFilter();
     }
 
-    /**
-     * @When I resend the order confirmation email
-     */
+    #[When('I resend the order confirmation email')]
     public function iResendTheOrderConfirmationEmail(): void
     {
         $this->showPage->resendOrderConfirmationEmail();
     }
 
-    /**
-     * @When I resend the shipment confirmation email
-     */
+    #[When('I resend the shipment confirmation email')]
     public function iResendTheShipmentConfirmationEmail(): void
     {
         $this->showPage->resendShipmentConfirmationEmail();
     }
 
-    /**
-     * @When I change the :addressType country to :country
-     */
+    #[When('I change the :addressType country to :country')]
     public function iChangeTheCountryTo(string $addressType, string $country): void
     {
         match ($addressType) {
@@ -246,17 +203,13 @@ final readonly class ManagingOrdersContext implements Context
         };
     }
 
-    /**
-     * @Then I should see a single order from customer :customer
-     */
+    #[Then('I should see a single order from customer :customer')]
     public function iShouldSeeASingleOrderFromCustomer(CustomerInterface $customer): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['customer' => $customer->getEmail()]));
     }
 
-    /**
-     * @Then I should not be able to resend the shipment confirmation email
-     */
+    #[Then('I should not be able to resend the shipment confirmation email')]
     public function iShouldNotBeAbleToResendTheShipmentConfirmationEmail(): void
     {
         Assert::false(
@@ -265,26 +218,20 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see :amount orders in the list
-     * @Then I should see a single order in the list
-     */
+    #[Then('I should see :amount orders in the list')]
+    #[Then('I should see a single order in the list')]
     public function iShouldSeeASingleOrderInTheList(int $count = 1): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then it should have been placed by the customer :customerEmail
-     */
+    #[Then('it should have been placed by the customer :customerEmail')]
     public function itShouldBePlacedByCustomer(string $customerEmail): void
     {
         Assert::true($this->showPage->hasCustomer($customerEmail));
     }
 
-    /**
-     * @Then it should be shipped to :customerName, :street, :postcode, :city, :countryName
-     */
+    #[Then('it should be shipped to :customerName, :street, :postcode, :city, :countryName')]
     public function itShouldBeShippedToCustomerAtAddress(
         string $customerName,
         string $street,
@@ -295,9 +242,7 @@ final readonly class ManagingOrdersContext implements Context
         $this->itShouldBeShippedTo(null, $customerName, $street, $postcode, $city, $countryName);
     }
 
-    /**
-     * @Then /^(this order) should (?:|still )be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/
-     */
+    #[Then('/^(this order) should (?:|still )be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/')]
     public function itShouldBeShippedTo(
         ?OrderInterface $order,
         string $customerName,
@@ -313,10 +258,8 @@ final readonly class ManagingOrdersContext implements Context
         Assert::true($this->showPage->hasShippingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
-    /**
-     * @Then it should be billed to :customerName, :street, :postcode, :city, :countryName
-     * @Then the order should be billed to :customerName, :street, :postcode, :city, :countryName
-     */
+    #[Then('it should be billed to :customerName, :street, :postcode, :city, :countryName')]
+    #[Then('the order should be billed to :customerName, :street, :postcode, :city, :countryName')]
     public function itShouldBeBilledToCustomerAtAddress(
         string $customerName,
         string $street,
@@ -327,9 +270,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::true($this->showPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
-    /**
-     * @Then /^(?:it|this order) should(?:| still) have "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address$/
-     */
+    #[Then('/^(?:it|this order) should(?:| still) have "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address$/')]
     public function itShouldHaveAsItsBillingAddress(
         string $customerName,
         string $street,
@@ -342,9 +283,7 @@ final readonly class ManagingOrdersContext implements Context
         Assert::true($this->showPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
-    /**
-     * @Then I should be able to choose the :province province for the :addressType address
-     */
+    #[Then('I should be able to choose the :province province for the :addressType address')]
     public function iShouldBeAbleToChooseTheProvinceForTheAddressType(ProvinceInterface $province, string $addressType): void
     {
         Assert::inArray(
@@ -357,217 +296,163 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have no shipping address set
-     */
+    #[Then('it should have no shipping address set')]
     public function itShouldHaveNoShippingAddressSet(): void
     {
         Assert::false($this->showPage->hasShippingAddressVisible());
     }
 
-    /**
-     * @Then it should be shipped via the :shippingMethodName shipping method
-     */
+    #[Then('it should be shipped via the :shippingMethodName shipping method')]
     public function itShouldBeShippedViaShippingMethod(string $shippingMethodName): void
     {
         Assert::true($this->showPage->hasShipment($shippingMethodName));
     }
 
-    /**
-     * @Then it should be paid with :paymentMethodName
-     */
+    #[Then('it should be paid with :paymentMethodName')]
     public function itShouldBePaidWith(string $paymentMethodName): void
     {
         Assert::true($this->showPage->hasPayment($paymentMethodName));
     }
 
-    /**
-     * @Then /^it should have (\d+) items$/
-     */
+    #[Then('/^it should have (\d+) items$/')]
     public function itShouldHaveAmountOfItems(int $amount = 1): void
     {
         Assert::same($this->showPage->countItems(), $amount);
     }
 
-    /**
-     * @Then the product named :productName should be in the items list
-     */
+    #[Then('the product named :productName should be in the items list')]
     public function theProductShouldBeInTheItemsList(string $productName): void
     {
         Assert::true($this->showPage->isProductInTheList($productName));
     }
 
-    /**
-     * @Then the order's items total should be :itemsTotal
-     */
+    #[Then('the order\'s items total should be :itemsTotal')]
     public function theOrdersItemsTotalShouldBe(string $itemsTotal): void
     {
         Assert::eq($this->showPage->getItemsTotal(), $itemsTotal);
     }
 
-    /**
-     * @Then /^the order's total should(?:| still) be "([^"]+)"$/
-     */
+    #[Then('/^the order\'s total should(?:| still) be "([^"]+)"$/')]
     public function theOrdersTotalShouldBe(string $total): void
     {
         Assert::eq($this->showPage->getTotal(), $total);
     }
 
-    /**
-     * @Then there should be a shipping charge :shippingCharge for :shippingMethodName method
-     */
+    #[Then('there should be a shipping charge :shippingCharge for :shippingMethodName method')]
     public function thereShouldBeAShippingChargeForMethod(string $shippingCharge, string $shippingMethodName): void
     {
         Assert::true($this->showPage->hasShippingCharge($shippingCharge, $shippingMethodName));
     }
 
-    /**
-     * @Then there should be a shipping tax :shippingTax for :shippingMethodName method
-     */
+    #[Then('there should be a shipping tax :shippingTax for :shippingMethodName method')]
     public function thereShouldBeAShippingTaxForMethod(string $shippingTax, string $shippingMethodName): void
     {
         Assert::true($this->showPage->hasShippingTax($shippingTax, $shippingMethodName));
     }
 
-    /**
-     * @Then the order's shipping total should be :shippingTotal
-     */
+    #[Then('the order\'s shipping total should be :shippingTotal')]
     public function theOrdersShippingTotalShouldBe(string $shippingTotal): void
     {
         Assert::eq($this->showPage->getShippingTotal(), $shippingTotal);
     }
 
-    /**
-     * @Then the order's payment should (also) be :paymentAmount
-     */
+    #[Then('the order\'s payment should (also) be :paymentAmount')]
     public function theOrdersPaymentShouldBe(string $paymentAmount): void
     {
         Assert::eq($this->showPage->getPaymentAmount(), $paymentAmount);
     }
 
-    /**
-     * @Then the order should have tax :tax
-     */
+    #[Then('the order should have tax :tax')]
     public function theOrderShouldHaveTax(string $tax): void
     {
         Assert::true($this->showPage->hasTax($tax));
     }
 
-    /**
-     * @Then /^the order's tax total should(?:| still) be "([^"]+)"$/
-     */
+    #[Then('/^the order\'s tax total should(?:| still) be "([^"]+)"$/')]
     public function theOrdersTaxTotalShouldBe(string $taxTotal): void
     {
         Assert::eq($this->showPage->getTaxTotal(), $taxTotal);
     }
 
-    /**
-     * @Then the order's promotion discount should be :promotionAmount from :promotionName promotion
-     */
+    #[Then('the order\'s promotion discount should be :promotionAmount from :promotionName promotion')]
     public function theOrdersPromotionDiscountShouldBeFromPromotion(string $promotionAmount, string $promotionName): void
     {
         Assert::true($this->showPage->hasPromotionDiscount($promotionName, $promotionAmount));
     }
 
-    /**
-     * @Then the order's shipping promotion should be :promotion
-     */
+    #[Then('the order\'s shipping promotion should be :promotion')]
     public function theOrdersShippingPromotionDiscountShouldBe(string $promotionData): void
     {
         Assert::same($this->showPage->getShippingPromotionData(), $promotionData);
     }
 
-    /**
-     * @Then /^the order's promotion total should(?:| still) be "([^"]+)"$/
-     */
+    #[Then('/^the order\'s promotion total should(?:| still) be "([^"]+)"$/')]
     public function theOrdersPromotionTotalShouldBe(string $promotionTotal): void
     {
         Assert::same($this->showPage->getOrderPromotionTotal(), $promotionTotal);
     }
 
-    /**
-     * @When I check :itemName data
-     */
+    #[When('I check :itemName data')]
     public function iCheckData(string $itemName): void
     {
         $this->sharedStorage->set('item', $itemName);
     }
 
-    /**
-     * @Then /^(its) code should be "([^"]+)"$/
-     */
+    #[Then('/^(its) code should be "([^"]+)"$/')]
     public function itemCodeShouldBe(string $itemName, string $code): void
     {
         Assert::same($this->showPage->getItemCode($itemName), $code);
     }
 
-    /**
-     * @Then /^(its) unit price should be ([^"]+)$/
-     */
+    #[Then('/^(its) unit price should be ([^"]+)$/')]
     public function itemUnitPriceShouldBe(string $itemName, string $unitPrice): void
     {
         Assert::eq($this->showPage->getItemUnitPrice($itemName), $unitPrice);
     }
 
-    /**
-     * @Then /^(its) discounted unit price should be ([^"]+)$/
-     */
+    #[Then('/^(its) discounted unit price should be ([^"]+)$/')]
     public function itemDiscountedUnitPriceShouldBe(string $itemName, string $discountedUnitPrice): void
     {
         Assert::eq($this->showPage->getItemDiscountedUnitPrice($itemName), $discountedUnitPrice);
     }
 
-    /**
-     * @Then /^(its) quantity should be ([^"]+)$/
-     */
+    #[Then('/^(its) quantity should be ([^"]+)$/')]
     public function itemQuantityShouldBe(string $itemName, int $quantity): void
     {
         Assert::eq($this->showPage->getItemQuantity($itemName), $quantity);
     }
 
-    /**
-     * @Then /^(its) subtotal should be ([^"]+)$/
-     */
+    #[Then('/^(its) subtotal should be ([^"]+)$/')]
     public function itemSubtotalShouldBe(string $itemName, string $subtotal): void
     {
         Assert::eq($this->showPage->getItemSubtotal($itemName), $subtotal);
     }
 
-    /**
-     * @Then /^(its) discount should be ([^"]+)$/
-     */
+    #[Then('/^(its) discount should be ([^"]+)$/')]
     public function theItemShouldHaveDiscount(string $itemName, string $discount): void
     {
         Assert::eq($this->showPage->getItemDiscount($itemName), $discount);
     }
 
-    /**
-     * @Then /^(its) tax should be ([^"]+)$/
-     */
+    #[Then('/^(its) tax should be ([^"]+)$/')]
     public function itemTaxShouldBe(string $itemName, string $tax): void
     {
         Assert::eq($this->showPage->getItemTax($itemName), $tax);
     }
 
-    /**
-     * @Then /^(its) tax included in price should be ([^"]+)$/
-     */
+    #[Then('/^(its) tax included in price should be ([^"]+)$/')]
     public function itsTaxIncludedInPriceShouldBe(string $itemName, string $tax): void
     {
         Assert::same($this->showPage->getItemTaxIncludedInPrice($itemName), $tax);
     }
 
-    /**
-     * @Then /^(its) total should be ([^"]+)$/
-     */
+    #[Then('/^(its) total should be ([^"]+)$/')]
     public function itemTotalShouldBe(string $itemName, string $total): void
     {
         Assert::eq($this->showPage->getItemTotal($itemName), $total);
     }
 
-    /**
-     * @Then I should be notified that the order's payment has been successfully completed
-     */
+    #[Then('I should be notified that the order\'s payment has been successfully completed')]
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyCompleted(): void
     {
         $this->notificationChecker->checkNotification(
@@ -576,9 +461,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the order's payment could not be finalized due to insufficient stock
-     */
+    #[Then('I should be notified that the order\'s payment could not be finalized due to insufficient stock')]
     public function iShouldBeNotifiedThatTheOrdersPaymentCouldNotBeFinalizedDueToInsufficientStock(): void
     {
         $this->notificationChecker->checkNotification(
@@ -587,9 +470,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the order's payment has been successfully refunded
-     */
+    #[Then('I should be notified that the order\'s payment has been successfully refunded')]
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyRefunded(): void
     {
         $this->notificationChecker->checkNotification(
@@ -598,50 +479,38 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then it should have payment state :paymentState
-     * @Then it should have payment with state :paymentState
-     */
+    #[Then('it should have payment state :paymentState')]
+    #[Then('it should have payment with state :paymentState')]
     public function itShouldHavePaymentState(string $paymentState): void
     {
         Assert::true($this->showPage->hasPaymentWithState($paymentState));
     }
 
-    /**
-     * @Then it should have order's payment state :orderPaymentState
-     */
+    #[Then('it should have order\'s payment state :orderPaymentState')]
     public function itShouldHaveOrderPaymentState(string $orderPaymentState): void
     {
         Assert::same($this->showPage->getPaymentState(), $orderPaymentState);
     }
 
-    /**
-     * @Then it should have order's shipping state :orderShippingState
-     */
+    #[Then('it should have order\'s shipping state :orderShippingState')]
     public function itShouldHaveOrderShippingState(string $orderShippingState): void
     {
         Assert::same($this->showPage->getShippingState(), $orderShippingState);
     }
 
-    /**
-     * @Then its payment state should be refunded
-     */
+    #[Then('its payment state should be refunded')]
     public function itsPaymentStateShouldBeRefunded(): void
     {
         Assert::same($this->showPage->getPaymentState(), 'Refunded');
     }
 
-    /**
-     * @Then /^I should not be able to mark (this order) as paid again$/
-     */
+    #[Then('/^I should not be able to mark (this order) as paid again$/')]
     public function iShouldNotBeAbleToFinalizeItsPayment(OrderInterface $order): void
     {
         Assert::false($this->showPage->canCompleteOrderLastPayment($order));
     }
 
-    /**
-     * @Then I should be notified that the order has been successfully shipped
-     */
+    #[Then('I should be notified that the order has been successfully shipped')]
     public function iShouldBeNotifiedThatTheOrderHasBeenSuccessfullyShipped(): void
     {
         $this->notificationChecker->checkNotification(
@@ -650,25 +519,19 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should not be able to ship (this order)$/
-     */
+    #[Then('/^I should not be able to ship (this order)$/')]
     public function iShouldNotBeAbleToShipThisOrder(OrderInterface $order): void
     {
         Assert::false($this->showPage->canShipOrder($order));
     }
 
-    /**
-     * @When I cancel this order
-     */
+    #[When('I cancel this order')]
     public function iCancelThisOrder(): void
     {
         $this->showPage->cancelOrder();
     }
 
-    /**
-     * @Then I should be notified that it has been successfully updated
-     */
+    #[Then('I should be notified that it has been successfully updated')]
     public function iShouldBeNotifiedAboutItHasBeenSuccessfullyCanceled(): void
     {
         $this->notificationChecker->checkNotification(
@@ -677,34 +540,26 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to cancel this order
-     */
+    #[Then('I should not be able to cancel this order')]
     public function iShouldNotBeAbleToCancelThisOrder(): void
     {
         Assert::false($this->showPage->hasCancelButton());
     }
 
-    /**
-     * @Then this order should have state :state
-     * @Then its state should be :state
-     */
+    #[Then('this order should have state :state')]
+    #[Then('its state should be :state')]
     public function itsStateShouldBe(string $state): void
     {
         Assert::same($this->showPage->getOrderState(), $state);
     }
 
-    /**
-     * @Then it should( still) have a :state state
-     */
+    #[Then('it should( still) have a :state state')]
     public function itShouldHaveState(string $state): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['state' => $state]));
     }
 
-    /**
-     * @Then /^(the administrator) should know about (this additional note) for (this order made by "[^"]+")$/
-     */
+    #[Then('/^(the administrator) should know about (this additional note) for (this order made by "[^"]+")$/')]
     public function theCustomerServiceShouldKnowAboutThisAdditionalNotes(
         AdminUserInterface $user,
         string $note,
@@ -720,58 +575,44 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see an order with :orderNumber number
-     */
+    #[Then('I should see an order with :orderNumber number')]
     public function iShouldSeeOrderWithNumber(string $orderNumber): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @Then I should not see an order with :orderNumber number
-     */
+    #[Then('I should not see an order with :orderNumber number')]
     public function iShouldNotSeeOrderWithNumber(string $orderNumber): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @Then I should not see any orders with currency :currencyCode
-     */
+    #[Then('I should not see any orders with currency :currencyCode')]
     public function iShouldNotSeeAnyOrderWithCurrency(string $currencyCode): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['currencyCode' => $currencyCode]));
     }
 
-    /**
-     * @Then the first order should have number :number
-     */
+    #[Then('the first order should have number :number')]
     public function theFirstOrderShouldHaveNumber(string $number): void
     {
         Assert::eq($this->indexPage->getColumnFields('number')[0], $number);
     }
 
-    /**
-     * @Then it should have shipment in state :shipmentState
-     */
+    #[Then('it should have shipment in state :shipmentState')]
     public function itShouldHaveShipmentState(string $shipmentState): void
     {
         Assert::true($this->showPage->hasShipmentWithState($shipmentState));
     }
 
-    /**
-     * @Then order :orderNumber should have shipment state :shippingState
-     */
+    #[Then('order :orderNumber should have shipment state :shippingState')]
     public function thisOrderShipmentStateShouldBe(string $shippingState): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $shippingState]));
     }
 
-    /**
-     * @Then the order :order should have order payment state :orderPaymentState
-     * @Then /^(this order) should have order payment state "([^"]+)"$/
-     */
+    #[Then('the order :order should have order payment state :orderPaymentState')]
+    #[Then('/^(this order) should have order payment state "([^"]+)"$/')]
     public function theOrderShouldHavePaymentState(OrderInterface $order, string $orderPaymentState): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
@@ -783,26 +624,20 @@ final readonly class ManagingOrdersContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
     }
 
-    /**
-     * @Then the order :order should have order shipping state :orderShippingState
-     * @Then /^(this order) should have order shipping state "([^"]+)"$/
-     */
+    #[Then('the order :order should have order shipping state :orderShippingState')]
+    #[Then('/^(this order) should have order shipping state "([^"]+)"$/')]
     public function theOrderShouldHaveShippingState(OrderInterface $order, string $orderShippingState): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderShippingState]));
     }
 
-    /**
-     * @Then /^there should be(?:| only) (\d+) payments?$/
-     */
+    #[Then('/^there should be(?:| only) (\d+) payments?$/')]
     public function theOrderShouldHaveNumberOfPayments(string $number): void
     {
         Assert::same($this->showPage->getPaymentsCount(), (int) $number);
     }
 
-    /**
-     * @Then I should see the order :orderNumber with total :total
-     */
+    #[Then('I should see the order :orderNumber with total :total')]
     public function iShouldSeeTheOrderWithTotal(string $orderNumber, string $total): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([
@@ -811,33 +646,25 @@ final readonly class ManagingOrdersContext implements Context
         ]));
     }
 
-    /**
-     * @When /^I want to modify a customer's (?:billing|shipping) address of (this order)$/
-     */
+    #[When('/^I want to modify a customer\'s (?:billing|shipping) address of (this order)$/')]
     public function iWantToModifyACustomerSShippingAddress(OrderInterface $order): void
     {
         $this->updatePage->open(['id' => $order->getId()]);
     }
 
-    /**
-     * @When /^I specify their (?:|new )shipping (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     */
+    #[When('/^I specify their (?:|new )shipping (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
     public function iSpecifyTheirShippingAddressAsFor(AddressInterface $address): void
     {
         $this->updatePage->specifyShippingAddress($address);
     }
 
-    /**
-     * @When /^I specify their (?:|new )billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/
-     */
+    #[When('/^I specify their (?:|new )billing (address as "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)")$/')]
     public function iSpecifyTheirBillingAddressAsFor(AddressInterface $address): void
     {
         $this->updatePage->specifyBillingAddress($address);
     }
 
-    /**
-     * @Then /^I should be notified that all mandatory (shipping|billing) address details are incomplete$/
-     */
+    #[Then('/^I should be notified that all mandatory (shipping|billing) address details are incomplete$/')]
     public function iShouldBeNotifiedThatAllMandatoryAddressDetailsAreIncomplete(string $type): void
     {
         /** @var array<int, string> $mandatoryAddressFields */
@@ -854,57 +681,43 @@ final readonly class ManagingOrdersContext implements Context
         $this->assertElementValidationMessage($type, 'country', 'Please select country.');
     }
 
-    /**
-     * @Then I should see :provinceName as province in the shipping address
-     */
+    #[Then('I should see :provinceName as province in the shipping address')]
     public function iShouldSeeAsProvinceInTheShippingAddress(string $provinceName): void
     {
         Assert::true($this->showPage->hasShippingProvinceName($provinceName));
     }
 
-    /**
-     * @Then I should see :provinceName as province in the billing address
-     */
+    #[Then('I should see :provinceName as province in the billing address')]
     public function iShouldSeeAdProvinceInTheBillingAddress(string $provinceName): void
     {
         Assert::true($this->showPage->hasBillingProvinceName($provinceName));
     }
 
-    /**
-     * @Then I should see this customer's IP address
-     */
+    #[Then('I should see this customer\'s IP address')]
     public function iShouldSeeCustomersIpAddress(): void
     {
         Assert::notEmpty($this->showPage->getIpAddressAssigned());
     }
 
-    /**
-     * @When /^I (clear the billing address) information$/
-     */
+    #[When('/^I (clear the billing address) information$/')]
     public function iClearTheBillingAddressInformation(AddressInterface $address): void
     {
         $this->updatePage->specifyBillingAddress($address);
     }
 
-    /**
-     * @When /^I (clear the shipping address) information$/
-     */
+    #[When('/^I (clear the shipping address) information$/')]
     public function iClearTheShippingAddressInformation(AddressInterface $address): void
     {
         $this->updatePage->specifyShippingAddress($address);
     }
 
-    /**
-     * @When /^I do not specify new information$/
-     */
+    #[When('/^I do not specify new information$/')]
     public function iDoNotSpecifyNewInformation(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @Then /^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/
-     */
+    #[Then('/^(the administrator) should see that (order placed by "[^"]+") has "([^"]+)" currency$/')]
     public function theAdministratorShouldSeeThatThisOrderHasBeenPlacedIn(
         AdminUserInterface $user,
         OrderInterface $order,
@@ -917,9 +730,7 @@ final readonly class ManagingOrdersContext implements Context
         });
     }
 
-    /**
-     * @Then /^(the administrator) should see the order with total "([^"]+)" in order list$/
-     */
+    #[Then('/^(the administrator) should see the order with total "([^"]+)" in order list$/')]
     public function theAdministratorShouldSeeTheOrderWithTotalInOrderList(AdminUserInterface $user, string $total): void
     {
         $this->sharedSecurityService->performActionAsAdminUser($user, function () use ($total) {
@@ -929,82 +740,62 @@ final readonly class ManagingOrdersContext implements Context
         });
     }
 
-    /**
-     * @Then I should not be able to refund this payment
-     */
+    #[Then('I should not be able to refund this payment')]
     public function iShouldNotBeAbleToRefundThisPayment(): void
     {
         Assert::false($this->showPage->hasRefundButton());
     }
 
-    /**
-     * @Then I should not see information about shipments
-     */
+    #[Then('I should not see information about shipments')]
     public function iShouldNotSeeInformationAboutShipments(): void
     {
         Assert::same($this->showPage->getShipmentsCount(), 0);
     }
 
-    /**
-     * @Then the :productName product's unit price should be :price
-     */
+    #[Then('the :productName product\'s unit price should be :price')]
     public function productUnitPriceShouldBe(string $productName, string $price): void
     {
         Assert::same($this->showPage->getItemUnitPrice($productName), $price);
     }
 
-    /**
-     * @Then the :productName product's item discount should be :price
-     */
+    #[Then('the :productName product\'s item discount should be :price')]
     public function productItemDiscountShouldBe(string $productName, string $price): void
     {
         Assert::same($this->showPage->getItemDiscount($productName), $price);
     }
 
-    /**
-     * @Then the :productName product's order discount should be :price
-     */
+    #[Then('the :productName product\'s order discount should be :price')]
     public function productOrderDiscountShouldBe(string $productName, string $price): void
     {
         Assert::same($this->showPage->getItemOrderDiscount($productName), $price);
     }
 
-    /**
-     * @Then the :productName product's quantity should be :quantity
-     */
+    #[Then('the :productName product\'s quantity should be :quantity')]
     public function productQuantityShouldBe(string $productName, string $quantity): void
     {
         Assert::same($this->showPage->getItemQuantity($productName), $quantity);
     }
 
-    /**
-     * @Then the :productName product's subtotal should be :subTotal
-     */
+    #[Then('the :productName product\'s subtotal should be :subTotal')]
     public function productSubtotalShouldBe(string $productName, string $subTotal): void
     {
         Assert::same($this->showPage->getItemSubtotal($productName), $subTotal);
     }
 
-    /**
-     * @Then the :productName product's discounted unit price should be :price
-     */
+    #[Then('the :productName product\'s discounted unit price should be :price')]
     public function productDiscountedUnitPriceShouldBe(string $productName, string $price): void
     {
         Assert::same($this->showPage->getItemDiscountedUnitPrice($productName), $price);
     }
 
-    /**
-     * @Then I should be informed that there are no payments
-     */
+    #[Then('I should be informed that there are no payments')]
     public function iShouldSeeInformationAboutNoPayments(): void
     {
         Assert::same($this->showPage->getPaymentsCount(), 0);
         Assert::true($this->showPage->hasInformationAboutNoPayment());
     }
 
-    /**
-     * @Then /^I should be notified that the (order|shipment) confirmation email has been successfully resent to the customer$/
-     */
+    #[Then('/^I should be notified that the (order|shipment) confirmation email has been successfully resent to the customer$/')]
     public function iShouldBeNotifiedThatTheOrderConfirmationEmailHasBeenSuccessfullyResentToTheCustomer(string $type): void
     {
         $this->notificationChecker->checkNotification(
@@ -1013,9 +804,7 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to resend the order confirmation email
-     */
+    #[Then('I should not be able to resend the order confirmation email')]
     public function iShouldNotBeAbleToResendTheOrderConfirmationEmail(): void
     {
         Assert::false(
@@ -1024,17 +813,13 @@ final readonly class ManagingOrdersContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the shipping date as :dateTime
-     */
+    #[Then('I should see the shipping date as :dateTime')]
     public function iShouldSeeTheShippingDateAs(string $dateTime): void
     {
         Assert::same($this->showPage->getShippedAtDate(), $dateTime);
     }
 
-    /**
-     * @Then I should be informed that the order does not exist
-     */
+    #[Then('I should be informed that the order does not exist')]
     public function iShouldBeInformedThatTheOrderDoesNotExist(): void
     {
         Assert::same($this->errorPage->getCode(), 404);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
@@ -41,19 +44,15 @@ final readonly class ManagingPaymentMethodsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to modify the :paymentMethod payment method
-     */
+    #[When('I want to modify the :paymentMethod payment method')]
     public function iWantToModifyAPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->updatePage->open(['id' => $paymentMethod->getId()]);
     }
 
-    /**
-     * @When I name it :name in :language
-     * @When I rename it to :name in :language
-     * @When I remove its name from :language translation
-     */
+    #[When('I name it :name in :language')]
+    #[When('I rename it to :name in :language')]
+    #[When('I remove its name from :language translation')]
     public function iNameItIn(string $language, ?string $name = null): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -62,51 +61,39 @@ final readonly class ManagingPaymentMethodsContext implements Context
         $currentPage->nameIt($name ?? '', $language);
     }
 
-    /**
-     * @When I enable sandbox mode
-     */
+    #[When('I enable sandbox mode')]
     public function iEnableSandboxMode(): void
     {
         $this->updatePage->enableSandboxMode();
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->updatePage->enable();
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->updatePage->disable();
     }
 
-    /**
-     * @When I delete the :paymentMethod payment method
-     * @When I try to delete the :paymentMethod payment method
-     */
+    #[When('I delete the :paymentMethod payment method')]
+    #[When('I try to delete the :paymentMethod payment method')]
     public function iDeletePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['code' => $paymentMethod->getCode(), 'name' => $paymentMethod->getName()]);
     }
 
-    /**
-     * @Then /^(?:this payment method|its gateway configuration) "([^"]+)" should be "([^"]+)"$/
-     */
+    #[Then('/^(?:this payment method|its gateway configuration) "([^"]+)" should be "([^"]+)"$/')]
     public function itsGatewayConfigurationShouldBe(string $element, string $value): void
     {
         Assert::true(
@@ -115,161 +102,125 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then this payment method should be in sandbox mode
-     */
+    #[Then('this payment method should be in sandbox mode')]
     public function thisPaymentMethodShouldBeInSandboxMode(): void
     {
         Assert::true($this->updatePage->isPaymentMethodInSandboxMode());
     }
 
-    /**
-     * @When I want to create a new offline payment method
-     * @When I want to create a new payment method with :factory gateway factory
-     */
+    #[When('I want to create a new offline payment method')]
+    #[When('I want to create a new payment method with :factory gateway factory')]
     public function iWantToCreateANewPaymentMethod(string $factory = 'Offline'): void
     {
         $this->createPage->open(['factory' => array_search($factory, $this->gatewayFactories, true)]);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I describe it as :description in :language
-     */
+    #[When('I describe it as :description in :language')]
     public function iDescribeItAsIn(string $description, string $language): void
     {
         $this->createPage->describeIt($description, $language);
     }
 
-    /**
-     * @When make it available in channel :channel
-     */
+    #[When('make it available in channel :channel')]
     public function iMakeItAvailableInChannel(string $channel): void
     {
         $this->createPage->checkChannel($channel);
     }
 
-    /**
-     * @Given I set its instruction as :instructions in :language
-     */
+    #[Given('I set its instruction as :instructions in :language')]
     public function iSetItsInstructionAsIn(string $instructions, string $language): void
     {
         $this->createPage->setInstructions($instructions, $language);
     }
 
     /**
-     * @When I add it
-     * @When I try to add it
      *
      * @throws ElementNotFoundException
      */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I cancel my changes
-     */
+    #[When('I cancel my changes')]
     public function iCancelMyChanges(): void
     {
         $this->createPage->cancelChanges();
     }
 
-    /**
-     * @When I check (also) the :paymentMethodName payment method
-     */
+    #[When('I check (also) the :paymentMethodName payment method')]
     public function iCheckThePaymentMethod(string $paymentMethodName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $paymentMethodName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see the payment method :paymentMethodName
-     */
+    #[Then('I should see the payment method :paymentMethodName')]
     public function IShouldSeeThePaymentMethod(string $paymentMethodName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $paymentMethodName]));
     }
 
-    /**
-     * @Then I should not see the payment method :paymentMethodName
-     */
+    #[Then('I should not see the payment method :paymentMethodName')]
     public function IShouldNotSeeThePaymentMethod(string $paymentMethodName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $paymentMethodName]));
     }
 
-    /**
-     * @Then the payment method :paymentMethodName should appear in the registry
-     * @Then the payment method :paymentMethodName should be in the registry
-     * @Then I should see the payment method :paymentMethodName in the list
-     */
+    #[Then('the payment method :paymentMethodName should appear in the registry')]
+    #[Then('the payment method :paymentMethodName should be in the registry')]
+    #[Then('I should see the payment method :paymentMethodName in the list')]
     public function thePaymentMethodShouldAppearInTheRegistry(string $paymentMethodName): void
     {
         $this->thereShouldStillBeOnlyOnePaymentMethodWith('name', $paymentMethodName);
     }
 
-    /**
-     * @Given /^(this payment method) should still be in the registry$/
-     */
+    #[Given('/^(this payment method) should still be in the registry$/')]
     public function thisPaymentMethodShouldStillBeInTheRegistry(PaymentMethodInterface $paymentMethod): void
     {
         $this->thePaymentMethodShouldAppearInTheRegistry($paymentMethod->getName());
     }
 
-    /**
-     * @Given I am browsing payment methods
-     * @When I browse payment methods
-     */
+    #[Given('I am browsing payment methods')]
+    #[When('I browse payment methods')]
     public function iBrowsePaymentMethods(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I choose enabled filter
-     */
+    #[When('I choose enabled filter')]
     public function iChooseEnabledFilter(): void
     {
         $this->indexPage->chooseEnabledFilter();
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then the first payment method on the list should have :field :value
-     */
+    #[Then('the first payment method on the list should have :field :value')]
     public function theFirstPaymentMethodOnTheListShouldHave(string $field, string $value): void
     {
         Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
-    /**
-     * @Then the last payment method on the list should have :field :value
-     */
+    #[Then('the last payment method on the list should have :field :value')]
     public function theLastPaymentMethodOnTheListShouldHave(string $field, string $value): void
     {
         $values = $this->indexPage->getColumnFields($field);
@@ -277,42 +228,37 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::same(end($values), $value);
     }
 
-    /**
-     * @Given the payment methods are already sorted by :field
-     * @When I switch the way payment methods are sorted by :field
-     * @When I start sorting payment methods by :field
-     * @When I switch the way payment methods are sorted to descending by :field
-     */
+    #[Given('the payment methods are already sorted by :field')]
+    #[When('I switch the way payment methods are sorted by :field')]
+    #[When('I start sorting payment methods by :field')]
+    #[When('I switch the way payment methods are sorted to descending by :field')]
     public function iSortPaymentMethodsBy(string $field): void
     {
         $this->indexPage->sortBy($field);
     }
 
-    /**
-     * @Then I should see a single payment method in the list
-     * @Then I should see :amount payment methods in the list
-     */
+    #[Then('I should see a single payment method in the list')]
+    #[Then('I should see :amount payment methods in the list')]
     public function iShouldSeePaymentMethodsInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
     /**
-     * @Then I should be notified that :element is required
-     * @Then I should be notified that I have to specify payment method :element
      *
      * @throws ElementNotFoundException
      */
+    #[Then('I should be notified that :element is required')]
+    #[Then('I should be notified that I have to specify payment method :element')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         $this->assertFieldValidationMessage($element, sprintf('Please enter payment method %s.', $element));
     }
 
     /**
-     * @Then I should be notified that gateway name should contain only letters and underscores
-     *
      * @throws ElementNotFoundException
      */
+    #[Then('I should be notified that gateway name should contain only letters and underscores')]
     public function iShouldBeNotifiedThatGatewayNameShouldContainOnlyLettersAndUnderscores(): void
     {
         Assert::same(
@@ -321,9 +267,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the payment method with :element :value should not be added
-     */
+    #[Then('the payment method with :element :value should not be added')]
     public function thePaymentMethodWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         $this->iBrowsePaymentMethods();
@@ -331,9 +275,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then /^(this payment method) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this payment method) should still be named "([^"]+)"$/')]
     public function thisShippingMethodNameShouldBe(PaymentMethodInterface $paymentMethod, string $paymentMethodName): void
     {
         $this->iBrowsePaymentMethods();
@@ -355,50 +297,38 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 
-    /**
-     * @Then the code field should be disabled
-     * @Then I should not be able to edit its code
-     */
+    #[Then('the code field should be disabled')]
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @Then the factory name field should be disabled
-     */
+    #[Then('the factory name field should be disabled')]
     public function theFactoryNameFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isFactoryNameFieldDisabled());
     }
 
-    /**
-     * @Then I should not be able to edit its usePayum field
-     */
+    #[Then('I should not be able to edit its usePayum field')]
     public function theUsePayumFieldShouldBeDisabled(): void
     {
         Assert::true($this->updatePage->isUsePayumFieldDisabled());
     }
 
-    /**
-     * @Then this payment method should be enabled
-     */
+    #[Then('this payment method should be enabled')]
     public function thisPaymentMethodShouldBeEnabled(): void
     {
         Assert::true($this->updatePage->isPaymentMethodEnabled());
     }
 
-    /**
-     * @Then this payment method should be disabled
-     */
+    #[Then('this payment method should be disabled')]
     public function thisPaymentMethodShouldBeDisabled(): void
     {
         Assert::false($this->updatePage->isPaymentMethodEnabled());
     }
 
-    /**
-     * @Given the payment method :paymentMethod should have instructions :instructions in :language
-     */
+    #[Given('the payment method :paymentMethod should have instructions :instructions in :language')]
     public function thePaymentMethodShouldHaveInstructionsIn(
         PaymentMethodInterface $paymentMethod,
         string $instructions,
@@ -409,9 +339,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::same($this->updatePage->getPaymentMethodInstructions($language), $instructions);
     }
 
-    /**
-     * @Then the payment method :paymentMethod should be available in channel :channelName
-     */
+    #[Then('the payment method :paymentMethod should be available in channel :channelName')]
     public function thePaymentMethodShouldBeAvailableInChannel(
         PaymentMethodInterface $paymentMethod,
         string $channelName,
@@ -421,9 +349,7 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::true($this->updatePage->isAvailableInChannel($channelName));
     }
 
-    /**
-     * @Then /^(this payment method) should no longer exist in the registry$/
-     */
+    #[Then('/^(this payment method) should no longer exist in the registry$/')]
     public function thisPaymentMethodShouldNoLongerExistInTheRegistry(PaymentMethodInterface $paymentMethod): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage([
@@ -433,18 +359,15 @@ final readonly class ManagingPaymentMethodsContext implements Context
     }
 
     /**
-     * @Then I should be notified that payment method with this code already exists
-     *
      * @throws ElementNotFoundException
      */
+    #[Then('I should be notified that payment method with this code already exists')]
     public function iShouldBeNotifiedThatPaymentMethodWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->createPage->getValidationMessage('code'), 'The payment method with given code already exists.');
     }
 
-    /**
-     * @Then there should still be only one payment method with :element :code
-     */
+    #[Then('there should still be only one payment method with :element :code')]
     public function thereShouldStillBeOnlyOnePaymentMethodWith(string $element, string $code): void
     {
         $this->iBrowsePaymentMethods();
@@ -452,17 +375,13 @@ final readonly class ManagingPaymentMethodsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
-    /**
-     * @When I do not specify configuration password
-     */
+    #[When('I do not specify configuration password')]
     public function iDoNotSpecifyConfigurationPassword(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @Then I should be redirected to the previous page of only enabled payment methods
-     */
+    #[Then('I should be redirected to the previous page of only enabled payment methods')]
     public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter(): void
     {
         Assert::true($this->indexPage->isEnabledFilterApplied());

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentRequestsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentRequestsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Payment\PaymentRequest\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Payment\PaymentRequest\ShowPageInterface;
@@ -34,17 +36,13 @@ final readonly class ManagingPaymentRequestsContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse payment requests of an order :order
-     */
+    #[When('I browse payment requests of an order :order')]
     public function iBrowsePaymentRequestsOfACustomer(OrderInterface $order): void
     {
         $this->indexPage->open(['paymentId' => $order->getLastPayment()->getId()]);
     }
 
-    /**
-     * @When I view details of the payment request for the :order order
-     */
+    #[When('I view details of the payment request for the :order order')]
     public function iViewDetailsOfThePaymentRequestForTheOrder(OrderInterface $order): void
     {
         $payment = $order->getLastPayment();
@@ -56,84 +54,64 @@ final readonly class ManagingPaymentRequestsContext implements Context
         ]);
     }
 
-    /**
-     * @When I filter by the :action action
-     */
+    #[When('I filter by the :action action')]
     public function iFilterByTheAction(string $action): void
     {
         $this->indexPage->chooseActionToFilter($action);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter by the :paymentMethod payment method
-     */
+    #[When('I filter by the :paymentMethod payment method')]
     public function iFilterByThePaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         $this->indexPage->choosePaymentMethodToFilter($paymentMethod->getName());
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter by the :state state
-     */
+    #[When('I filter by the :state state')]
     public function iFilterByTheState(string $state): void
     {
         $this->indexPage->chooseStateToFilter($state);
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then /^there should be (\d+) payment requests? on the list$/
-     */
+    #[Then('/^there should be (\d+) payment requests? on the list$/')]
     public function thereShouldBeProductVariantsOnTheList(int $count): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then it should be the payment request with action :action
-     */
+    #[Then('it should be the payment request with action :action')]
     public function itShouldBeThePaymentRequestWithAction(string $action): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['action' => $action]));
     }
 
-    /**
-     * @Then it should be the payment request with payment method :paymentMethod
-     */
+    #[Then('it should be the payment request with payment method :paymentMethod')]
     public function itShouldBeThePaymentRequestWithPaymentMethod(PaymentMethodInterface $paymentMethod): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['method' => $paymentMethod->getName()]));
     }
 
-    /**
-     * @Then its :field should be :value
-     */
+    #[Then('its :field should be :value')]
     public function itsFieldShouldBe(string $field, string $value): void
     {
         Assert::same($this->showPage->getFieldText($field), $value);
     }
 
-    /**
-     * @Then its payload should has empty value
-     */
+    #[Then('its payload should has empty value')]
     public function itsPayloadShouldHasEmptyValue(): void
     {
         Assert::same($this->showPage->getFieldText('payload'), 'null');
     }
 
-    /**
-     * @Then its response data should has empty value
-     */
+    #[Then('its response data should has empty value')]
     public function itsResponseDataShouldBe(): void
     {
         Assert::same($this->showPage->getFieldText('response_data'), json_encode([]));
     }
 
-    /**
-     * @Then the administrator should see the payment request with action :action for :method payment method and state :state
-     */
+    #[Then('the administrator should see the payment request with action :action for :method payment method and state :state')]
     public function administratorShouldSeeThePaymentRequestWithActionAndState(string $action, string $paymentMethod, string $state): void
     {
         $adminUser = $this->sharedStorage->get('administrator');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Order\ShowPageInterface;
@@ -31,75 +34,57 @@ final class ManagingPaymentsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing payments
-     * @When I browse payments
-     */
+    #[Given('I am browsing payments')]
+    #[When('I browse payments')]
     public function iAmBrowsingPayments(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I choose :paymentState as a payment state
-     */
+    #[When('I choose :paymentState as a payment state')]
     public function iChooseAsAPaymentState(string $paymentState): void
     {
         $this->indexPage->chooseStateToFilter($paymentState);
     }
 
-    /**
-     * @When I complete the payment of order :orderNumber
-     */
+    #[When('I complete the payment of order :orderNumber')]
     public function iCompleteThePaymentOfOrder(string $orderNumber): void
     {
         $this->indexPage->completePaymentOfOrderWithNumber($orderNumber);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I go to the details of the first payment's order
-     */
+    #[When('I go to the details of the first payment\'s order')]
     public function iGoToTheDetailsOfTheFirstPaymentSOrder(): void
     {
         $this->indexPage->showOrderPageForNthPayment(1);
     }
 
-    /**
-     * @When I choose :channelName as a channel filter
-     */
+    #[When('I choose :channelName as a channel filter')]
     public function iChooseChannelAsAChannelFilter(string $channelName): void
     {
         $this->indexPage->chooseChannelFilter($channelName);
     }
 
-    /**
-     * @When I want to view the payment requests of the first payment
-     */
+    #[When('I want to view the payment requests of the first payment')]
     public function iWantToViewThePaymentRequestsOfTheFirstPayment(): void
     {
         $this->indexPage->showPaymentRequestOfNthPayment(1);
     }
 
-    /**
-     * @Then I should see :count payments in the list
-     * @Then I should see a single payment in the list
-     */
+    #[Then('I should see :count payments in the list')]
+    #[Then('I should see a single payment in the list')]
     public function iShouldSeePaymentsInTheList(int $count = 1): void
     {
         Assert::same($count, $this->indexPage->countItems());
     }
 
-    /**
-     * @Then the payment of the :orderNumber order should be :paymentState for :customer
-     */
+    #[Then('the payment of the :orderNumber order should be :paymentState for :customer')]
     public function thePaymentOfTheOrderShouldBeFor(
         string $orderNumber,
         string $paymentState,
@@ -114,59 +99,45 @@ final class ManagingPaymentsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage($parameters));
     }
 
-    /**
-     * @Then I should see order page with details of order :order
-     * @Then I should see the details of order :order
-     */
+    #[Then('I should see order page with details of order :order')]
+    #[Then('I should see the details of order :order')]
     public function iShouldSeeOrderPageWithDetailsOfOrder(OrderInterface $order): void
     {
         Assert::true($this->orderShowPage->isOpen(['id' => $order->getId()]));
     }
 
-    /**
-     * @Then I should see (also) the payment of the :orderNumber order
-     */
+    #[Then('I should see (also) the payment of the :orderNumber order')]
     public function iShouldSeeThePaymentOfTheOrder(string $orderNumber): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @Then I should see the payment of order :orderNumber as :paymentState
-     */
+    #[Then('I should see the payment of order :orderNumber as :paymentState')]
     public function iShouldSeeThePaymentOfOrderAs(string $orderNumber, string $paymentState): void
     {
         Assert::same($paymentState, $this->indexPage->getPaymentStateByOrderNumber($orderNumber));
     }
 
-    /**
-     * @Then I should be notified that the payment has been completed
-     */
+    #[Then('I should be notified that the payment has been completed')]
     public function iShouldBeNotifiedThatThePaymentHasBeenCompleted(): void
     {
         $this->notificationChecker->checkNotification('Payment has been completed.', NotificationType::success());
     }
 
-    /**
-     * @Then I should not see a payment of order :orderNumber
-     * @Then I should not see the payment of the :orderNumber order
-     */
+    #[Then('I should not see a payment of order :orderNumber')]
+    #[Then('I should not see the payment of the :orderNumber order')]
     public function iShouldNotSeeAPaymentOfOrder(string $orderNumber): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
-    /**
-     * @Then /^I should see payment for (the "[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/
-     */
+    #[Then('/^I should see payment for (the "[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/')]
     public function iShouldSeePaymentForTheOrderInTheList(string $orderNumber, int $position): void
     {
         Assert::true($this->indexPage->isPaymentWithOrderNumberInPosition($orderNumber, $position));
     }
 
-    /**
-     * @When /^I sort payments by date in (ascending|descending) order$/
-     */
+    #[When('/^I sort payments by date in (ascending|descending) order$/')]
     public function iSortPaymentsByRegistrationDate(string $order): void
     {
         $this->sortBy($order, 'createdAt');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\ProductAssociationType\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -34,78 +36,60 @@ final readonly class ManagingProductAssociationTypesContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse product association types
-     * @When I am browsing product association types
-     * @When I want to browse product association types
-     */
+    #[When('I browse product association types')]
+    #[When('I am browsing product association types')]
+    #[When('I want to browse product association types')]
     public function iWantToBrowseProductAssociationTypes(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I want to create a new product association type
-     */
+    #[When('I want to create a new product association type')]
     public function iWantToCreateANewProductAssociationType(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I want to modify the :productAssociationType product association type
-     */
+    #[When('I want to modify the :productAssociationType product association type')]
     public function iWantToModifyAPaymentMethod(ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->updatePage->open(['id' => $productAssociationType->getId()]);
     }
 
-    /**
-     * @When I name it :name in :language
-     */
+    #[When('I name it :name in :language')]
     public function iNameItIn(string $name, string $language): void
     {
         $this->formElement->setName($name, $language);
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I rename it to :name in :language
-     * @When I remove its name from :language translation
-     */
+    #[When('I rename it to :name in :language')]
+    #[When('I remove its name from :language translation')]
     public function iRenameItToInLanguage(string $language, string $name = ''): void
     {
         $this->formElement->setName($name, $language);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(string $code = ''): void
     {
         $this->formElement->setCode($code);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I delete the :productAssociationType product association type
-     */
+    #[When('I delete the :productAssociationType product association type')]
     public function iDeleteTheProductAssociationType(ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->iWantToBrowseProductAssociationTypes();
@@ -116,25 +100,19 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         ]);
     }
 
-    /**
-     * @When I check (also) the :productAssociationTypeName product association type
-     */
+    #[When('I check (also) the :productAssociationTypeName product association type')]
     public function iCheckTheProductAssociationType(string $productAssociationTypeName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $productAssociationTypeName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When /^I filter product association types with (code|name) containing "([^"]+)"/
-     */
+    #[When('/^I filter product association types with (code|name) containing "([^"]+)"/')]
     public function iFilterProductAssociationTypesWithFieldContaining(string $field, string $value): void
     {
         $this->indexPage->specifyFilterType($field, 'Contains');
@@ -143,27 +121,21 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I sort the product associations :sortType by :field
-     */
+    #[When('I sort the product associations :sortType by :field')]
     public function iSortProductAssociationsBy(string $sortingOrder, string $field): void
     {
         $this->indexPage->sortBy($field, $sortingOrder === 'descending' ? 'desc' : 'asc');
     }
 
-    /**
-     * @Then I should see a single product association type in the list
-     * @Then I should see only one product association type in the list
-     * @Then I should see :amount product association types in the list
-     */
+    #[Then('I should see a single product association type in the list')]
+    #[Then('I should see only one product association type in the list')]
+    #[Then('I should see :amount product association types in the list')]
     public function iShouldSeeProductAssociationTypesInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), (int) $amount);
     }
 
-    /**
-     * @Then I should see the product association type :name in the list
-     */
+    #[Then('I should see the product association type :name in the list')]
     public function iShouldSeeTheProductAssociationTypeInTheList(string $name): void
     {
         $this->iWantToBrowseProductAssociationTypes();
@@ -171,9 +143,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
-    /**
-     * @Then the product association type :productAssociationType should appear in the store
-     */
+    #[Then('the product association type :productAssociationType should appear in the store')]
     public function theProductAssociationTypeShouldAppearInTheStore(ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->indexPage->open();
@@ -181,10 +151,8 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productAssociationType->getName()]));
     }
 
-    /**
-     * @Then /^(this product association type) name should be "([^"]+)"$/
-     * @Then /^(this product association type) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this product association type) name should be "([^"]+)"$/')]
+    #[Then('/^(this product association type) should still be named "([^"]+)"$/')]
     public function thisProductAssociationTypeNameShouldBe(
         ProductAssociationTypeInterface $productAssociationType,
         string $productAssociationTypeName,
@@ -197,17 +165,13 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         ]));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then /^(this product association type) should no longer exist in the registry$/
-     */
+    #[Then('/^(this product association type) should no longer exist in the registry$/')]
     public function thisProductAssociationTypeShouldNoLongerExistInTheRegistry(
         ProductAssociationTypeInterface $productAssociationType,
     ): void {
@@ -217,9 +181,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         ]));
     }
 
-    /**
-     * @Then I should be notified that product association type with this code already exists
-     */
+    #[Then('I should be notified that product association type with this code already exists')]
     public function iShouldBeNotifiedThatProductAssociationTypeWithThisCodeAlreadyExists(): void
     {
         Assert::same(
@@ -228,9 +190,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one product association type with a :element :code
-     */
+    #[Then('there should still be only one product association type with a :element :code')]
     public function thereShouldStillBeOnlyOneProductAssociationTypeWith(string $element, string $code): void
     {
         $this->iWantToBrowseProductAssociationTypes();
@@ -238,9 +198,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         /** @var LocaleInterface $locale */
@@ -252,9 +210,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         );
     }
 
-    /**
-     * @Then the product association type with :element :value should not be added
-     */
+    #[Then('the product association type with :element :value should not be added')]
     public function theProductAssociationTypeWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         $this->iWantToBrowseProductAssociationTypes();
@@ -262,9 +218,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then the first product association on the list should have :field :value
-     */
+    #[Then('the first product association on the list should have :field :value')]
     public function theFirstProductAssociationOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -272,9 +226,7 @@ final readonly class ManagingProductAssociationTypesContext implements Context
         Assert::same(reset($fields), $value);
     }
 
-    /**
-     * @Then the last product association on the list should have :field :value
-     */
+    #[Then('the last product association on the list should have :field :value')]
     public function theLastProductAssociationOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\ProductAttribute\FilterElementInterface;
 use Sylius\Behat\Element\Admin\ProductAttribute\FormElementInterface;
@@ -33,76 +36,58 @@ final readonly class ManagingProductAttributesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new :type product attribute
-     */
+    #[When('I want to create a new :type product attribute')]
     public function iWantToCreateANewTextProductAttribute(string $type): void
     {
         $this->createPage->open(['type' => $type]);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     */
+    #[When('I name it :name in :localeCode')]
     public function iSpecifyItsNameAs(string $name, string $localeCode): void
     {
         $this->formElement->nameIt($name, $localeCode);
     }
 
-    /**
-     * @When I disable its translatability
-     */
+    #[When('I disable its translatability')]
     public function iDisableItsTranslatability(): void
     {
         $this->formElement->disableTranslatability();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I( also) add value :value in :localeCode
-     */
+    #[When('I( also) add value :value in :localeCode')]
     public function iAddValue(string $value, string $localeCode): void
     {
         $this->formElement->addAttributeValue($value, $localeCode);
     }
 
-    /**
-     * @When I delete value :value
-     */
+    #[When('I delete value :value')]
     public function iDeleteValue(string $value, string $localeCode = 'en_US'): void
     {
         $this->formElement->deleteAttributeValue($value, $localeCode);
     }
 
-    /**
-     * @When I change its value :oldValue to :newValue
-     */
+    #[When('I change its value :oldValue to :newValue')]
     public function iChangeItsValueTo(string $oldValue, string $newValue): void
     {
         $this->formElement->changeAttributeValue($oldValue, $newValue, 'en_US');
     }
 
-    /**
-     * @When I choose :type in the type filter
-     * @When I choose :firstType and :secondType in the type filter
-     */
+    #[When('I choose :type in the type filter')]
+    #[When('I choose :firstType and :secondType in the type filter')]
     public function iChooseInTheTypeFilter(string ...$types): void
     {
         foreach ($types as $type) {
@@ -110,34 +95,26 @@ final readonly class ManagingProductAttributesContext implements Context
         }
     }
 
-    /**
-     * @When I choose :translatable in the translatable filter
-     */
+    #[When('I choose :translatable in the translatable filter')]
     public function iChooseInTheTranslatableFilter(string $translatable): void
     {
         $this->filterElement->chooseTranslatable(ucfirst($translatable));
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->filterElement->filter();
     }
 
-    /**
-     * @Then /^I should(?:| also) see the product attribute "([^"]+)" in the list$/
-     */
+    #[Then('/^I should(?:| also) see the product attribute "([^"]+)" in the list$/')]
     public function iShouldSeeTheProductAttributeInTheList(string $name): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
-    /**
-     * @Then the :type attribute :name should appear in the store
-     * @Then the :type attribute :name should still be in the store
-     */
+    #[Then('the :type attribute :name should appear in the store')]
+    #[Then('the :type attribute :name should still be in the store')]
     public function theAttributeShouldAppearInTheStore(string $type, string $name): void
     {
         $this->indexPage->open();
@@ -148,50 +125,38 @@ final readonly class ManagingProductAttributesContext implements Context
         ));
     }
 
-    /**
-     * @When /^I want to edit (this product attribute)$/
-     */
+    #[When('/^I want to edit (this product attribute)$/')]
     public function iWantToEditThisAttribute(ProductAttributeInterface $productAttribute): void
     {
         $this->updatePage->open(['id' => $productAttribute->getId()]);
     }
 
-    /**
-     * @When I change its name to :name in :localeCode
-     */
+    #[When('I change its name to :name in :localeCode')]
     public function iChangeItNameToIn(string $name, string $localeCode): void
     {
         $this->formElement->changeName($name, $localeCode);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then the type field should be disabled
-     * @Then I should not be able to edit its type
-     */
+    #[Then('the type field should be disabled')]
+    #[Then('I should not be able to edit its type')]
     public function theTypeFieldShouldBeDisabled(): void
     {
         Assert::true($this->formElement->isTypeDisabled());
     }
 
-    /**
-     * @Then I should be notified that product attribute with this code already exists
-     */
+    #[Then('I should be notified that product attribute with this code already exists')]
     public function iShouldBeNotifiedThatProductAttributeWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'This code is already in use.');
     }
 
-    /**
-     * @Then there should still be only one product attribute with code :code
-     */
+    #[Then('there should still be only one product attribute with code :code')]
     public function thereShouldStillBeOnlyOneProductAttributeWithCode(string $code): void
     {
         $this->indexPage->open();
@@ -199,25 +164,19 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         $this->assertFieldValidationMessage($element, sprintf('Please enter attribute %s.', $element));
     }
 
-    /**
-     * @Given the attribute with :elementName :elementValue should not appear in the store
-     */
+    #[Given('the attribute with :elementName :elementValue should not appear in the store')]
     public function theAttributeWithCodeShouldNotAppearInTheStore(string $elementName, string $elementValue): void
     {
         $this->indexPage->open();
@@ -225,103 +184,79 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$elementName => $elementValue]));
     }
 
-    /**
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I remove its name from :localeCode translation')]
     public function iRemoveItsNameFromTranslation(string $localeCode): void
     {
         $this->formElement->changeName('', $localeCode);
     }
 
-    /**
-     * @Given I am browsing product attributes
-     * @When I browse product attributes
-     * @When I want to see all product attributes in store
-     */
+    #[Given('I am browsing product attributes')]
+    #[When('I browse product attributes')]
+    #[When('I want to see all product attributes in store')]
     public function iWantToSeeAllProductAttributesInStore(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I specify its min length as :min
-     * @When I specify its min entries value as :min
-     */
+    #[When('I specify its min length as :min')]
+    #[When('I specify its min entries value as :min')]
     public function iSpecifyItsMinValueAs(int $min): void
     {
         $this->formElement->specifyMinValue($min);
     }
 
-    /**
-     * @When I specify its max length as :max
-     * @When I specify its max entries value as :max
-     */
+    #[When('I specify its max length as :max')]
+    #[When('I specify its max entries value as :max')]
     public function iSpecifyItsMaxLengthAs(int $max): void
     {
         $this->formElement->specifyMaxValue($max);
     }
 
-    /**
-     * @When I check multiple option
-     */
+    #[When('I check multiple option')]
     public function iCheckMultipleOption(): void
     {
         $this->formElement->checkMultiple();
     }
 
-    /**
-     * @When I do not check multiple option
-     */
+    #[When('I do not check multiple option')]
     public function iDoNotCheckMultipleOption(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I check (also) the :productAttributeName product attribute
-     */
+    #[When('I check (also) the :productAttributeName product attribute')]
     public function iCheckTheProductAttribute(string $productAttributeName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $productAttributeName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see a single product attribute in the list
-     * @Then I should see :amountOfProductAttributes product attributes in the list
-     */
+    #[Then('I should see a single product attribute in the list')]
+    #[Then('I should see :amountOfProductAttributes product attributes in the list')]
     public function iShouldSeeCustomersInTheList(int $amountOfProductAttributes = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amountOfProductAttributes);
     }
 
-    /**
-     * @When /^I(?:| try to) delete (this product attribute)$/
-     */
+    #[When('/^I(?:| try to) delete (this product attribute)$/')]
     public function iDeleteThisProductAttribute(ProductAttributeInterface $productAttribute): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['code' => $productAttribute->getCode(), 'name' => $productAttribute->getName()]);
     }
 
-    /**
-     * @Then /^(this product attribute) should no longer exist in the registry$/
-     */
+    #[Then('/^(this product attribute) should no longer exist in the registry$/')]
     public function thisProductAttributeShouldNoLongerExistInTheRegistry(ProductAttributeInterface $productAttribute): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $productAttribute->getCode()]));
     }
 
-    /**
-     * @Then the first product attribute on the list should have name :name
-     */
+    #[Then('the first product attribute on the list should have name :name')]
     public function theFirstProductAttributeOnTheListShouldHave(string $name): void
     {
         $names = $this->indexPage->getColumnFields('name');
@@ -329,9 +264,7 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::same(reset($names), $name);
     }
 
-    /**
-     * @Then the last product attribute on the list should have name :name
-     */
+    #[Then('the last product attribute on the list should have name :name')]
     public function theLastProductAttributeOnTheListShouldHave(string $name): void
     {
         $names = $this->indexPage->getColumnFields('name');
@@ -339,26 +272,20 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::same(end($names), $name);
     }
 
-    /**
-     * @Then I should see the value :value in :localeCode locale
-     */
+    #[Then('I should see the value :value in :localeCode locale')]
     public function iShouldSeeTheValue(string $value, string $localeCode): void
     {
         Assert::true($this->formElement->hasAttributeValue($value, $localeCode));
     }
 
-    /**
-     * @Then I should not see the value :value in :localeCode locale
-     */
+    #[Then('I should not see the value :value in :localeCode locale')]
     public function iShouldNotSeeTheValue(string $value, string $localeCode): void
     {
         Assert::false($this->formElement->hasAttributeValue($value, $localeCode));
     }
 
-    /**
-     * @Then /^(this product attribute) should have value "([^"]*)"/
-     * @Then /^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/
-     */
+    #[Then('/^(this product attribute) should have value "([^"]*)"/')]
+    #[Then('/^the ("[^"]+" product attribute) should(?:| also) have value "([^"]+)"/')]
     public function theSelectAttributeShouldHaveValue(ProductAttributeInterface $productAttribute, string $value): void
     {
         $this->iWantToEditThisAttribute($productAttribute);
@@ -366,9 +293,7 @@ final readonly class ManagingProductAttributesContext implements Context
         Assert::true($this->formElement->hasAttributeValue($value, 'en_US'));
     }
 
-    /**
-     * @Then I should be notified that max length must be greater or equal to the min length
-     */
+    #[Then('I should be notified that max length must be greater or equal to the min length')]
     public function iShouldBeNotifiedThatMaxLengthMustBeGreaterOrEqualToTheMinLength(): void
     {
         Assert::same(
@@ -377,9 +302,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that max entries value must be greater or equal to the min entries value
-     */
+    #[Then('I should be notified that max entries value must be greater or equal to the min entries value')]
     public function iShouldBeNotifiedThatMaxEntriesValueMustBeGreaterOrEqualToTheMinEntriesValue(): void
     {
         Assert::same(
@@ -388,9 +311,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that min entries value must be lower or equal to the number of added choices
-     */
+    #[Then('I should be notified that min entries value must be lower or equal to the number of added choices')]
     public function iShouldBeNotifiedThatMinEntriesValueMustBeLowerOrEqualToTheNumberOfAddedChoices(): void
     {
         Assert::same(
@@ -399,9 +320,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that multiple must be true if min or max entries values are specified
-     */
+    #[Then('I should be notified that multiple must be true if min or max entries values are specified')]
     public function iShouldBeNotifiedThatMultipleMustBeTrueIfMinOrMaxEntriesValuesAreSpecified(): void
     {
         Assert::same(
@@ -410,9 +329,7 @@ final readonly class ManagingProductAttributesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product attribute) should not have value "([^"]*)"/
-     */
+    #[Then('/^(this product attribute) should not have value "([^"]*)"/')]
     public function theSelectAttributeShouldNotHaveValue(ProductAttributeInterface $productAttribute, string $value): void
     {
         $this->iWantToEditThisAttribute($productAttribute);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\ProductOption\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -34,17 +37,13 @@ final readonly class ManagingProductOptionsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new product option
-     */
+    #[When('I want to create a new product option')]
     public function iWantToCreateANewProductOption(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I want to modify the :productOption product option
-     */
+    #[When('I want to modify the :productOption product option')]
     public function iWantToModifyAProductOption(ProductOptionInterface $productOption): void
     {
         if (!$this->updatePage->isOpen(['id' => $productOption->getId()])) {
@@ -52,112 +51,86 @@ final readonly class ManagingProductOptionsContext implements Context
         }
     }
 
-    /**
-     * @When I specify a too long :field
-     */
+    #[When('I specify a too long :field')]
     public function iSpecifyATooLong(string $field): void
     {
         $this->formElement->specifyField(ucwords($field), str_repeat('a', 256));
     }
 
-    /**
-     * @Given I am browsing product options
-     * @When I browse product options
-     */
+    #[Given('I am browsing product options')]
+    #[When('I browse product options')]
     public function iBrowseProductOptions(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I name it :name in :language
-     */
+    #[When('I name it :name in :language')]
     public function iNameItInLanguage($name, $language): void
     {
         $this->formElement->setName($name, $language);
     }
 
-    /**
-     * @When I rename it to :name in :language
-     * @When I remove its name from :language translation
-     */
+    #[When('I rename it to :name in :language')]
+    #[When('I remove its name from :language translation')]
     public function iRenameItToInLanguage(string $language, ?string $name = null): void
     {
         $this->formElement->setName($name ?? '', $language);
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I add the :value option value identified by :code
-     * @When I add the :value option value identified by :code in :localeCode
-     */
+    #[When('I add the :value option value identified by :code')]
+    #[When('I add the :value option value identified by :code in :localeCode')]
     public function iAddTheOptionValueWithCodeAndValue(string $value, string $code, string $localeCode = 'en_US'): void
     {
         $this->formElement->addOptionValue($code, $localeCode, $value);
     }
 
-    /**
-     * @When I apply the option value identified by :code in :localeCode to all option values.
-     */
+    #[When('I apply the option value identified by :code in :localeCode to all option values.')]
     public function iApplyToAllTheOptionValueIdentifiedBy(string $code, string $localeCode): void
     {
         $this->formElement->applyToAllOptionValues($code, $localeCode);
     }
 
-    /**
-     * @When I delete the :value option value of this product option
-     */
+    #[When('I delete the :value option value of this product option')]
     public function iDeleteTheOptionValueWithCodeAndValue(string $value): void
     {
         $this->formElement->removeOptionValue($value);
     }
 
-    /**
-     * @When I check (also) the :productOptionName product option
-     */
+    #[When('I check (also) the :productOptionName product option')]
     public function iCheckTheProductOption(string $productOptionName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $productOptionName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see the product option :productOption in the list
-     * @Then the product option :productOption should appear in the registry
-     * @Then the product option :productOption should be in the registry
-     */
+    #[Then('I should see the product option :productOption in the list')]
+    #[Then('the product option :productOption should appear in the registry')]
+    #[Then('the product option :productOption should be in the registry')]
     public function theProductOptionShouldAppearInTheRegistry(ProductOptionInterface $productOption): void
     {
         $this->sharedStorage->set('product_option', $productOption);
@@ -166,17 +139,13 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productOption->getName()]));
     }
 
-    /**
-     * @Then I should be notified that product option with this code already exists
-     */
+    #[Then('I should be notified that product option with this code already exists')]
     public function iShouldBeNotifiedThatProductOptionWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'The option with given code already exists.');
     }
 
-    /**
-     * @Then there should still be only one product option with :element :value
-     */
+    #[Then('there should still be only one product option with :element :value')]
     public function thereShouldStillBeOnlyOneProductOptionWith(string $element, string $value): void
     {
         $this->iBrowseProductOptions();
@@ -184,17 +153,13 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         Assert::same($this->formElement->getValidationMessage($element, ['%locale_code%' => 'en_US']), sprintf('Please enter option %s.', $element));
     }
 
-    /**
-     * @Then the product option with :element :value should not be added
-     */
+    #[Then('the product option with :element :value should not be added')]
     public function theProductOptionWithElementValueShouldNotBeAdded(string $element, string $value): void
     {
         $this->iBrowseProductOptions();
@@ -202,10 +167,8 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then /^(this product option) should still be named "([^"]+)"$/
-     * @Then /^(this product option) name should be "([^"]+)"$/
-     */
+    #[Then('/^(this product option) should still be named "([^"]+)"$/')]
+    #[Then('/^(this product option) name should be "([^"]+)"$/')]
     public function thisProductOptionNameShouldStillBe(ProductOptionInterface $productOption, string $productOptionName): void
     {
         $this->iBrowseProductOptions();
@@ -216,37 +179,29 @@ final readonly class ManagingProductOptionsContext implements Context
         ]));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @When I do not add an option value
-     */
+    #[When('I do not add an option value')]
     public function iDoNotAddAnOptionValue()
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @Then I should see a single product option in the list
-     * @Then I should see :amount product options in the list
-     */
+    #[Then('I should see a single product option in the list')]
+    #[Then('I should see :amount product options in the list')]
     public function iShouldSeeProductOptionsInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
-    /**
-     * @Then /^(this product option) should have the "([^"]*)" option value$/
-     * @Then /^(product option "[^"]+") should have the "([^"]*)" option value$/
-     * @Then /^(product option "[^"]+") should still have the "([^"]*)" option value$/
-     * @Then /^(this product option) should have the "([^"]*)" option value in ("([^"]+)" locale)$/
-     */
+    #[Then('/^(this product option) should have the "([^"]*)" option value$/')]
+    #[Then('/^(product option "[^"]+") should have the "([^"]*)" option value$/')]
+    #[Then('/^(product option "[^"]+") should still have the "([^"]*)" option value$/')]
+    #[Then('/^(this product option) should have the "([^"]*)" option value in ("([^"]+)" locale)$/')]
     public function thisProductOptionShouldHaveTheOptionValue(
         ProductOptionInterface $productOption,
         string $optionValue,
@@ -257,10 +212,8 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::true($this->formElement->hasOptionValue($optionValue, $localeCode));
     }
 
-    /**
-     * @Then /^(this product option) should not have the "([^"]*)" option value$/
-     * @Then /^(this product option) should not have the "([^"]*)" option value in ("([^"]+)" locale)$/
-     */
+    #[Then('/^(this product option) should not have the "([^"]*)" option value$/')]
+    #[Then('/^(this product option) should not have the "([^"]*)" option value in ("([^"]+)" locale)$/')]
     public function thisProductOptionShouldNotHaveTheOptionValue(
         ProductOptionInterface $productOption,
         string $optionValue,
@@ -271,17 +224,13 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::false($this->formElement->hasOptionValue($optionValue, $localeCode));
     }
 
-    /**
-     * @Then the first product option in the list should have :field :value
-     */
+    #[Then('the first product option in the list should have :field :value')]
     public function theFirstProductOptionInTheListShouldHave(string $field, string $value): void
     {
         Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
-    /**
-     * @Then the last product option in the list should have :field :value
-     */
+    #[Then('the last product option in the list should have :field :value')]
     public function theLastProductOptionInTheListShouldHave(string $field, string $value): void
     {
         $values = $this->indexPage->getColumnFields($field);
@@ -289,10 +238,8 @@ final readonly class ManagingProductOptionsContext implements Context
         Assert::same(end($values), $value);
     }
 
-    /**
-     * @Then I should be notified that :field is too long
-     * @Then I should be notified that :field should be no longer than :maxLength characters
-     */
+    #[Then('I should be notified that :field is too long')]
+    #[Then('I should be notified that :field should be no longer than :maxLength characters')]
     public function iShouldBeNotifiedThatFieldValueIsTooLong(string $field, int $maxLength = 255): void
     {
         $validationMessage = $this->formElement->getValidationMessage(StringInflector::nameToLowercaseCode($field));

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\ProductReview\IndexPageInterface;
@@ -30,176 +33,134 @@ final class ManagingProductReviewsContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing product reviews
-     * @When I browse product reviews
-     * @When I want to browse product reviews
-     */
+    #[Given('I am browsing product reviews')]
+    #[When('I browse product reviews')]
+    #[When('I want to browse product reviews')]
     public function iWantToBrowseProductReviews(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I check (also) the :productReviewTitle product review
-     */
+    #[When('I check (also) the :productReviewTitle product review')]
     public function iCheckTheProductReview(string $productReviewTitle): void
     {
         $this->indexPage->checkResourceOnPage(['title' => $productReviewTitle]);
     }
 
-    /**
-     * @When I choose :state as a status filter
-     */
+    #[When('I choose :state as a status filter')]
     public function iChooseStateAsStatusFilter(string $state): void
     {
         $this->indexPage->filterByState($state);
     }
 
-    /**
-     * @When I filter with title containing :phrase
-     */
+    #[When('I filter with title containing :phrase')]
     public function iFilterWithTitleContaining(string $phrase): void
     {
         $this->indexPage->filterByTitle($phrase);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter by :productName product
-     */
+    #[When('I filter by :productName product')]
     public function iFilterByProduct(string $productName): void
     {
         $this->indexPage->filterByProduct($productName);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I sort the product reviews :sortingOrder by :field
-     */
+    #[When('I sort the product reviews :sortingOrder by :field')]
     public function iSortProductReviewsBy(string $sortingOrder, string $field): void
     {
         $this->indexPage->sortBy($field, $sortingOrder === 'descending' ? 'desc' : 'asc');
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I want to modify the :productReview product review
-     */
+    #[When('I want to modify the :productReview product review')]
     public function iWantToModifyTheProductReview(ReviewInterface $productReview): void
     {
         $this->updatePage->open(['id' => $productReview->getId()]);
     }
 
-    /**
-     * @When I change its title to :title
-     * @When I remove its title
-     */
+    #[When('I change its title to :title')]
+    #[When('I remove its title')]
     public function iChangeItsTitleTo(?string $title = null): void
     {
         $this->updatePage->specifyTitle($title ?? '');
     }
 
-    /**
-     * @When I change its comment to :comment
-     * @When I remove its comment
-     */
+    #[When('I change its comment to :comment')]
+    #[When('I remove its comment')]
     public function iChangeItsCommentTo(?string $comment = null): void
     {
         $this->updatePage->specifyComment($comment ?? '');
     }
 
-    /**
-     * @When I choose :rating as its rating
-     */
+    #[When('I choose :rating as its rating')]
     public function iChooseAsItsRating(string $rating): void
     {
         $this->updatePage->chooseRating($rating);
     }
 
-    /**
-     * @When I accept the :productReview product review
-     */
+    #[When('I accept the :productReview product review')]
     public function iAcceptTheProductReview(ReviewInterface $productReview): void
     {
         $this->indexPage->accept(['title' => $productReview->getTitle()]);
     }
 
-    /**
-     * @When I reject the :productReview product review
-     */
+    #[When('I reject the :productReview product review')]
     public function iRejectTheProductReview(ReviewInterface $productReview): void
     {
         $this->indexPage->reject(['title' => $productReview->getTitle()]);
     }
 
-    /**
-     * @Then I should (also) see the product review :title in the list
-     */
+    #[Then('I should (also) see the product review :title in the list')]
     public function iShouldSeeTheProductReviewTitleInTheList(string $title): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['title' => $title]));
     }
 
-    /**
-     * @Then I should see a single product review in the list
-     * @Then I should see :amount reviews in the list
-     */
+    #[Then('I should see a single product review in the list')]
+    #[Then('I should see :amount reviews in the list')]
     public function iShouldSeeReviewsInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
-    /**
-     * @Then /^this product review (comment|title) should be "([^"]+)"$/
-     */
+    #[Then('/^this product review (comment|title) should be "([^"]+)"$/')]
     public function thisProductReviewElementShouldBeValue(string $element, string $value): void
     {
         $this->assertElementValue($element, $value);
     }
 
-    /**
-     * @Then this product review rating should be :rating
-     */
+    #[Then('this product review rating should be :rating')]
     public function thisProductReviewRatingShouldBe(string $rating): void
     {
         Assert::same($this->updatePage->getRating(), $rating);
     }
 
-    /**
-     * @Then I should be editing review of product :productName
-     */
+    #[Then('I should be editing review of product :productName')]
     public function iShouldBeEditingReviewOfProduct(string $productName): void
     {
         Assert::same($this->updatePage->getProductName(), $productName);
     }
 
-    /**
-     * @Then I should see the customer's name :customerName
-     */
+    #[Then('I should see the customer\'s name :customerName')]
     public function iShouldSeeTheCustomerSName(string $customerName): void
     {
         Assert::same($this->updatePage->getCustomerName(), $customerName);
     }
 
-    /**
-     * @Then /^(this product review) status should be "([^"]+)"$/
-     */
+    #[Then('/^(this product review) status should be "([^"]+)"$/')]
     public function thisProductReviewStatusShouldBe(ReviewInterface $productReview, string $status): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([
@@ -208,9 +169,7 @@ final class ManagingProductReviewsContext implements Context
         ]));
     }
 
-    /**
-     * @Then /^I should be notified that it has been successfully (accepted|rejected)$/
-     */
+    #[Then('/^I should be notified that it has been successfully (accepted|rejected)$/')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyUpdated(string $action): void
     {
         $this->notificationChecker->checkNotification(
@@ -219,34 +178,26 @@ final class ManagingProductReviewsContext implements Context
         );
     }
 
-    /**
-     * @When I delete the :productReview product review
-     */
+    #[When('I delete the :productReview product review')]
     public function iDeleteTheProductReview(ReviewInterface $productReview): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['title' => $productReview->getTitle()]);
     }
 
-    /**
-     * @Then /^(this product review) should no longer exist in the registry$/
-     */
+    #[Then('/^(this product review) should no longer exist in the registry$/')]
     public function thisProductReviewShouldNoLongerExistInTheRegistry(ReviewInterface $productReview): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['title' => $productReview->getTitle()]));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
         $this->assertFieldValidationMessage($element, sprintf('Review %s should not be blank.', $element));
     }
 
-    /**
-     * @Then /^this product review should still be titled "([^"]+)"$/
-     */
+    #[Then('/^this product review should still be titled "([^"]+)"$/')]
     public function thisProductReviewTitleShouldBeTitled(string $productReviewTitle): void
     {
         $this->iWantToBrowseProductReviews();
@@ -254,9 +205,7 @@ final class ManagingProductReviewsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['title' => $productReviewTitle]));
     }
 
-    /**
-     * @Then /^(this product review) should still have a comment "([^"]+)"$/
-     */
+    #[Then('/^(this product review) should still have a comment "([^"]+)"$/')]
     public function thisProductReviewShouldStillHaveAComment(ReviewInterface $productReview, string $comment): void
     {
         $this->iWantToModifyTheProductReview($productReview);
@@ -264,9 +213,7 @@ final class ManagingProductReviewsContext implements Context
         $this->assertElementValue('comment', $comment);
     }
 
-    /**
-     * @Then the first product review in the list should have title :title
-     */
+    #[Then('the first product review in the list should have title :title')]
     public function theFirstProductReviewInTheListShouldHaveTitle(string $title): void
     {
         $titles = $this->indexPage->getColumnFields('title');
@@ -274,9 +221,7 @@ final class ManagingProductReviewsContext implements Context
         Assert::contains(reset($titles), $title);
     }
 
-    /**
-     * @Then the last product review in the list should have title :title
-     */
+    #[Then('the last product review in the list should have title :title')]
     public function theLastProductReviewInTheListShouldHaveTitle(string $title): void
     {
         $titles = $this->indexPage->getColumnFields('title');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductTaxonsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Product\TaxonomyFormElementInterface;
 use Sylius\Behat\Page\Admin\Product\UpdateSimpleProductPageInterface;
@@ -28,18 +30,14 @@ final readonly class ManagingProductTaxonsContext implements Context
     ) {
     }
 
-    /**
-     * @When I add :taxon taxon to the :product product
-     * @When I assign the :taxon taxon to the :product product
-     */
+    #[When('I add :taxon taxon to the :product product')]
+    #[When('I assign the :taxon taxon to the :product product')]
     public function iAddTaxonToTheProduct(ProductInterface $product, TaxonInterface $taxon): void
     {
         $this->taxonomyFormElement->checkProductTaxon($taxon);
     }
 
-    /**
-     * @When I change that the :product product does not belong to the :taxon taxon
-     */
+    #[When('I change that the :product product does not belong to the :taxon taxon')]
     public function iChangeThatTheProductDoesNotBelongToTheTaxon(
         ProductInterface $product,
         TaxonInterface $taxon,
@@ -51,57 +49,43 @@ final readonly class ManagingProductTaxonsContext implements Context
         $this->taxonomyFormElement->uncheckProductTaxon($taxon);
     }
 
-    /**
-     * @When I check all taxons
-     */
+    #[When('I check all taxons')]
     public function iCheckAllTaxons(): void
     {
         $this->taxonomyFormElement->checkAllTaxons();
     }
 
-    /**
-     * @When I uncheck all taxons
-     */
+    #[When('I uncheck all taxons')]
     public function iUncheckAllTaxons(): void
     {
         $this->taxonomyFormElement->uncheckAllTaxons();
     }
 
-    /**
-     * @When I filter taxons by :phrase
-     */
+    #[When('I filter taxons by :phrase')]
     public function iFilterTaxonsBy(string $phrase): void
     {
         $this->taxonomyFormElement->filterTaxonsBy($phrase);
     }
 
-    /**
-     * @Then the product :product should have the :taxon taxon
-     */
+    #[Then('the product :product should have the :taxon taxon')]
     public function thisProductTaxonShouldHaveTheTaxon(TaxonInterface $taxon): void
     {
         Assert::true($this->taxonomyFormElement->isTaxonChosen($taxon->getCode()));
     }
 
-    /**
-     * @Then the product :product should not have the :taxon taxon
-     */
+    #[Then('the product :product should not have the :taxon taxon')]
     public function thisProductTaxonShouldNotHaveTheTaxon(TaxonInterface $taxon): void
     {
         Assert::false($this->taxonomyFormElement->isTaxonChosen($taxon->getCode()));
     }
 
-    /**
-     * @Then I should see the :taxon taxon
-     */
+    #[Then('I should see the :taxon taxon')]
     public function iShouldSeeTheTaxon(TaxonInterface $taxon): void
     {
         Assert::true($this->taxonomyFormElement->hasTaxon($taxon->getCode()));
     }
 
-    /**
-     * @Then I should not see the :taxon taxon
-     */
+    #[Then('I should not see the :taxon taxon')]
     public function iShouldNotSeeTheTaxon(TaxonInterface $taxon): void
     {
         Assert::false($this->taxonomyFormElement->hasTaxon($taxon->getCode()));

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\NotificationType;
@@ -46,221 +48,167 @@ final class ManagingProductVariantsContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I want to create a new variant of (this product)$/
-     */
+    #[When('/^I want to create a new variant of (this product)$/')]
     public function iWantToCreateANewProduct(ProductInterface $product)
     {
         $this->createPage->open(['productId' => $product->getId()]);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :name in :language
-     */
+    #[When('I name it :name in :language')]
     public function iNameItIn($name, $language)
     {
         $this->createPage->nameItIn($name, $language);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I change its :optionName option to :optionValue
-     */
+    #[When('I change its :optionName option to :optionValue')]
     public function iChangeItsOptionTo(string $optionName, string $optionValue): void
     {
         $this->updatePage->selectOption(strtoupper($optionName), $optionValue);
     }
 
-    /**
-     * @When I disable its inventory tracking
-     */
+    #[When('I disable its inventory tracking')]
     public function iDisableItsTracking()
     {
         $this->updatePage->disableTracking();
     }
 
-    /**
-     * @When I enable its inventory tracking
-     */
+    #[When('I enable its inventory tracking')]
     public function iEnableItsTracking()
     {
         $this->updatePage->enableTracking();
     }
 
-    /**
-     * @When /^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     * @When I do not set its price
-     */
+    #[When('/^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
+    #[When('I do not set its price')]
     public function iSetItsPriceTo(?string $price = null, ?ChannelInterface $channel = null)
     {
         $this->createPage->specifyPrice($price ?? '', $channel ?? $this->sharedStorage->get('channel'));
     }
 
-    /**
-     * @When I set its price to a huge number for the :channel channel
-     */
+    #[When('I set its price to a huge number for the :channel channel')]
     public function iSetItsPriceToHugeNumberForTheChannel(ChannelInterface $channel): void
     {
         $this->iSetItsPriceTo(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When I set its original price to a huge number for the :channel channel
-     */
+    #[When('I set its original price to a huge number for the :channel channel')]
     public function iSetItsOriginalPriceToHugeNumberForTheChannel(ChannelInterface $channel): void
     {
         $this->iSetItsOriginalPriceTo(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When I set its minimum price to a huge number for the :channel channel
-     */
+    #[When('I set its minimum price to a huge number for the :channel channel')]
     public function iSetItsMinimumPriceAsOutOfRangeValueForChannel(ChannelInterface $channel): void
     {
         $this->iSetItsMinimumPriceTo(self::HUGE_NUMBER, $channel);
     }
 
-    /**
-     * @When /^I set its price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsNegativePriceTo(string $price, ChannelInterface $channel): void
     {
         $this->createPage->specifyPrice('-' . $price, $channel);
     }
 
-    /**
-     * @When /^I set its minimum price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its minimum price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsMinimumPriceTo(string $price, ChannelInterface $channel): void
     {
         $this->createPage->specifyMinimumPrice($price, $channel);
     }
 
-    /**
-     * @When I remove its price from :channel channel
-     */
+    #[When('I remove its price from :channel channel')]
     public function iRemoveItsPriceForChannel(ChannelInterface $channel): void
     {
         $this->iSetItsPriceTo('', $channel);
     }
 
-    /**
-     * @When /^I set its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsOriginalPriceTo(string $originalPrice, ChannelInterface $channel)
     {
         $this->createPage->specifyOriginalPrice($originalPrice, $channel);
     }
 
-    /**
-     * @When /^I set its minimum price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its minimum price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsNegativeMinimumPriceTo(string $price, ChannelInterface $channel): void
     {
         $this->createPage->specifyMinimumPrice('-' . $price, $channel);
     }
 
-    /**
-     * @When /^I set its original price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its original price to "-(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsNegativeOriginalPriceTo(string $originalPrice, ChannelInterface $channel)
     {
         $this->createPage->specifyOriginalPrice('-' . $originalPrice, $channel);
     }
 
-    /**
-     * @When I set its height, width, depth and weight to :number
-     */
+    #[When('I set its height, width, depth and weight to :number')]
     public function iSetItsDimensionsTo($value)
     {
         $this->createPage->specifyHeightWidthDepthAndWeight($value, $value, $value, $value);
     }
 
-    /**
-     * @When I do not specify its current stock
-     */
+    #[When('I do not specify its current stock')]
     public function iDoNetSetItsCurrentStockTo()
     {
         $this->createPage->specifyCurrentStock('');
     }
 
-    /**
-     * @When I choose :calculatorName calculator
-     */
+    #[When('I choose :calculatorName calculator')]
     public function iChooseCalculator(string $calculatorName): void
     {
         $this->createPage->choosePricingCalculator($calculatorName);
     }
 
-    /**
-     * @When I set its :optionName option to :optionValue
-     */
+    #[When('I set its :optionName option to :optionValue')]
     public function iSetItsOptionAs(string $optionName, string $optionValue): void
     {
         $this->createPage->selectOption($optionName, $optionValue);
     }
 
-    /**
-     * @When I set the position of :name to :position
-     */
+    #[When('I set the position of :name to :position')]
     public function iSetThePositionOfTo(string $name, int $position): void
     {
         $this->indexPage->setPosition($name, $position);
     }
 
-    /**
-     * @When I save my new elements order
-     */
+    #[When('I save my new elements order')]
     public function iSaveMyNewElementsOrder(): void
     {
         $this->indexPage->savePositions();
     }
 
-    /**
-     * @When I do not want to have shipping required for this product( variant)
-     */
+    #[When('I do not want to have shipping required for this product( variant)')]
     public function iDoNotWantToHaveShippingRequiredForThisProduct(): void
     {
         $this->createPage->setShippingRequired(false);
     }
 
-    /**
-     * @When I check (also) the :productVariantName product variant
-     */
+    #[When('I check (also) the :productVariantName product variant')]
     public function iCheckTheProductVariantName(string $productVariantName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $productVariantName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When /^I delete the ("[^"]+" variant of product "[^"]+")$/
-     * @When /^I try to delete the ("[^"]+" variant of product "[^"]+")$/
-     */
+    #[When('/^I delete the ("[^"]+" variant of product "[^"]+")$/')]
+    #[When('/^I try to delete the ("[^"]+" variant of product "[^"]+")$/')]
     public function iDeleteTheVariantOfProduct(ProductVariantInterface $productVariant): void
     {
         $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
@@ -268,42 +216,32 @@ final class ManagingProductVariantsContext implements Context
         $this->indexPage->deleteResourceOnPage(['code' => $productVariant->getCode()]);
     }
 
-    /**
-     * @When /^I want to modify the ("[^"]+" product variant)$/
-     */
+    #[When('/^I want to modify the ("[^"]+" product variant)$/')]
     public function iWantToModifyAProduct(ProductVariantInterface $productVariant): void
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
     }
 
-    /**
-     * @When /^I choose to show this product in the (channel "([^"]+)")$/
-     */
+    #[When('/^I choose to show this product in the (channel "([^"]+)")$/')]
     public function iChooseToShowThisProductInTheChannel(ChannelInterface $channel): void
     {
         $this->updatePage->showProductInChannel($channel);
     }
 
-    /**
-     * @When I choose to show this product in this channel
-     */
+    #[When('I choose to show this product in this channel')]
     public function iChooseToShowThisProductInThisChannel(): void
     {
         $this->updatePage->showProductInSingleChannel();
     }
 
-    /**
-     * @When I generate it
-     * @When I try to generate it
-     */
+    #[When('I generate it')]
+    #[When('I try to generate it')]
     public function iClickGenerate(): void
     {
         $this->generatePage->generate();
     }
 
-    /**
-     * @When /^I specify that the (\d)(?:st|nd|rd|th) variant is identified by "([^"]+)" code and costs "(?:€|£|\$)([^"]+)" in (("[^"]+") channel)$/
-     */
+    #[When('/^I specify that the (\d)(?:st|nd|rd|th) variant is identified by "([^"]+)" code and costs "(?:€|£|\$)([^"]+)" in (("[^"]+") channel)$/')]
     public function iSpecifyThereAreVariantsIdentifiedByCodeWithCost(
         int $nthVariant,
         string $code,
@@ -314,115 +252,87 @@ final class ManagingProductVariantsContext implements Context
         $this->generatePage->specifyPrice($nthVariant - 1, $price, $channel->getCode());
     }
 
-    /**
-     * @When /^I specify that the (\d)(?:st|nd|rd|th) variant is identified by "([^"]+)" code$/
-     */
+    #[When('/^I specify that the (\d)(?:st|nd|rd|th) variant is identified by "([^"]+)" code$/')]
     public function iSpecifyThereAreVariantsIdentifiedByCode(int $nthVariant, string $code): void
     {
         $this->generatePage->specifyCode($nthVariant - 1, $code);
     }
 
-    /**
-     * @When /^I specify that the (\d)(?:st|nd|rd|th) variant costs "(?:€|£|\$)([^"]+)" in (("[^"]+") channel)$/
-     */
+    #[When('/^I specify that the (\d)(?:st|nd|rd|th) variant costs "(?:€|£|\$)([^"]+)" in (("[^"]+") channel)$/')]
     public function iSpecifyThereAreVariantsWithCost(int $nthVariant, int $price, ChannelInterface $channel): void
     {
         $this->generatePage->specifyPrice($nthVariant - 1, $price, $channel->getCode());
     }
 
-    /**
-     * @When /^I remove (\d)(?:st|nd|rd|th) variant from the list$/
-     */
+    #[When('/^I remove (\d)(?:st|nd|rd|th) variant from the list$/')]
     public function iRemoveVariantFromTheList(int $nthVariant): void
     {
         $this->generatePage->removeVariant($nthVariant - 1);
     }
 
-    /**
-     * @When I set its shipping category as :shippingCategoryName
-     */
+    #[When('I set its shipping category as :shippingCategoryName')]
     public function iSetItsShippingCategoryAs(string $shippingCategoryName): void
     {
         $this->createPage->selectShippingCategory($shippingCategoryName);
     }
 
-    /**
-     * @When I do not specify any information about variants
-     */
+    #[When('I do not specify any information about variants')]
     public function iDoNotSpecifyAnyInformationAboutVariants(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I change its quantity of inventory to :amount
-     */
+    #[When('I change its quantity of inventory to :amount')]
     public function iChangeItsQuantityOfInventoryTo(int $amount): void
     {
         $this->updatePage->specifyCurrentStock($amount);
     }
 
-    /**
-     * @When /^I want to generate new variants for (this product)$/
-     * @When /^I try to generate new variants for (this product)$/
-     */
+    #[When('/^I want to generate new variants for (this product)$/')]
+    #[When('/^I try to generate new variants for (this product)$/')]
     public function iTryToGenerateNewVariantsForThisProduct(ProductInterface $product): void
     {
         $this->generatePage->open(['productId' => $product->getId()]);
     }
 
-    /**
-     * @When /^I disable it$/
-     */
+    #[When('/^I disable it$/')]
     public function iDisableIt(): void
     {
         $this->updatePage->disable();
     }
 
-    /**
-     * @When /^I enable it$/
-     */
+    #[When('/^I enable it$/')]
     public function iEnableIt(): void
     {
         $this->updatePage->enable();
     }
 
-    /**
-     * @When /^I change its price to "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^I change its price to "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function iChangeItsPriceToForChannel(int $price, ChannelInterface $channel): void
     {
         $this->updatePage->specifyPrice($price, $channel);
     }
 
-    /**
-     * @When I want to see the list of variants of the :product product
-     */
+    #[When('I want to see the list of variants of the :product product')]
     public function iWantToSeeTheListOfVariantsOfTheProduct(ProductInterface $product): void
     {
         $this->indexPage->open(['productId' => $product->getId()]);
     }
 
-    /**
-     * @When I go to generate variants page
-     */
+    #[When('I go to generate variants page')]
     public function iGoToGenerateVariantsPage(): void
     {
         $this->indexPage->goToVariantGeneration();
     }
 
-    /**
-     * @Then I should be on the :product product generate variants page
-     */
+    #[Then('I should be on the :product product generate variants page')]
     public function iShouldBeOnTheProductGenerateVariantsPage(ProductInterface $product): void
     {
         $this->generatePage->verify(['productId' => $product->getId()]);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/
-     * @Then /^the (variant with code "[^"]+") should be priced at "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/')]
+    #[Then('/^the (variant with code "[^"]+") should be priced at "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/')]
     public function theVariantWithCodeShouldBePricedAtForChannel(ProductVariantInterface $productVariant, string $price, ChannelInterface $channel)
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
@@ -430,10 +340,8 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($this->updatePage->getPriceForChannel($channel), $price);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should have minimum price (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/
-     * @Then /^the (variant with code "[^"]+") should have minimum price "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should have minimum price (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/')]
+    #[Then('/^the (variant with code "[^"]+") should have minimum price "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/')]
     public function theVariantWithCodeShouldHaveMinimumPriceForChannel(ProductVariantInterface $productVariant, string $price, ChannelInterface $channel): void
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
@@ -441,10 +349,8 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($this->updatePage->getMinimumPriceForChannel($channel), $price);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should be originally priced at (?:€|£|\$)([^"]+) for (channel "[^"]+")$/
-     * @Then /^the (variant with code "[^"]+") should be originally priced at "(?:€|£|\$)([^"]+)" for (channel "[^"]+")$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should be originally priced at (?:€|£|\$)([^"]+) for (channel "[^"]+")$/')]
+    #[Then('/^the (variant with code "[^"]+") should be originally priced at "(?:€|£|\$)([^"]+)" for (channel "[^"]+")$/')]
     public function theVariantWithCodeShouldBeOriginalPricedAtForChannel(
         ProductVariantInterface $productVariant,
         string $price,
@@ -455,9 +361,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($this->updatePage->getOriginalPriceForChannel($channel), $price);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should be named "([^"]+)" in ("([^"]+)" locale)$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should be named "([^"]+)" in ("([^"]+)" locale)$/')]
     public function theVariantWithCodeShouldBeNamedIn(ProductVariantInterface $productVariant, $name, $language)
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
@@ -465,10 +369,8 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($this->updatePage->getNameInLanguage($language), $name);
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should have an original price of (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/
-     * @Then /^the (variant with code "[^"]+") should have an original price of "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should have an original price of (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/')]
+    #[Then('/^the (variant with code "[^"]+") should have an original price of "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/')]
     public function theVariantWithCodeShouldHaveAnOriginalPriceOfForChannel(ProductVariantInterface $productVariant, $originalPrice, ChannelInterface $channel)
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
@@ -479,9 +381,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that this variant is in use and cannot be deleted
-     */
+    #[Then('I should be notified that this variant is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure()
     {
         $this->notificationChecker->checkNotification(
@@ -490,41 +390,31 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then the code field should be disabled
-     */
+    #[Then('the code field should be disabled')]
     public function theCodeFieldShouldBeDisabled()
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired($element)
     {
         $this->assertValidationMessage($element, sprintf('Please enter the %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that code has to be unique
-     */
+    #[Then('I should be notified that code has to be unique')]
     public function iShouldBeNotifiedThatCodeHasToBeUnique()
     {
         $this->assertValidationMessage('code', 'Product variant code must be unique.');
     }
 
-    /**
-     * @Then I should be notified that current stock is required
-     */
+    #[Then('I should be notified that current stock is required')]
     public function iShouldBeNotifiedThatOnHandIsRequired()
     {
         $this->assertValidationMessage('on_hand', 'Please enter on hand.');
     }
 
-    /**
-     * @Then I should be notified that height, width, depth and weight cannot be lower than 0
-     */
+    #[Then('I should be notified that height, width, depth and weight cannot be lower than 0')]
     public function iShouldBeNotifiedThatIsHeightWidthDepthWeightCannotBeLowerThan()
     {
         $this->assertValidationMessage('height', 'Height cannot be negative.');
@@ -533,9 +423,7 @@ final class ManagingProductVariantsContext implements Context
         $this->assertValidationMessage('weight', 'Weight cannot be negative.');
     }
 
-    /**
-     * @Then I should be notified that price cannot be lower than 0
-     */
+    #[Then('I should be notified that price cannot be lower than 0')]
     public function iShouldBeNotifiedThatPriceCannotBeLowerThen(): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -544,9 +432,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::contains($currentPage->getPricesValidationMessage(), 'Price cannot be lower than 0.');
     }
 
-    /**
-     * @Then I should be notified that price cannot be greater than max value allowed
-     */
+    #[Then('I should be notified that price cannot be greater than max value allowed')]
     public function iShouldBeNotifiedThatPriceCannotBeGreaterThanMaxValueAllowed(): void
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -555,9 +441,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::contains($currentPage->getPricesValidationMessage(), sprintf('Value must be less than %s.', self::HUGE_NUMBER));
     }
 
-    /**
-     * @Then I should be notified that this variant already exists
-     */
+    #[Then('I should be notified that this variant already exists')]
     public function iShouldBeNotifiedThatThisVariantAlreadyExists()
     {
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
@@ -566,9 +450,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($currentPage->getValidationMessageForForm(), 'Variant with this option set already exists.');
     }
 
-    /**
-     * @Then /^I should be notified that code is required for the (\d)(?:st|nd|rd|th) variant$/
-     */
+    #[Then('/^I should be notified that code is required for the (\d)(?:st|nd|rd|th) variant$/')]
     public function iShouldBeNotifiedThatCodeIsRequiredForVariant($position)
     {
         Assert::same(
@@ -577,9 +459,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that price for the (\d+)(?:|st|nd|rd|th) variant in ("([^"]+)" channel) must be defined$/
-     */
+    #[Then('/^I should be notified that price for the (\d+)(?:|st|nd|rd|th) variant in ("([^"]+)" channel) must be defined$/')]
     public function iShouldBeNotifiedThatPriceForTheVariantInChannelMustBeDefined(
         int $position,
         ChannelInterface $channel,
@@ -590,9 +470,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that variant code must be unique within this product for the (\d)(?:st|nd|rd|th) variant$/
-     */
+    #[Then('/^I should be notified that variant code must be unique within this product for the (\d)(?:st|nd|rd|th) variant$/')]
     public function iShouldBeNotifiedThatVariantCodeMustBeUniqueWithinThisProductForYheVariant($position)
     {
         Assert::same(
@@ -601,9 +479,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that prices in :channel channel must be defined
-     */
+    #[Then('I should be notified that prices in :channel channel must be defined')]
     public function iShouldBeNotifiedThatPricesInAllChannelsMustBeDefined(ChannelInterface $channel): void
     {
         Assert::contains(
@@ -612,9 +488,7 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then /^inventory of (this variant) should not be tracked$/
-     */
+    #[Then('/^inventory of (this variant) should not be tracked$/')]
     public function thisProductVariantShouldNotBeTracked(ProductVariantInterface $productVariant)
     {
         $this->iWantToModifyAProduct($productVariant);
@@ -622,9 +496,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::false($this->updatePage->isTracked());
     }
 
-    /**
-     * @Then /^inventory of (this variant) should be tracked$/
-     */
+    #[Then('/^inventory of (this variant) should be tracked$/')]
     public function thisProductVariantShouldBeTracked(ProductVariantInterface $productVariant)
     {
         $this->iWantToModifyAProduct($productVariant);
@@ -632,25 +504,19 @@ final class ManagingProductVariantsContext implements Context
         Assert::true($this->updatePage->isTracked());
     }
 
-    /**
-     * @Then I should be notified that it has been successfully generated
-     */
+    #[Then('I should be notified that it has been successfully generated')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyGenerated()
     {
         $this->notificationChecker->checkNotification('Success Product variants have been successfully generated.', NotificationType::success());
     }
 
-    /**
-     * @Then I should not be able to generate any variants
-     */
+    #[Then('I should not be able to generate any variants')]
     public function iShouldNotBeAbleToGenerateAnyVariants(): void
     {
         Assert::false($this->generatePage->isGenerationPossible());
     }
 
-    /**
-     * @Then /^the (variant with code "[^"]+") should not have shipping required$/
-     */
+    #[Then('/^the (variant with code "[^"]+") should not have shipping required$/')]
     public function theVariantWithCodeShouldNotHaveShippingRequired(ProductVariantInterface $productVariant)
     {
         $this->updatePage->open(['productId' => $productVariant->getProduct()->getId(), 'id' => $productVariant->getId()]);
@@ -658,9 +524,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::false($this->updatePage->isShippingRequired());
     }
 
-    /**
-     * @Then I should be notified that on hand quantity must be greater than the number of on hold units
-     */
+    #[Then('I should be notified that on hand quantity must be greater than the number of on hold units')]
     public function iShouldBeNotifiedThatOnHandQuantityMustBeGreaterThanTheNumberOfOnHoldUnits()
     {
         Assert::same(
@@ -669,17 +533,13 @@ final class ManagingProductVariantsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that variants cannot be generated from options without any values
-     */
+    #[Then('I should be notified that variants cannot be generated from options without any values')]
     public function iShouldBeNotifiedThatVariantsCannotBeGeneratedFromOptionsWithoutAnyValues(): void
     {
         $this->notificationChecker->checkNotification('Cannot generate variants for a product without options values', NotificationType::failure());
     }
 
-    /**
-     * @Then I should not have configured price for :channel channel
-     */
+    #[Then('I should not have configured price for :channel channel')]
     public function iShouldNotHaveConfiguredPriceForChannel(ChannelInterface $channel): void
     {
         /** @var ProductVariantInterface $product */
@@ -690,9 +550,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::same($this->updatePage->getPriceForChannel($channel), '');
     }
 
-    /**
-     * @Then I should have original price equal to :price in :channel channel
-     */
+    #[Then('I should have original price equal to :price in :channel channel')]
     public function iShouldHaveOriginalPriceEqualInChannel(string $price, ChannelInterface $channel): void
     {
         /** @var ProductVariantInterface $product */
@@ -703,25 +561,19 @@ final class ManagingProductVariantsContext implements Context
         Assert::contains($price, $this->updatePage->getOriginalPriceForChannel($channel));
     }
 
-    /**
-     * @Then I should see the :optionName option as :valueName
-     */
+    #[Then('I should see the :optionName option as :valueName')]
     public function iShouldSeeTheOptionAs(string $optionName, string $valueName): void
     {
         Assert::true($this->updatePage->isSelectedOptionValueOnPage($optionName, $valueName));
     }
 
-    /**
-     * @Then I should not be able to show this product in shop
-     */
+    #[Then('I should not be able to show this product in shop')]
     public function iShouldNotBeAbleToShowThisProductInShop(): void
     {
         Assert::true($this->updatePage->isShowInShopButtonDisabled());
     }
 
-    /**
-     * @Then /^(this variant) should be disabled$/
-     */
+    #[Then('/^(this variant) should be disabled$/')]
     public function thisVariantShouldBeDisabled(ProductVariantInterface $productVariant): void
     {
         $this->iWantToModifyAProduct($productVariant);
@@ -729,9 +581,7 @@ final class ManagingProductVariantsContext implements Context
         Assert::false($this->updatePage->isEnabled());
     }
 
-    /**
-     * @Then /^(this variant) should be enabled$/
-     */
+    #[Then('/^(this variant) should be enabled$/')]
     public function thisVariantShouldBeEnabled(ProductVariantInterface $productVariant): void
     {
         $this->iWantToModifyAProduct($productVariant);
@@ -739,25 +589,19 @@ final class ManagingProductVariantsContext implements Context
         Assert::true($this->updatePage->isEnabled());
     }
 
-    /**
-     * @Then I should (also) see a variant named :name
-     */
+    #[Then('I should (also) see a variant named :name')]
     public function iShouldSeeAVariantNamed(string $name): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
-    /**
-     * @Then I should (also) see :count variant(s) with no name
-     */
+    #[Then('I should (also) see :count variant(s) with no name')]
     public function IShouldSeeCountVariantsWithNoName(int $count = 1): void
     {
         Assert::same($this->indexPage->countItemsWithNoName(), $count);
     }
 
-    /**
-     * @Then the variant :productVariant should have :optionName option as :optionValue
-     */
+    #[Then('the variant :productVariant should have :optionName option as :optionValue')]
     public function theVariantShouldHaveOptionAs(
         ProductVariantInterface $productVariant,
         string $optionName,
@@ -768,25 +612,19 @@ final class ManagingProductVariantsContext implements Context
         Assert::true($this->updatePage->isSelectedOptionValueOnPage($optionName, $optionValue));
     }
 
-    /**
-     * @Then /^I should not be able to remove (\d)(?:st|nd|rd|th) product variant$/
-     */
+    #[Then('/^I should not be able to remove (\d)(?:st|nd|rd|th) product variant$/')]
     public function iShouldNotBeAbleToRemove(int $nthVariant): void
     {
         Assert::false($this->generatePage->isProductVariantRemovable($nthVariant - 1));
     }
 
-    /**
-     * @Then /^I should be able to remove (\d)(?:st|nd|rd|th) product variant$/
-     */
+    #[Then('/^I should be able to remove (\d)(?:st|nd|rd|th) product variant$/')]
     public function iShouldBeAbleToRemove(int $nthVariant): void
     {
         Assert::true($this->generatePage->isProductVariantRemovable($nthVariant - 1));
     }
 
-    /**
-     * @Then I should not be able to go to the generate variants page
-     */
+    #[Then('I should not be able to go to the generate variants page')]
     public function iShouldNotBeAbleToGoToTheGenerateVariantsPage(): void
     {
         Assert::false($this->indexPage->hasGenerateVariantsButton(), 'Generate variants button should not be visible');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\ProductVariant\UpdatePageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -24,9 +25,7 @@ final class ManagingProductVariantsPricesContext implements Context
     {
     }
 
-    /**
-     * @When /^I change the price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/
-     */
+    #[When('/^I change the price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/')]
     public function iChangeThePriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         int $price,
@@ -37,9 +36,7 @@ final class ManagingProductVariantsPricesContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When /^I change the original price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/
-     */
+    #[When('/^I change the original price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/')]
     public function iChangeTheOriginalPriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         int $originalPrice,
@@ -50,9 +47,7 @@ final class ManagingProductVariantsPricesContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @When /^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/
-     */
+    #[When('/^I remove the original price of the ("[^"]+" product variant) in ("[^"]+" channel)$/')]
     public function iRemoveTheOriginalPriceOfTheProductVariantInChannel(
         ProductVariantInterface $variant,
         ChannelInterface $channel,

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\Product\AssociationsFormElementInterface;
@@ -73,26 +76,20 @@ final readonly class ManagingProductsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new simple product
-     */
+    #[When('I want to create a new simple product')]
     public function iWantToCreateANewSimpleProduct(): void
     {
         $this->testHelper->waitUntilPageOpens($this->createSimpleProductPage);
     }
 
-    /**
-     * @When I want to create a new configurable product
-     */
+    #[When('I want to create a new configurable product')]
     public function iWantToCreateANewConfigurableProduct(): void
     {
         $this->testHelper->waitUntilPageOpens($this->createConfigurableProductPage);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $currentPage = $this->resolveCurrentPage();
@@ -100,44 +97,34 @@ final readonly class ManagingProductsContext implements Context
         $currentPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I name it :name in :localeCode locale
-     * @When I rename it to :name in :localeCode locale
-     * @When I should be able to name it :name in :localeCode locale
-     */
+    #[When('I name it :name in :localeCode locale')]
+    #[When('I rename it to :name in :localeCode locale')]
+    #[When('I should be able to name it :name in :localeCode locale')]
     public function iRenameItToInLocale(string $name, string $localeCode): void
     {
         $this->translationsFormElement->nameItIn($name, $localeCode);
     }
 
-    /**
-     * @When I remove its name from :localeCode translation
-     */
+    #[When('I remove its name from :localeCode translation')]
     public function iRemoveItsNameFromTranslation(string $localeCode): void
     {
         $this->translationsFormElement->nameItIn('', $localeCode);
     }
 
-    /**
-     * @When I generate its slug in :localeCode locale
-     */
+    #[When('I generate its slug in :localeCode locale')]
     public function iGenerateItsSlugIn(string $localeCode): void
     {
         $this->translationsFormElement->generateSlug($localeCode);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         /** @var CreatePageInterface $currentPage */
@@ -146,111 +133,85 @@ final readonly class ManagingProductsContext implements Context
         $currentPage->create();
     }
 
-    /**
-     * @When I disable its inventory tracking
-     */
+    #[When('I disable its inventory tracking')]
     public function iDisableItsTracking(): void
     {
         $this->updateSimpleProductPage->disableTracking();
     }
 
-    /**
-     * @When I enable its inventory tracking
-     */
+    #[When('I enable its inventory tracking')]
     public function iEnableItsTracking(): void
     {
         $this->updateSimpleProductPage->enableTracking();
     }
 
-    /**
-     * @When /^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsPriceTo(string $price, ChannelInterface $channel): void
     {
         $this->channelPricingsFormElement->specifyPrice($channel, $price);
     }
 
-    /**
-     * @When /^I set its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I set its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iSetItsOriginalPriceTo(int $originalPrice, ChannelInterface $channel): void
     {
         $this->channelPricingsFormElement->specifyOriginalPrice($channel, $originalPrice);
     }
 
-    /**
-     * @When I make it available in channel :channel
-     */
+    #[When('I make it available in channel :channel')]
     public function iMakeItAvailableInChannel(ChannelInterface $channel): void
     {
         $this->createSimpleProductPage->checkChannel($channel->getCode());
     }
 
-    /**
-     * @When I enable it in channel :channel
-     */
+    #[When('I enable it in channel :channel')]
     public function iEnableItInChannel(ChannelInterface $channel): void
     {
         // Temporary solution until we will make current page resolver work with product pages
         $this->updateConfigurableProductPage->checkChannel($channel->getCode());
     }
 
-    /**
-     * @When I set its slug to :slug
-     * @When I set its slug to :slug in :localeCode locale
-     * @When I remove its slug
-     */
+    #[When('I set its slug to :slug')]
+    #[When('I set its slug to :slug in :localeCode locale')]
+    #[When('I remove its slug')]
     public function iSetItsSlugToIn(?string $slug = null, string $localeCode = 'en_US'): void
     {
         $this->translationsFormElement->specifySlugIn($slug, $localeCode);
     }
 
-    /**
-     * @When I choose to show this product in the :channel channel
-     */
+    #[When('I choose to show this product in the :channel channel')]
     public function iChooseToShowThisProductInTheChannel(ChannelInterface $channel): void
     {
         $this->updateSimpleProductPage->showProductInChannel($channel);
     }
 
-    /**
-     * @When I choose to show this product in this channel
-     */
+    #[When('I choose to show this product in this channel')]
     public function iChooseToShowThisProductInThisChannel(): void
     {
         $this->updateSimpleProductPage->showProductInSingleChannel();
     }
 
-    /**
-     * @When I choose :channelName as a channel filter
-     */
+    #[When('I choose :channelName as a channel filter')]
     public function iChooseChannelAsAChannelFilter(string $channelName): void
     {
         $this->indexPage->chooseChannelFilter($channelName);
     }
 
-    /**
-     * @When I choose enabled filter
-     */
+    #[When('I choose enabled filter')]
     public function iChooseEnabledFilter(): void
     {
         $this->indexPage->chooseEnabledFilter();
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then I should see the product :productName in the list
-     * @Then the product :productName should appear in the store
-     * @Then the product :productName should be in the shop
-     * @Then this product should still be named :productName
-     */
+    #[Then('I should see the product :productName in the list')]
+    #[Then('the product :productName should appear in the store')]
+    #[Then('the product :productName should be in the shop')]
+    #[Then('this product should still be named :productName')]
     public function theProductShouldAppearInTheShop(string $productName): void
     {
         $this->iWantToBrowseProducts();
@@ -258,96 +219,74 @@ final readonly class ManagingProductsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productName]));
     }
 
-    /**
-     * @Given I am browsing products
-     * @When I browse products
-     * @When I want to browse products
-     */
+    #[Given('I am browsing products')]
+    #[When('I browse products')]
+    #[When('I want to browse products')]
     public function iWantToBrowseProducts(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I am browsing products from ("([^"]+)" taxon)$/
-     */
+    #[When('/^I am browsing products from ("([^"]+)" taxon)$/')]
     public function iAmBrowsingProductsFromTaxon(TaxonInterface $taxon): void
     {
         $this->indexPerTaxonPage->open(['taxonId' => $taxon->getId()]);
     }
 
-    /**
-     * @When /^I am browsing the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/
-     * @When /^I go to the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/
-     */
+    #[When('/^I am browsing the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/')]
+    #[When('/^I go to the (\d+)(?:st|nd|rd|th) page of products from ("([^"]+)" taxon)$/')]
     public function iAmBrowsingProductsFromTaxonPage(int $page, TaxonInterface $taxon): void
     {
         $this->indexPerTaxonPage->open(['taxonId' => $taxon->getId(), 'page' => $page]);
     }
 
-    /**
-     * @When I filter them by :taxonName taxon
-     */
+    #[When('I filter them by :taxonName taxon')]
     public function iFilterThemByTaxon(string $taxonName): void
     {
         $this->indexPage->filterByTaxon($taxonName);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I filter them by :productName product
-     */
+    #[When('I filter them by :productName product')]
     public function iFilterThemByProduct(string $productName): void
     {
         $this->indexPerTaxonPage->filterByName($productName);
         $this->indexPerTaxonPage->filter();
     }
 
-    /**
-     * @When I filter them by :taxonName main taxon
-     */
+    #[When('I filter them by :taxonName main taxon')]
     public function iFilterThemByMainTaxon(string $taxonName): void
     {
         $this->indexPage->filterByMainTaxon($taxonName);
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I check (also) the :productName product
-     */
+    #[When('I check (also) the :productName product')]
     public function iCheckTheProduct(string $productName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $productName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should( still) see a product with :field :value
-     */
+    #[Then('I should( still) see a product with :field :value')]
     public function iShouldSeeProductWith(string $field, string $value): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage([$field => $value]));
     }
 
-    /**
-     * @Then I should not see any product with :field :value
-     */
+    #[Then('I should not see any product with :field :value')]
     public function iShouldNotSeeAnyProductWith(string $field, string $value): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage([$field => $value]));
     }
 
-    /**
-     * @Then the first product on the list should have :field :value
-     * @Then the first product on the list within this taxon should have :field :value
-     */
+    #[Then('the first product on the list should have :field :value')]
+    #[Then('the first product on the list within this taxon should have :field :value')]
     public function theFirstProductOnTheListShouldHave(string $field, string $value): void
     {
         $currentPage = $this->resolveCurrentPage();
@@ -355,9 +294,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($currentPage->getColumnFields($field)[0], $value);
     }
 
-    /**
-     * @Then /^the (\d+)(?:st|nd|rd|th) product on this page should be named "([^"]+)"$/
-     */
+    #[Then('/^the (\d+)(?:st|nd|rd|th) product on this page should be named "([^"]+)"$/')]
     public function theNthProductOnThisPageShouldBeNamed(int $position, string $value): void
     {
         $values = $this->indexPerTaxonPage->getColumnFields('name');
@@ -367,18 +304,14 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('product_taxon_name', $value);
     }
 
-    /**
-     * @Then this product should be at position :position
-     */
+    #[Then('this product should be at position :position')]
     public function theNthProductOnThisPageShouldBeAtPosition(int $position): void
     {
         $productName = $this->sharedStorage->get('product_taxon_name');
         Assert::same($this->indexPerTaxonPage->getProductPosition($productName), $position);
     }
 
-    /**
-     * @Then the one before last product on the list should have :field :value
-     */
+    #[Then('the one before last product on the list should have :field :value')]
     public function theOneBeforeLastProductOnTheListShouldHave(string $field, string $value): void
     {
         $values = $this->indexPerTaxonPage->getColumnFields($field);
@@ -388,9 +321,7 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('product_taxon_name', $value);
     }
 
-    /**
-     * @Then the one before last product on the list should have name :productName with position :position
-     */
+    #[Then('the one before last product on the list should have name :productName with position :position')]
     public function theOneBeforeLastProductOnTheListShouldHaveNameWithPosition(string $productName, int $position): void
     {
         $productNames = $this->indexPerTaxonPage->getColumnFields('name');
@@ -401,9 +332,7 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('product_taxon_name', $productName);
     }
 
-    /**
-     * @Then the one before last image on the list should have type :type with position :position
-     */
+    #[Then('the one before last image on the list should have type :type with position :position')]
     public function theOneBeforeLastImageOnTheListShouldHaveNameWithPosition(string $imageType, int $position): void
     {
         $images = $this->mediaFormElement->getImages();
@@ -416,9 +345,7 @@ final readonly class ManagingProductsContext implements Context
         $this->mediaFormElement->assertImageTypeAndPosition($oneBeforeLastImage, $imageType, $position);
     }
 
-    /**
-     * @Then the last image on the list should have type :type with position :position
-     */
+    #[Then('the last image on the list should have type :type with position :position')]
     public function theLastImageOnTheListShouldHaveNameWithPosition(string $imageType, int $position): void
     {
         $images = $this->mediaFormElement->getImages();
@@ -427,10 +354,8 @@ final readonly class ManagingProductsContext implements Context
         $this->mediaFormElement->assertImageTypeAndPosition($lastImage, $imageType, $position);
     }
 
-    /**
-     * @Then the last product on the list should have :field :value
-     * @Then the last product on the list within this taxon should have :field :value
-     */
+    #[Then('the last product on the list should have :field :value')]
+    #[Then('the last product on the list within this taxon should have :field :value')]
     public function theLastProductOnTheListShouldHave(string $field, string $value): void
     {
         $values = $this->indexPerTaxonPage->getColumnFields($field);
@@ -440,9 +365,7 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('product_taxon_name', $value);
     }
 
-    /**
-     * @Then the last product on the list should have name :productName with position :position
-     */
+    #[Then('the last product on the list should have name :productName with position :position')]
     public function theLastProductOnTheListShouldHaveNameWithPosition(string $productName, int $position): void
     {
         $productNames = $this->indexPerTaxonPage->getColumnFields('name');
@@ -453,20 +376,16 @@ final readonly class ManagingProductsContext implements Context
         $this->sharedStorage->set('product_taxon_name', $productName);
     }
 
-    /**
-     * @When I switch the way products are sorted :sortType by :field
-     * @When I start sorting products by :field
-     * @When the products are already sorted :sortType by :field
-     * @When I sort the products :sortType by :field
-     */
+    #[When('I switch the way products are sorted :sortType by :field')]
+    #[When('I start sorting products by :field')]
+    #[When('the products are already sorted :sortType by :field')]
+    #[When('I sort the products :sortType by :field')]
     public function iSortProductsBy(string $field): void
     {
         $this->indexPage->sortBy($field);
     }
 
-    /**
-     * @When I sort this taxon's products :sortType by :field
-     */
+    #[When('I sort this taxon\'s products :sortType by :field')]
     public function iSortThisTaxonsProductsBy(string $sortType, string $field): void
     {
         $this->indexPerTaxonPage->sortBy(
@@ -475,18 +394,14 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see a single product in the list
-     * @Then I should see :numberOfProducts products in the list
-     */
+    #[Then('I should see a single product in the list')]
+    #[Then('I should see :numberOfProducts products in the list')]
     public function iShouldSeeProductsInTheList(int $numberOfProducts = 1): void
     {
         Assert::same($this->indexPage->countItems(), $numberOfProducts);
     }
 
-    /**
-     * @Then /^(this product) should not exist in the product catalog$/
-     */
+    #[Then('/^(this product) should not exist in the product catalog$/')]
     public function productShouldNotExist(ProductInterface $product): void
     {
         $this->iWantToBrowseProducts();
@@ -494,9 +409,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $product->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that this product is in use and cannot be deleted
-     */
+    #[Then('I should be notified that this product is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure(): void
     {
         $this->notificationChecker->checkNotification(
@@ -505,21 +418,17 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should still exist in the product catalog$/
-     */
+    #[Then('/^(this product) should still exist in the product catalog$/')]
     public function productShouldExistInTheProductCatalog(ProductInterface $product): void
     {
         $this->theProductShouldAppearInTheShop($product->getName());
     }
 
-    /**
-     * @When I want to modify the :product product
-     * @When /^I want to modify (this product)$/
-     * @When /^I want to edit (this product)$/
-     * @When I modify the :product product
-     * @When I want to modify the images of :product product
-     */
+    #[When('I want to modify the :product product')]
+    #[When('/^I want to modify (this product)$/')]
+    #[When('/^I want to edit (this product)$/')]
+    #[When('I modify the :product product')]
+    #[When('I want to modify the images of :product product')]
     public function iWantToModifyAProduct(ProductInterface $product): void
     {
         $this->sharedStorage->set('product', $product);
@@ -527,17 +436,13 @@ final readonly class ManagingProductsContext implements Context
         $this->testHelper->waitUntilPageOpens($this->updateSimpleProductPage, ['id' => $product->getId()]);
     }
 
-    /**
-     * @When /^I go to the (\d)(?:st|nd|rd|th) page$/
-     */
+    #[When('/^I go to the (\d)(?:st|nd|rd|th) page$/')]
     public function iGoToPage(int $page): void
     {
         $this->indexPage->goToPage($page);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         $currentPage = $this->resolveCurrentPage();
@@ -545,9 +450,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::true($currentPage->isCodeDisabled());
     }
 
-    /**
-     * @Then this product name should be :name in :localeCode locale
-     */
+    #[Then('this product name should be :name in :localeCode locale')]
     public function thisProductNameShouldBe(string $name, string $localeCode): void
     {
         Assert::true(
@@ -556,9 +459,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that (code|name|slug) is required$/
-     */
+    #[Then('/^I should be notified that (code|name|slug) is required$/')]
     public function iShouldBeNotifiedThatIsRequired(string $element, string $localeCode = 'en_US'): void
     {
         $validationMessage = match ($element) {
@@ -571,9 +472,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($validationMessage, sprintf('Please enter product %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that meta keywords are too long
-     */
+    #[Then('I should be notified that meta keywords are too long')]
     public function iShouldBeNotifiedThatMetaKeywordsAreTooLong(): void
     {
         Assert::same(
@@ -582,9 +481,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that meta description is too long
-     */
+    #[Then('I should be notified that meta description is too long')]
     public function iShouldBeNotifiedThatMetaDescriptionIsTooLong(): void
     {
         Assert::same(
@@ -593,9 +490,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @When I cancel my changes
-     */
+    #[When('I cancel my changes')]
     public function iCancelChanges(): void
     {
         $currentPage = $this->resolveCurrentPage();
@@ -603,102 +498,78 @@ final readonly class ManagingProductsContext implements Context
         $currentPage->cancelChanges();
     }
 
-    /**
-     * @When /^I change its price to (?:€|£|\$)([^"]+) for ("([^"]+)" channel)$/
-     */
+    #[When('/^I change its price to (?:€|£|\$)([^"]+) for ("([^"]+)" channel)$/')]
     public function iChangeItsPriceTo(string $price, ChannelInterface $channel): void
     {
         $this->channelPricingsFormElement->specifyPrice($channel, $price);
     }
 
-    /**
-     * @When /^I change its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/
-     */
+    #[When('/^I change its original price to "(?:€|£|\$)([^"]+)" for ("([^"]+)" channel)$/')]
     public function iChangeItsOriginalPriceTo(int $originalPrice, ChannelInterface $channel): void
     {
         $this->channelPricingsFormElement->specifyOriginalPrice($channel, $originalPrice);
     }
 
-    /**
-     * @Given I add the :optionName option to it
-     */
+    #[Given('I add the :optionName option to it')]
     public function iAddTheOptionToIt(string $optionName): void
     {
         $this->createConfigurableProductPage->selectOption($optionName);
     }
 
-    /**
-     * @When I add the :attributeName attribute
-     * @When I add the :attributeName attribute to it
-     */
+    #[When('I add the :attributeName attribute')]
+    #[When('I add the :attributeName attribute to it')]
     public function iAddTheAttribute(string $attributeName): void
     {
         $this->attributesFormElement->addAttribute($attributeName);
     }
 
-    /**
-     * @When I set its :attributeName attribute to :value in :localeCode locale
-     * @When I do not set its :attributeName attribute in :localeCode locale
-     * @When I set the :attributeName attribute value to :value in :localeCode locale
-     */
+    #[When('I set its :attributeName attribute to :value in :localeCode locale')]
+    #[When('I do not set its :attributeName attribute in :localeCode locale')]
+    #[When('I set the :attributeName attribute value to :value in :localeCode locale')]
     public function iSetItsAttributeToInLocale(string $attributeName, ?string $value = null, string $localeCode = 'en_US'): void
     {
         $this->attributesFormElement->updateAttribute($attributeName, $value ?? '', $localeCode);
     }
 
-    /**
-     * @When I select :value value in :localeCode for the :attribute attribute
-     */
+    #[When('I select :value value in :localeCode for the :attribute attribute')]
     public function iSelectValueInLanguageForTheAttribute(string $value, string $localeCode, string $attribute): void
     {
         $this->attributesFormElement->updateAttribute($attribute, $value, $localeCode);
     }
 
-    /**
-     * @When I select :value value for the :attribute attribute
-     */
+    #[When('I select :value value for the :attribute attribute')]
     public function iSelectValueForTheAttribute(string $value, string $attribute): void
     {
         $this->attributesFormElement->updateAttribute($attribute, $value, '');
     }
 
-    /**
-     * @When I set its non-translatable :attributeName attribute to :value
-     */
+    #[When('I set its non-translatable :attributeName attribute to :value')]
     public function iSetItsNonTranslatableAttributeTo(string $attributeName, string $value): void
     {
         $this->attributesFormElement->updateAttribute($attributeName, $value, '');
     }
 
-    /**
-     * @When I remove its :attribute attribute
-     * @When I remove its :attribute attribute from :localeCode
-     */
+    #[When('I remove its :attribute attribute')]
+    #[When('I remove its :attribute attribute from :localeCode')]
     public function iRemoveItsAttribute(string $attribute, string $localeCode = 'en_US'): void
     {
         $this->attributesFormElement->removeAttribute($attribute, $localeCode);
     }
 
-    /**
-     * @When I try to add new attributes
-     */
+    #[When('I try to add new attributes')]
     public function iTryToAddNewAttributes(): void
     {
         $this->attributesFormElement->addSelectedAttributes();
     }
 
-    /**
-     * @When I do not want to have shipping required for this product
-     */
+    #[When('I do not want to have shipping required for this product')]
     public function iDoNotWantToHaveShippingRequiredForThisProduct(): void
     {
         $this->createSimpleProductPage->setShippingRequired(false);
     }
 
-    /**
-     * @Then attribute :attributeName of product :product should be :value
-     * @Then attribute :attributeName of product :product should be :value in :localeCode locale
-     */
+    #[Then('attribute :attributeName of product :product should be :value')]
+    #[Then('attribute :attributeName of product :product should be :value in :localeCode locale')]
     public function itsAttributeShouldBe(string $attributeName, ProductInterface $product, string $value, string $localeCode = 'en_US'): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -706,10 +577,8 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->attributesFormElement->getAttributeValue($attributeName, $localeCode), $value);
     }
 
-    /**
-     * @Then select attribute :attributeName of product :product should be :value in :localeCode locale
-     * @Then select attribute :attributeName of product :product should be :value
-     */
+    #[Then('select attribute :attributeName of product :product should be :value in :localeCode locale')]
+    #[Then('select attribute :attributeName of product :product should be :value')]
     public function itsSelectAttributeShouldBeInLocale(
         string $attributeName,
         ProductInterface $product,
@@ -721,9 +590,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->attributesFormElement->getAttributeValue($attributeName, $localeCode), $value);
     }
 
-    /**
-     * @Then non-translatable attribute :attributeName of product :product should be :value
-     */
+    #[Then('non-translatable attribute :attributeName of product :product should be :value')]
     public function itsNonTranslatableAttributeShouldBe(string $attributeName, ProductInterface $product, string $value): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -731,9 +598,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->attributesFormElement->getAttributeValue($attributeName, ''), $value);
     }
 
-    /**
-     * @Then /^(product "[^"]+") should not have a "([^"]+)" attribute$/
-     */
+    #[Then('/^(product "[^"]+") should not have a "([^"]+)" attribute$/')]
     public function productShouldNotHaveAttribute(ProductInterface $product, string $attribute): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -741,18 +606,14 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->attributesFormElement->hasAttribute($attribute));
     }
 
-    /**
-     * @Then /^product "[^"]+" should not have any attributes$/
-     * @Then /^product "[^"]+" should have (\d+) attributes?$/
-     */
+    #[Then('/^product "[^"]+" should not have any attributes$/')]
+    #[Then('/^product "[^"]+" should have (\d+) attributes?$/')]
     public function productShouldNotHaveAnyAttributes(int $count = 0): void
     {
         Assert::same($this->attributesFormElement->getNumberOfAttributes(), $count);
     }
 
-    /**
-     * @Then product with :element :value should not be added
-     */
+    #[Then('product with :element :value should not be added')]
     public function productWithNameShouldNotBeAdded(string $element, string $value): void
     {
         $this->iWantToBrowseProducts();
@@ -760,25 +621,19 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @When I set its meta keywords to too long string in :localeCode
-     */
+    #[When('I set its meta keywords to too long string in :localeCode')]
     public function iSetItsMetaKeywordsToTooLongStringIn(string $localeCode): void
     {
         $this->translationsFormElement->setMetaKeywords(str_repeat('a', 256), $localeCode);
     }
 
-    /**
-     * @When I set its meta description to too long string in :localeCode
-     */
+    #[When('I set its meta description to too long string in :localeCode')]
     public function iSetItsMetaDescriptionToTooLongStringIn(string $localeCode): void
     {
         $this->translationsFormElement->setMetaDescription(str_repeat('a', 256), $localeCode);
     }
 
-    /**
-     * @When I want to choose main taxon for product :product
-     */
+    #[When('I want to choose main taxon for product :product')]
     public function iWantToChooseMainTaxonForProduct(ProductInterface $product): void
     {
         $this->iWantToModifyAProduct($product);
@@ -787,59 +642,45 @@ final readonly class ManagingProductsContext implements Context
         $currentPage->open(['id' => $product->getId()]);
     }
 
-    /**
-     * @Then I should be able to choose taxon :taxonName from the list
-     */
+    #[Then('I should be able to choose taxon :taxonName from the list')]
     public function iShouldBeAbleToChooseTaxonForThisProduct(string $taxonName): void
     {
         Assert::true($this->taxonomyFormElement->isTaxonVisibleInMainTaxonList($taxonName));
     }
 
-    /**
-     * @Then I should not be able to choose taxon :taxonName from the list
-     */
+    #[Then('I should not be able to choose taxon :taxonName from the list')]
     public function iShouldNotBeAbleToChooseTaxonForThisProduct(string $taxonName): void
     {
         Assert::false($this->taxonomyFormElement->isTaxonVisibleInMainTaxonList($taxonName));
     }
 
-    /**
-     * @Then /^this product should have (?:a|an) "([^"]+)" option$/
-     */
+    #[Then('/^this product should have (?:a|an) "([^"]+)" option$/')]
     public function thisProductShouldHaveOption(string $productOption): void
     {
         $this->updateConfigurableProductPage->isProductOptionChosen($productOption);
     }
 
-    /**
-     * @Then I should not be able to edit its options
-     */
+    #[Then('I should not be able to edit its options')]
     public function iShouldNotBeAbleToEditItsOptions(): void
     {
         Assert::true($this->updateConfigurableProductPage->isProductOptionsDisabled());
     }
 
-    /**
-     * @When /^I choose main (taxon "[^"]+")$/
-     * @Then /^I should be able to choose main (taxon "[^"]+")$/
-     */
+    #[When('/^I choose main (taxon "[^"]+")$/')]
+    #[Then('/^I should be able to choose main (taxon "[^"]+")$/')]
     public function iChooseMainTaxon(TaxonInterface $taxon): void
     {
         $this->taxonomyFormElement->selectMainTaxon($taxon->getName());
     }
 
-    /**
-     * @Then I should see non-translatable attribute :attribute with value :value%
-     */
+    #[Then('I should see non-translatable attribute :attribute with value :value%')]
     public function iShouldSeeNonTranslatableAttributeWithValue(string $attribute, string $value): void
     {
         Assert::same($this->attributesFormElement->getValueNonTranslatableAttribute($attribute), $value);
     }
 
-    /**
-     * @Then /^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)"$/
-     * @Then /^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)" (in the "[^"]+" locale)$/
-     */
+    #[Then('/^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)"$/')]
+    #[Then('/^the slug of the ("[^"]+" product) should(?:| still) be "([^"]+)" (in the "[^"]+" locale)$/')]
     public function productSlugShouldBe(ProductInterface $product, string $slug, string $localeCode = 'en_US'): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -847,18 +688,14 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->translationsFormElement->getSlug($localeCode), $slug);
     }
 
-    /**
-     * @Then /^(this product) main taxon should be "([^"]+)"$/
-     * @Then /^main taxon of (product "[^"]+") should be "([^"]+)"$/
-     */
+    #[Then('/^(this product) main taxon should be "([^"]+)"$/')]
+    #[Then('/^main taxon of (product "[^"]+") should be "([^"]+)"$/')]
     public function thisProductMainTaxonShouldBe(ProductInterface $product, string $taxonName): void
     {
         Assert::same($taxonName, $this->taxonomyFormElement->getMainTaxon());
     }
 
-    /**
-     * @Then /^inventory of (this product) should not be tracked$/
-     */
+    #[Then('/^inventory of (this product) should not be tracked$/')]
     public function thisProductShouldNotBeTracked(ProductInterface $product): void
     {
         $this->iWantToModifyAProduct($product);
@@ -866,9 +703,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->updateSimpleProductPage->isTracked());
     }
 
-    /**
-     * @Then /^inventory of (this product) should be tracked$/
-     */
+    #[Then('/^inventory of (this product) should be tracked$/')]
     public function thisProductShouldBeTracked(ProductInterface $product): void
     {
         $this->iWantToModifyAProduct($product);
@@ -876,20 +711,16 @@ final readonly class ManagingProductsContext implements Context
         Assert::true($this->updateSimpleProductPage->isTracked());
     }
 
-    /**
-     * @When I attach the :path image with :type type
-     * @When I attach the :path image
-     * @When I attach the :path image with :type type to this product
-     * @When I attach the :path image to this product
-     */
+    #[When('I attach the :path image with :type type')]
+    #[When('I attach the :path image')]
+    #[When('I attach the :path image with :type type to this product')]
+    #[When('I attach the :path image to this product')]
     public function iAttachImageWithType(string $path, ?string $type = null): void
     {
         $this->mediaFormElement->attachImage($path, $type);
     }
 
-    /**
-     * @When I attach the :path image with selected :productVariant variant to this product
-     */
+    #[When('I attach the :path image with selected :productVariant variant to this product')]
     public function iAttachImageWithSelectedVariantToThisProduct(
         string $path,
         ProductVariantInterface $productVariant,
@@ -897,19 +728,15 @@ final readonly class ManagingProductsContext implements Context
         $this->mediaFormElement->attachImage(path: $path, productVariant: $productVariant);
     }
 
-    /**
-     * @When I select :productVariant variant for the first image
-     */
+    #[When('I select :productVariant variant for the first image')]
     public function iSelectVariantForTheFirstImage(ProductVariantInterface $productVariant): void
     {
         $this->mediaFormElement->selectVariantForFirstImage($productVariant);
     }
 
-    /**
-     * @When I associate as :productAssociationType the :productName product
-     * @When I associate as :productAssociationType the :firstProductName and :secondProductName products
-     * @Then I should be able to associate as :productAssociationType the :productName product
-     */
+    #[When('I associate as :productAssociationType the :productName product')]
+    #[When('I associate as :productAssociationType the :firstProductName and :secondProductName products')]
+    #[Then('I should be able to associate as :productAssociationType the :productName product')]
     public function iAssociateProductsAsProductAssociation(
         ProductAssociationTypeInterface $productAssociationType,
         string ...$productsNames,
@@ -917,9 +744,7 @@ final readonly class ManagingProductsContext implements Context
         $this->associationsFormElement->associateProducts($productAssociationType, $productsNames);
     }
 
-    /**
-     * @When I remove an associated product :product from :productAssociationType
-     */
+    #[When('I remove an associated product :product from :productAssociationType')]
     public function iRemoveAnAssociatedProductFromProductAssociation(
         ProductInterface $product,
         ProductAssociationTypeInterface $productAssociationType,
@@ -927,41 +752,31 @@ final readonly class ManagingProductsContext implements Context
         $this->associationsFormElement->removeAssociatedProduct($product, $productAssociationType);
     }
 
-    /**
-     * @When I go to the variants list
-     */
+    #[When('I go to the variants list')]
     public function iGoToTheVariantsList(): void
     {
         $this->resolveCurrentPage()->goToVariantsList();
     }
 
-    /**
-     * @When I go to the variant creation page
-     */
+    #[When('I go to the variant creation page')]
     public function iGoToTheVariantCreationPage(): void
     {
         $this->resolveCurrentPage()->goToVariantCreation();
     }
 
-    /**
-     * @When I go to the variant generation page
-     */
+    #[When('I go to the variant generation page')]
     public function iGoToTheVariantGenerationPage(): void
     {
         $this->resolveCurrentPage()->goToVariantGeneration();
     }
 
-    /**
-     * @Then /^(?:this product|the product "[^"]+"|it) should(?:| also) have an image with "([^"]*)" type$/
-     */
+    #[Then('/^(?:this product|the product "[^"]+"|it) should(?:| also) have an image with "([^"]*)" type$/')]
     public function thisProductShouldHaveAnImageWithType(string $type): void
     {
         Assert::true($this->mediaFormElement->hasImageWithType($type));
     }
 
-    /**
-     * @Then its image should have :productVariant variant selected
-     */
+    #[Then('its image should have :productVariant variant selected')]
     public function itsImageShouldHaveVariantSelected(ProductVariantInterface $productVariant): void
     {
         Assert::true(
@@ -974,65 +789,49 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (product "[^"]+") should still have an accessible image$/
-     */
+    #[Then('/^the (product "[^"]+") should still have an accessible image$/')]
     public function productShouldStillHaveAnAccessibleImage(ProductInterface $product): void
     {
         Assert::true($this->indexPage->hasProductAccessibleImage($product->getCode()));
     }
 
-    /**
-     * @Then /^(?:this product|it)(?:| also) should not have any images with "([^"]*)" type$/
-     */
+    #[Then('/^(?:this product|it)(?:| also) should not have any images with "([^"]*)" type$/')]
     public function thisProductShouldNotHaveAnyImagesWithType(string $code): void
     {
         Assert::false($this->mediaFormElement->hasImageWithType($code));
     }
 
-    /**
-     * @When I change the image with the :type type to :path
-     */
+    #[When('I change the image with the :type type to :path')]
     public function iChangeItsImageToPathForTheType(string $type, string $path): void
     {
         $this->mediaFormElement->changeImageWithType($type, $path);
     }
 
-    /**
-     * @When /^I(?:| also) remove an image with "([^"]*)" type$/
-     */
+    #[When('/^I(?:| also) remove an image with "([^"]*)" type$/')]
     public function iRemoveAnImageWithType(string $code): void
     {
         $this->mediaFormElement->removeImageWithType($code);
     }
 
-    /**
-     * @When I remove the first image
-     */
+    #[When('I remove the first image')]
     public function iRemoveTheFirstImage(): void
     {
         $this->mediaFormElement->removeFirstImage();
     }
 
-    /**
-     * @When I change the first image type to :type
-     */
+    #[When('I change the first image type to :type')]
     public function iChangeTheFirstImageTypeTo(string $type): void
     {
         $this->mediaFormElement->modifyFirstImageType($type);
     }
 
-    /**
-     * @When I change the :type image position to :position
-     */
+    #[When('I change the :type image position to :position')]
     public function iChangeTheImagePositionTo(string $image, int $position): void
     {
         $this->mediaFormElement->modifyPositionOfImageWithType($image, $position);
     }
 
-    /**
-     * @Then /^(this product) should not have any images$/
-     */
+    #[Then('/^(this product) should not have any images$/')]
     public function thisProductShouldNotHaveImages(ProductInterface $product): void
     {
         $this->iWantToModifyAProduct($product);
@@ -1040,9 +839,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->mediaFormElement->countImages(), 0);
     }
 
-    /**
-     * @Then /^(this product) should(?:| still) have (?:only one|(\d+)) images?$/
-     */
+    #[Then('/^(this product) should(?:| still) have (?:only one|(\d+)) images?$/')]
     public function thereShouldStillBeOnlyOneImageInThisProduct(ProductInterface $product, int $count = 1): void
     {
         $this->iWantToModifyAProduct($product);
@@ -1050,9 +847,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->mediaFormElement->countImages(), $count);
     }
 
-    /**
-     * @Then /^there should be no reviews of (this product)$/
-     */
+    #[Then('/^there should be no reviews of (this product)$/')]
     public function thereAreNoProductReviews(ProductInterface $product): void
     {
         $this->productReviewIndexPage->open();
@@ -1060,9 +855,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->productReviewIndexPage->isSingleResourceOnPage(['reviewSubject' => $product->getName()]));
     }
 
-    /**
-     * @Then this product should( also) have an association :productAssociationType with product :product
-     */
+    #[Then('this product should( also) have an association :productAssociationType with product :product')]
     public function theProductShouldHaveAnAssociationWithProduct(
         ProductAssociationTypeInterface $productAssociationType,
         ProductInterface $product,
@@ -1078,11 +871,11 @@ final readonly class ManagingProductsContext implements Context
     }
 
     /**
-     * @Then /^this product should have an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/
-     * @Then /^this product should also have an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/
      *
      * @param array<ProductInterface> $products
      */
+    #[Then('/^this product should have an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/')]
+    #[Then('/^this product should also have an (association "[^"]+") with (products "[^"]+" and "[^"]+")$/')]
     public function theProductsShouldHaveAnAssociationWithProducts(
         ProductAssociationTypeInterface $productAssociationType,
         array $products,
@@ -1092,9 +885,7 @@ final readonly class ManagingProductsContext implements Context
         }
     }
 
-    /**
-     * @Then this product should not have an association :productAssociationType with product :product
-     */
+    #[Then('this product should not have an association :productAssociationType with product :product')]
     public function theProductShouldNotHaveAnAssociationWithProduct(
         ProductAssociationTypeInterface $productAssociationType,
         ProductInterface $product,
@@ -1102,9 +893,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->associationsFormElement->hasAssociatedProduct($product, $productAssociationType));
     }
 
-    /**
-     * @Then I should be notified that original price can not be defined without price
-     */
+    #[Then('I should be notified that original price can not be defined without price')]
     public function iShouldBeNotifiedThatOriginalPriceCanNotBeDefinedWithoutPrice(): void
     {
         Assert::same(
@@ -1113,25 +902,19 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that svg file is not allowed
-     */
+    #[Then('I should be notified that svg file is not allowed')]
     public function iShouldBeNotifiedThatSvgTypeIsNotAllowed(): void
     {
         $this->mediaFormElement->hasValidationErrorWithMessage('This file type is not allowed.');
     }
 
-    /**
-     * @Then I should be notified that simple product code has to be unique
-     */
+    #[Then('I should be notified that simple product code has to be unique')]
     public function iShouldBeNotifiedThatSimpleProductCodeHasToBeUnique(): void
     {
         $this->assertValidationMessage('code', 'Simple product code must be unique among all products and product variants.');
     }
 
-    /**
-     * @Then I should be notified that slug has to be unique
-     */
+    #[Then('I should be notified that slug has to be unique')]
     public function iShouldBeNotifiedThatSlugHasToBeUnique(): void
     {
         Assert::same(
@@ -1140,17 +923,13 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code has to be unique
-     */
+    #[Then('I should be notified that code has to be unique')]
     public function iShouldBeNotifiedThatCodeHasToBeUnique(): void
     {
         $this->assertValidationMessage('code', 'Product code must be unique.');
     }
 
-    /**
-     * @Then I should be notified that price must be defined for :channel channel
-     */
+    #[Then('I should be notified that price must be defined for :channel channel')]
     public function iShouldBeNotifiedThatPriceMustBeDefinedForChannel(ChannelInterface $channel): void
     {
         Assert::same(
@@ -1159,41 +938,31 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then they should have order like :firstProductName, :secondProductName and :thirdProductName
-     */
+    #[Then('they should have order like :firstProductName, :secondProductName and :thirdProductName')]
     public function theyShouldHaveOrderLikeAnd(string ...$productNames): void
     {
         Assert::true($this->indexPerTaxonPage->hasProductsInOrder($productNames));
     }
 
-    /**
-     * @When I save my new configuration
-     */
+    #[When('I save my new configuration')]
     public function iSaveMyNewConfiguration(): void
     {
         $this->indexPerTaxonPage->savePositions();
     }
 
-    /**
-     * @When I set the position of :productName to :position
-     */
+    #[When('I set the position of :productName to :position')]
     public function iSetThePositionOfTo(string $productName, string $position): void
     {
         $this->indexPerTaxonPage->setPositionOfProduct($productName, $position);
     }
 
-    /**
-     * @When /^I remove its price from ("[^"]+" channel)$/
-     */
+    #[When('/^I remove its price from ("[^"]+" channel)$/')]
     public function iRemoveItsPriceForChannel(ChannelInterface $channel): void
     {
         $this->iSetItsPriceTo('', $channel);
     }
 
-    /**
-     * @Then this product should( still) have slug :value in :localeCode (locale)
-     */
+    #[Then('this product should( still) have slug :value in :localeCode (locale)')]
     public function thisProductElementShouldHaveSlugIn(string $slug, string $localeCode): void
     {
         $this->testHelper->waitUntilAssertionPasses(function () use ($localeCode, $slug): void {
@@ -1201,18 +970,14 @@ final readonly class ManagingProductsContext implements Context
         });
     }
 
-    /**
-     * @When I set its shipping category as :shippingCategoryName
-     */
+    #[When('I set its shipping category as :shippingCategoryName')]
     public function iSetItsShippingCategoryAs(string $shippingCategoryName): void
     {
         $this->createSimpleProductPage->selectShippingCategory($shippingCategoryName);
     }
 
-    /**
-     * @Then /^(it|this product) should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/
-     * @Then /^(product "[^"]+") should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/
-     */
+    #[Then('/^(it|this product) should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/')]
+    #[Then('/^(product "[^"]+") should be priced at (?:€|£|\$)([^"]+) for (channel "([^"]+)")$/')]
     public function itShouldBePricedAtForChannel(ProductInterface $product, string $price, ChannelInterface $channel): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -1220,9 +985,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::same($this->channelPricingsFormElement->getPriceForChannel($channel), $price);
     }
 
-    /**
-     * @Then /^(its|this products) original price should be "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/
-     */
+    #[Then('/^(its|this products) original price should be "(?:€|£|\$)([^"]+)" for (channel "([^"]+)")$/')]
     public function itsOriginalPriceForChannel(ProductInterface $product, string $originalPrice, ChannelInterface $channel): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -1233,9 +996,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this product) should no longer have price for channel "([^"]+)"$/
-     */
+    #[Then('/^(this product) should no longer have price for channel "([^"]+)"$/')]
     public function thisProductShouldNoLongerHavePriceForChannel(ProductInterface $product, string $channelName): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -1246,9 +1007,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I have to define product variants' prices for newly assigned channels first
-     */
+    #[Then('I should be notified that I have to define product variants\' prices for newly assigned channels first')]
     public function iShouldBeNotifiedThatIHaveToDefineProductVariantsPricesForNewlyAssignedChannelsFirst(): void
     {
         Assert::same(
@@ -1257,9 +1016,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^the (product "[^"]+") should not have shipping required$/
-     */
+    #[Then('/^the (product "[^"]+") should not have shipping required$/')]
     public function theProductWithCodeShouldNotHaveShippingRequired(ProductInterface $product): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -1267,9 +1024,7 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->updateSimpleProductPage->isShippingRequired());
     }
 
-    /**
-     * @Then I should be notified that I have to define the :attribute attribute in :localeCode locale
-     */
+    #[Then('I should be notified that I have to define the :attribute attribute in :localeCode locale')]
     public function iShouldBeNotifiedThatIHaveToDefineTheAttributeInLocale(string $attribute, string $localeCode): void
     {
         Assert::same(
@@ -1278,9 +1033,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the :attribute attribute in :localeCode locale should be longer than :number
-     */
+    #[Then('I should be notified that the :attribute attribute in :localeCode locale should be longer than :number')]
     public function iShouldBeNotifiedThatTheAttributeInShouldBeLongerThan(string $attribute, string $localeCode, int $number): void
     {
         Assert::same(
@@ -1289,41 +1042,31 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be on the variant creation page for (this product)$/
-     */
+    #[Then('/^I should be on the variant creation page for (this product)$/')]
     public function iShouldBeOnTheVariantCreationPageForThisProduct(ProductInterface $product): void
     {
         Assert::true($this->variantCreatePage->isOpen(['productId' => $product->getId()]));
     }
 
-    /**
-     * @Then /^I should be on the variant generation page for (this product)$/
-     */
+    #[Then('/^I should be on the variant generation page for (this product)$/')]
     public function iShouldBeOnTheVariantGenerationPageForThisProduct(ProductInterface $product): void
     {
         Assert::true($this->variantGeneratePage->isOpen(['productId' => $product->getId()]));
     }
 
-    /**
-     * @Then I should see inventory of this product
-     */
+    #[Then('I should see inventory of this product')]
     public function iShouldSeeInventoryOfThisProduct(): void
     {
         Assert::true($this->updateSimpleProductPage->hasTab('inventory'));
     }
 
-    /**
-     * @Then I should not see inventory of this product
-     */
+    #[Then('I should not see inventory of this product')]
     public function iShouldNotSeeInventoryOfThisProduct(): void
     {
         Assert::false($this->updateConfigurableProductPage->hasTab('inventory'));
     }
 
-    /**
-     * @Then I should be notified that the position :invalidPosition is invalid
-     */
+    #[Then('I should be notified that the position :invalidPosition is invalid')]
     public function iShouldBeNotifiedThatThePositionIsInvalid(string $invalidPosition): void
     {
         $this->notificationChecker->checkNotification(
@@ -1332,25 +1075,19 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to show this product in shop
-     */
+    #[Then('I should not be able to show this product in shop')]
     public function iShouldNotBeAbleToShowThisProductInShop(): void
     {
         Assert::true($this->updateSimpleProductPage->isShowInShopButtonDisabled());
     }
 
-    /**
-     * @When /^I disable it$/
-     */
+    #[When('/^I disable it$/')]
     public function iDisableIt(): void
     {
         $this->updateSimpleProductPage->disable();
     }
 
-    /**
-     * @Then /^(this product) should be disabled along with its variant$/
-     */
+    #[Then('/^(this product) should be disabled along with its variant$/')]
     public function thisProductShouldBeDisabledAlongWithItsVariant(ProductInterface $product): void
     {
         Assert::true($product->isSimple());
@@ -1364,17 +1101,13 @@ final readonly class ManagingProductsContext implements Context
         Assert::false($this->variantUpdatePage->isEnabled());
     }
 
-    /**
-     * @When /^I enable it$/
-     */
+    #[When('/^I enable it$/')]
     public function iEnableIt(): void
     {
         $this->updateSimpleProductPage->enable();
     }
 
-    /**
-     * @Then /^(this product) should be enabled along with its variant$/
-     */
+    #[Then('/^(this product) should be enabled along with its variant$/')]
     public function thisProductShouldBeEnabledAlongWithItsVariant(ProductInterface $product): void
     {
         Assert::true($product->isSimple());
@@ -1388,74 +1121,56 @@ final readonly class ManagingProductsContext implements Context
         Assert::true($this->variantUpdatePage->isEnabled());
     }
 
-    /**
-     * @Then I should not have configured price for :channel channel
-     */
+    #[Then('I should not have configured price for :channel channel')]
     public function iShouldNotHaveConfiguredPriceForChannel(ChannelInterface $channel): void
     {
         Assert::same($this->channelPricingsFormElement->getPriceForChannel($channel), '');
     }
 
-    /**
-     * @Then I should have original price equal to :price in :channel channel
-     */
+    #[Then('I should have original price equal to :price in :channel channel')]
     public function iShouldHaveOriginalPriceEqualInChannel(string $price, ChannelInterface $channel): void
     {
         Assert::contains($price, $this->channelPricingsFormElement->getOriginalPriceForChannel($channel));
     }
 
-    /**
-     * @Then the first product on the list shouldn't have a name
-     */
+    #[Then('the first product on the list shouldn\'t have a name')]
     public function theFirstProductOnTheListShouldNotHaveName(): void
     {
         Assert::true($this->indexPage->checkFirstProductHasDataAttribute('data-test-missing-translation-paragraph'));
     }
 
-    /**
-     * @Then the last product on the list shouldn't have a name
-     */
+    #[Then('the last product on the list shouldn\'t have a name')]
     public function theLastProductOnTheListShouldNotHaveName(): void
     {
         Assert::true($this->indexPage->checkLastProductHasDataAttribute('data-test-missing-translation-paragraph'));
     }
 
-    /**
-     * @Then I should be redirected to the previous page of only enabled products
-     */
+    #[Then('I should be redirected to the previous page of only enabled products')]
     public function iShouldBeRedirectedToThePreviousFilteredPageWithFilter(): void
     {
         Assert::true($this->indexPage->isEnabledFilterApplied());
     }
 
-    /**
-     * @Then /^I should be redirected to the ([^"]+)(nd) page of only enabled products$/
-     */
+    #[Then('/^I should be redirected to the ([^"]+)(nd) page of only enabled products$/')]
     public function iShouldBeRedirectedToThePreviousFilteredPageWithFilterAndPage(int $page): void
     {
         Assert::true($this->indexPage->isEnabledFilterApplied());
         Assert::eq($this->indexPage->getPageNumber(), $page);
     }
 
-    /**
-     * @Then the show product's page button should be enabled
-     */
+    #[Then('the show product\'s page button should be enabled')]
     public function theShowProductsPageButtonShouldBeEnabled(): void
     {
         Assert::false($this->updateSimpleProductPage->isShowInShopButtonDisabled());
     }
 
-    /**
-     * @Then the show product's page button should be disabled
-     */
+    #[Then('the show product\'s page button should be disabled')]
     public function theShowProductsPageButtonShouldBeDisabled(): void
     {
         Assert::true($this->updateSimpleProductPage->isShowInShopButtonDisabled());
     }
 
-    /**
-     * @Then /^it should be leading to (the product)'s page in the ("[^"]+" locale)$/
-     */
+    #[Then('/^it should be leading to (the product)\'s page in the ("[^"]+" locale)$/')]
     public function itShouldBeLeadingToTheProductPageInTheLocale(ProductInterface $product, string $localeCode): void
     {
         $productTranslation = $product->getTranslation($localeCode);
@@ -1467,25 +1182,19 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the :attributeName attribute value for :localeCode is required
-     */
+    #[Then('I should be notified that the :attributeName attribute value for :localeCode is required')]
     public function iShouldBeNotifiedThatTheAttributeValueIsRequired(string $attributeName, string $localeCode): void
     {
         Assert::true($this->attributesFormElement->hasAttributeError($attributeName, $localeCode));
     }
 
-    /**
-     * @Then I should not be able to go to the generate variants page
-     */
+    #[Then('I should not be able to go to the generate variants page')]
     public function iShouldNotBeAbleToGoToTheGenerateVariantsPage(): void
     {
         Assert::false($this->updateSimpleProductPage->hasGenerateVariantsButton(), 'Generate variants button should not be visible');
     }
 
-    /**
-     * @Then I should see the :product product
-     */
+    #[Then('I should see the :product product')]
     public function iShouldSeeTheProduct(ProductInterface $product): void
     {
         Assert::true(
@@ -1494,9 +1203,7 @@ final readonly class ManagingProductsContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see the :product product
-     */
+    #[Then('I should not see the :product product')]
     public function iShouldNotSeeTheProduct(ProductInterface $product): void
     {
         Assert::false(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\PromotionCoupon\FormElementInterface;
 use Sylius\Behat\NotificationType;
@@ -37,254 +40,194 @@ final class ManagingPromotionCouponsContext implements Context
     ) {
     }
 
-    /**
-     * @Given /^I am browsing coupons of (this promotion)$/
-     * @Given /^I browse coupons of (this promotion)$/
-     * @When /^I want to view all coupons of (this promotion)$/
-     * @When /^I browse all coupons of ("[^"]+" promotion)$/
-     */
+    #[Given('/^I am browsing coupons of (this promotion)$/')]
+    #[Given('/^I browse coupons of (this promotion)$/')]
+    #[When('/^I want to view all coupons of (this promotion)$/')]
+    #[When('/^I browse all coupons of ("[^"]+" promotion)$/')]
     public function iWantToViewAllCouponsOfThisPromotion(PromotionInterface $promotion): void
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
     }
 
-    /**
-     * @When /^I want to create a new coupon for (this promotion)$/
-     */
+    #[When('/^I want to create a new coupon for (this promotion)$/')]
     public function iWantToCreateANewCouponForThisPromotion(PromotionInterface $promotion): void
     {
         $this->createPage->open(['promotionId' => $promotion->getId()]);
     }
 
-    /**
-     * @When /^I want to modify the ("[^"]+" coupon) for (this promotion)$/
-     */
+    #[When('/^I want to modify the ("[^"]+" coupon) for (this promotion)$/')]
     public function iWantToModifyTheCoupon(PromotionCouponInterface $coupon, PromotionInterface $promotion): void
     {
         $this->updatePage->open(['id' => $coupon->getId(), 'promotionId' => $promotion->getId()]);
     }
 
-    /**
-     * @When /^I want to generate new coupons for (this promotion)$/
-     */
+    #[When('/^I want to generate new coupons for (this promotion)$/')]
     public function iWantToGenerateNewCouponsForThisPromotion(PromotionInterface $promotion): void
     {
         $this->generatePage->open(['promotionId' => $promotion->getId()]);
     }
 
-    /**
-     * @When /^I specify their code length as (\d+)$/
-     * @When I do not specify their code length
-     */
+    #[When('/^I specify their code length as (\d+)$/')]
+    #[When('I do not specify their code length')]
     public function iSpecifyTheirCodeLengthAs(?int $codeLength = null): void
     {
         $this->generatePage->specifyCodeLength($codeLength);
     }
 
-    /**
-     * @When I specify their prefix as :prefix
-     */
+    #[When('I specify their prefix as :prefix')]
     public function specifyPrefixAs(string $prefix): void
     {
         $this->generatePage->specifyPrefix($prefix);
     }
 
-    /**
-     * @When I specify their suffix as :suffix
-     */
+    #[When('I specify their suffix as :suffix')]
     public function specifySuffixAs(string $suffix): void
     {
         $this->generatePage->specifySuffix($suffix);
     }
 
-    /**
-     * @When /^I limit generated coupons usage to (\d+) times?$/
-     */
+    #[When('/^I limit generated coupons usage to (\d+) times?$/')]
     public function iSetGeneratedCouponsUsageLimitTo(int $limit): void
     {
         $this->generatePage->setUsageLimit($limit);
     }
 
-    /**
-     * @When I make generated coupons valid until :date
-     */
+    #[When('I make generated coupons valid until :date')]
     public function iMakeGeneratedCouponsValidUntil(\DateTimeInterface $date): void
     {
         $this->generatePage->setExpiresAt($date);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I specify a too long code
-     */
+    #[When('I specify a too long code')]
     public function iSpecifyATooLong(): void
     {
         $this->formElement->specifyCode(str_repeat('a', 256));
     }
 
-    /**
-     * @When I limit its usage to :limit time(s)
-     */
+    #[When('I limit its usage to :limit time(s)')]
     public function iLimitItsUsageLimitTo(int $limit): void
     {
         $this->formElement->setUsageLimit($limit);
     }
 
-    /**
-     * @When I change its usage limit to :limit
-     */
+    #[When('I change its usage limit to :limit')]
     public function iChangeItsUsageLimitTo(int $limit): void
     {
         $this->formElement->setUsageLimit($limit);
     }
 
-    /**
-     * @When I specify its amount as :amount
-     * @When I do not specify its amount
-     * @When I choose the amount of :amount coupons to be generated
-     */
+    #[When('I specify its amount as :amount')]
+    #[When('I do not specify its amount')]
+    #[When('I choose the amount of :amount coupons to be generated')]
     public function iSpecifyItsAmountAs(?int $amount = null): void
     {
         $this->generatePage->specifyAmount($amount);
     }
 
-    /**
-     * @When /^I limit its per customer usage to ([^"]+) times?$/
-     */
+    #[When('/^I limit its per customer usage to ([^"]+) times?$/')]
     public function iLimitItsPerCustomerUsageLimitTo(int $limit): void
     {
         $this->formElement->setCustomerUsageLimit($limit);
     }
 
-    /**
-     * @When I change its per customer usage limit to :limit
-     */
+    #[When('I change its per customer usage limit to :limit')]
     public function iChangeItsPerCustomerUsageLimitTo(int $limit): void
     {
         $this->formElement->setCustomerUsageLimit($limit);
     }
 
-    /**
-     * @When I make it not reusable from cancelled orders
-     */
+    #[When('I make it not reusable from cancelled orders')]
     public function iMakeItReusableFromCancelledOrders(): void
     {
         $this->formElement->toggleReusableFromCancelledOrders(false);
     }
 
-    /**
-     * @When I make it valid until :date
-     */
+    #[When('I make it valid until :date')]
     public function iMakeItValidUntil(\DateTimeInterface $date): void
     {
         $this->formElement->setExpiresAt($date);
     }
 
-    /**
-     * @When I change its expiration date to :date
-     */
+    #[When('I change its expiration date to :date')]
     public function iChangeItsExpirationDateTo(\DateTimeInterface $date): void
     {
         $this->formElement->setExpiresAt($date);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I generate it
-     * @When I generate these coupons
-     * @When I try to generate it
-     * @When I try to generate these coupons
-     */
+    #[When('I generate it')]
+    #[When('I generate these coupons')]
+    #[When('I try to generate it')]
+    #[When('I try to generate these coupons')]
     public function iGenerateIt(): void
     {
         $this->generatePage->generate();
     }
 
-    /**
-     * @When /^I delete ("[^"]+" coupon) related to (this promotion)$/
-     * @When /^I try to delete ("[^"]+" coupon) related to (this promotion)$/
-     */
+    #[When('/^I delete ("[^"]+" coupon) related to (this promotion)$/')]
+    #[When('/^I try to delete ("[^"]+" coupon) related to (this promotion)$/')]
     public function iDeleteCouponRelatedToThisPromotion(PromotionCouponInterface $coupon, PromotionInterface $promotion): void
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
         $this->indexPage->deleteResourceOnPage(['code' => $coupon->getCode()]);
     }
 
-    /**
-     * @When I check (also) the :couponCode coupon
-     */
+    #[When('I check (also) the :couponCode coupon')]
     public function iCheckTheCoupon(string $couponCode): void
     {
         $this->indexPage->checkResourceOnPage(['code' => $couponCode]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) number of uses$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) number of uses$/')]
     public function iSortCouponsByNumberOfUses(string $order): void
     {
         $this->sortBy($order, 'used');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) code$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) code$/')]
     public function iSortCouponsByCode(string $order): void
     {
         $this->sortBy($order, 'code');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) usage limit$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) usage limit$/')]
     public function iSortCouponsByUsageLimit(string $order): void
     {
         $this->sortBy($order, 'usageLimit');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) usage limit per customer$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) usage limit per customer$/')]
     public function iSortCouponsByPerCustomerUsageLimit(string $order): void
     {
         $this->sortBy($order, 'perCustomerUsageLimit');
     }
 
-    /**
-     * @When /^I sort coupons by (ascending|descending) expiration date$/
-     */
+    #[When('/^I sort coupons by (ascending|descending) expiration date$/')]
     public function iSortCouponsByExpirationDate(string $order): void
     {
         $this->sortBy($order, 'expiresAt');
     }
 
-    /**
-     * @Then /^there should(?:| still) be (\d+) coupons? related to (this promotion)$/
-     */
+    #[Then('/^there should(?:| still) be (\d+) coupons? related to (this promotion)$/')]
     public function thereShouldBeCouponRelatedTo(int $number, PromotionInterface $promotion): void
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
@@ -292,18 +235,14 @@ final class ManagingPromotionCouponsContext implements Context
         Assert::same($this->indexPage->countItems(), $number);
     }
 
-    /**
-     * @When I filter by code containing :phrase
-     */
+    #[When('I filter by code containing :phrase')]
     public function iFilterByCodeContaining(string $phrase): void
     {
         $this->indexPage->filterByCode($phrase);
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then all of the coupon codes should be prefixed with :prefix
-     */
+    #[Then('all of the coupon codes should be prefixed with :prefix')]
     public function allOfTheCouponCodesShouldBePrefixedWith(string $prefix): void
     {
         foreach ($this->indexPage->getColumnFields('code') as $couponCode) {
@@ -311,9 +250,7 @@ final class ManagingPromotionCouponsContext implements Context
         }
     }
 
-    /**
-     * @Then all of the coupon codes should be suffixed with :suffix
-     */
+    #[Then('all of the coupon codes should be suffixed with :suffix')]
     public function allOfTheCouponCodesShouldBeSuffixedWith(string $suffix): void
     {
         foreach ($this->indexPage->getColumnFields('code') as $couponCode) {
@@ -321,59 +258,45 @@ final class ManagingPromotionCouponsContext implements Context
         }
     }
 
-    /**
-     * @Then I should see a single coupon in the list
-     */
+    #[Then('I should see a single coupon in the list')]
     public function iShouldSeeASingleCouponInTheList(): void
     {
         Assert::same($this->indexPage->countItems(), 1);
     }
 
-    /**
-     * @Then there should be a coupon with code :code
-     * @Then there should be a :promotion promotion with a coupon code :code
-     * @Then I should see the promotion coupon :code in the list
-     */
+    #[Then('there should be a coupon with code :code')]
+    #[Then('there should be a :promotion promotion with a coupon code :code')]
+    #[Then('I should see the promotion coupon :code in the list')]
     public function thereShouldBeCouponWithCode(string $code): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    /**
-     * @Then this coupon should be valid until :date
-     */
+    #[Then('this coupon should be valid until :date')]
     public function thisCouponShouldBeValidUntil(\DateTime $date): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['expiresAt' => $date->format('d-m-Y')]));
     }
 
-    /**
-     * @Then /^this coupon should have (\d+) usage limit$/
-     */
+    #[Then('/^this coupon should have (\d+) usage limit$/')]
     public function thisCouponShouldHaveUsageLimit($limit): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['usageLimit' => $limit]));
     }
 
-    /**
-     * @Then /^("[^"]+" coupon) should be used (\d+) time(?:|s)$/
-     */
+    #[Then('/^("[^"]+" coupon) should be used (\d+) time(?:|s)$/')]
     public function couponShouldHaveUsageLimit(PromotionCouponInterface $promotionCoupon, int $used): void
     {
         Assert::same($this->indexPage->getUsedNumber($promotionCoupon->getCode()), $used);
     }
 
-    /**
-     * @Then /^this coupon should have (\d+) per customer usage limit$/
-     */
+    #[Then('/^this coupon should have (\d+) per customer usage limit$/')]
     public function thisCouponShouldHavePerCustomerUsageLimit($limit): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['perCustomerUsageLimit' => $limit]));
     }
 
-    /**
-     * @Then /^(this coupon) should not be reusable from cancelled orders$/
-     */
+    #[Then('/^(this coupon) should not be reusable from cancelled orders$/')]
     public function thisCouponShouldBeReusableFromCancelledOrders(PromotionCouponInterface $coupon): void
     {
         $this->updatePage->open(['id' => $coupon->getId(), 'promotionId' => $coupon->getPromotion()->getId()]);
@@ -381,18 +304,14 @@ final class ManagingPromotionCouponsContext implements Context
         Assert::false($this->formElement->isReusableFromCancelledOrders());
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     * @Then the code field should be disabled
-     */
+    #[Then('I should not be able to edit its code')]
+    #[Then('the code field should be disabled')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then I should be notified that code is too long
-     */
+    #[Then('I should be notified that code is too long')]
     public function iShouldBeNotifiedThatCodeIsTooLong(): void
     {
         Assert::contains(
@@ -401,49 +320,37 @@ final class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that coupon with this code already exists
-     */
+    #[Then('I should be notified that coupon with this code already exists')]
     public function iShouldBeNotifiedThatCouponWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'This coupon already exists.');
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired($element): void
     {
         Assert::same($this->formElement->getValidationMessage($element), sprintf('Please enter coupon %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that generate amount is required
-     */
+    #[Then('I should be notified that generate amount is required')]
     public function iShouldBeNotifiedThatGenerateAmountIsRequired(): void
     {
         Assert::same($this->generatePage->getValidationMessage('amount'), 'Please enter amount of coupons to generate.');
     }
 
-    /**
-     * @Then I should be notified that generate code length is required
-     */
+    #[Then('I should be notified that generate code length is required')]
     public function iShouldBeNotifiedThatCodeLengthIsRequired(): void
     {
         Assert::same($this->generatePage->getValidationMessage('code_length'), 'Please enter coupon code length.');
     }
 
-    /**
-     * @Then I should be notified that generate code length is out of range
-     */
+    #[Then('I should be notified that generate code length is out of range')]
     public function iShouldBeNotifiedThatCodeLengthIsOutOfRange(): void
     {
         Assert::same($this->generatePage->getValidationMessage('code_length'), 'Coupon code length must be between 1 and 40.');
     }
 
-    /**
-     * @Then /^there should still be only one coupon with code "([^"]+)" related to (this promotion)$/
-     */
+    #[Then('/^there should still be only one coupon with code "([^"]+)" related to (this promotion)$/')]
     public function thereShouldStillBeOnlyOneCouponWithCodeRelatedTo($code, PromotionInterface $promotion): void
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
@@ -451,41 +358,31 @@ final class ManagingPromotionCouponsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    /**
-     * @Then I should be notified that coupon usage limit must be at least one
-     */
+    #[Then('I should be notified that coupon usage limit must be at least one')]
     public function iShouldBeNotifiedThatCouponUsageLimitMustBeAtLeast(): void
     {
         Assert::same($this->formElement->getValidationMessage('usage_limit'), 'Coupon usage limit must be at least 1.');
     }
 
-    /**
-     * @Then I should be notified that coupon usage limit per customer must be at least one
-     */
+    #[Then('I should be notified that coupon usage limit per customer must be at least one')]
     public function iShouldBeNotifiedThatCouponUsageLimitPerCustomerMustBeAtLeast(): void
     {
         Assert::same($this->formElement->getValidationMessage('per_customer_usage_limit'), 'Coupon usage limit per customer must be at least 1.');
     }
 
-    /**
-     * @Then /^(this coupon) should no longer exist in the coupon registry$/
-     */
+    #[Then('/^(this coupon) should no longer exist in the coupon registry$/')]
     public function couponShouldNotExistInTheRegistry(PromotionCouponInterface $coupon): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that they have been successfully generated
-     */
+    #[Then('I should be notified that they have been successfully generated')]
     public function iShouldBeNotifiedThatTheyHaveBeenSuccessfullyGenerated(): void
     {
         $this->notificationChecker->checkNotification('Success Promotion coupons have been successfully generated.', NotificationType::success());
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure(): void
     {
         $this->notificationChecker->checkNotification(
@@ -494,17 +391,13 @@ final class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this coupon) should still exist in the registry$/
-     */
+    #[Then('/^(this coupon) should still exist in the registry$/')]
     public function couponShouldStillExistInTheRegistry(PromotionCouponInterface $coupon): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that generating :amount coupons with code length equal to :codeLength is not possible
-     */
+    #[Then('I should be notified that generating :amount coupons with code length equal to :codeLength is not possible')]
     public function iShouldBeNotifiedThatGeneratingCouponsWithCodeLengthIsNotPossible(int $amount, int $codeLength): void
     {
         Assert::contains(
@@ -513,34 +406,26 @@ final class ManagingPromotionCouponsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the coupon :couponCode in the list
-     */
+    #[Then('I should see the coupon :couponCode in the list')]
     public function iShouldSeeTheCouponInTheList(string $couponCode): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $couponCode]));
     }
 
-    /**
-     * @Then I should see :count coupons on the list
-     */
+    #[Then('I should see :count coupons on the list')]
     public function iShouldSeeCountCouponsOnTheList(int $count): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then the first coupon should have code :code
-     */
+    #[Then('the first coupon should have code :code')]
     public function theFirstCouponShouldHaveCode(string $code): void
     {
         Assert::same($this->indexPage->getColumnFields('code')[0], $code);
     }
 
-    /**
-     * @Then I should see a single promotion coupon in the list
-     * @Then there should be :amount promotion coupons
-     */
+    #[Then('I should see a single promotion coupon in the list')]
+    #[Then('there should be :amount promotion coupons')]
     public function thereShouldBePromotionCoupon(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\Promotion\FormElementInterface;
@@ -55,58 +58,46 @@ final class ManagingPromotionsContext implements Context
     ) {
     }
 
-    /**
-     * @When I create a new promotion
-     * @When I want to create a new promotion
-     */
+    #[When('I create a new promotion')]
+    #[When('I want to create a new promotion')]
     public function iWantToCreateANewPromotion(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I want to browse promotions
-     * @When I browse promotions
-     */
+    #[When('I want to browse promotions')]
+    #[When('I browse promotions')]
     public function iWantToBrowsePromotions(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :name
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I name it :name')]
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iNameIt($name = null)
     {
         $this->createPage->nameIt($name ?? '');
     }
 
-    /**
-     * @When I set its priority to :priority
-     * @When I remove its priority
-     */
+    #[When('I set its priority to :priority')]
+    #[When('I remove its priority')]
     public function iRemoveItsPriority(?int $priority = null): void
     {
         $this->formElement->setPriority($priority);
     }
 
-    /**
-     * @Then the :promotionName promotion should appear in the registry
-     * @Then the :promotionName promotion should exist in the registry
-     * @Then this promotion should still be named :promotionName
-     * @Then promotion :promotionName should still exist in the registry
-     */
+    #[Then('the :promotionName promotion should appear in the registry')]
+    #[Then('the :promotionName promotion should exist in the registry')]
+    #[Then('this promotion should still be named :promotionName')]
+    #[Then('promotion :promotionName should still exist in the registry')]
     public function thePromotionShouldAppearInTheRegistry(string $promotionName): void
     {
         $this->indexPage->open();
@@ -114,44 +105,34 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $promotionName]));
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I specify its label as :label in :localeCode locale
-     */
+    #[When('I specify its label as :label in :localeCode locale')]
     public function iSpecifyItsLabelInLocaleCode(string $label, string $localeCode): void
     {
         $this->formElement->setLabel($label, $localeCode);
     }
 
-    /**
-     * @When I replace its label with a string exceeding the limit in :localeCode locale
-     */
+    #[When('I replace its label with a string exceeding the limit in :localeCode locale')]
     public function iSpecifyItsLabelWithAStringExceedingTheLimitInLocale(string $localeCode): void
     {
         $this->formElement->setLabel(str_repeat('a', 256), $localeCode);
     }
 
-    /**
-     * @When the :promotion promotion should have a label :label in :localeCode locale
-     */
+    #[When('the :promotion promotion should have a label :label in :localeCode locale')]
     public function thePromotionShouldHaveLabelInLocale(PromotionInterface $promotion, string $label, string $localeCode): void
     {
         $this->updatePage->open(['id' => $promotion->getId()]);
         $this->formElement->hasLabel($label, $localeCode);
     }
 
-    /**
-     * @When I add the "Has at least one from taxons" rule configured with :firstTaxon taxon
-     * @When I add the "Has at least one from taxons" rule configured with :firstTaxon taxon and :secondTaxon taxon
-     */
+    #[When('I add the "Has at least one from taxons" rule configured with :firstTaxon taxon')]
+    #[When('I add the "Has at least one from taxons" rule configured with :firstTaxon taxon and :secondTaxon taxon')]
     public function iAddTheHasTaxonRuleConfiguredWith(string ...$taxons): void
     {
         $this->formElement->addRule(HasTaxonRuleChecker::TYPE);
@@ -159,9 +140,7 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->selectAutocompleteRuleOptions($taxons);
     }
 
-    /**
-     * @When /^I add the "Total price of items from taxon" rule configured with "([^"]+)" taxon and "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Total price of items from taxon" rule configured with "([^"]+)" taxon and "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/')]
     public function iAddTheRuleConfiguredWith(string $taxonName, $amount, ChannelInterface $channel): void
     {
         $this->formElement->addRule(TotalOfItemsFromTaxonRuleChecker::TYPE);
@@ -169,9 +148,7 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillRuleOptionForChannel($channel->getCode(), 'Amount', $amount);
     }
 
-    /**
-     * @When /^I add the "Item total" rule configured with "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel) and "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Item total" rule configured with "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel) and "(?:€|£|\$)([^"]+)" amount for ("[^"]+" channel)$/')]
     public function iAddTheItemTotalRuleConfiguredWithTwoChannel(
         $firstAmount,
         ChannelInterface $firstChannel,
@@ -183,68 +160,52 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillRuleOptionForChannel($secondChannel->getCode(), 'Amount', $secondAmount);
     }
 
-    /**
-     * @When /^I add the "Order fixed discount" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Order fixed discount" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function iAddTheOrderFixedDiscountActionConfiguredWithAmountForChannel($amount, ChannelInterface $channel): void
     {
         $this->formElement->addAction(FixedDiscountPromotionActionCommand::TYPE);
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', $amount);
     }
 
-    /**
-     * @When /^I add the "Item fixed discount" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Item fixed discount" action configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function iAddTheItemFixedDiscountActionConfiguredWithAmountForChannel($amount, ChannelInterface $channel): void
     {
         $this->formElement->addAction(UnitFixedDiscountPromotionActionCommand::TYPE);
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', $amount);
     }
 
-    /**
-     * @When /^it is(?:| also) configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/
-     */
+    #[When('/^it is(?:| also) configured with amount of "(?:€|£|\$)([^"]+)" for ("[^"]+" channel)$/')]
     public function itIsConfiguredWithAmountForChannel($amount, ChannelInterface $channel)
     {
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Amount', $amount);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price greater than "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price greater than "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMinPriceFilterRangeForChannel(ChannelInterface $channel, $minimum)
     {
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Min', $minimum);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price lesser than "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price lesser than "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMaxPriceFilterRangeForChannel(ChannelInterface $channel, $maximum)
     {
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Max', $maximum);
     }
 
-    /**
-     * @When /^I specify that on ("[^"]+" channel) this action should be applied to items with price between "(?:€|£|\$)([^"]+)" and "(?:€|£|\$)([^"]+)"$/
-     */
+    #[When('/^I specify that on ("[^"]+" channel) this action should be applied to items with price between "(?:€|£|\$)([^"]+)" and "(?:€|£|\$)([^"]+)"$/')]
     public function iAddAMinMaxPriceFilterRangeForChannel(ChannelInterface $channel, $minimum, $maximum)
     {
         $this->iAddAMinPriceFilterRangeForChannel($channel, $minimum);
         $this->iAddAMaxPriceFilterRangeForChannel($channel, $maximum);
     }
 
-    /**
-     * @When I specify that this action should be applied to items from :taxonName category for :channel channel
-     */
+    #[When('I specify that this action should be applied to items from :taxonName category for :channel channel')]
     public function iSpecifyThatThisActionShouldBeAppliedToItemsFromCategory(string $taxonName, ChannelInterface $channel): void
     {
         $this->formElement->selectAutocompleteActionFilterOptions([$taxonName], $channel->getCode(), 'taxons');
     }
 
-    /**
-     * @When /^I add the "Item percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%" for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Item percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%" for ("[^"]+" channel)$/')]
     public function iAddTheItemPercentageDiscountActionConfiguredWithAPercentageValueForChannel(
         string $percentage,
         ChannelInterface $channel,
@@ -253,9 +214,7 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Percentage', $percentage);
     }
 
-    /**
-     * @When /^I add the "Order percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%" for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Order percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%" for ("[^"]+" channel)$/')]
     public function iAddTheOrderPercentageDiscountActionConfiguredWithAPercentageValueForChannel(
         string $percentage,
         ChannelInterface $channel,
@@ -264,9 +223,7 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Percentage', $percentage);
     }
 
-    /**
-     * @When I add the "Order percentage discount" action configured without a percentage value for :channel channel
-     */
+    #[When('I add the "Order percentage discount" action configured without a percentage value for :channel channel')]
     public function iAddTheOrderPercentageDiscountActionConfiguredWithoutAPercentageValueForChannel(
         ChannelInterface $channel,
     ): void {
@@ -274,9 +231,7 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Percentage', '');
     }
 
-    /**
-     * @When I add the "Item percentage discount" action configured without a percentage value for :channel channel
-     */
+    #[When('I add the "Item percentage discount" action configured without a percentage value for :channel channel')]
     public function iAddTheItemPercentageDiscountActionConfiguredWithoutAPercentageValueForChannel(
         ChannelInterface $channel,
     ): void {
@@ -284,10 +239,8 @@ final class ManagingPromotionsContext implements Context
         $this->formElement->fillActionOptionForChannel($channel->getCode(), 'Percentage', '');
     }
 
-    /**
-     * @When /^I add the "Order percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%"$/
-     * @When I add the "Order percentage discount" action configured without a percentage value
-     */
+    #[When('/^I add the "Order percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%"$/')]
+    #[When('I add the "Order percentage discount" action configured without a percentage value')]
     public function iAddTheOrderPercentageDiscountActionConfiguredWithAPercentageValue($percentage = null)
     {
         $this->formElement->addAction(PercentageDiscountPromotionActionCommand::TYPE);
@@ -295,135 +248,105 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
-     * @When /^I add the "Item percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%"$/
-     * @When I add the "Item percentage discount" action configured without a percentage value
+     * @WhenI add the "Item percentage discount" action configured without a percentage value
      */
+    #[When('/^I add the "Item percentage discount" action configured with a percentage value of "(?:|-)([^"]+)%"$/')]
     public function iAddTheItemPercentageDiscountActionConfiguredWithAPercentageValue($percentage = null)
     {
         $this->formElement->addAction(UnitPercentageDiscountPromotionActionCommand::TYPE);
         $this->formElement->fillActionOption('Percentage', $percentage ?? '');
     }
 
-    /**
-     * @When I add the "Customer group" rule for :customerGroupName group
-     */
+    #[When('I add the "Customer group" rule for :customerGroupName group')]
     public function iAddTheCustomerGroupRuleConfiguredForGroup($customerGroupName)
     {
         $this->formElement->addRule(CustomerGroupRuleChecker::TYPE);
         $this->formElement->selectRuleOption('Customer group', $customerGroupName);
     }
 
-    /**
-     * @When I check (also) the :promotionName promotion
-     */
+    #[When('I check (also) the :promotionName promotion')]
     public function iCheckThePromotion(string $promotionName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $promotionName]);
     }
 
-    /**
-     * @When I remove its last rule
-     */
+    #[When('I remove its last rule')]
     public function iRemoveItsLastRule(): void
     {
         $this->formElement->removeLastRule();
     }
 
-    /**
-     * @When I remove its last action
-     */
+    #[When('I remove its last action')]
     public function iRemoveItsLastAction(): void
     {
         $this->formElement->removeLastAction();
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I archive the :promotionName promotion
-     */
+    #[When('I archive the :promotionName promotion')]
     public function iArchiveThePromotion(string $promotionName): void
     {
         $actions = $this->indexPage->getActionsForResource(['name' => $promotionName]);
         $actions->pressButton('Archive');
     }
 
-    /**
-     * @When I restore the :promotionName promotion
-     */
+    #[When('I restore the :promotionName promotion')]
     public function iRestoreThePromotion(string $promotionName): void
     {
         $actions = $this->indexPage->getActionsForResource(['name' => $promotionName]);
         $actions->pressButton('Restore');
     }
 
-    /**
-     * @When I filter archival promotions
-     */
+    #[When('I filter archival promotions')]
     public function iFilterArchivalPromotions(): void
     {
         $this->indexPage->chooseArchival('Yes');
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then I should see a single promotion in the list
-     * @Then there should be :amount promotions
-     */
+    #[Then('I should see a single promotion in the list')]
+    #[Then('there should be :amount promotions')]
     public function thereShouldBePromotion(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
-    /**
-     * @Then /^(this promotion) should be coupon based$/
-     */
+    #[Then('/^(this promotion) should be coupon based$/')]
     public function thisPromotionShouldBeCouponBased(PromotionInterface $promotion)
     {
         Assert::true($this->indexPage->isCouponBasedFor($promotion));
     }
 
-    /**
-     * @Then /^I should be able to manage coupons for (this promotion)$/
-     */
+    #[Then('/^I should be able to manage coupons for (this promotion)$/')]
     public function iShouldBeAbleToManageCouponsForThisPromotion(PromotionInterface $promotion)
     {
         Assert::true($this->indexPage->isAbleToManageCouponsFor($promotion));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired($element)
     {
         $this->assertFieldValidationMessage($element, sprintf('Please enter promotion %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that a :element value should be a numeric value
-     */
+    #[Then('I should be notified that a :element value should be a numeric value')]
     public function iShouldBeNotifiedThatAMinimalValueShouldBeNumeric($element)
     {
         $this->assertFieldValidationMessage($element, 'Please enter a valid money amount.');
     }
 
-    /**
-     * @Then I should be notified that promotion with this code already exists
-     */
+    #[Then('I should be notified that promotion with this code already exists')]
     public function iShouldBeNotifiedThatPromotionWithThisCodeAlreadyExists()
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'The promotion with given code already exists.');
     }
 
-    /**
-     * @Then promotion with :element :name should not be added
-     */
+    #[Then('promotion with :element :name should not be added')]
     public function promotionWithElementValueShouldNotBeAdded($element, $name)
     {
         $this->indexPage->open();
@@ -431,9 +354,7 @@ final class ManagingPromotionsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
-    /**
-     * @Then there should still be only one promotion with :element :value
-     */
+    #[Then('there should still be only one promotion with :element :value')]
     public function thereShouldStillBeOnlyOnePromotionWith($element, $value)
     {
         $this->indexPage->open();
@@ -441,17 +362,13 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @When I set its usage limit to :usageLimit
-     */
+    #[When('I set its usage limit to :usageLimit')]
     public function iSetItsUsageLimitTo(int $usageLimit): void
     {
         $this->formElement->setUsageLimit($usageLimit);
     }
 
-    /**
-     * @Then the :promotion promotion should be available to be used only :usageLimit times
-     */
+    #[Then('the :promotion promotion should be available to be used only :usageLimit times')]
     public function thePromotionShouldBeAvailableToUseOnlyTimes(PromotionInterface $promotion, int $usageLimit): void
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -459,65 +376,49 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->updatePage->hasResourceValues(['usage_limit' => $usageLimit]));
     }
 
-    /**
-     * @When I set it as exclusive
-     */
+    #[When('I set it as exclusive')]
     public function iSetItAsExclusive(): void
     {
         $this->formElement->makeExclusive();
     }
 
-    /**
-     * @When I set it as not applies to discounted by catalog promotion items
-     */
+    #[When('I set it as not applies to discounted by catalog promotion items')]
     public function iSetItAsNotAppliesToDiscountedByCatalogPromotionItems(): void
     {
         $this->formElement->makeNotAppliesToDiscountedItem();
     }
 
-    /**
-     * @Then the :promotion promotion should be exclusive
-     */
+    #[Then('the :promotion promotion should be exclusive')]
     public function thePromotionShouldBeExclusive(PromotionInterface $promotion): void
     {
         $this->assertIfFieldIsTrue($promotion, 'exclusive');
     }
 
-    /**
-     * @Then the :promotion promotion should not applies to discounted items
-     */
+    #[Then('the :promotion promotion should not applies to discounted items')]
     public function thePromotionShouldNotAppliesToDiscountedItems(PromotionInterface $promotion): void
     {
         $this->assertIfFieldIsFalse($promotion, 'applies_to_discounted');
     }
 
-    /**
-     * @When I make it coupon based
-     */
+    #[When('I make it coupon based')]
     public function iMakeItCouponBased(): void
     {
         $this->formElement->makeCouponBased();
     }
 
-    /**
-     * @Then the :promotion promotion should be coupon based
-     */
+    #[Then('the :promotion promotion should be coupon based')]
     public function thePromotionShouldBeCouponBased(PromotionInterface $promotion): void
     {
         $this->assertIfFieldIsTrue($promotion, 'coupon_based');
     }
 
-    /**
-     * @When I make it applicable for the :channelName channel
-     */
+    #[When('I make it applicable for the :channelName channel')]
     public function iMakeItApplicableForTheChannel(string $channelName): void
     {
         $this->formElement->checkChannel($channelName);
     }
 
-    /**
-     * @Then the :promotion promotion should be applicable for the :channelName channel
-     */
+    #[Then('the :promotion promotion should be applicable for the :channelName channel')]
     public function thePromotionShouldBeApplicableForTheChannel(PromotionInterface $promotion, string $channelName): void
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -525,19 +426,15 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->updatePage->checkChannelsState($channelName));
     }
 
-    /**
-     * @When I want to modify a :promotion promotion
-     * @When /^I want to modify (this promotion)$/
-     * @When I modify a :promotion promotion
-     */
+    #[When('I want to modify a :promotion promotion')]
+    #[When('/^I want to modify (this promotion)$/')]
+    #[When('I modify a :promotion promotion')]
     public function iWantToModifyAPromotion(PromotionInterface $promotion): void
     {
         $this->updatePage->open(['id' => $promotion->getId()]);
     }
 
-    /**
-     * @When /^I edit (this promotion) percentage action to have "([^"]+)%"$/
-     */
+    #[When('/^I edit (this promotion) percentage action to have "([^"]+)%"$/')]
     public function iEditPromotionToHaveDiscount(PromotionInterface $promotion, string $amount): void
     {
         $this->updatePage->open(['id' => $promotion->getId()]);
@@ -545,18 +442,14 @@ final class ManagingPromotionsContext implements Context
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @When /^I delete a ("([^"]+)" promotion)$/
-     * @When /^I try to delete a ("([^"]+)" promotion)$/
-     */
+    #[When('/^I delete a ("([^"]+)" promotion)$/')]
+    #[When('/^I try to delete a ("([^"]+)" promotion)$/')]
     public function iDeletePromotion(PromotionInterface $promotion)
     {
         $this->sharedStorage->set('promotion', $promotion);
@@ -565,9 +458,7 @@ final class ManagingPromotionsContext implements Context
         $this->indexPage->deleteResourceOnPage(['name' => $promotion->getName()]);
     }
 
-    /**
-     * @Then /^(this promotion) should no longer exist in the promotion registry$/
-     */
+    #[Then('/^(this promotion) should no longer exist in the promotion registry$/')]
     public function promotionShouldNotExistInTheRegistry(PromotionInterface $promotion)
     {
         $this->indexPage->open();
@@ -575,9 +466,7 @@ final class ManagingPromotionsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $promotion->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that it is in use and cannot be deleted
-     */
+    #[Then('I should be notified that it is in use and cannot be deleted')]
     public function iShouldBeNotifiedOfFailure()
     {
         $this->notificationChecker->checkNotification(
@@ -586,18 +475,14 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I make it available from :startsDate to :endsDate
-     */
+    #[When('I make it available from :startsDate to :endsDate')]
     public function iMakeItAvailableFromTo(\DateTimeInterface $startsDate, \DateTimeInterface $endsDate): void
     {
         $this->formElement->setStartsAt($startsDate);
         $this->formElement->setEndsAt($endsDate);
     }
 
-    /**
-     * @Then the :promotion promotion should be available from :startsDate to :endsDate
-     */
+    #[Then('the :promotion promotion should be available from :startsDate to :endsDate')]
     public function thePromotionShouldBeAvailableFromTo(PromotionInterface $promotion, \DateTimeInterface $startsDate, \DateTimeInterface $endsDate)
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -606,17 +491,13 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->updatePage->hasEndsAt($endsDate));
     }
 
-    /**
-     * @Then I should be notified that promotion cannot end before it starts
-     */
+    #[Then('I should be notified that promotion cannot end before it starts')]
     public function iShouldBeNotifiedThatPromotionCannotEndBeforeItsEvenStarts(): void
     {
         Assert::same($this->formElement->getValidationMessage('ends_at_date'), 'End date cannot be set prior start date.');
     }
 
-    /**
-     * @Then I should be notified that this value should not be blank
-     */
+    #[Then('I should be notified that this value should not be blank')]
     public function iShouldBeNotifiedThatThisValueShouldNotBeBlank(): void
     {
         Assert::same(
@@ -625,11 +506,9 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that a percentage discount value must be between 0% and 100%
-     * @Then I should be notified that a percentage discount value must be at least 0%
-     * @Then I should be notified that the maximum value of a percentage discount is 100%
-     */
+    #[Then('I should be notified that a percentage discount value must be between 0% and 100%')]
+    #[Then('I should be notified that a percentage discount value must be at least 0%')]
+    #[Then('I should be notified that the maximum value of a percentage discount is 100%')]
     public function iShouldBeNotifiedThatPercentageDiscountShouldBeBetween(): void
     {
         Assert::same(
@@ -638,10 +517,8 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the promotion :promotion should be used :usage time(s)
-     * @Then the promotion :promotion should not be used
-     */
+    #[Then('the promotion :promotion should be used :usage time(s)')]
+    #[Then('the promotion :promotion should not be used')]
     public function thePromotionShouldBeUsedTime(PromotionInterface $promotion, int $usage = 0): void
     {
         Assert::same(
@@ -651,26 +528,20 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @When I add the "Contains product" rule configured with the :productName product
-     */
+    #[When('I add the "Contains product" rule configured with the :productName product')]
     public function iAddTheRuleConfiguredWithTheProduct(string $productName): void
     {
         $this->formElement->addRule(ContainsProductRuleChecker::TYPE);
         $this->formElement->selectAutocompleteRuleOptions([$productName]);
     }
 
-    /**
-     * @When I specify that this action should be applied to the :productName product for :channel channel
-     */
+    #[When('I specify that this action should be applied to the :productName product for :channel channel')]
     public function iSpecifyThatThisActionShouldBeAppliedToTheProduct(string $productName, ChannelInterface $channel): void
     {
         $this->formElement->selectAutocompleteActionFilterOptions([$productName], $channel->getCode(), 'products');
     }
 
-    /**
-     * @Then I should see :count promotions on the list
-     */
+    #[Then('I should see :count promotions on the list')]
     public function iShouldSeePromotionsOnTheList(int $count): void
     {
         $actualCount = $this->indexPage->countItems();
@@ -682,9 +553,7 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the first promotion on the list should have :field :value
-     */
+    #[Then('the first promotion on the list should have :field :value')]
     public function theFirstPromotionOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -697,9 +566,7 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then the last promotion on the list should have :field :value
-     */
+    #[Then('the last promotion on the list should have :field :value')]
     public function theLastPromotionOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -712,9 +579,7 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Given the :promotion promotion should have priority :priority
-     */
+    #[Given('the :promotion promotion should have priority :priority')]
     public function thePromotionsShouldHavePriority(PromotionInterface $promotion, int $priority)
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -722,42 +587,32 @@ final class ManagingPromotionsContext implements Context
         Assert::same($this->formElement->getPriority(), $priority);
     }
 
-    /**
-     * @When I want to manage this promotion coupons
-     */
+    #[When('I want to manage this promotion coupons')]
     public function iWantToManageThisPromotionSCoupons(): void
     {
         $this->updatePage->manageCoupons();
     }
 
-    /**
-     * @Then I should not be able to access coupons management page
-     */
+    #[Then('I should not be able to access coupons management page')]
     public function iShouldNotBeAbleToAccessCouponsManagementPage(): void
     {
         Assert::false($this->updatePage->isCouponManagementAvailable());
     }
 
-    /**
-     * @Then /^I should be on (this promotion)'s coupons management page$/
-     */
+    #[Then('/^I should be on (this promotion)\'s coupons management page$/')]
     public function iShouldBeOnThisPromotionSCouponsManagementPage(PromotionInterface $promotion): void
     {
         Assert::true($this->indexCouponPage->isOpen(['promotionId' => $promotion->getId()]));
     }
 
-    /**
-     * @Then I should be able to modify a :promotion promotion
-     */
+    #[Then('I should be able to modify a :promotion promotion')]
     public function iShouldBeAbleToModifyAPromotion(PromotionInterface $promotion): void
     {
         $this->iWantToModifyAPromotion($promotion);
         $this->updatePage->saveChanges();
     }
 
-    /**
-     * @Then the :promotion promotion should have :ruleName rule configured
-     */
+    #[Then('the :promotion promotion should have :ruleName rule configured')]
     public function thePromotionShouldHaveRuleConfigured(PromotionInterface $promotion, string $ruleName): void
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -766,9 +621,7 @@ final class ManagingPromotionsContext implements Context
         Assert::true($this->updatePage->hasRule($ruleName));
     }
 
-    /**
-     * @Then the :promotion promotion should not have any rule configured
-     */
+    #[Then('the :promotion promotion should not have any rule configured')]
     public function thePromotionShouldNotHaveAnyRuleConfigured(PromotionInterface $promotion): void
     {
         $this->iWantToModifyAPromotion($promotion);
@@ -776,9 +629,7 @@ final class ManagingPromotionsContext implements Context
         Assert::false($this->updatePage->hasAnyRule());
     }
 
-    /**
-     * @When /^I filter promotions by coupon code equal "([^"]+)"/
-     */
+    #[When('/^I filter promotions by coupon code equal "([^"]+)"/')]
     public function iFilterPromotionsByCouponCodeEqual(string $value): void
     {
         $this->indexPage->specifyFilterType('coupon_code', 'equal');
@@ -787,105 +638,79 @@ final class ManagingPromotionsContext implements Context
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I add a new rule
-     */
+    #[When('I add a new rule')]
     public function iAddANewRule(): void
     {
         $this->formElement->addRule(CartQuantityRuleChecker::TYPE);
     }
 
-    /**
-     * @When I add a new action
-     */
+    #[When('I add a new action')]
     public function iAddANewAction(): void
     {
         $this->formElement->addAction(FixedDiscountPromotionActionCommand::TYPE);
     }
 
-    /**
-     * @When /^I remove the discount (amount|percentage) for ("[^"]+" channel)$/
-     */
+    #[When('/^I remove the discount (amount|percentage) for ("[^"]+" channel)$/')]
     public function iRemoveTheDiscountForChannel(string $field, ChannelInterface $channel): void
     {
         $this->updatePage->removeActionFieldValue($channel->getCode(), $field);
     }
 
-    /**
-     * @When I remove the rule amount for :channel channel
-     */
+    #[When('I remove the rule amount for :channel channel')]
     public function iRemoveTheRuleAmountForChannel(ChannelInterface $channel): void
     {
         $this->updatePage->removeRuleAmount($channel->getCode());
     }
 
-    /**
-     * @Then I should see the rule configuration form
-     */
+    #[Then('I should see the rule configuration form')]
     public function iShouldSeeTheRuleConfigurationForm(): void
     {
         Assert::true($this->formElement->checkIfRuleConfigurationFormIsVisible(), 'Cart promotion rule configuration form is not visible.');
     }
 
-    /**
-     * @Then I should not see the rule configuration form
-     */
+    #[Then('I should not see the rule configuration form')]
     public function iShouldNotSeeTheRuleConfigurationForm(): void
     {
         Assert::false($this->formElement->checkIfRuleConfigurationFormIsVisible(), 'Cart promotion rule configuration form is visible.');
     }
 
-    /**
-     * @Then it should have :amount of order percentage discount
-     */
+    #[Then('it should have :amount of order percentage discount')]
     public function itShouldHaveOfOrderPercentageDiscount(string $amount): void
     {
         Assert::same($this->updatePage->getOrderPercentageDiscountActionValue(), $amount);
     }
 
-    /**
-     * @Then it should have :amount of item percentage discount configured for :channel channel
-     */
+    #[Then('it should have :amount of item percentage discount configured for :channel channel')]
     public function itShouldHaveOfItemPercentageDiscount(string $amount, ChannelInterface $channel): void
     {
         Assert::same($this->updatePage->getItemPercentageDiscountActionValue($channel->getCode()), $amount);
     }
 
-    /**
-     * @Then I should see the action configuration form
-     */
+    #[Then('I should see the action configuration form')]
     public function iShouldSeeTheActionConfigurationForm(): void
     {
         Assert::true($this->formElement->checkIfActionConfigurationFormIsVisible(), 'Cart promotion action configuration form is not visible.');
     }
 
-    /**
-     * @Then I should not see the action configuration form
-     */
+    #[Then('I should not see the action configuration form')]
     public function iShouldNotSeeTheActionConfigurationForm(): void
     {
         Assert::false($this->formElement->checkIfActionConfigurationFormIsVisible(), 'Cart promotion action configuration form is visible.');
     }
 
-    /**
-     * @Then /^I should see that the rule for ("[^"]+" channel) has (\d+) validation errors?$/
-     */
+    #[Then('/^I should see that the rule for ("[^"]+" channel) has (\d+) validation errors?$/')]
     public function iShouldSeeThatTheRuleForChannelHasCountValidationErrors(ChannelInterface $channel, int $count): void
     {
         Assert::same($this->updatePage->getRuleValidationErrorsCount($channel->getCode()), $count);
     }
 
-    /**
-     * @Then /^I should see that the action for ("[^"]+" channel) has (\d+) validation errors?$/
-     */
+    #[Then('/^I should see that the action for ("[^"]+" channel) has (\d+) validation errors?$/')]
     public function iShouldSeeThatTheActionForChannelHasCountValidationErrors(ChannelInterface $channel, int $count): void
     {
         Assert::same($this->updatePage->getActionValidationErrorsCount($channel->getCode()), $count);
     }
 
-    /**
-     * @Then I should be notified that :promotion promotion has been updated
-     */
+    #[Then('I should be notified that :promotion promotion has been updated')]
     public function iShouldBeNotifiedThatPromotionsHaveBeenUpdated(PromotionInterface $promotion): void
     {
         $this->notificationChecker->checkNotification(
@@ -894,9 +719,7 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that promotion label in :localeCode locale is too long
-     */
+    #[Then('I should be notified that promotion label in :localeCode locale is too long')]
     public function iShouldBeNotifiedThatPromotionLabelIsTooLong(string $localeCode): void
     {
         Assert::same(
@@ -905,33 +728,25 @@ final class ManagingPromotionsContext implements Context
         );
     }
 
-    /**
-     * @Then I should see the promotion :promotionName in the list
-     */
+    #[Then('I should see the promotion :promotionName in the list')]
     public function iShouldSeeThePromotionInTheList(string $promotionName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $promotionName]));
     }
 
-    /**
-     * @Then I should not see the promotion :promotionName in the list
-     */
+    #[Then('I should not see the promotion :promotionName in the list')]
     public function iShouldNotSeeThePromotionInTheList(string $promotionName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $promotionName]));
     }
 
-    /**
-     * @Then I should be viewing non archival promotions
-     */
+    #[Then('I should be viewing non archival promotions')]
     public function iShouldBeViewingNonArchivalPromotions(): void
     {
         Assert::false($this->indexPage->isArchivalFilterEnabled());
     }
 
-    /**
-     * @Then the :promotion promotion should be successfully created
-     */
+    #[Then('the :promotion promotion should be successfully created')]
     public function thePromotionShouldBeSuccessfullyCreated(PromotionInterface $promotion): void
     {
         $this->updatePage->verify(['id' => $promotion->getId()]);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShipmentsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShipmentsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Order\ShowPageInterface as OrderShowPageInterface;
@@ -34,18 +36,14 @@ final class ManagingShipmentsContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse shipments
-     */
+    #[When('I browse shipments')]
     public function iBrowseShipments(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Then the shipment of the :orderNumber order should be :shippingState for :customer
-     * @Then the shipment of the :orderNumber order should be :shippingState for :customer in :channel channel
-     */
+    #[Then('the shipment of the :orderNumber order should be :shippingState for :customer')]
+    #[Then('the shipment of the :orderNumber order should be :shippingState for :customer in :channel channel')]
     public function shipmentOfOrderShouldBe(
         string $orderNumber,
         string $shippingState,
@@ -65,147 +63,111 @@ final class ManagingShipmentsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage($parameters));
     }
 
-    /**
-     * @When I choose :shipmentState as a shipment state
-     */
+    #[When('I choose :shipmentState as a shipment state')]
     public function iChooseShipmentState(string $shipmentState): void
     {
         $this->indexPage->chooseStateToFilter($shipmentState);
     }
 
-    /**
-     * @When I choose :channelName as a channel filter
-     */
+    #[When('I choose :channelName as a channel filter')]
     public function iChooseChannelAsAChannelFilter(string $channelName): void
     {
         $this->indexPage->chooseChannelFilter($channelName);
     }
 
-    /**
-     * @When I choose :shippingMethodName as a shipping method filter
-     */
+    #[When('I choose :shippingMethodName as a shipping method filter')]
     public function iChooseAsAShippingMethodFilter(string $shippingMethodName): void
     {
         $this->indexPage->chooseShippingMethodFilter($shippingMethodName);
     }
 
-    /**
-     * @When I filter
-     */
+    #[When('I filter')]
     public function iFilter(): void
     {
         $this->indexPage->filter();
     }
 
-    /**
-     * @When I view the first shipment of the order :order
-     */
+    #[When('I view the first shipment of the order :order')]
     public function iViewTheShipmentOfTheOrder(OrderInterface $order): void
     {
         $this->showPage->open(['id' => $order->getShipments()->first()->getId()]);
     }
 
-    /**
-     * @Then I should see( only) :count shipment(s) in the list
-     * @Then I should see a single shipment in the list
-     */
+    #[Then('I should see( only) :count shipment(s) in the list')]
+    #[Then('I should see a single shipment in the list')]
     public function iShouldSeeCountShipmentsInList(int $count = 1): void
     {
         Assert::same($this->indexPage->countItems(), $count);
     }
 
-    /**
-     * @Then I should see a shipment of order :orderNumber
-     */
+    #[Then('I should see a shipment of order :orderNumber')]
     public function iShouldSeeShipmentWithOrderNumber(string $orderNumber): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['order' => $orderNumber]));
     }
 
-    /**
-     * @Then I should not see a shipment of order :orderNumber
-     */
+    #[Then('I should not see a shipment of order :orderNumber')]
     public function iShouldNotSeeShipmentWithOrderNumber(string $orderNumber): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['order' => $orderNumber]));
     }
 
-    /**
-     * @When I ship the shipment of order :orderNumber
-     */
+    #[When('I ship the shipment of order :orderNumber')]
     public function iShipShipmentOfOrder(string $orderNumber): void
     {
         $this->indexPage->shipShipmentOfOrderWithNumber($orderNumber);
     }
 
-    /**
-     * @Then I should see the shipment of order :orderNumber as :shippingState
-     */
+    #[Then('I should see the shipment of order :orderNumber as :shippingState')]
     public function iShouldSeeTheShipmentOfOrderAs(string $orderNumber, string $shippingState): void
     {
         Assert::same($shippingState, $this->indexPage->getShipmentStatusByOrderNumber($orderNumber));
     }
 
-    /**
-     * @Then I should be notified that the shipment has been successfully shipped
-     */
+    #[Then('I should be notified that the shipment has been successfully shipped')]
     public function iShouldBeNotifiedThatTheShipmentHasBeenSuccessfullyShipped(): void
     {
         $this->notificationChecker->checkNotification('Shipment has been successfully shipped.', NotificationType::success());
     }
 
-    /**
-     * @When I move to the details of first shipment's order
-     */
+    #[When('I move to the details of first shipment\'s order')]
     public function iMoveToDetailsOfFirstShipment(): void
     {
         $this->indexPage->showOrderPageForNthShipment(1);
     }
 
-    /**
-     * @When I ship the shipment of order :orderNumber with :trackingCode tracking code
-     */
+    #[When('I ship the shipment of order :orderNumber with :trackingCode tracking code')]
     public function iShipTheShipmentOfOrderWithTrackingCode(string $orderNumber, string $trackingCode): void
     {
         $this->indexPage->shipShipmentOfOrderWithTrackingCode($orderNumber, $trackingCode);
     }
 
-    /**
-     * @Then I should see order page with details of order :order
-     * @Then I should see the details of order :order
-     */
+    #[Then('I should see order page with details of order :order')]
+    #[Then('I should see the details of order :order')]
     public function iShouldSeeOrderPageWithDetailsOfOrder(OrderInterface $order): void
     {
         Assert::true($this->orderShowPage->isOpen(['id' => $order->getId()]));
     }
 
-    /**
-     * @Then /^I should see shipment for (the "[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/
-     */
+    #[Then('/^I should see shipment for (the "[^"]+" order) as (\d+)(?:|st|nd|rd|th) in the list$/')]
     public function iShouldSeeShipmentForTheOrderInTheList(string $orderNumber, int $position): void
     {
         Assert::true($this->indexPage->isShipmentWithOrderNumberInPosition($orderNumber, $position));
     }
 
-    /**
-     * @Then I should see :amount :product units in the list
-     */
+    #[Then('I should see :amount :product units in the list')]
     public function iShouldSeeUnitsInTheList(int $amount, string $productName): void
     {
         Assert::same($this->showPage->getAmountOfUnits($productName), $amount);
     }
 
-    /**
-     * @Then I should see the shipment of order :orderNumber shipped at :dateTime
-     */
+    #[Then('I should see the shipment of order :orderNumber shipped at :dateTime')]
     public function iShouldSeeTheShippingDateAs(string $orderNumber, string $dateTime): void
     {
         Assert::same($this->indexPage->getShippedAtDate($orderNumber), $dateTime);
     }
 
-    /**
-     * @Then I should see the shipment state as :shipmentState
-     */
+    #[Then('I should see the shipment state as :shipmentState')]
     public function iShouldSeeTheShipmentStateAs(string $shipmentState): void
     {
         Assert::same($this->showPage->getState(), $shipmentState);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
@@ -33,51 +35,39 @@ class ManagingShippingCategoriesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new shipping category
-     */
+    #[When('I want to create a new shipping category')]
     public function iWantToCreateANewShippingCategory(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When /^I browse shipping categories$/
-     */
+    #[When('/^I browse shipping categories$/')]
     public function iWantToBrowseShippingCategories(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Then I should see a single shipping category in the list
-     * @Then I should see :numberOfShippingCategories shipping categories in the list
-     */
+    #[Then('I should see a single shipping category in the list')]
+    #[Then('I should see :numberOfShippingCategories shipping categories in the list')]
     public function iShouldSeeShippingCategoriesInTheList(int $numberOfShippingCategories = 1): void
     {
         Assert::same($this->indexPage->countItems(), $numberOfShippingCategories);
     }
 
-    /**
-     * @When I specify its description as :shippingCategoryDescription
-     */
+    #[When('I specify its description as :shippingCategoryDescription')]
     public function iSpecifyItsDescriptionAs(string $shippingCategoryDescription): void
     {
         $this->createPage->specifyDescription($shippingCategoryDescription);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatCodeIsRequired(string $element): void
     {
         Assert::same(
@@ -86,36 +76,28 @@ class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @When I do not specify its code
-     * @When I specify its code as :code
-     */
+    #[When('I do not specify its code')]
+    #[When('I specify its code as :code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I name it :shippingCategoryName
-     * @When I do not specify its name
-     */
+    #[When('I name it :shippingCategoryName')]
+    #[When('I do not specify its name')]
     public function iNameIt($shippingCategoryName = null): void
     {
         $this->createPage->nameIt($shippingCategoryName ?? '');
     }
 
-    /**
-     * @Then I should see the shipping category :shippingCategoryName in the list
-     */
+    #[Then('I should see the shipping category :shippingCategoryName in the list')]
     public function iShouldSeeTheShippingCategoryInTheList(string $shippingCategoryName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $shippingCategoryName]));
     }
 
-    /**
-     * @Then /^the (shipping category "([^"]+)") should be in the registry$/
-     * @Then /^the (shipping category "([^"]+)") should appear in the registry$/
-     */
+    #[Then('/^the (shipping category "([^"]+)") should be in the registry$/')]
+    #[Then('/^the (shipping category "([^"]+)") should appear in the registry$/')]
     public function theShippingCategoryShouldAppearInTheRegistry(ShippingCategoryInterface $shippingCategory): void
     {
         $this->iWantToBrowseShippingCategories();
@@ -123,83 +105,63 @@ class ManagingShippingCategoriesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]));
     }
 
-    /**
-     * @When I delete shipping category :shippingCategoryName
-     */
+    #[When('I delete shipping category :shippingCategoryName')]
     public function iDeleteShippingCategory(string $shippingCategoryName): void
     {
         $this->iWantToBrowseShippingCategories();
         $this->indexPage->deleteResourceOnPage(['name' => $shippingCategoryName]);
     }
 
-    /**
-     * @Then /^(this shipping category) should no longer exist in the registry$/
-     */
+    #[Then('/^(this shipping category) should no longer exist in the registry$/')]
     public function thisShippingCategoryShouldNoLongerExistInTheRegistry(ShippingCategoryInterface $shippingCategory)
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]));
     }
 
-    /**
-     * @Then shipping category with name :shippingCategoryName should not be added
-     */
+    #[Then('shipping category with name :shippingCategoryName should not be added')]
     public function shippingCategoryWithNameShouldNotBeAdded(string $shippingCategoryName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $shippingCategoryName]));
     }
 
-    /**
-     * @When /^I modify a (shipping category "([^"]+)")$/
-     * @When /^I want to modify a (shipping category "([^"]+)")$/
-     */
+    #[When('/^I modify a (shipping category "([^"]+)")$/')]
+    #[When('/^I want to modify a (shipping category "([^"]+)")$/')]
     public function iWantToModifyAShippingCategory(ShippingCategoryInterface $shippingCategory): void
     {
         $this->updatePage->open(['id' => $shippingCategory->getId()]);
     }
 
-    /**
-     * @When I rename it to :name
-     */
+    #[When('I rename it to :name')]
     public function iNameItIn(string $name): void
     {
         $this->createPage->nameIt($name ?? '');
     }
 
-    /**
-     * @When I check (also) the :shippingCategoryName shipping category
-     */
+    #[When('I check (also) the :shippingCategoryName shipping category')]
     public function iCheckTheShippingCategory(string $shippingCategoryName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $shippingCategoryName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->updatePage->isCodeDisabled(), 'Shipping category code should be disabled');
     }
 
-    /**
-     * @Then this shipping category name should be :shippingCategoryName
-     */
+    #[Then('this shipping category name should be :shippingCategoryName')]
     public function thisShippingCategoryNameShouldBe(string $shippingCategoryName): void
     {
         Assert::true($this->updatePage->hasResourceValues(['name' => $shippingCategoryName]));
     }
 
-    /**
-     * @Then I should be notified that shipping category with this code already exists
-     */
+    #[Then('I should be notified that shipping category with this code already exists')]
     public function iShouldBeNotifiedThatShippingCategoryWithThisCodeAlreadyExists(): void
     {
         Assert::same(
@@ -208,9 +170,7 @@ class ManagingShippingCategoriesContext implements Context
         );
     }
 
-    /**
-     * @Then there should still be only one shipping category with code :code
-     */
+    #[Then('there should still be only one shipping category with code :code')]
     public function thereShouldStillBeOnlyOneShippingCategoryWith(string $code): void
     {
         $this->iWantToBrowseShippingCategories();

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Element\Admin\ShippingMethod\FormElementInterface;
@@ -41,85 +43,65 @@ final readonly class ManagingShippingMethodsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new shipping method
-     */
+    #[When('I want to create a new shipping method')]
     public function iWantToCreateANewShippingMethod(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->shippingMethodFormElement->setCode($code ?? '');
     }
 
-    /**
-     * @When I specify its position as :position
-     */
+    #[When('I specify its position as :position')]
     public function iSpecifyItsPositionAs(int $position): void
     {
         $this->shippingMethodFormElement->setPosition($position);
     }
 
-    /**
-     * @When I name it :name in :language
-     * @When I rename it to :name in :language
-     */
+    #[When('I name it :name in :language')]
+    #[When('I rename it to :name in :language')]
     public function iNameItIn(string $name, string $language): void
     {
         $this->shippingMethodFormElement->setName($name, $language);
     }
 
-    /**
-     * @When I describe it as :description in :language
-     */
+    #[When('I describe it as :description in :language')]
     public function iDescribeItAsIn(string $description, string $language): void
     {
         $this->shippingMethodFormElement->setDescription($description, $language);
     }
 
-    /**
-     * @When I define it for the zone named :zone
-     */
+    #[When('I define it for the zone named :zone')]
     public function iDefineItForTheZone(ZoneInterface $zone): void
     {
         $this->shippingMethodFormElement->setZoneCode($zone->getCode());
     }
 
-    /**
-     * @When I make it available in channel :channel
-     */
+    #[When('I make it available in channel :channel')]
     public function iMakeItAvailableInChannel(ChannelInterface $channel): void
     {
         $this->shippingMethodFormElement->checkChannel($channel->getCode());
     }
 
-    /**
-     * @When I specify its amount as :amount for :channel channel
-     */
+    #[When('I specify its amount as :amount for :channel channel')]
     public function iSpecifyItsAmountForChannel(int $amount, ChannelInterface $channel): void
     {
         $this->shippingMethodFormElement->setCalculatorConfigurationAmountForChannel($channel->getCode(), $amount);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I choose :calculatorName calculator
-     * @When I do not specify amount for :calculatorName calculator
-     */
+    #[When('I choose :calculatorName calculator')]
+    #[When('I do not specify amount for :calculatorName calculator')]
     public function iChooseCalculator(string $calculatorName): void
     {
         $this->shippingMethodFormElement->chooseCalculator($calculatorName);
@@ -131,27 +113,21 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->shippingMethodFormElement->setField($label, $value);
     }
 
-    /**
-     * @When I check (also) the :shippingMethodName shipping method
-     */
+    #[When('I check (also) the :shippingMethodName shipping method')]
     public function iCheckTheShippingMethod(string $shippingMethodName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $shippingMethodName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then I should see the shipping method :shipmentMethodName in the list
-     * @Then the shipping method :shipmentMethodName should appear in the registry
-     * @Then the shipping method :shipmentMethodName should be in the registry
-     */
+    #[Then('I should see the shipping method :shipmentMethodName in the list')]
+    #[Then('the shipping method :shipmentMethodName should appear in the registry')]
+    #[Then('the shipping method :shipmentMethodName should be in the registry')]
     public function theShipmentMethodShouldAppearInTheRegistry(string $shipmentMethodName): void
     {
         $this->iWantToBrowseShippingMethods();
@@ -159,9 +135,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $shipmentMethodName]));
     }
 
-    /**
-     * @Then the shipping method :shipmentMethodName should not appear in the registry
-     */
+    #[Then('the shipping method :shipmentMethodName should not appear in the registry')]
     public function theShipmentMethodShouldNotAppearInTheRegistry(string $shipmentMethodName): void
     {
         $this->iWantToBrowseShippingMethods();
@@ -169,17 +143,13 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $shipmentMethodName]));
     }
 
-    /**
-     * @Given /^(this shipping method) should still be in the registry$/
-     */
+    #[Given('/^(this shipping method) should still be in the registry$/')]
     public function thisShippingMethodShouldStillBeInTheRegistry(ShippingMethodInterface $shippingMethod)
     {
         $this->theShipmentMethodShouldAppearInTheRegistry($shippingMethod->getName());
     }
 
-    /**
-     * @Then the shipping method :shippingMethod should be available in channel :channel
-     */
+    #[Then('the shipping method :shippingMethod should be available in channel :channel')]
     public function theShippingMethodShouldBeAvailableInChannel(
         ShippingMethodInterface $shippingMethod,
         ChannelInterface $channel,
@@ -196,17 +166,13 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that shipping method with this code already exists
-     */
+    #[Then('I should be notified that shipping method with this code already exists')]
     public function iShouldBeNotifiedThatShippingMethodWithThisCodeAlreadyExists()
     {
         Assert::same($this->shippingMethodFormElement->getValidationMessage('code'), 'The shipping method with given code already exists.');
     }
 
-    /**
-     * @Then there should still be only one shipping method with :element :code
-     */
+    #[Then('there should still be only one shipping method with :element :code')]
     public function thereShouldStillBeOnlyOneShippingMethodWith($element, $code)
     {
         $this->iWantToBrowseShippingMethods();
@@ -214,27 +180,21 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
-    /**
-     * @When I want to modify a shipping method :shippingMethod
-     * @When /^I want to modify (this shipping method)$/
-     */
+    #[When('I want to modify a shipping method :shippingMethod')]
+    #[When('/^I want to modify (this shipping method)$/')]
     public function iWantToModifyAShippingMethod(ShippingMethodInterface $shippingMethod)
     {
         $this->updatePage->open(['id' => $shippingMethod->getId()]);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function theCodeFieldShouldBeDisabled()
     {
         Assert::true($this->shippingMethodFormElement->isCodeDisabled());
     }
 
-    /**
-     * @Then /^(this shipping method) name should be "([^"]+)"$/
-     * @Then /^(this shipping method) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this shipping method) name should be "([^"]+)"$/')]
+    #[Then('/^(this shipping method) should still be named "([^"]+)"$/')]
     public function thisShippingMethodNameShouldBe(ShippingMethodInterface $shippingMethod, $shippingMethodName)
     {
         $this->iWantToBrowseShippingMethods();
@@ -245,9 +205,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         ]));
     }
 
-    /**
-     * @Then /^I should be notified that (code) is required$/
-     */
+    #[Then('/^I should be notified that (code) is required$/')]
     public function iShouldBeNotifiedThatCodeIsRequired(string $field): void
     {
         Assert::same(
@@ -256,9 +214,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that name is required
-     */
+    #[Then('I should be notified that name is required')]
     public function iShouldBeNotifiedThatNameIsRequired($localeCode = 'en_US'): void
     {
         Assert::same(
@@ -267,9 +223,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code needs to contain only specific symbols
-     */
+    #[Then('I should be notified that code needs to contain only specific symbols')]
     public function iShouldBeNotifiedThatCodeNeedsToContainOnlySpecificSymbols(): void
     {
         $this->assertFieldValidationMessage(
@@ -278,52 +232,40 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I archive the :name shipping method
-     */
+    #[When('I archive the :name shipping method')]
     public function iArchiveTheShippingMethod(string $name): void
     {
         $this->indexPage->archiveShippingMethod($name);
     }
 
-    /**
-     * @When I restore the :name shipping method
-     */
+    #[When('I restore the :name shipping method')]
     public function iRestoreTheShippingMethod(string $name): void
     {
         $this->indexPage->restoreShippingMethod($name);
     }
 
-    /**
-     * @Then I should be viewing non archival shipping methods
-     */
+    #[Then('I should be viewing non archival shipping methods')]
     public function iShouldBeViewingNonArchivalShippingMethods()
     {
         Assert::false($this->indexPage->isArchivalFilterEnabled());
     }
 
-    /**
-     * @Then I should see a single shipping method in the list
-     * @Then I should see :numberOfShippingMethods shipping methods in the list
-     * @Then I should see :numberOfShippingMethods shipping methods on the list
-     */
+    #[Then('I should see a single shipping method in the list')]
+    #[Then('I should see :numberOfShippingMethods shipping methods in the list')]
+    #[Then('I should see :numberOfShippingMethods shipping methods on the list')]
     public function thereShouldBeNoShippingMethodsOnTheList(int $numberOfShippingMethods = 1): void
     {
         Assert::same($this->indexPage->countItems(), $numberOfShippingMethods);
     }
 
-    /**
-     * @Then the only shipping method on the list should be :name
-     */
+    #[Then('the only shipping method on the list should be :name')]
     public function theOnlyShippingMethodOnTheListShouldBe($name)
     {
         Assert::same((int) $this->indexPage->countItems(), 1);
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
-    /**
-     * @Then shipping method with :element :name should not be added
-     */
+    #[Then('shipping method with :element :name should not be added')]
     public function shippingMethodWithElementValueShouldNotBeAdded($element, $name)
     {
         $this->iWantToBrowseShippingMethods();
@@ -331,60 +273,46 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
-    /**
-     * @When I do not name it
-     */
+    #[When('I do not name it')]
     public function iDoNotNameIt()
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I do not specify its zone
-     */
+    #[When('I do not specify its zone')]
     public function iDoNotSpecifyItsZone()
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I remove its zone
-     */
+    #[When('I remove its zone')]
     public function iRemoveItsZone(): void
     {
         $this->shippingMethodFormElement->setZoneCode('');
     }
 
-    /**
-     * @Then I should be notified that :element has to be selected
-     * @Then I should be notified that the :element is required
-     */
+    #[Then('I should be notified that :element has to be selected')]
+    #[Then('I should be notified that the :element is required')]
     public function iShouldBeNotifiedThatElementHasToBeSelected(string $element): void
     {
         $this->assertFieldValidationMessage($element, sprintf('Please select shipping method %s.', $element));
     }
 
-    /**
-     * @When I remove its name from :language translation
-     */
+    #[When('I remove its name from :language translation')]
     public function iRemoveItsNameFromTranslation(string $language): void
     {
         $this->shippingMethodFormElement->setName('', $language);
     }
 
-    /**
-     * @Given I am browsing shipping methods
-     * @When I browse shipping methods
-     * @When I want to browse shipping methods
-     */
+    #[Given('I am browsing shipping methods')]
+    #[When('I browse shipping methods')]
+    #[When('I want to browse shipping methods')]
     public function iWantToBrowseShippingMethods()
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Given I am browsing archival shipping methods
-     */
+    #[Given('I am browsing archival shipping methods')]
     public function iAmBrowsingArchivalShippingMethods()
     {
         $this->indexPage->open();
@@ -392,18 +320,14 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->indexPage->filter();
     }
 
-    /**
-     * @Given I filter archival shipping methods
-     */
+    #[Given('I filter archival shipping methods')]
     public function iFilterArchivalShippingMethods()
     {
         $this->indexPage->chooseArchival('Yes');
         $this->indexPage->filter();
     }
 
-    /**
-     * @Then the first shipping method on the list should have :field :value
-     */
+    #[Then('the first shipping method on the list should have :field :value')]
     public function theFirstShippingMethodOnTheListShouldHave($field, $value)
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -411,9 +335,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same(reset($fields), $value);
     }
 
-    /**
-     * @Then the last shipping method on the list should have :field :value
-     */
+    #[Then('the last shipping method on the list should have :field :value')]
     public function theLastShippingMethodOnTheListShouldHave($field, $value)
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -421,77 +343,59 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same(end($fields), $value);
     }
 
-    /**
-     * @Given the shipping methods are already sorted :sortType by :field
-     * @When I switch the way shipping methods are sorted :sortType by :field
-     * @When I sort the shipping methods :sortType by :field
-     */
+    #[Given('the shipping methods are already sorted :sortType by :field')]
+    #[When('I switch the way shipping methods are sorted :sortType by :field')]
+    #[When('I sort the shipping methods :sortType by :field')]
     public function iSortShippingMethodsBy(string $sortType, string $field): void
     {
         $this->indexPage->sortBy($field);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt()
     {
         $this->shippingMethodFormElement->enable();
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt()
     {
         $this->shippingMethodFormElement->disable();
     }
 
-    /**
-     * @When I specify a too long :field
-     */
+    #[When('I specify a too long :field')]
     public function iSpecifyATooLong(string $field): void
     {
         $this->shippingMethodFormElement->setField(ucwords($field), str_repeat('a', 256));
     }
 
-    /**
-     * @Then /^(this shipping method) should be disabled$/
-     */
+    #[Then('/^(this shipping method) should be disabled$/')]
     public function thisShippingMethodShouldBeDisabled(ShippingMethodInterface $shippingMethod)
     {
         Assert::true($this->indexPage->isShippingMethodDisabled($shippingMethod));
     }
 
-    /**
-     * @Then /^(this shipping method) should be enabled$/
-     */
+    #[Then('/^(this shipping method) should be enabled$/')]
     public function thisShippingMethodShouldBeEnabled(ShippingMethodInterface $shippingMethod)
     {
         Assert::true($this->indexPage->isShippingMethodEnabled($shippingMethod));
     }
 
-    /**
-     * @When I delete shipping method :shippingMethod
-     * @When I try to delete shipping method :shippingMethod
-     */
+    #[When('I delete shipping method :shippingMethod')]
+    #[When('I try to delete shipping method :shippingMethod')]
     public function iDeleteShippingMethod(ShippingMethodInterface $shippingMethod): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['name' => $shippingMethod->getName()]);
     }
 
-    /**
-     * @Then /^(this shipping method) should no longer exist in the registry$/
-     */
+    #[Then('/^(this shipping method) should no longer exist in the registry$/')]
     public function thisShippingMethodShouldNoLongerExistInTheRegistry(ShippingMethodInterface $shippingMethod)
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $shippingMethod->getCode()]));
     }
 
-    /**
-     * @Then I should be notified that amount for :channel channel should not be blank
-     */
+    #[Then('I should be notified that amount for :channel channel should not be blank')]
     public function iShouldBeNotifiedThatAmountForChannelShouldNotBeBlank(ChannelInterface $channel)
     {
         Assert::same(
@@ -500,9 +404,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that shipping charge for :channel channel cannot be lower than 0
-     */
+    #[Then('I should be notified that shipping charge for :channel channel cannot be lower than 0')]
     public function iShouldBeNotifiedThatShippingChargeForChannelCannotBeLowerThan0(ChannelInterface $channel): void
     {
         Assert::same(
@@ -511,36 +413,28 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @When I add the "Total weight greater than or equal" rule configured with :weight
-     */
+    #[When('I add the "Total weight greater than or equal" rule configured with :weight')]
     public function iAddTheTotalWeightGreaterThanOrEqualRuleConfiguredWith(int $weight): void
     {
         $this->shippingMethodFormElement->addRule(TotalWeightGreaterThanOrEqualRuleChecker::TYPE);
         $this->shippingMethodFormElement->fillLastRuleOption('Weight', (string) $weight);
     }
 
-    /**
-     * @When I add the "Total weight greater than or equal" rule configured with invalid data
-     */
+    #[When('I add the "Total weight greater than or equal" rule configured with invalid data')]
     public function iAddTheTotalWeightGreaterThanOrEqualRuleConfiguredWithInvalidData(): void
     {
         $this->shippingMethodFormElement->addRule(TotalWeightGreaterThanOrEqualRuleChecker::TYPE);
         $this->shippingMethodFormElement->fillLastRuleOption('Weight', 'invalid data');
     }
 
-    /**
-     * @When I add the "Total weight less than or equal" rule configured with :weight
-     */
+    #[When('I add the "Total weight less than or equal" rule configured with :weight')]
     public function iAddTheTotalWeightLessThanOrEqualRuleConfiguredWith(int $weight): void
     {
         $this->shippingMethodFormElement->addRule(TotalWeightLessThanOrEqualRuleChecker::TYPE);
         $this->shippingMethodFormElement->fillLastRuleOption('Weight', (string) $weight);
     }
 
-    /**
-     * @When /^I add the "([^"]+)" rule configured with (?:€|£|\$)([^"]+) for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "([^"]+)" rule configured with (?:€|£|\$)([^"]+) for ("[^"]+" channel)$/')]
     public function iAddTheItemsTotalLessThanOrEqualRuleConfiguredWith(string $rule, mixed $value, ChannelInterface $channel): void
     {
         $ruleTypes = [
@@ -552,26 +446,20 @@ final readonly class ManagingShippingMethodsContext implements Context
         $this->shippingMethodFormElement->fillLastRuleOptionForChannel($channel->getCode(), 'Amount', (string) $value);
     }
 
-    /**
-     * @When /^I add the "Items total less than or equal" rule configured with invalid data for ("[^"]+" channel)$/
-     */
+    #[When('/^I add the "Items total less than or equal" rule configured with invalid data for ("[^"]+" channel)$/')]
     public function iAddTheItemsTotalLessThanOrEqualRuleConfiguredWithInvalidData(ChannelInterface $channel): void
     {
         $this->shippingMethodFormElement->addRule(OrderTotalLessThanOrEqualRuleChecker::TYPE);
         $this->shippingMethodFormElement->fillLastRuleOptionForChannel($channel->getCode(), 'Amount', 'Invalid data');
     }
 
-    /**
-     * @When /^I remove the shipping charges of ("[^"]+" channel)$/
-     */
+    #[When('/^I remove the shipping charges of ("[^"]+" channel)$/')]
     public function iRemoveTheShippingChargesOfChannel(ChannelInterface $channel): void
     {
         $this->shippingMethodFormElement->setCalculatorConfigurationAmountForChannel($channel->getCode(), null);
     }
 
-    /**
-     * @Then /^I should see that the shipping charges for ("[^"]+" channel) has (\d+) validation errors?$/
-     */
+    #[Then('/^I should see that the shipping charges for ("[^"]+" channel) has (\d+) validation errors?$/')]
     public function iShouldSeeThatTheShippingChargesForChannelHasCountValidationErrors(
         ChannelInterface $channel,
         int $count,
@@ -582,9 +470,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the weight rule has an invalid configuration
-     */
+    #[Then('I should be notified that the weight rule has an invalid configuration')]
     public function iShouldBeNotifiedThatTheWeightRuleHasAnInvalidConfiguration(): void
     {
         $channel = $this->sharedStorage->get('channel');
@@ -594,9 +480,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the amount rule has an invalid configuration in :channel channel
-     */
+    #[Then('I should be notified that the amount rule has an invalid configuration in :channel channel')]
     public function iShouldBeNotifiedThatTheAmountRuleHasAnInvalidConfigurationInChannel(ChannelInterface $channel): void
     {
         Assert::same(
@@ -605,10 +489,8 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that :field is too long
-     * @Then I should be notified that :field should be no longer than :maxLength characters
-     */
+    #[Then('I should be notified that :field is too long')]
+    #[Then('I should be notified that :field should be no longer than :maxLength characters')]
     public function iShouldBeNotifiedThatFieldValueIsTooLong(string $field, int $maxLength = 255): void
     {
         $validationMessage = $this->shippingMethodFormElement->getValidationMessage(StringInflector::nameToLowercaseCode($field));
@@ -619,9 +501,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         );
     }
 
-    /**
-     * @Then the :shippingMethod shipping method should be successfully created
-     */
+    #[Then('the :shippingMethod shipping method should be successfully created')]
     public function theShippingMethodShouldBeSuccessfullyCreated(ShippingMethodInterface $shippingMethod): void
     {
         $this->updatePage->verify(['id' => $shippingMethod->getId()]);
@@ -633,9 +513,7 @@ final readonly class ManagingShippingMethodsContext implements Context
         Assert::same($this->shippingMethodFormElement->getValidationMessage($element), $expectedMessage);
     }
 
-    /**
-     * @Then I should be notified that Maximum delivery time must be greater than or equal to the minimum.
-     */
+    #[Then('I should be notified that Maximum delivery time must be greater than or equal to the minimum.')]
     public function iShouldBeNotifiedThatMaxDeliveryIsGreaterOrEqualMin(): void
     {
         $this->assertFieldValidationMessage('max_delivery_time_days', 'Maximum delivery time must be greater than or equal to the minimum.');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\TaxCategory\FormElementInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
@@ -31,200 +34,154 @@ final readonly class ManagingTaxCategoriesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new tax category
-     */
+    #[When('I want to create a new tax category')]
     public function iWantToCreateNewTaxCategory(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->setCode($code ?? '');
     }
 
-    /**
-     * @When I specify a too long :field
-     */
+    #[When('I specify a too long :field')]
     public function iSpecifyATooLongCode(string $field): void
     {
         $this->formElement->fillElement(str_repeat('a', 256), $field);
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iNameIt($name = null): void
     {
         $this->formElement->setName($name ?? '');
     }
 
-    /**
-     * @When I describe it as :description
-     */
+    #[When('I describe it as :description')]
     public function iDescribeItAs($description): void
     {
         $this->formElement->setDescription($description);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I want to modify a tax category :taxCategory
-     * @When /^I want to modify (this tax category)$/
-     */
+    #[When('I want to modify a tax category :taxCategory')]
+    #[When('/^I want to modify (this tax category)$/')]
     public function iWantToModifyTaxCategory(TaxCategoryInterface $taxCategory): void
     {
         $this->updatePage->open(['id' => $taxCategory->getId()]);
     }
 
-    /**
-     * @Given I am browsing tax categories
-     * @When I browse tax categories
-     */
+    #[Given('I am browsing tax categories')]
+    #[When('I browse tax categories')]
     public function iWantToBrowseTaxCategories(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I check (also) the :taxCategoryName tax category
-     */
+    #[When('I check (also) the :taxCategoryName tax category')]
     public function iCheckTheTaxCategory(string $taxCategoryName): void
     {
         $this->indexPage->checkResourceOnPage(['nameAndDescription' => $taxCategoryName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I delete tax category :taxCategory
-     */
+    #[When('I delete tax category :taxCategory')]
     public function iDeletedTaxCategory(TaxCategoryInterface $taxCategory): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['code' => $taxCategory->getCode()]);
     }
 
-    /**
-     * @Then /^(this tax category) should no longer exist in the registry$/
-     */
+    #[Then('/^(this tax category) should no longer exist in the registry$/')]
     public function thisTaxCategoryShouldNoLongerExistInTheRegistry(TaxCategoryInterface $taxCategory): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode()]));
     }
 
-    /**
-     * @Then I should see the tax category :taxCategoryName in the list
-     * @Then the tax category :taxCategoryName should appear in the registry
-     */
+    #[Then('I should see the tax category :taxCategoryName in the list')]
+    #[Then('the tax category :taxCategoryName should appear in the registry')]
     public function theTaxCategoryShouldAppearInTheRegistry(string $taxCategoryName): void
     {
         $this->indexPage->open();
         Assert::true($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $taxCategoryName]));
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then /^(this tax category) name should be "([^"]+)"$/
-     * @Then /^(this tax category) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this tax category) name should be "([^"]+)"$/')]
+    #[Then('/^(this tax category) should still be named "([^"]+)"$/')]
     public function thisTaxCategoryNameShouldBe(TaxCategoryInterface $taxCategory, $taxCategoryName): void
     {
         $this->indexPage->open();
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode(), 'nameAndDescription' => $taxCategoryName]));
     }
 
-    /**
-     * @Then I should be notified that tax category with this code already exists
-     */
+    #[Then('I should be notified that tax category with this code already exists')]
     public function iShouldBeNotifiedThatTaxCategoryWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'The tax category with given code already exists.');
     }
 
-    /**
-     * @Then there should still be only one tax category with :element :code
-     */
+    #[Then('there should still be only one tax category with :element :code')]
     public function thereShouldStillBeOnlyOneTaxCategoryWith($element, $code): void
     {
         $this->indexPage->open();
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired($element): void
     {
         Assert::same($this->formElement->getValidationMessage($element), sprintf('Please enter tax category %s.', $element));
     }
 
-    /**
-     * @Then tax category with :element :name should not be added
-     */
+    #[Then('tax category with :element :name should not be added')]
     public function taxCategoryWithElementValueShouldNotBeAdded($element, $name): void
     {
         $this->indexPage->open();
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
-    /**
-     * @Then I should see a single tax category in the list
-     * @Then I should see :amount tax categories in the list
-     */
+    #[Then('I should see a single tax category in the list')]
+    #[Then('I should see :amount tax categories in the list')]
     public function iShouldSeeTaxCategoriesInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
-    /**
-     * @Then I should see the tax category :taxCategoryName
-     */
+    #[Then('I should see the tax category :taxCategoryName')]
     public function IShouldSeeTheTaxCategory(string $taxCategoryName): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $taxCategoryName]));
     }
 
-    /**
-     * @Then I should not see the tax category :taxCategoryName
-     */
+    #[Then('I should not see the tax category :taxCategoryName')]
     public function IShouldNotSeeTheTaxCategory(string $taxCategoryName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $taxCategoryName]));
     }
 
-    /**
-     * @Then I should be notified that :field is too long
-     */
+    #[Then('I should be notified that :field is too long')]
     public function iShouldBeNotifiedThatIsTooLong(string $field): void
     {
         Assert::contains(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ValidationTrait;
 use Sylius\Behat\Element\Admin\TaxRate\FilterElementInterface;
@@ -37,108 +40,84 @@ final class ManagingTaxRateContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new tax rate
-     */
+    #[When('I want to create a new tax rate')]
     public function iWantToCreateNewTaxRate()
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->createPage->specifyCode($code ?? '');
     }
 
-    /**
-     * @When /^I specify its amount as ([^"]+)%$/
-     * @When I do not specify its amount
-     * @When I remove its amount
-     */
+    #[When('/^I specify its amount as ([^"]+)%$/')]
+    #[When('I do not specify its amount')]
+    #[When('I remove its amount')]
     public function iSpecifyItsAmountAs($amount = null)
     {
         $this->createPage->specifyAmount($amount ?? '');
     }
 
-    /**
-     * @When I make it start at :startDate and end at :endDate
-     */
+    #[When('I make it start at :startDate and end at :endDate')]
     public function iMakeItStartAtAndEndAt(string $startDate, string $endDate): void
     {
         $this->createPage->specifyStartDate(new \DateTime($startDate));
         $this->createPage->specifyEndDate(new \DateTime($endDate));
     }
 
-    /**
-     * @When I set the start date to :startDate
-     */
+    #[When('I set the start date to :startDate')]
     public function iSetTheStartDateTo(string $startDate): void
     {
         $this->createPage->specifyStartDate(new \DateTime($startDate));
     }
 
-    /**
-     * @When I set the end date to :endDate
-     */
+    #[When('I set the end date to :endDate')]
     public function iSetTheEndDateTo(string $endDate): void
     {
         $this->createPage->specifyStartDate(new \DateTime($endDate));
     }
 
-    /**
-     * @When I define it for the :zoneName zone
-     * @When I change its zone to :zoneName
-     */
+    #[When('I define it for the :zoneName zone')]
+    #[When('I change its zone to :zoneName')]
     public function iDefineItForTheZone($zoneName)
     {
         $this->createPage->chooseZone($zoneName);
     }
 
-    /**
-     * @When I make it applicable for the :taxCategoryName tax category
-     * @When I change it to be applicable for the :taxCategoryName tax category
-     */
+    #[When('I make it applicable for the :taxCategoryName tax category')]
+    #[When('I change it to be applicable for the :taxCategoryName tax category')]
     public function iMakeItApplicableForTheTaxCategory($taxCategoryName)
     {
         $this->createPage->chooseCategory($taxCategoryName);
     }
 
-    /**
-     * @When I choose the default tax calculator
-     */
+    #[When('I choose the default tax calculator')]
     public function iWantToUseTheDefaultTaxCalculator()
     {
         $this->createPage->chooseCalculator('default');
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     * @When I do not name it
-     * @When I remove its name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
+    #[When('I do not name it')]
+    #[When('I remove its name')]
     public function iNameIt($name = null)
     {
         $this->createPage->nameIt($name ?? '');
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt()
     {
         $this->createPage->create();
     }
 
-    /**
-     * @Then I should see the tax rate :taxRateName in the list
-     * @Then the tax rate :taxRateName should appear in the registry
-     */
+    #[Then('I should see the tax rate :taxRateName in the list')]
+    #[Then('the tax rate :taxRateName should appear in the registry')]
     public function theTaxRateShouldAppearInTheRegistry(string $taxRateName): void
     {
         $this->indexPage->open();
@@ -146,9 +125,7 @@ final class ManagingTaxRateContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $taxRateName]));
     }
 
-    /**
-     * @Then the tax rate :taxRate should be included in price
-     */
+    #[Then('the tax rate :taxRate should be included in price')]
     public function theTaxRateShouldIncludePrice(TaxRateInterface $taxRate): void
     {
         $this->updatePage->open(['id' => $taxRate->getId()]);
@@ -159,9 +136,7 @@ final class ManagingTaxRateContext implements Context
         );
     }
 
-    /**
-     * @Then I should not see a tax rate with name :name
-     */
+    #[Then('I should not see a tax rate with name :name')]
     public function iShouldNotSeeATaxRateWithName(string $taxRateName): void
     {
         Assert::false(
@@ -170,70 +145,54 @@ final class ManagingTaxRateContext implements Context
         );
     }
 
-    /**
-     * @When I delete tax rate :taxRate
-     */
+    #[When('I delete tax rate :taxRate')]
     public function iDeletedTaxRate(TaxRateInterface $taxRate)
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['name' => $taxRate->getName()]);
     }
 
-    /**
-     * @Then /^(this tax rate) should no longer exist in the registry$/
-     */
+    #[Then('/^(this tax rate) should no longer exist in the registry$/')]
     public function thisTaxRateShouldNoLongerExistInTheRegistry(TaxRateInterface $taxRate)
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $taxRate->getCode()]));
     }
 
-    /**
-     * @When I want to modify a tax rate :taxRate
-     * @When /^I want to modify (this tax rate)$/
-     */
+    #[When('I want to modify a tax rate :taxRate')]
+    #[When('/^I want to modify (this tax rate)$/')]
     public function iWantToModifyTaxRate(TaxRateInterface $taxRate)
     {
         $this->updatePage->open(['id' => $taxRate->getId()]);
     }
 
-    /**
-     * @Then the code field should be disabled
-     * @Then I should not be able to edit its code
-     */
+    #[Then('the code field should be disabled')]
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->updatePage->isCodeDisabled());
     }
 
-    /**
-     * @Then /^(this tax rate) name should be "([^"]+)"$/
-     * @Then /^(this tax rate) should still be named "([^"]+)"$/
-     */
+    #[Then('/^(this tax rate) name should be "([^"]+)"$/')]
+    #[Then('/^(this tax rate) should still be named "([^"]+)"$/')]
     public function thisTaxRateNameShouldBe(TaxRateInterface $taxRate, $taxRateName)
     {
         $this->assertFieldValue($taxRate, 'name', $taxRateName);
     }
 
-    /**
-     * @Then /^(this tax rate) amount should be ([^"]+)%$/
-     * @Then /^(this tax rate) amount should still be ([^"]+)%$/
-     */
+    #[Then('/^(this tax rate) amount should be ([^"]+)%$/')]
+    #[Then('/^(this tax rate) amount should still be ([^"]+)%$/')]
     public function thisTaxRateAmountShouldBe(TaxRateInterface $taxRate, $taxRateAmount)
     {
         $this->assertFieldValue($taxRate, 'amount', $taxRateAmount);
     }
 
-    /**
-     * @Then I should be notified that tax rate with this code already exists
-     */
+    #[Then('I should be notified that tax rate with this code already exists')]
     public function iShouldBeNotifiedThatTaxRateWithThisCodeAlreadyExists()
     {
         $this->assertFieldValidationMessage('code', 'The tax rate with given code already exists.');
     }
 
-    /**
-     * @Then there should still be only one tax rate with :element :code
-     */
+    #[Then('there should still be only one tax rate with :element :code')]
     public function thereShouldStillBeOnlyOneTaxRateWith($element, $code)
     {
         $this->indexPage->open();
@@ -241,49 +200,37 @@ final class ManagingTaxRateContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
-    /**
-     * @Then /^(this tax rate) should be applicable for the "([^"]+)" tax category$/
-     */
+    #[Then('/^(this tax rate) should be applicable for the "([^"]+)" tax category$/')]
     public function thisTaxRateShouldBeApplicableForTaxCategory(TaxRateInterface $taxRate, $taxCategory)
     {
         $this->assertFieldValue($taxRate, 'category', $taxCategory);
     }
 
-    /**
-     * @Then /^(this tax rate) should be applicable in "([^"]+)" zone$/
-     */
+    #[Then('/^(this tax rate) should be applicable in "([^"]+)" zone$/')]
     public function thisTaxRateShouldBeApplicableInZone(TaxRateInterface $taxRate, $zone)
     {
         $this->assertFieldValue($taxRate, 'zone', $zone);
     }
 
-    /**
-     * @Then I should be notified that :element has to be selected
-     */
+    #[Then('I should be notified that :element has to be selected')]
     public function iShouldBeNotifiedThatElementHasToBeSelected($element)
     {
         $this->assertFieldValidationMessage($element, sprintf('Please select tax %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired($element)
     {
         $this->assertFieldValidationMessage($element, sprintf('Please enter tax rate %s.', $element));
     }
 
-    /**
-     * @Then I should be notified that :element is invalid
-     */
+    #[Then('I should be notified that :element is invalid')]
     public function iShouldBeNotifiedThatIsInvalid(string $element): void
     {
         $this->assertFieldValidationMessage($element, sprintf('The tax rate %s is invalid.', $element));
     }
 
-    /**
-     * @Then tax rate with :element :name should not be added
-     */
+    #[Then('tax rate with :element :name should not be added')]
     public function taxRateWithElementValueShouldNotBeAdded($element, $name)
     {
         $this->indexPage->open();
@@ -291,99 +238,75 @@ final class ManagingTaxRateContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
-    /**
-     * @When I do not specify its zone
-     */
+    #[When('I do not specify its zone')]
     public function iDoNotSpecifyItsZone()
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I remove its zone
-     */
+    #[When('I remove its zone')]
     public function iRemoveItsZone()
     {
         $this->updatePage->removeZone();
     }
 
-    /**
-     * @When I do not specify related tax category
-     */
+    #[When('I do not specify related tax category')]
     public function iDoNotSpecifyRelatedTaxCategory()
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When I check (also) the :taxRateName tax rate
-     */
+    #[When('I check (also) the :taxRateName tax rate')]
     public function iCheckTheTaxRate(string $taxRateName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $taxRateName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @When I browse tax rates
-     */
+    #[When('I browse tax rates')]
     public function iWantToBrowseTaxRates(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @Then I should see a single tax rate in the list
-     */
+    #[Then('I should see a single tax rate in the list')]
     public function iShouldSeeASingleTaxRateInTheList(): void
     {
         Assert::same($this->indexPage->countItems(), 1);
     }
 
-    /**
-     * @Given I choose "Included in price" option
-     */
+    #[Given('I choose "Included in price" option')]
     public function iChooseOption()
     {
         $this->createPage->chooseIncludedInPrice();
     }
 
-    /**
-     * @Then I should be notified that tax rate should not end before it starts
-     */
+    #[Then('I should be notified that tax rate should not end before it starts')]
     public function iShouldBeNotifiedThatTaxRateShouldNotEndBeforeItStarts(): void
     {
         $this->assertFieldValidationMessage('end_date', 'The tax rate should not end before it starts');
     }
 
-    /**
-     * @When /^I filter tax rates by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter tax rates by (end|start) date from "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterTaxRatesByDateFrom(string $dateType, string $date): void
     {
         $this->filterElement->specifyDateFrom($dateType, $date);
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter tax rates by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter tax rates by (end|start) date up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterTaxRatesByDateUpTo(string $dateType, string $date): void
     {
         $this->filterElement->specifyDateTo($dateType, $date);
         $this->filterElement->filter();
     }
 
-    /**
-     * @When /^I filter tax rates by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/
-     */
+    #[When('/^I filter tax rates by (end|start) date from "(\d{4}-\d{2}-\d{2})" up to "(\d{4}-\d{2}-\d{2})"$/')]
     public function iFilterTaxRatesByDateFromDateToDate(string $dateType, string $fromDate, string $toDate): void
     {
         $this->filterElement->specifyDateFrom($dateType, $fromDate);

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Step\When;
 use Sylius\Behat\Element\Admin\Product\TaxonomyFormElementInterface;
@@ -20,7 +21,6 @@ use Sylius\Behat\Element\Admin\Taxon\FormElementInterface;
 use Sylius\Behat\Element\Admin\Taxon\ImageFormElementInterface;
 use Sylius\Behat\Element\Admin\Taxon\TreeElementInterface;
 use Sylius\Behat\NotificationType;
-use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface;
 use Sylius\Behat\Page\Admin\Product\UpdateSimpleProductPageInterface;
@@ -35,7 +35,7 @@ final readonly class ManagingTaxonsContext implements Context
 {
     public function __construct(
         private SharedStorageInterface $sharedStorage,
-        private CreatePageInterface $createPage,
+        private BaseCreatePageInterface $createPage,
         private BaseCreatePageInterface $createForParentPage,
         private UpdatePageInterface $updatePage,
         private FormElementInterface $formElement,
@@ -48,26 +48,20 @@ final readonly class ManagingTaxonsContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new taxon
-     * @When I want to see all taxons in store
-     */
+    #[When('I want to create a new taxon')]
+    #[When('I want to see all taxons in store')]
     public function iWantToCreateANewTaxon(): void
     {
         $this->createPage->open();
     }
 
-    /**
-     * @When I want to create a new taxon for :taxon
-     */
+    #[When('I want to create a new taxon for :taxon')]
     public function iWantToCreateANewTaxonForParent(TaxonInterface $taxon): void
     {
         $this->testHelper->waitUntilPageOpens($this->createForParentPage, ['id' => $taxon->getId()]);
     }
 
-    /**
-     * @When /^I want to modify the ("[^"]+" taxon)$/
-     */
+    #[When('/^I want to modify the ("[^"]+" taxon)$/')]
     public function iWantToModifyATaxon(TaxonInterface $taxon): void
     {
         $this->sharedStorage->set('taxon', $taxon);
@@ -75,156 +69,120 @@ final readonly class ManagingTaxonsContext implements Context
         $this->testHelper->waitUntilPageOpens($this->updatePage, ['id' => $taxon->getId()]);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(?string $code = null): void
     {
         $this->formElement->specifyCode($code ?? '');
     }
 
-    /**
-     * @When I specify a too long code
-     */
+    #[When('I specify a too long code')]
     public function iSpecifyATooLong(): void
     {
         $this->formElement->specifyCode(str_repeat('a', 256));
     }
 
-    /**
-     * @When I name it :name in :localeCode
-     * @When I rename it to :name in :localeCode
-     * @When I do not specify its name
-     */
+    #[When('I name it :name in :localeCode')]
+    #[When('I rename it to :name in :localeCode')]
+    #[When('I do not specify its name')]
     public function iNameItIn(?string $name = null, ?string $localeCode = 'en_US'): void
     {
         $this->formElement->nameIt($name ?? '', $localeCode);
     }
 
-    /**
-     * @When I set its slug to :slug
-     * @When I do not specify its slug
-     * @When I set its slug to :slug in :localeCode
-     */
+    #[When('I set its slug to :slug')]
+    #[When('I do not specify its slug')]
+    #[When('I set its slug to :slug in :localeCode')]
     public function iSetItsSlugToIn(?string $slug = null, ?string $localeCode = 'en_US'): void
     {
         $this->formElement->slugIt($slug ?? '', $localeCode);
     }
 
-    /**
-     * @When I generate its slug in :localeCode
-     */
+    #[When('I generate its slug in :localeCode')]
     public function iGenerateItsSlugIn(string $localeCode): void
     {
         $this->formElement->generateSlug($localeCode);
     }
 
-    /**
-     * @When I change its description to :description in :localeCode
-     */
+    #[When('I change its description to :description in :localeCode')]
     public function iChangeItsDescriptionToIn(string $description, string $localeCode): void
     {
         $this->formElement->describeItAs($description, $localeCode);
     }
 
-    /**
-     * @When I describe it as :description in :localeCode
-     */
+    #[When('I describe it as :description in :localeCode')]
     public function iDescribeItAs(string $description, string $localeCode): void
     {
         $this->formElement->describeItAs($description, $localeCode);
     }
 
-    /**
-     * @When /^I set its (parent taxon to "[^"]+")$/
-     */
+    #[When('/^I set its (parent taxon to "[^"]+")$/')]
     public function iSetItsParentTaxonTo(TaxonInterface $taxon): void
     {
         $this->formElement->chooseParent($taxon);
     }
 
-    /**
-     * @When /^I change its (parent taxon to "[^"]+")$/
-     * @Then /^I should be able to change its (parent taxon to "[^"]+")$/
-     */
+    #[When('/^I change its (parent taxon to "[^"]+")$/')]
+    #[Then('/^I should be able to change its (parent taxon to "[^"]+")$/')]
     public function iChangeItsParentTaxonTo(TaxonInterface $taxon): void
     {
         $this->formElement->removeCurrentParent();
         $this->formElement->chooseParent($taxon);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I attach the :path image with :type type
-     * @When I attach the :path image with :type type to this taxon
-     * @When I attach the :path image
-     * @When I attach the :path image to this taxon
-     */
+    #[When('I attach the :path image with :type type')]
+    #[When('I attach the :path image with :type type to this taxon')]
+    #[When('I attach the :path image')]
+    #[When('I attach the :path image to this taxon')]
     public function iAttachImageWithType(string $path, ?string $type = null): void
     {
         $this->imageFormElement->attachImage($path, $type);
     }
 
-    /**
-     * @When /^I(?:| also) remove an image with "([^"]*)" type$/
-     */
+    #[When('/^I(?:| also) remove an image with "([^"]*)" type$/')]
     public function iRemoveAnImageWithType(string $type): void
     {
         $this->imageFormElement->removeImageWithType($type);
     }
 
-    /**
-     * @When I remove the first image
-     */
+    #[When('I remove the first image')]
     public function iRemoveTheFirstImage(): void
     {
         $this->imageFormElement->removeFirstImage();
     }
 
-    /**
-     * @When I move up :taxonName taxon
-     */
+    #[When('I move up :taxonName taxon')]
     public function iMoveUpTaxon(string $taxonName): void
     {
         $this->treeElement->moveUpTaxon($taxonName);
     }
 
-    /**
-     * @When I move down :taxonName taxon
-     */
+    #[When('I move down :taxonName taxon')]
     public function iMoveDownTaxon(string $taxonName): void
     {
         $this->treeElement->moveDownTaxon($taxonName);
     }
 
-    /**
-     * @When I enable it
-     */
+    #[When('I enable it')]
     public function iEnableIt(): void
     {
         $this->formElement->enable();
     }
 
-    /**
-     * @When I disable it
-     */
+    #[When('I disable it')]
     public function iDisableIt(): void
     {
         $this->formElement->disable();
     }
 
-    /**
-     * @Then /^the ("[^"]+" taxon) should appear in the registry$/
-     */
+    #[Then('/^the ("[^"]+" taxon) should appear in the registry$/')]
     public function theTaxonShouldAppearInTheRegistry(TaxonInterface $taxon): void
     {
         $this->updatePage->open(['id' => $taxon->getId()]);
@@ -237,35 +195,27 @@ final readonly class ManagingTaxonsContext implements Context
         $this->sharedStorage->set('autocompleteSearchResults', $this->formElement->searchParentTaxon($searchTerm));
     }
 
-    /**
-     * @Then this taxon :element should be :value
-     * @Then this taxon :element should be :value in :localeCode
-     * @Then this taxon should have :element :value in :localeCode
-     */
+    #[Then('this taxon :element should be :value')]
+    #[Then('this taxon :element should be :value in :localeCode')]
+    #[Then('this taxon should have :element :value in :localeCode')]
     public function thisTaxonElementShouldBe(string $element, string $value, ?string $localeCode = 'en_US'): void
     {
         Assert::same($this->formElement->getTranslationFieldValue($element, $localeCode), $value);
     }
 
-    /**
-     * @Then the slug of the :taxonName taxon should( still) be :slug
-     */
+    #[Then('the slug of the :taxonName taxon should( still) be :slug')]
     public function theSlugOfTheTaxonShouldBe(string $taxonName, string $slug): void
     {
         $this->thisTaxonElementShouldBe('slug', $slug);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then the product :product should no longer have a main taxon
-     */
+    #[Then('the product :product should no longer have a main taxon')]
     public function theProductShouldNoLongerHaveAMainTaxon(ProductInterface $product): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
@@ -273,33 +223,25 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::null($this->productTaxonomyFormElement->getMainTaxon());
     }
 
-    /**
-     * @Then /^this taxon should (belongs to "[^"]+")$/
-     */
+    #[Then('/^this taxon should (belongs to "[^"]+")$/')]
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon): void
     {
         Assert::same($this->formElement->getParent(), $taxon->getName());
     }
 
-    /**
-     * @Then it should not belong to any other taxon
-     */
+    #[Then('it should not belong to any other taxon')]
     public function itShouldNotBelongToAnyOtherTaxon(): void
     {
         Assert::isEmpty($this->formElement->getParent());
     }
 
-    /**
-     * @Then I should be notified that taxon with this code already exists
-     */
+    #[Then('I should be notified that taxon with this code already exists')]
     public function iShouldBeNotifiedThatTaxonWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'Taxon with given code already exists.');
     }
 
-    /**
-     * @Then I should be notified that taxon slug must be unique
-     */
+    #[Then('I should be notified that taxon slug must be unique')]
     public function iShouldBeNotifiedThatTaxonSlugMustBeUnique(): void
     {
         Assert::same(
@@ -308,9 +250,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should be notified that (name|slug) is required$/
-     */
+    #[Then('/^I should be notified that (name|slug) is required$/')]
     public function iShouldBeNotifiedThatTranslationFieldIsRequired(string $element): void
     {
         Assert::same(
@@ -319,9 +259,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code is required
-     */
+    #[Then('I should be notified that code is required')]
     public function iShouldBeNotifiedThatCodeIsRequired(): void
     {
         Assert::same(
@@ -330,9 +268,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that code is too long
-     */
+    #[Then('I should be notified that code is too long')]
     public function iShouldBeNotifiedThatCodeIsTooLong(): void
     {
         Assert::contains(
@@ -341,18 +277,14 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then /^there should(?:| still) be only one taxon with code "([^"]+)"$/
-     */
+    #[Then('/^there should(?:| still) be only one taxon with code "([^"]+)"$/')]
     public function thereShouldStillBeOnlyOneTaxonWithCode(string $code): void
     {
         Assert::same($this->formElement->getCode(), $code);
     }
 
-    /**
-     * @Then /^taxon named "([^"]+)" should not be added$/
-     * @Then the taxon named :name should no longer exist in the registry
-     */
+    #[Then('/^taxon named "([^"]+)" should not be added$/')]
+    #[Then('the taxon named :name should no longer exist in the registry')]
     public function taxonNamedShouldNotBeAdded(string $name): void
     {
         if (!$this->createPage->isOpen()) {
@@ -362,25 +294,19 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::false($this->treeElement->isTaxonOnTheList($name));
     }
 
-    /**
-     * @Then /^I should see (\d+) taxons on the list$/
-     */
+    #[Then('/^I should see (\d+) taxons on the list$/')]
     public function iShouldSeeTaxonsInTheList(int $number): void
     {
         Assert::same($this->treeElement->countTaxons(), $number);
     }
 
-    /**
-     * @Then I should see the taxon named :name in the list
-     */
+    #[Then('I should see the taxon named :name in the list')]
     public function iShouldSeeTheTaxonNamedInTheList(string $name): void
     {
         Assert::true($this->treeElement->isTaxonOnTheList($name));
     }
 
-    /**
-     * @Then the order of taxons should be :firstTaxon, :secondTaxon, :thirdTaxon and :fourthTaxon
-     */
+    #[Then('the order of taxons should be :firstTaxon, :secondTaxon, :thirdTaxon and :fourthTaxon')]
     public function theOrderOfTaxonsShouldBe(string ...$taxonsNames): void
     {
         $taxons = $this->treeElement->getTaxonsNames();
@@ -388,25 +314,19 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::same($taxons, $taxonsNames);
     }
 
-    /**
-     * @Then /^(?:it|this taxon) should(?:| also) have an image with "([^"]*)" type$/
-     */
+    #[Then('/^(?:it|this taxon) should(?:| also) have an image with "([^"]*)" type$/')]
     public function thisTaxonShouldHaveAnImageWithType(string $type): void
     {
         Assert::true($this->imageFormElement->isImageWithTypeDisplayed($type));
     }
 
-    /**
-     * @Then /^(?:this taxon|it) should not have(?:| also) any images with "([^"]*)" type$/
-     */
+    #[Then('/^(?:this taxon|it) should not have(?:| also) any images with "([^"]*)" type$/')]
     public function thisTaxonShouldNotHaveAnImageWithType(string $code): void
     {
         Assert::false($this->imageFormElement->isImageWithTypeDisplayed($code));
     }
 
-    /**
-     * @Then /^(this taxon) should not have any images$/
-     */
+    #[Then('/^(this taxon) should not have any images$/')]
     public function thisTaxonShouldNotHaveAnyImages(TaxonInterface $taxon): void
     {
         $this->iWantToModifyATaxon($taxon);
@@ -414,26 +334,20 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::same($this->imageFormElement->countImages(), 0);
     }
 
-    /**
-     * @When I change the image with the :type type to :path
-     */
+    #[When('I change the image with the :type type to :path')]
     public function iChangeItsImageToPathForTheType(string $path, string $type): void
     {
         $this->imageFormElement->changeImageWithType($type, $path);
     }
 
-    /**
-     * @When I change the first image type to :type
-     */
+    #[When('I change the first image type to :type')]
     public function iChangeTheFirstImageTypeTo(string $type): void
     {
         $this->imageFormElement->modifyFirstImageType($type);
     }
 
-    /**
-     * @Then /^(this taxon) should have only one image$/
-     * @Then /^(this taxon) should(?:| still) have (\d+) images?$/
-     */
+    #[Then('/^(this taxon) should have only one image$/')]
+    #[Then('/^(this taxon) should(?:| still) have (\d+) images?$/')]
     public function thereShouldStillBeOnlyOneImageInThisTaxon(TaxonInterface $taxon, int $count = 1): void
     {
         $this->iWantToModifyATaxon($taxon);
@@ -441,9 +355,7 @@ final readonly class ManagingTaxonsContext implements Context
         Assert::same($this->imageFormElement->countImages(), (int) $count);
     }
 
-    /**
-     * @Then I should be notified that I cannot delete a menu taxon of any channel
-     */
+    #[Then('I should be notified that I cannot delete a menu taxon of any channel')]
     public function iShouldBeNotifiedThatICannotDeleteAMenuTaxonOfAnyChannel(): void
     {
         $this->notificationChecker->checkNotification(
@@ -452,9 +364,7 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I cannot delete a taxon in use
-     */
+    #[Then('I should be notified that I cannot delete a taxon in use')]
     public function iShouldBeNotifiedThatICannotDeleteATaxonInUse(): void
     {
         $this->notificationChecker->checkNotification(
@@ -463,41 +373,31 @@ final readonly class ManagingTaxonsContext implements Context
         );
     }
 
-    /**
-     * @Then the first taxon on the list should be :taxonName
-     */
+    #[Then('the first taxon on the list should be :taxonName')]
     public function theFirstTaxonOnTheListShouldBe(string $taxonName): void
     {
         Assert::same($this->treeElement->getFirstTaxonOnTheList(), $taxonName);
     }
 
-    /**
-     * @Then the last taxon on the list should be :taxonName
-     */
+    #[Then('the last taxon on the list should be :taxonName')]
     public function theLastTaxonOnTheListShouldBe(string $taxonName): void
     {
         Assert::same($this->treeElement->getLastTaxonOnTheList(), $taxonName);
     }
 
-    /**
-     * @Then /^(?:this taxon|it) should be enabled$/
-     */
+    #[Then('/^(?:this taxon|it) should be enabled$/')]
     public function itShouldBeEnabled(): void
     {
         Assert::true($this->formElement->isEnabled());
     }
 
-    /**
-     * @Then /^(?:this taxon|it) should be disabled$/
-     */
+    #[Then('/^(?:this taxon|it) should be disabled$/')]
     public function itShouldBeDisabled(): void
     {
         Assert::false($this->formElement->isEnabled());
     }
 
-    /**
-     * @Then /^I should see "([^"]*)" in the found results$/
-     */
+    #[Then('/^I should see "([^"]*)" in the found results$/')]
     public function iShouldSeeInTheFoundResults(string $taxonName): void
     {
         $autocompleteSearchResults = $this->sharedStorage->get('autocompleteSearchResults');

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTranslatableEntitiesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTranslatableEntitiesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Element\Admin\Taxon\FormElementInterface;
@@ -27,25 +29,19 @@ final readonly class ManagingTranslatableEntitiesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new translatable entity
-     */
+    #[When('I want to create a new translatable entity')]
     public function iWantToCreateANewTranslatableEntity(): void
     {
         $this->taxonCreatePage->open();
     }
 
-    /**
-     * @Then I should be able to translate it in :localeCode
-     */
+    #[Then('I should be able to translate it in :localeCode')]
     public function iShouldBeAbleToTranslateItIn(string $localeCode): void
     {
         $this->taxonFormElement->describeItAs('Description', $localeCode);
     }
 
-    /**
-     * @Then I should not be able to translate it in :localeCode
-     */
+    #[Then('I should not be able to translate it in :localeCode')]
     public function iShouldNotBeAbleToTranslateItIn(string $localeCode): void
     {
         Assert::throws(

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Element\Admin\Zone\FormElementInterface;
@@ -35,44 +38,34 @@ final class ManagingZonesContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to create a new zone consisting of :memberType
-     */
+    #[When('I want to create a new zone consisting of :memberType')]
     public function iWantToCreateANewZoneWithMembers(string $memberType): void
     {
         $this->createPage->open(['type' => $memberType]);
     }
 
-    /**
-     * @When I browse zones
-     * @When I want to see all zones in store
-     */
+    #[When('I browse zones')]
+    #[When('I want to see all zones in store')]
     public function iWantToSeeAllZonesInStore(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When /^I want to modify the (zone named "[^"]+")$/
-     */
+    #[When('/^I want to modify the (zone named "[^"]+")$/')]
     public function iWantToModifyAZoneNamed(ZoneInterface $zone): void
     {
         $this->updatePage->open(['id' => $zone->getId()]);
     }
 
-    /**
-     * @When /^I(?:| try to) delete the (zone named "([^"]+)")$/
-     */
+    #[When('/^I(?:| try to) delete the (zone named "([^"]+)")$/')]
     public function iDeleteZoneNamed(ZoneInterface $zone): void
     {
         $this->indexPage->open();
         $this->indexPage->deleteResourceOnPage(['name' => $zone->getName(), 'code' => $zone->getCode()]);
     }
 
-    /**
-     * @When /^I(?:| also) remove the "([^"]+)" (?:country|province|zone) member$/
-     * @When /^I(?:| also) remove the "([^"]+)", "([^"]+)" and "([^"]+)" (?:country|province|zone) members$/
-     */
+    #[When('/^I(?:| also) remove the "([^"]+)" (?:country|province|zone) member$/')]
+    #[When('/^I(?:| also) remove the "([^"]+)", "([^"]+)" and "([^"]+)" (?:country|province|zone) members$/')]
     public function iRemoveMembers(string ...$members): void
     {
         foreach ($members as $member) {
@@ -80,94 +73,72 @@ final class ManagingZonesContext implements Context
         }
     }
 
-    /**
-     * @When I name it :name
-     * @When I rename it to :name
-     * @When I do not specify its name
-     */
+    #[When('I name it :name')]
+    #[When('I rename it to :name')]
+    #[When('I do not specify its name')]
     public function iNameIt(string $name = ''): void
     {
         $this->formElement->nameIt($name);
     }
 
-    /**
-     * @When I specify its code as :code
-     * @When I do not specify its code
-     */
+    #[When('I specify its code as :code')]
+    #[When('I do not specify its code')]
     public function iSpecifyItsCodeAs(string $code = ''): void
     {
         $this->formElement->specifyCode($code);
     }
 
-    /**
-     * @When I specify a too long code
-     */
+    #[When('I specify a too long code')]
     public function iSpecifyATooLong(): void
     {
         $this->formElement->specifyCode(str_repeat('a', 256));
     }
 
-    /**
-     * @When I do not add a country member
-     */
+    #[When('I do not add a country member')]
     public function iDoNotAddACountryMember(): void
     {
         // Intentionally left blank to fulfill context expectation
     }
 
-    /**
-     * @When /^I add a (?:country|province|zone) "([^"]+)"$/
-     */
+    #[When('/^I add a (?:country|province|zone) "([^"]+)"$/')]
     public function iAddAZoneMember(string $name): void
     {
         $this->formElement->addMember();
         $this->formElement->chooseMember($name);
     }
 
-    /**
-     * @When I select its scope as :scope
-     */
+    #[When('I select its scope as :scope')]
     public function iSelectItsScopeAs($scope): void
     {
         $this->formElement->selectScope($scope);
     }
 
-    /**
-     * @When I set its priority to :priority
-     */
+    #[When('I set its priority to :priority')]
     public function iSetItsPriorityTo(int $priority): void
     {
         $this->formElement->prioritizeIt($priority);
     }
 
-    /**
-     * @When I add it
-     * @When I try to add it
-     */
+    #[When('I add it')]
+    #[When('I try to add it')]
     public function iAddIt(): void
     {
         $this->createPage->create();
     }
 
-    /**
-     * @When I check (also) the :zoneName zone
-     */
+    #[When('I check (also) the :zoneName zone')]
     public function iCheckTheZone(string $zoneName): void
     {
         $this->indexPage->checkResourceOnPage(['name' => $zoneName]);
     }
 
-    /**
-     * @When I delete them
-     */
+    #[When('I delete them')]
     public function iDeleteThem(): void
     {
         $this->indexPage->bulkDelete();
     }
 
-    /**
-     * @Then /^the (zone named "[^"]+") with the "([^"]+)" (?:country|province|zone) member should appear in the registry$/
-     */
+    #[Then('/^the (zone named "[^"]+") with the "([^"]+)" (?:country|province|zone) member should appear in the registry$/')]
     public function theZoneWithTheCountryShouldAppearInTheRegistry(
         ZoneInterface $zone,
         string $member,
@@ -181,17 +152,13 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Given its scope should be :scope
-     */
+    #[Given('its scope should be :scope')]
     public function itsScopeShouldBe(string $scope): void
     {
         Assert::same($this->formElement->getScope(), $scope);
     }
 
-    /**
-     * @Then /^(this zone) should have only the "([^"]*)" (?:country|province|zone) member$/
-     */
+    #[Then('/^(this zone) should have only the "([^"]*)" (?:country|province|zone) member$/')]
     public function thisZoneShouldHaveOnlyTheMember(
         ZoneInterface $zone,
         string $member,
@@ -205,9 +172,7 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^(this zone) name should be "([^"]*)"/
-     */
+    #[Then('/^(this zone) name should be "([^"]*)"/')]
     public function thisZoneNameShouldBe(ZoneInterface $zone, string $name): void
     {
         $this->updatePage->open(['id' => $zone->getId()]);
@@ -215,25 +180,19 @@ final class ManagingZonesContext implements Context
         Assert::same($this->formElement->getName(), $name);
     }
 
-    /**
-     * @Then I should not be able to edit its code
-     */
+    #[Then('I should not be able to edit its code')]
     public function iShouldNotBeAbleToEditItsCode(): void
     {
         Assert::true($this->formElement->isCodeDisabled());
     }
 
-    /**
-     * @Then /^I should be notified that zone with this code already exists$/
-     */
+    #[Then('/^I should be notified that zone with this code already exists$/')]
     public function iShouldBeNotifiedThatZoneWithThisCodeAlreadyExists(): void
     {
         Assert::same($this->formElement->getValidationMessage('code'), 'Zone code must be unique.');
     }
 
-    /**
-     * @Then /^there should still be only one zone with code "([^"]*)"$/
-     */
+    #[Then('/^there should still be only one zone with code "([^"]*)"$/')]
     public function thereShouldStillBeOnlyOneZoneWithCode(string $code): void
     {
         $this->indexPage->open();
@@ -241,17 +200,13 @@ final class ManagingZonesContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
-    /**
-     * @Then I should be notified that :element is required
-     */
+    #[Then('I should be notified that :element is required')]
     public function iShouldBeNotifiedThatIsRequired(string $element): void
     {
         Assert::same($this->formElement->getValidationMessage($element), sprintf('Please enter zone %s.', $element));
     }
 
-    /**
-     * @Then zone with :element :value should not be added
-     */
+    #[Then('zone with :element :value should not be added')]
     public function zoneWithNameShouldNotBeAdded(string $element, string $value): void
     {
         $this->indexPage->open();
@@ -259,25 +214,19 @@ final class ManagingZonesContext implements Context
         Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
-    /**
-     * @Then /^I should be notified that at least one zone member is required$/
-     */
+    #[Then('/^I should be notified that at least one zone member is required$/')]
     public function iShouldBeNotifiedThatAtLeastOneZoneMemberIsRequired(): void
     {
         Assert::same($this->formElement->getFormValidationMessage(), 'Please add at least 1 zone member.');
     }
 
-    /**
-     * @Then I should not be able to edit its type
-     */
+    #[Then('I should not be able to edit its type')]
     public function iShouldNotBeAbleToEditItsType(): void
     {
         Assert::true($this->formElement->isTypeFieldDisabled());
     }
 
-    /**
-     * @Then it should be of :type type
-     */
+    #[Then('it should be of :type type')]
     public function itShouldBeOfType(string $type): void
     {
         Assert::same(
@@ -286,43 +235,33 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then the zone named :zoneName should no longer exist in the registry
-     */
+    #[Then('the zone named :zoneName should no longer exist in the registry')]
     public function thisZoneShouldNoLongerExistInTheRegistry(string $zoneName): void
     {
         Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $zoneName]));
     }
 
-    /**
-     * @Then I should see a single zone in the list
-     * @Then I should see :amount zones in the list
-     */
+    #[Then('I should see a single zone in the list')]
+    #[Then('I should see :amount zones in the list')]
     public function iShouldSeeZonesInTheList(int $amount = 1): void
     {
         Assert::same($this->indexPage->countItems(), $amount);
     }
 
-    /**
-     * @Then /^I should(?:| still) see the (zone named "([^"]+)") in the list$/
-     */
+    #[Then('/^I should(?:| still) see the (zone named "([^"]+)") in the list$/')]
     public function iShouldSeeTheZoneNamedInTheList(ZoneInterface $zone): void
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $zone->getCode(), 'name' => $zone->getName()]));
     }
 
-    /**
-     * @Then I should be notified that the zone is in use and cannot be deleted
-     * @Then I should be notified that this zone cannot be deleted
-     */
+    #[Then('I should be notified that the zone is in use and cannot be deleted')]
+    #[Then('I should be notified that this zone cannot be deleted')]
     public function iShouldBeNotifiedThatTheZoneIsInUseAndCannotBeDeleted(): void
     {
         $this->notificationChecker->checkNotification('Error Cannot delete, the Zone is in use.', NotificationType::failure());
     }
 
-    /**
-     * @Then I should be notified that code is too long
-     */
+    #[Then('I should be notified that code is too long')]
     public function iShouldBeNotifiedThatCodeIsTooLong(): void
     {
         Assert::contains(
@@ -331,9 +270,7 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then /^I should not be able to add the "([^"]+)" (?:country|province|zone) as a member$/
-     */
+    #[Then('/^I should not be able to add the "([^"]+)" (?:country|province|zone) as a member$/')]
     public function iShouldNotBeAbleToAddTheMember(string $name): void
     {
         $this->formElement->addMember();
@@ -347,9 +284,7 @@ final class ManagingZonesContext implements Context
         throw new \InvalidArgumentException(sprintf('Member "%s" should not be selectable.', $name));
     }
 
-    /**
-     * @Then the first zone on the list should have :field :value
-     */
+    #[Then('the first zone on the list should have :field :value')]
     public function theFirstZoneOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -362,9 +297,7 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Then the last zone on the list should have :field :value
-     */
+    #[Then('the last zone on the list should have :field :value')]
     public function theLastZoneOnTheListShouldHave(string $field, string $value): void
     {
         $fields = $this->indexPage->getColumnFields($field);
@@ -377,9 +310,7 @@ final class ManagingZonesContext implements Context
         );
     }
 
-    /**
-     * @Given the :zone zone should have priority :priority
-     */
+    #[Given('the :zone zone should have priority :priority')]
     public function theZoneShouldHavePriority(ZoneInterface $zone, int $priority)
     {
         $this->iWantToModifyAZoneNamed($zone);

--- a/src/Sylius/Behat/Context/Ui/Admin/NavigatingBetweenProductShowAndEditPagesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/NavigatingBetweenProductShowAndEditPagesContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Context\Ui\Admin\Helper\ProductTypeEnum;
 use Sylius\Behat\Page\Admin\Product\CreateConfigurableProductPageInterface;
@@ -37,41 +39,31 @@ final class NavigatingBetweenProductShowAndEditPagesContext implements Context
     ) {
     }
 
-    /**
-     * @When I access the :product product
-     */
+    #[When('I access the :product product')]
     public function iAccessTheProduct(ProductInterface $product): void
     {
         $this->productShowPage->open(['id' => $product->getId()]);
     }
 
-    /**
-     * @When I go to edit page
-     */
+    #[When('I go to edit page')]
     public function iGoToEditPage(): void
     {
         $this->productShowPage->switchToEditPage();
     }
 
-    /**
-     * @When I go to show page
-     */
+    #[When('I go to show page')]
     public function iGoToShowPage(): void
     {
         $this->updateSimpleProductPage->switchToShowPage();
     }
 
-    /**
-     * @When I go to edit page of :variant variant
-     */
+    #[When('I go to edit page of :variant variant')]
     public function iGoToEditPageOfVariant(ProductVariantInterface $variant): void
     {
         $this->productShowPage->showVariantEditPage($variant);
     }
 
-    /**
-     * @When /^I want to create a new (simple|configurable) product$/
-     */
+    #[When('/^I want to create a new (simple|configurable) product$/')]
     public function iWantToCreateANewProduct(string $productType): void
     {
         $productType = ProductTypeEnum::from($productType);
@@ -84,49 +76,37 @@ final class NavigatingBetweenProductShowAndEditPagesContext implements Context
         $this->currentProductType = $productType;
     }
 
-    /**
-     * @When I want to modify the :product product
-     */
+    #[When('I want to modify the :product product')]
     public function iWantToModifyAProduct(ProductInterface $product): void
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
     }
 
-    /**
-     * @When I change position of the :image image to :position
-     */
+    #[When('I change position of the :image image to :position')]
     public function iChangePositionOfTheImageTo(string $image, int $position): void
     {
         $this->updateSimpleProductPage->changeImagePosition($image, $position);
     }
 
-    /**
-     * @Then I should be on :product product edit page
-     */
+    #[Then('I should be on :product product edit page')]
     public function iShouldBeOnProductEditPage(ProductInterface $product): void
     {
         Assert::true($this->updateSimpleProductPage->isOpen(['id' => $product->getId()]));
     }
 
-    /**
-     * @Then I should be on :variant variant edit page
-     */
+    #[Then('I should be on :variant variant edit page')]
     public function iShouldBeOnVariantEditPage(ProductVariantInterface $variant): void
     {
         Assert::true($this->updateVariantProductPage->isOpen(['productId' => $variant->getProduct()->getId(), 'id' => $variant->getId()]));
     }
 
-    /**
-     * @Then I should be on :product product show page
-     */
+    #[Then('I should be on :product product show page')]
     public function iShouldBeOnProductShowPage(ProductInterface $product): void
     {
         Assert::true($this->productShowPage->isOpen(['id' => $product->getId()]));
     }
 
-    /**
-     * @Then I should not be able to open the product show page
-     */
+    #[Then('I should not be able to open the product show page')]
     public function iShouldNotBeAbleToAccessTheProductShowPage(): void
     {
         match (ProductTypeEnum::from($this->currentProductType->value)) {

--- a/src/Sylius/Behat/Context/Ui/Admin/NotificationContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/NotificationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\NotificationsElementInterface;
 use Sylius\Behat\NotificationType;
@@ -25,28 +26,22 @@ final readonly class NotificationContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should be notified that it has been successfully created
-     */
+    #[Then('I should be notified that it has been successfully created')]
     public function iShouldBeNotifiedItHasBeenSuccessfullyCreated(): void
     {
         Assert::true($this->notificationsElement->hasNotification((string) NotificationType::success(), 'has been successfully created.'));
     }
 
-    /**
-     * @Then I should be notified that it has been successfully edited
-     * @Then I should be notified that it has been successfully uploaded
-     * @Then I should be notified that the changes have been successfully applied
-     */
+    #[Then('I should be notified that it has been successfully edited')]
+    #[Then('I should be notified that it has been successfully uploaded')]
+    #[Then('I should be notified that the changes have been successfully applied')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyEdited(): void
     {
         Assert::true($this->notificationsElement->hasNotification((string) NotificationType::success(), 'has been successfully updated.'));
     }
 
-    /**
-     * @Then I should be notified that it :has been successfully deleted
-     * @Then I should be notified that they :have been successfully deleted
-     */
+    #[Then('I should be notified that it :has been successfully deleted')]
+    #[Then('I should be notified that they :have been successfully deleted')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyDeleted(string $hasHave): void
     {
         Assert::true(
@@ -57,9 +52,7 @@ final readonly class NotificationContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the removal operation has started successfully
-     */
+    #[Then('I should be notified that the removal operation has started successfully')]
     public function iShouldBeNotifiedThatTheRemovalOperationHasStartedSuccessfully(): void
     {
         Assert::true(
@@ -70,9 +63,7 @@ final readonly class NotificationContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it is in use
-     */
+    #[Then('I should be notified that it is in use')]
     public function iShouldBeNotifiedThatItIsInUse(): void
     {
         Assert::true($this->notificationsElement->hasNotification((string) NotificationType::error(), 'Cannot delete'));

--- a/src/Sylius/Behat/Context/Ui/Admin/OrderHistoryContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/OrderHistoryContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Order\HistoryPageInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -25,25 +27,19 @@ final class OrderHistoryContext implements Context
     ) {
     }
 
-    /**
-     * @When I browse order's :order history
-     */
+    #[When('I browse order\'s :order history')]
     public function iBrowseOrderHistory(OrderInterface $order): void
     {
         $this->historyPage->open(['id' => $order->getId()]);
     }
 
-    /**
-     * @Then there should be :count shipping address changes in the registry
-     */
+    #[Then('there should be :count shipping address changes in the registry')]
     public function thereShouldBeCountShippingAddressChangesInTheRegistry(int $count): void
     {
         Assert::same($this->historyPage->countShippingAddressChanges(), $count);
     }
 
-    /**
-     * @Then there should be :count billing address changes in the registry
-     */
+    #[Then('there should be :count billing address changes in the registry')]
     public function thereShouldBeCountBillingAddressChangesInTheRegistry(int $count): void
     {
         Assert::same($this->historyPage->countBillingAddressChanges(), $count);

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductCreationContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductCreationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Product\ChannelPricingsFormElementInterface;
 use Sylius\Behat\Element\Admin\Product\TaxonomyFormElementInterface;
@@ -32,9 +33,7 @@ final readonly class ProductCreationContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I create a new simple product ("[^"]+") priced at "(?:€|£|\$)([^"]+)" with ("[^"]+" taxon) in the ("[^"]+" channel)$/
-     */
+    #[When('/^I create a new simple product ("[^"]+") priced at "(?:€|£|\$)([^"]+)" with ("[^"]+" taxon) in the ("[^"]+" channel)$/')]
     public function iCreateANewSimpleProductPricedAtWithTaxonInTheChannel(
         string $name,
         string $price,

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Product\ShowPage\AssociationsElementInterface;
 use Sylius\Behat\Element\Product\ShowPage\AttributesElementInterface;
@@ -53,124 +56,94 @@ final readonly class ProductShowPageContext implements Context
     ) {
     }
 
-    /**
-     * @Given I am browsing products
-     */
+    #[Given('I am browsing products')]
     public function iAmBrowsingProducts(): void
     {
         $this->indexPage->open();
     }
 
-    /**
-     * @When I try to reach nonexistent product
-     */
+    #[When('I try to reach nonexistent product')]
     public function iTryToReachNonexistentProductPage(): void
     {
         $this->productShowPage->tryToOpen(['id' => 0, '_locale' => 'en_US']);
     }
 
-    /**
-     * @When I access :product product page
-     * @When I access the :product product
-     */
+    #[When('I access :product product page')]
+    #[When('I access the :product product')]
     public function iAccessTheProduct(ProductInterface $product): void
     {
         $this->indexPage->showProductPage($product->getName());
     }
 
-    /**
-     * @When I show this product in the :channel channel
-     */
+    #[When('I show this product in the :channel channel')]
     public function iShowThisProductInTheChannel(string $channel): void
     {
         $this->productShowPage->showProductInChannel($channel);
     }
 
-    /**
-     * @When I show this product in this channel
-     */
+    #[When('I show this product in this channel')]
     public function iShowThisProductInThisChannel(): void
     {
         $this->productShowPage->showProductInSingleChannel();
     }
 
-    /**
-     * @When I access :product product
-     */
+    #[When('I access :product product')]
     public function iAccessProduct(ProductInterface $product): void
     {
         $this->productShowPage->open(['id' => $product->getId()]);
     }
 
-    /**
-     * @When I access the price history of a simple product for :channel channel
-     */
+    #[When('I access the price history of a simple product for :channel channel')]
     public function iAccessThePriceHistoryIndexPageOfSimpleProductForChannel(ChannelInterface $channel): void
     {
         $pricingRow = $this->pricingElement->getSimpleProductPricingRowForChannel($channel->getCode());
         $pricingRow->find('css', '[data-test-price-history]')->click();
     }
 
-    /**
-     * @When I access the price history of a product variant :variant for :channel channel
-     */
+    #[When('I access the price history of a product variant :variant for :channel channel')]
     public function iAccessThePriceHistoryIndexPageOfVariantForChannel(ProductVariantInterface $variant, ChannelInterface $channel): void
     {
         $pricingRow = $this->pricingElement->getVariantPricingRowForChannel($variant->getCode(), $channel->getCode());
         $pricingRow->find('css', '[data-test-price-history]')->click();
     }
 
-    /**
-     * @Then I should see this product's product page
-     */
+    #[Then('I should see this product\'s product page')]
     public function iShouldSeeThisProductPage(ProductInterface $product): void
     {
         Assert::true($this->productShowPage->isOpen(['id' => $product->getId()]));
     }
 
-    /**
-     * @Then I should see product show page without variants
-     */
+    #[Then('I should see product show page without variants')]
     public function iShouldSeeProductShowPageWithoutVariants(): void
     {
         Assert::true($this->productShowPage->isSimpleProductPage());
     }
 
-    /**
-     * @Then I should see product show page with variants
-     */
+    #[Then('I should see product show page with variants')]
     public function iShouldSeeProductShowPageWithVariants(): void
     {
         Assert::false($this->productShowPage->isSimpleProductPage());
     }
 
-    /**
-     * @Then I should see product name :productName
-     */
+    #[Then('I should see product name :productName')]
     public function iShouldSeeProductName(string $productName): void
     {
         Assert::same($productName, $this->productShowPage->getName());
     }
 
-    /**
-     * @Then I should see product breadcrumb :breadcrumb
-     */
+    #[Then('I should see product breadcrumb :breadcrumb')]
     public function iShouldSeeBreadcrumb(string $breadcrumb): void
     {
         Assert::contains($this->productShowPage->getBreadcrumb(), $breadcrumb);
     }
 
-    /**
-     * @Then I should see price :price for channel :channel
-     */
+    #[Then('I should see price :price for channel :channel')]
     public function iShouldSeePriceForChannel(string $price, ChannelInterface $channel): void
     {
         Assert::same($this->pricingElement->getPriceForChannel($channel->getCode()), $price);
     }
 
-    /**
-     * @Then I should see :lowestPriceBeforeDiscount as its lowest price before the discount in :channel channel
-     */
+    #[Then('I should see :lowestPriceBeforeDiscount as its lowest price before the discount in :channel channel')]
     public function iShouldSeeAsItsLowestPriceBeforeTheDiscountInChannel(
         string $lowestPriceBeforeDiscount,
         ChannelInterface $channel,
@@ -178,17 +151,13 @@ final readonly class ProductShowPageContext implements Context
         Assert::same($this->pricingElement->getLowestPriceBeforeDiscountForChannel($channel->getCode()), $lowestPriceBeforeDiscount);
     }
 
-    /**
-     * @Then I should not see the lowest price before the discount in :channel channel
-     */
+    #[Then('I should not see the lowest price before the discount in :channel channel')]
     public function iShouldNotSeeTheLowestPriceBeforeTheDiscountInChannel(ChannelInterface $channel): void
     {
         Assert::same($this->pricingElement->getLowestPriceBeforeDiscountForChannel($channel->getCode()), '-');
     }
 
-    /**
-     * @Then I should see the lowest price before the discount of :lowestPriceBeforeDiscount for :variant variant in :channel channel
-     */
+    #[Then('I should see the lowest price before the discount of :lowestPriceBeforeDiscount for :variant variant in :channel channel')]
     public function iShouldSeeVariantWithTheLowestPriceBeforeTheDiscountOfInChannel(
         string $lowestPriceBeforeDiscount,
         ProductVariantInterface $variant,
@@ -201,9 +170,7 @@ final readonly class ProductShowPageContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not see the lowest price before the discount for :variant variant in :channel channel
-     */
+    #[Then('I should not see the lowest price before the discount for :variant variant in :channel channel')]
     public function iShouldNotSeeTheLowestPriceBeforeTheDiscountForVariantInChannel(
         ProductVariantInterface $variant,
         ChannelInterface $channel,
@@ -215,201 +182,151 @@ final readonly class ProductShowPageContext implements Context
         ));
     }
 
-    /**
-     * @Then I should not see price for channel :channelName
-     */
+    #[Then('I should not see price for channel :channelName')]
     public function iShouldNotSeePriceForChannel(string $channelName): void
     {
         Assert::same($this->pricingElement->getPriceForChannel($channelName), '');
     }
 
-    /**
-     * @Then I should see original price :price for channel :channel
-     */
+    #[Then('I should see original price :price for channel :channel')]
     public function iShouldSeeOriginalPriceForChannel(string $originalPrice, ChannelInterface $channel): void
     {
         Assert::same($this->pricingElement->getOriginalPriceForChannel($channel->getCode()), $originalPrice);
     }
 
-    /**
-     * @Then I should see product's code is :code
-     */
+    #[Then('I should see product\'s code is :code')]
     public function iShouldSeeProductCodeIs(string $code): void
     {
         Assert::same($this->detailsElement->getProductCode(), $code);
     }
 
-    /**
-     * @Then I should see the product is enabled for channel :channel
-     */
+    #[Then('I should see the product is enabled for channel :channel')]
     public function iShouldSeeProductIsEnabledForChannels(ChannelInterface $channel): void
     {
         Assert::true($this->detailsElement->hasChannel($channel->getCode()));
     }
 
-    /**
-     * @Then I should see the product in neither channel
-     */
+    #[Then('I should see the product in neither channel')]
     public function iShouldSeeTheProductInNeitherChannel(): void
     {
         Assert::same($this->detailsElement->countChannels(), 0);
     }
 
-    /**
-     * @Then I should see :currentStock as a current stock of this product
-     */
+    #[Then('I should see :currentStock as a current stock of this product')]
     public function iShouldSeeAsACurrentStockOfThisProduct(int $currentStock): void
     {
         Assert::same($this->detailsElement->getProductCurrentStock(), $currentStock);
     }
 
-    /**
-     * @Then I should see product's tax category is :taxCategory
-     */
+    #[Then('I should see product\'s tax category is :taxCategory')]
     public function iShouldSeeProductTaxCategoryIs(string $taxCategory): void
     {
         Assert::same($this->detailsElement->getProductTaxCategory(), $taxCategory);
     }
 
-    /**
-     * @Then I should see main taxon is :mainTaxonName
-     */
+    #[Then('I should see main taxon is :mainTaxonName')]
     public function iShouldSeeMainTaxonIs(string $mainTaxonName): void
     {
         Assert::same($this->taxonomyElement->getProductMainTaxon(), $mainTaxonName);
     }
 
-    /**
-     * @Then I should see product taxon :taxonName
-     */
+    #[Then('I should see product taxon :taxonName')]
     public function iShouldSeeProductTaxon(string $taxonName): void
     {
         Assert::contains($this->taxonomyElement->getProductTaxons(), $taxonName);
     }
 
-    /**
-     * @Then I should see product's shipping category is :shippingCategory
-     */
+    #[Then('I should see product\'s shipping category is :shippingCategory')]
     public function iShouldSeeProductShippingCategoryIs(string $shippingCategory): void
     {
         Assert::same($this->shippingElement->getProductShippingCategory(), $shippingCategory);
     }
 
-    /**
-     * @Then I should see product's width is :width
-     */
+    #[Then('I should see product\'s width is :width')]
     public function iShouldSeeProductWidthIs(float $width): void
     {
         Assert::same($this->shippingElement->getProductWidth(), $width);
     }
 
-    /**
-     * @Then I should see product's height is :height
-     */
+    #[Then('I should see product\'s height is :height')]
     public function iShouldSeeProductHeightIs(float $height): void
     {
         Assert::same($this->shippingElement->getProductHeight(), $height);
     }
 
-    /**
-     * @Then I should see product's depth is :depth
-     */
+    #[Then('I should see product\'s depth is :depth')]
     public function iShouldSeeProductDepthIs(float $depth): void
     {
         Assert::same($this->shippingElement->getProductDepth(), $depth);
     }
 
-    /**
-     * @Then I should see product's weight is :weight
-     */
+    #[Then('I should see product\'s weight is :weight')]
     public function iShouldSeeProductWeightIs(float $weight): void
     {
         Assert::same($this->shippingElement->getProductWeight(), $weight);
     }
 
-    /**
-     * @Then I should see an image related to this product
-     */
+    #[Then('I should see an image related to this product')]
     public function iShouldSeeImageRelatedToThisProduct(): void
     {
         Assert::true($this->mediaElement->isImageDisplayed());
     }
 
-    /**
-     * @Then I should see product name is :name
-     */
+    #[Then('I should see product name is :name')]
     public function iShouldSeeProductNameIs(string $name): void
     {
         Assert::same($this->translationsElement->getName(), $name);
     }
 
-    /**
-     * @Then I should see product slug is :slug
-     */
+    #[Then('I should see product slug is :slug')]
     public function iShouldSeeProductSlugIs(string $slug): void
     {
         Assert::same($this->translationsElement->getSlug(), $slug);
     }
 
-    /**
-     * @Then I should see product's description is :description
-     */
+    #[Then('I should see product\'s description is :description')]
     public function iShouldSeeProductSDescriptionIs(string $description): void
     {
         Assert::same($this->translationsElement->getDescription(), $description);
     }
 
-    /**
-     * @Then I should see product's meta keyword(s) is/are :metaKeywords
-     */
+    #[Then('I should see product\'s meta keyword(s) is/are :metaKeywords')]
     public function iShouldSeeProductMetaKeywordsAre(string $metaKeywords): void
     {
         Assert::same($this->translationsElement->getProductMetaKeywords(), $metaKeywords);
     }
 
-    /**
-     * @Then I should see product's short description is :shortDescription
-     */
+    #[Then('I should see product\'s short description is :shortDescription')]
     public function iShouldSeeProductShortDescriptionIs(string $shortDescription): void
     {
         Assert::same($this->translationsElement->getShortDescription(), $shortDescription);
     }
 
-    /**
-     * @Then I should see product association :association with :productName
-     */
+    #[Then('I should see product association :association with :productName')]
     public function iShouldSeeProductAssociationWith(string $association, string $productName): void
     {
         Assert::true($this->associationsElement->isAssociatedWith($association, $productName));
     }
 
-    /**
-     * @Then I should see product association type :association
-     */
+    #[Then('I should see product association type :association')]
     public function iShouldSeeProductAssociationType(string $association): void
     {
         Assert::true($this->associationsElement->hasAssociation($association));
     }
 
-    /**
-     * @Then I should see option :optionName
-     */
+    #[Then('I should see option :optionName')]
     public function iShouldSeeOption(string $optionName): void
     {
         Assert::true($this->optionsElement->isOptionDefined($optionName));
     }
 
-    /**
-     * @Then I should see :count variants
-     */
+    #[Then('I should see :count variants')]
     public function iShouldSeeVariants(int $count): void
     {
         Assert::same($this->variantsElement->countVariantsOnPage(), $count);
     }
 
-    /**
-     * @Then I should see :variantName variant with code :code, priced :price and current stock :currentStock and in :channel channel
-     */
+    #[Then('I should see :variantName variant with code :code, priced :price and current stock :currentStock and in :channel channel')]
     public function iShouldSeeVariantWithCodePriceAndCurrentStock(
         string $variantName,
         string $code,
@@ -426,41 +343,31 @@ final readonly class ProductShowPageContext implements Context
         ));
     }
 
-    /**
-     * @Then I should see the :variant variant
-     */
+    #[Then('I should see the :variant variant')]
     public function iShouldSeeTheVariant(ProductVariantInterface $variant): void
     {
         Assert::true($this->variantsElement->hasProductVariant($variant->getCode()));
     }
 
-    /**
-     * @Then I should see attribute :attribute with value :value in :locale locale
-     */
+    #[Then('I should see attribute :attribute with value :value in :locale locale')]
     public function iShouldSeeAttributeWithValueInLocale(string $attribute, string $value, LocaleInterface $locale): void
     {
         Assert::true($this->attributesElement->hasAttributeInLocale($attribute, $locale->getCode(), $value));
     }
 
-    /**
-     * @Then /^I should see non-translatable attribute "([^"]+)" with value ([^"]+)%$/
-     */
+    #[Then('/^I should see non-translatable attribute "([^"]+)" with value ([^"]+)%$/')]
     public function iShouldSeeNonTranslatableAttributeWithValue(string $attribute, string $value): void
     {
         Assert::true($this->attributesElement->hasNonTranslatableAttribute($attribute, (float) $value / 100));
     }
 
-    /**
-     * @Then I should not be able to show this product in shop
-     */
+    #[Then('I should not be able to show this product in shop')]
     public function iShouldNotBeAbleToShowThisProductInShop(): void
     {
         Assert::true($this->productShowPage->isShowInShopButtonDisabled());
     }
 
-    /**
-     * @Then this product price should be decreased by catalog promotion :catalogPromotion in :channel channel
-     */
+    #[Then('this product price should be decreased by catalog promotion :catalogPromotion in :channel channel')]
     public function thisProductPriceShouldBeDecreasedByCatalogPromotion(
         CatalogPromotionInterface $catalogPromotion,
         ChannelInterface $channel,
@@ -474,9 +381,7 @@ final readonly class ProductShowPageContext implements Context
         Assert::inArray($url, $this->pricingElement->getCatalogPromotionLinksForChannel($channel->getCode()));
     }
 
-    /**
-     * @Then :variantName variant price should be decreased by catalog promotion :catalogPromotion in :channelName channel
-     */
+    #[Then(':variantName variant price should be decreased by catalog promotion :catalogPromotion in :channelName channel')]
     public function variantPriceShouldBeDecreasedByCatalogPromotion(
         string $variantName,
         CatalogPromotionInterface $catalogPromotion,
@@ -491,9 +396,7 @@ final readonly class ProductShowPageContext implements Context
         Assert::inArray($url, $this->productShowPage->getAppliedCatalogPromotionsLinks($variantName, $channelName));
     }
 
-    /**
-     * @Then :variantName variant price should not be decreased by catalog promotion :catalogPromotion in :channelName channel
-     */
+    #[Then(':variantName variant price should not be decreased by catalog promotion :catalogPromotion in :channelName channel')]
     public function variantPriceShouldNotBeDecreasedByCatalogPromotion(
         string $variantName,
         CatalogPromotionInterface $catalogPromotion,

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductVariantsCreationContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductVariantsCreationContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -25,9 +26,7 @@ final class ProductVariantsCreationContext implements Context
     {
     }
 
-    /**
-     * @When /^I create a new "([^"]+)" variant priced at "(?:€|£|\$)([^"]+)" for ("[^"]+" product) in the ("[^"]+" channel)$/
-     */
+    #[When('/^I create a new "([^"]+)" variant priced at "(?:€|£|\$)([^"]+)" for ("[^"]+" product) in the ("[^"]+" channel)$/')]
     public function iCreateANewVariantPricedAtForProductInTheChannel(
         string $name,
         string $price,

--- a/src/Sylius/Behat/Context/Ui/Admin/RemovingProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/RemovingProductContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Product\IndexPageInterface;
@@ -30,10 +32,8 @@ final class RemovingProductContext implements Context
     ) {
     }
 
-    /**
-     * @When I delete the :product product
-     * @When I try to delete the :product product
-     */
+    #[When('I delete the :product product')]
+    #[When('I try to delete the :product product')]
     public function iDeleteProduct(ProductInterface $product): void
     {
         $this->sharedStorage->set('product', $product);
@@ -42,9 +42,7 @@ final class RemovingProductContext implements Context
         $this->indexPage->deleteResourceOnPage(['name' => $product->getName()]);
     }
 
-    /**
-     * @When I delete the :product product on filtered page
-     */
+    #[When('I delete the :product product on filtered page')]
     public function iDeleteProductOnFilteredPage(ProductInterface $product): void
     {
         $this->sharedStorage->set('product', $product);
@@ -52,9 +50,7 @@ final class RemovingProductContext implements Context
         $this->indexPage->deleteResourceOnPage(['name' => $product->getName()]);
     }
 
-    /**
-     * @Then /^(this product) should still exist$/
-     */
+    #[Then('/^(this product) should still exist$/')]
     public function theProductShouldStillExist(ProductInterface $product): void
     {
         $this->indexPage->open();
@@ -62,9 +58,7 @@ final class RemovingProductContext implements Context
         Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $product->getName()]));
     }
 
-    /**
-     * @Then I should be notified that this product could not be deleted as it is in use by a promotion rule
-     */
+    #[Then('I should be notified that this product could not be deleted as it is in use by a promotion rule')]
     public function iShouldBeNotifiedThatThisProductCouldNotBeDeleted(): void
     {
         $this->notificationChecker->checkNotification(

--- a/src/Sylius/Behat/Context/Ui/Admin/RemovingTaxonContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/RemovingTaxonContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Taxon\TreeElementInterface;
 use Sylius\Behat\NotificationType;
@@ -30,20 +32,16 @@ final readonly class RemovingTaxonContext implements Context
     ) {
     }
 
-    /**
-     * @When I remove taxon named :taxon
-     * @When I delete taxon named :taxon
-     * @When I try to delete taxon named :taxon
-     */
+    #[When('I remove taxon named :taxon')]
+    #[When('I delete taxon named :taxon')]
+    #[When('I try to delete taxon named :taxon')]
     public function iRemoveTaxonNamed(TaxonInterface $taxon): void
     {
         $this->createPage->open();
         $this->treeElement->deleteTaxon($taxon->getName());
     }
 
-    /**
-     * @Then the :taxonName taxon should still exist
-     */
+    #[Then('the :taxonName taxon should still exist')]
     public function theTaxonShouldStillExist(string $taxonName): void
     {
         $this->createPage->open();
@@ -51,9 +49,7 @@ final readonly class RemovingTaxonContext implements Context
         Assert::true($this->treeElement->isTaxonOnTheList($taxonName));
     }
 
-    /**
-     * @Then I should be notified that this taxon could not be deleted as it is in use by a promotion rule
-     */
+    #[Then('I should be notified that this taxon could not be deleted as it is in use by a promotion rule')]
     public function iShouldBeNotifiedThatThisTaxonCouldNotBeDeleted(): void
     {
         $this->notificationChecker->checkNotification(

--- a/src/Sylius/Behat/Context/Ui/Admin/ResettingPasswordContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ResettingPasswordContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Account\ResetElementInterface;
 use Sylius\Behat\NotificationType;
@@ -32,60 +34,46 @@ final class ResettingPasswordContext implements Context
     ) {
     }
 
-    /**
-     * @When I want to reset password
-     */
+    #[When('I want to reset password')]
     public function iWantToResetPassword(): void
     {
         $this->requestPasswordResetPage->open();
     }
 
-    /**
-     * @When I specify email as :email
-     * @When I do not specify an email
-     */
+    #[When('I specify email as :email')]
+    #[When('I do not specify an email')]
     public function iSpecifyEmailAs(string $email = ''): void
     {
         $this->requestPasswordResetPage->specifyEmail($email);
     }
 
-    /**
-     * @When /^I(?:| try to) reset it$/
-     */
+    #[When('/^I(?:| try to) reset it$/')]
     public function iResetIt(): void
     {
         $this->resetElement->reset();
     }
 
-    /**
-     * @When /^(I)(?:| try to) follow the instructions to reset my password$/
-     */
+    #[When('/^(I)(?:| try to) follow the instructions to reset my password$/')]
     public function iFollowTheInstructionsToResetMyPassword(AdminUserInterface $admin): void
     {
         $this->resetPasswordPage->tryToOpen(['token' => $admin->getPasswordResetToken()]);
     }
 
-    /**
-     * @When I specify my new password as :password
-     * @When I do not specify my new password
-     */
+    #[When('I specify my new password as :password')]
+    #[When('I do not specify my new password')]
     public function iSpecifyMyNewPassword(string $password = ''): void
     {
         $this->resetPasswordPage->specifyNewPassword($password);
     }
 
-    /**
-     * @When I confirm my new password as :password
-     * @When I do not confirm my new password
-     */
+    #[When('I confirm my new password as :password')]
+    #[When('I do not confirm my new password')]
     public function iConfirmMyNewPassword(string $password = ''): void
     {
         $this->resetPasswordPage->specifyPasswordConfirmation($password);
     }
 
-    /**
-     * @Then I should be notified that email with reset instruction has been sent
-     */
+    #[Then('I should be notified that email with reset instruction has been sent')]
     public function iShouldBeNotifiedThatEmailWithResetInstructionHasBeenSent(): void
     {
         $this->notificationChecker->checkNotification(
@@ -94,9 +82,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the email is required
-     */
+    #[Then('I should be notified that the email is required')]
     public function iShouldBeNotifiedThatTheEmailIsRequired(): void
     {
         Assert::same(
@@ -105,9 +91,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the email is not valid
-     */
+    #[Then('I should be notified that the email is not valid')]
     public function iShouldBeNotifiedThatTheEmailIsNotValid(): void
     {
         Assert::same(
@@ -116,9 +100,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that my password has been successfully changed
-     */
+    #[Then('I should be notified that my password has been successfully changed')]
     public function iShouldBeNotifiedThatMyPasswordHasBeenSuccessfullyChanged(): void
     {
         $this->notificationChecker->checkNotification(
@@ -127,9 +109,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should not be able to change my password again with the same token
-     */
+    #[Then('I should not be able to change my password again with the same token')]
     public function iShouldNotBeAbleToChangeMyPasswordAgainWithTheSameToken(): void
     {
         $this->resetPasswordPage->tryToOpen(['token' => 'itotallyforgotmypassword']);
@@ -137,9 +117,7 @@ final class ResettingPasswordContext implements Context
         Assert::false($this->resetPasswordPage->isOpen(), 'User should not be on the forgotten password page');
     }
 
-    /**
-     * @Then I should be notified that the password reset token has expired
-     */
+    #[Then('I should be notified that the password reset token has expired')]
     public function iShouldBeNotifiedThatThePasswordResetTokenHasExpired(): void
     {
         $this->notificationChecker->checkNotification(
@@ -148,9 +126,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the new password is required
-     */
+    #[Then('I should be notified that the new password is required')]
     public function iShouldBeNotifiedThatTheNewPasswordIsRequired(): void
     {
         Assert::contains(
@@ -159,9 +135,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the entered passwords do not match
-     */
+    #[Then('I should be notified that the entered passwords do not match')]
     public function iShouldBeNotifiedThatTheEnteredPasswordsDoNotMatch(): void
     {
         Assert::contains(
@@ -170,9 +144,7 @@ final class ResettingPasswordContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that the password should be at least :length characters long
-     */
+    #[Then('I should be notified that the password should be at least :length characters long')]
     public function iShouldBeNotifiedThatThePasswordShouldBeAtLeastCharactersLong(int $length): void
     {
         Assert::true($this->resetPasswordPage->checkValidationMessageFor(

--- a/src/Sylius/Behat/Context/Ui/Admin/SearchFilterContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/SearchFilterContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui\Admin;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\Admin\Crud\Index\SearchFilterElementInterface;
 
@@ -23,11 +24,9 @@ final readonly class SearchFilterContext implements Context
     ) {
     }
 
-    /**
-     * @When /^I search for [^"]+ with "([^"]+)"(?:| name| code)$/
-     * @When /^I search for [^"]+ by "([^"]+)"$/
-     * @When /^I search by "([^"]+)" [^"]+$/
-     */
+    #[When('/^I search for [^"]+ with "([^"]+)"(?:| name| code)$/')]
+    #[When('/^I search for [^"]+ by "([^"]+)"$/')]
+    #[When('/^I search by "([^"]+)" [^"]+$/')]
     public function iSearchResourceWith(string $phrase): void
     {
         $this->searchFilterElement->searchWith($phrase);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |partially #18822 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated Behat test step annotations from PHPDoc-style (@When, @Then, @Given) to PHP 8 native attributes across administrative UI test contexts.
  * Improved test infrastructure code quality, maintainability, and consistency through modernized annotation syntax.
  * Updated 50+ test context files with standardized attribute-based step definitions for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->