### PR TITLE
Convert Behat annotations to PHP attributes in Api common contexts

### DIFF
--- a/src/Sylius/Behat/Context/Api/Common/ResponseContext.php
+++ b/src/Sylius/Behat/Context/Api/Common/ResponseContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Api\Common;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
@@ -26,9 +27,7 @@ final readonly class ResponseContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should be notified that it has been successfully edited
-     */
+    #[Then('I should be notified that it has been successfully edited')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyEdited(): void
     {
         Assert::true(
@@ -40,9 +39,7 @@ final readonly class ResponseContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that it has been successfully uploaded
-     */
+    #[Then('I should be notified that it has been successfully uploaded')]
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyUploaded(): void
     {
         Assert::true(
@@ -54,9 +51,7 @@ final readonly class ResponseContext implements Context
         );
     }
 
-    /**
-     * @Then I should be notified that I can no longer change payment method of this order
-     */
+    #[Then('I should be notified that I can no longer change payment method of this order')]
     public function iShouldBeNotifiedThatICanNoLongerChangePaymentMethodOfThisOrder(): void
     {
         Assert::true($this->responseChecker->hasViolationWithMessage(


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18822
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated test context annotations from docblock format to PHP 8 attributes. Multiple test assertion methods have been systematically converted to use the new attribute syntax throughout the testing framework. All existing functionality and test behavior remain completely unchanged by these updates. These structural code changes represent a modernization effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->