### PR TITLE
[Admin] Fix images not being emitted with Webpack 5.105+

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/assets/entrypoint.js
@@ -19,9 +19,5 @@ import './scripts/sticky-header';
 
 import './scripts/bootstrap';
 
-import './images/404.svg';
-import './images/loader.svg';
-import './images/no_data.svg';
-import './images/sylius-logo.svg';
-import './images/sylius-logo-dark-text.png';
-import './images/sylius-plus-sidebar.svg';
+const imagesContext = require.context('./images', true, /\.(jpg|jpeg|png|svg|gif|webp)$/);
+imagesContext.keys().forEach(imagesContext);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Since webpack 5.105.0, asset modules are considered side-effect free. This causes admin images imported via import (side-effect-only imports) to be tree-shaken away, the files are never emitted to the build output.

  The shop entrypoint already uses require.context() which is not subject to this optimization. This change aligns the admin entrypoint with the same approach.
