### PR TITLE
Convert Behat annotations to PHP attributes in UI contexts

### DIFF
--- a/src/Sylius/Behat/Context/Ui/BrowserContext.php
+++ b/src/Sylius/Behat/Context/Ui/BrowserContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\When;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Element\BrowserElementInterface;
 
@@ -22,9 +23,7 @@ final class BrowserContext implements Context
     {
     }
 
-    /**
-     * @When I go back one page in the browser
-     */
+    #[When('I go back one page in the browser')]
     public function iGoBackOnePageInTheBrowser(): void
     {
         $this->browserElement->goBack();

--- a/src/Sylius/Behat/Context/Ui/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Ui/ChannelContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Channel\CreatePageInterface;
 use Sylius\Behat\Page\Shop\HomePageInterface;
@@ -35,9 +37,7 @@ final class ChannelContext implements Context
     ) {
     }
 
-    /**
-     * @When I create a new channel :channelName
-     */
+    #[When('I create a new channel :channelName')]
     public function iCreateNewChannel(string $channelName): void
     {
         $this->channelCreatePage->open();
@@ -49,12 +49,10 @@ final class ChannelContext implements Context
         $this->sharedStorage->set('channel', $channel);
     }
 
-    /**
-     * @When /^I visit (this channel)'s homepage$/
-     * @When /^I (?:am browsing|start browsing|try to browse|browse) (that channel)$/
-     * @When /^I (?:am browsing|start browsing|try to browse|browse) (?:|the )("[^"]+" channel)$/
-     * @When /^I (?:am browsing|start browsing|try to browse|browse) (?:|the )(channel "[^"]+")$/
-     */
+    #[When('/^I visit (this channel)\'s homepage$/')]
+    #[When('/^I (?:am browsing|start browsing|try to browse|browse) (that channel)$/')]
+    #[When('/^I (?:am browsing|start browsing|try to browse|browse) (?:|the )("[^"]+" channel)$/')]
+    #[When('/^I (?:am browsing|start browsing|try to browse|browse) (?:|the )(channel "[^"]+")$/')]
     public function iVisitChannelHomepage(ChannelInterface $channel): void
     {
         $this->sharedStorage->set('hostname', $channel->getHostname());
@@ -67,17 +65,13 @@ final class ChannelContext implements Context
         $this->sharedStorage->set('current_locale_code', $defaultLocale->getCode());
     }
 
-    /**
-     * @When I visit plugin's main page
-     */
+    #[When('I visit plugin\'s main page')]
     public function visitPluginMainPage(): void
     {
         $this->pluginMainPage->open();
     }
 
-    /**
-     * @Then I should see a plugin's main page with content :content
-     */
+    #[Then('I should see a plugin\'s main page with content :content')]
     public function shouldSeePluginMainPageWithContent(string $content): void
     {
         Assert::same($this->pluginMainPage->getContent(), $content);

--- a/src/Sylius/Behat/Context/Ui/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Ui/CustomerContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Page\Admin\Customer\ShowPageInterface;
@@ -27,9 +28,7 @@ final class CustomerContext implements Context
     ) {
     }
 
-    /**
-     * @Then I should not be able to delete it again
-     */
+    #[Then('I should not be able to delete it again')]
     public function iShouldNotBeAbleToDeleteCustomerAgain()
     {
         $customer = $this->sharedStorage->get('customer');
@@ -45,9 +44,7 @@ final class CustomerContext implements Context
         throw new \DomainException('Delete account should throw an exception!');
     }
 
-    /**
-     * @Then the customer with this email should still exist
-     */
+    #[Then('the customer with this email should still exist')]
     public function customerShouldStillExist()
     {
         $deletedUser = $this->sharedStorage->get('deleted_user');

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\Checker\EmailCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -30,19 +31,15 @@ final class EmailContext implements Context
     ) {
     }
 
-    /**
-     * @Then it should be sent to :recipient
-     * @Then the email with contact request should be sent to :recipient
-     */
+    #[Then('it should be sent to :recipient')]
+    #[Then('the email with contact request should be sent to :recipient')]
     public function anEmailShouldBeSentTo(string $recipient): void
     {
         Assert::true($this->emailChecker->hasRecipient($recipient));
     }
 
-    /**
-     * @Then an email with reset token should be sent to :recipient
-     * @Then an email with reset token should be sent to :recipient in :localeCode locale
-     */
+    #[Then('an email with reset token should be sent to :recipient')]
+    #[Then('an email with reset token should be sent to :recipient in :localeCode locale')]
     public function anEmailWithResetTokenShouldBeSentTo(string $recipient, string $localeCode = 'en_US'): void
     {
         $this->assertEmailContainsMessageTo(
@@ -51,9 +48,7 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then an email with the :method shipment's confirmation for the :orderNumber order should be sent to :email
-     */
+    #[Then('an email with the :method shipment\'s confirmation for the :orderNumber order should be sent to :email')]
     public function anEmailWithShipmentsConfirmationForTheOrderShouldBeSentTo(string $method, string $orderNumber, string $recipient): void
     {
         Assert::true($this->emailChecker->hasMessageTo(
@@ -66,18 +61,14 @@ final class EmailContext implements Context
         ));
     }
 
-    /**
-     * @Then :count email(s) should be sent to :recipient
-     */
+    #[Then(':count email(s) should be sent to :recipient')]
     public function numberOfEmailsShouldBeSentTo(int $count, string $recipient): void
     {
         Assert::same($this->emailChecker->countMessagesTo($recipient), $count);
     }
 
-    /**
-     * @Then a welcoming email should have been sent to :recipient
-     * @Then a welcoming email should have been sent to :recipient in :localeCode locale
-     */
+    #[Then('a welcoming email should have been sent to :recipient')]
+    #[Then('a welcoming email should have been sent to :recipient in :localeCode locale')]
     public function aWelcomingEmailShouldHaveBeenSentTo(string $recipient, string $localeCode = 'en_US'): void
     {
         $this->assertEmailContainsMessageTo(
@@ -86,9 +77,7 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then a verification email should have been sent to :recipient
-     */
+    #[Then('a verification email should have been sent to :recipient')]
     public function aVerificationEmailShouldHaveBeenSentTo(string $recipient): void
     {
         $this->assertEmailContainsMessageTo(
@@ -97,9 +86,7 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then a welcoming email should not have been sent to :recipient
-     */
+    #[Then('a welcoming email should not have been sent to :recipient')]
     public function aWelcomingEmailShouldNotHaveBeenSentTo(string $recipient): void
     {
         $this->assertEmailDoesNotContainMessageTo(
@@ -108,10 +95,8 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then an email with the confirmation of the order :order should be sent to :email
-     * @Then an email with the confirmation of the order :order should be sent to :email in :localeCode locale
-     */
+    #[Then('an email with the confirmation of the order :order should be sent to :email')]
+    #[Then('an email with the confirmation of the order :order should be sent to :email in :localeCode locale')]
     public function anEmailWithTheConfirmationOfTheOrderShouldBeSentTo(
         OrderInterface $order,
         string $recipient,
@@ -128,9 +113,7 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then an email with the confirmation of the order :order should not be sent to :email
-     */
+    #[Then('an email with the confirmation of the order :order should not be sent to :email')]
     public function anEmailWithTheConfirmationOfTheOrderShouldNotBeSentTo(
         OrderInterface $order,
         string $recipient,
@@ -147,21 +130,17 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then /^an email with the summary of (order placed by "[^"]+") should be sent to him$/
-     * @Then /^an email with the summary of (order placed by "[^"]+") should be sent to him in ("([^"]+)" locale)$/
-     */
+    #[Then('/^an email with the summary of (order placed by "[^"]+") should be sent to him$/')]
+    #[Then('/^an email with the summary of (order placed by "[^"]+") should be sent to him in ("([^"]+)" locale)$/')]
     public function anEmailWithSummaryOfOrderPlacedByShouldBeSentTo(OrderInterface $order, string $localeCode = 'en_US'): void
     {
         $this->anEmailWithTheConfirmationOfTheOrderShouldBeSentTo($order, $order->getCustomer()->getEmailCanonical(), $localeCode);
     }
 
-    /**
-     * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)"$/
-     * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)" in ("([^"]+)" locale)$/
-     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient
-     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient in :localeCode locale
-     */
+    #[Then('/^an email with shipment\'s details of (this order) should be sent to "([^"]+)"$/')]
+    #[Then('/^an email with shipment\'s details of (this order) should be sent to "([^"]+)" in ("([^"]+)" locale)$/')]
+    #[Then('an email with the shipment\'s confirmation of the order :order should be sent to :recipient')]
+    #[Then('an email with the shipment\'s confirmation of the order :order should be sent to :recipient in :localeCode locale')]
     public function anEmailWithShipmentDetailsOfOrderShouldBeSentTo(
         OrderInterface $order,
         string $recipient,
@@ -188,9 +167,7 @@ final class EmailContext implements Context
         }
     }
 
-    /**
-     * @Then an email with instructions on how to reset the administrator's password should be sent to :recipient
-     */
+    #[Then('an email with instructions on how to reset the administrator\'s password should be sent to :recipient')]
     public function anEmailWithInstructionsOnHowToResetTheAdministratorsPasswordShouldBeSentTo(string $recipient): void
     {
         $this->assertEmailContainsMessageTo(
@@ -199,17 +176,13 @@ final class EmailContext implements Context
         );
     }
 
-    /**
-     * @Then :recipient should receive no emails
-     */
+    #[Then(':recipient should receive no emails')]
     public function recipientShouldReceiveNoEmails(string $recipient): void
     {
         Assert::false($this->emailChecker->hasRecipient($recipient));
     }
 
-    /**
-     * @Then only one email should have been sent to :recipient
-     */
+    #[Then('only one email should have been sent to :recipient')]
     public function onlyOneEmailShouldHaveBeenSentTo(string $recipient): void
     {
         Assert::eq($this->emailChecker->countMessagesTo($recipient), 1);

--- a/src/Sylius/Behat/Context/Ui/ThemeContext.php
+++ b/src/Sylius/Behat/Context/Ui/ThemeContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Channel\IndexPageInterface;
 use Sylius\Behat\Page\Admin\Channel\UpdatePageInterface;
@@ -32,9 +34,7 @@ final readonly class ThemeContext implements Context
     ) {
     }
 
-    /**
-     * @When I set :channel channel theme to :theme
-     */
+    #[When('I set :channel channel theme to :theme')]
     public function iSetChannelThemeTo(ChannelInterface $channel, ThemeInterface $theme): void
     {
         $this->channelUpdatePage->open(['id' => $channel->getId()]);
@@ -45,9 +45,7 @@ final readonly class ThemeContext implements Context
         $this->sharedStorage->set('theme', $theme);
     }
 
-    /**
-     * @When /^I unset theme on (that channel)$/
-     */
+    #[When('/^I unset theme on (that channel)$/')]
     public function iUnsetThemeOnChannel(ChannelInterface $channel): void
     {
         $this->channelUpdatePage->open(['id' => $channel->getId()]);
@@ -55,9 +53,7 @@ final readonly class ThemeContext implements Context
         $this->channelUpdatePage->saveChanges();
     }
 
-    /**
-     * @Then /^(that channel) should not use any theme$/
-     */
+    #[Then('/^(that channel) should not use any theme$/')]
     public function channelShouldNotUseAnyTheme(ChannelInterface $channel): void
     {
         $this->channelIndexPage->open();
@@ -65,9 +61,7 @@ final readonly class ThemeContext implements Context
         Assert::same($this->channelIndexPage->getUsedThemeName($channel->getCode()), 'Default');
     }
 
-    /**
-     * @Then /^(that channel) should use (that theme)$/
-     */
+    #[Then('/^(that channel) should use (that theme)$/')]
     public function channelShouldUseTheme(ChannelInterface $channel, ThemeInterface $theme): void
     {
         $this->channelIndexPage->open();
@@ -75,9 +69,7 @@ final readonly class ThemeContext implements Context
         Assert::same($this->channelIndexPage->getUsedThemeName($channel->getCode()), $theme->getName());
     }
 
-    /**
-     * @Then /^I should see a homepage from ((?:this|that) theme)$/
-     */
+    #[Then('/^I should see a homepage from ((?:this|that) theme)$/')]
     public function iShouldSeeThemedHomepage(ThemeInterface $theme): void
     {
         $content = file_get_contents(rtrim($theme->getPath(), '/') . '/templates/bundles/SyliusShopBundle/homepage/index.html.twig');
@@ -85,9 +77,7 @@ final readonly class ThemeContext implements Context
         Assert::same($this->homePage->getContent(), $content);
     }
 
-    /**
-     * @Then I should not see a homepage from :theme theme
-     */
+    #[Then('I should not see a homepage from :theme theme')]
     public function iShouldNotSeeThemedHomepage(ThemeInterface $theme): void
     {
         $content = file_get_contents(rtrim($theme->getPath(), '/') . '/templates/bundles/SyliusShopBundle/homepage/index.html.twig');

--- a/src/Sylius/Behat/Context/Ui/UserContext.php
+++ b/src/Sylius/Behat/Context/Ui/UserContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Ui;
 
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Page\Admin\Customer\ShowPageInterface;
 use Sylius\Behat\Page\Shop\HomePageInterface;
@@ -31,17 +33,13 @@ final class UserContext implements Context
     ) {
     }
 
-    /**
-     * @When I log out
-     */
+    #[When('I log out')]
     public function iLogOut()
     {
         $this->homePage->logOut();
     }
 
-    /**
-     * @When I delete the account of :email user
-     */
+    #[When('I delete the account of :email user')]
     public function iDeleteAccount($email)
     {
         /** @var ShopUserInterface $user */
@@ -53,9 +51,7 @@ final class UserContext implements Context
         $this->customerShowPage->deleteAccount();
     }
 
-    /**
-     * @Then the customer should have no account
-     */
+    #[Then('the customer should have no account')]
     public function theCustomerShouldHaveNoAccount(): void
     {
         $deletedUser = $this->sharedStorage->get('deleted_user');


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18822
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized test framework by migrating step definitions from docblock annotations to PHP 8 attributes across UI context test files (Browser, Channel, Customer, Email, Theme, and User contexts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->