### PR TITLE
Convert Behat annotations to PHP attributes in Transform contexts

### DIFF
--- a/src/Sylius/Behat/Context/Transform/AddressContext.php
+++ b/src/Sylius/Behat/Context/Transform/AddressContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
@@ -31,11 +32,9 @@ final class AddressContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^to "([^"]+)"$/
-     * @Transform /^"([^"]+)" based \w+ address$/
-     * @Transform /^"([^"]+)" based address$/
-     */
+    #[Transform('/^to "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" based \w+ address$/')]
+    #[Transform('/^"([^"]+)" based address$/')]
     public function createNewAddress($countryName)
     {
         return $this->exampleAddressFactory->create([
@@ -44,10 +43,8 @@ final class AddressContext implements Context
         ]);
     }
 
-    /**
-     * @Transform /^address (?:as |is |to )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/
-     * @Transform /^"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" specified as$/
-     */
+    #[Transform('/^address (?:as |is |to )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" for "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" specified as$/')]
     public function createNewAddressWith($city, $street, $postcode, $countryName, $customerName)
     {
         [$firstName, $lastName] = explode(' ', $customerName);
@@ -65,22 +62,18 @@ final class AddressContext implements Context
         ]);
     }
 
-    /**
-     * @Transform /^clear the (shipping|billing) address$/
-     * @Transform /^do not specify any (shipping|billing) address$/
-     */
+    #[Transform('/^clear the (shipping|billing) address$/')]
+    #[Transform('/^do not specify any (shipping|billing) address$/')]
     public function createEmptyAddress()
     {
         return $this->addressFactory->createNew();
     }
 
-    /**
-     * @Transform /^address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/
-     * @Transform /^"([^"]+)" addressed it to "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)", "([^"]+)"$/
-     * @Transform /^of "([^"]+)" in the "([^"]+)", "([^"]+)" "([^"]+)", "([^"]+)", "([^"]+)"$/
-     * @Transform /^addressed it to "([^"]+)", "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)", "([^"]+)"$/
-     * @Transform /^address (?:|is |as )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/
-     */
+    #[Transform('/^address for "([^"]+)" from "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" addressed it to "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^of "([^"]+)" in the "([^"]+)", "([^"]+)" "([^"]+)", "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^addressed it to "([^"]+)", "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^address (?:|is |as )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/')]
     public function createNewAddressWithNameAndProvince($name, $street, $postcode, $city, $countryName, $provinceName)
     {
         [$firstName, $lastName] = explode(' ', $name);
@@ -99,14 +92,12 @@ final class AddressContext implements Context
         ]);
     }
 
-    /**
-     * @Transform /^"([^"]+)" addressed it to "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)"$/
-     * @Transform /^of "([^"]+)" in the "([^"]+)", "([^"]+)" "([^"]+)", "([^"]+)"$/
-     * @Transform /^addressed it to "([^"]+)", "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)"$/
-     * @Transform /^address (?:|is |as )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/
-     * @Transform /^"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address$/
-     * @Transform /^be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/
-     */
+    #[Transform('/^"([^"]+)" addressed it to "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)"$/')]
+    #[Transform('/^of "([^"]+)" in the "([^"]+)", "([^"]+)" "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^addressed it to "([^"]+)", "([^"]+)", "([^"]+)" "([^"]+)" in the "([^"]+)"$/')]
+    #[Transform('/^address (?:|is |as )"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)" as its(?:| new) billing address$/')]
+    #[Transform('/^be shipped to "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)", "([^"]+)"$/')]
     public function createNewAddressWithName($name, $street, $postcode, $city, $countryName)
     {
         [$firstName, $lastName] = explode(' ', $name);
@@ -124,9 +115,7 @@ final class AddressContext implements Context
         ]);
     }
 
-    /**
-     * @Transform /^"([^"]+)" street$/
-     */
+    #[Transform('/^"([^"]+)" street$/')]
     public function getByStreet($street)
     {
         $address = $this->addressRepository->findOneBy(['street' => $street]);
@@ -135,10 +124,8 @@ final class AddressContext implements Context
         return $address;
     }
 
-    /**
-     * @Transform /^address of "([^"]+)"$/
-     * @Transform /^address belongs to "([^"]+)"$/
-     */
+    #[Transform('/^address of "([^"]+)"$/')]
+    #[Transform('/^address belongs to "([^"]+)"$/')]
     public function getByFullName(string $fullName): AddressInterface
     {
         [$firstName, $lastName] = explode(' ', $fullName);

--- a/src/Sylius/Behat/Context/Transform/AdminUserContext.php
+++ b/src/Sylius/Behat/Context/Transform/AdminUserContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;
@@ -27,9 +28,7 @@ final class AdminUserContext implements Context
     ) {
     }
 
-    /**
-     * @Transform :adminUser
-     */
+    #[Transform(':adminUser')]
     public function getAdminUserByEmail(string $email): AdminUserInterface
     {
         $adminUser = $this->adminUserRepository->findOneBy(['email' => $email]);
@@ -39,9 +38,7 @@ final class AdminUserContext implements Context
         return $adminUser;
     }
 
-    /**
-     * @Transform /^(I|my)$/
-     */
+    #[Transform('/^(I|my)$/')]
     public function getLoggedAdminUser()
     {
         return $this->sharedStorage->get('administrator');

--- a/src/Sylius/Behat/Context/Transform/CartContext.php
+++ b/src/Sylius/Behat/Context/Transform/CartContext.php
@@ -31,9 +31,7 @@ final readonly class CartContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^(cart)$/
-     */
+    #[Transform('/^(cart)$/')]
     public function provideCartToken(): ?string
     {
         try {
@@ -59,9 +57,7 @@ final readonly class CartContext implements Context
         ]);
     }
 
-    /**
-     * @Transform /^(customer's latest cart)$/
-     */
+    #[Transform('/^(customer\'s latest cart)$/')]
     public function provideLatestCart(): OrderInterface
     {
         $carts = $this->orderRepository->findBy(

--- a/src/Sylius/Behat/Context/Transform/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Transform/CatalogPromotionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -24,10 +25,8 @@ final class CatalogPromotionContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" catalog promotion$/
-     * @Transform :catalogPromotion
-     */
+    #[Transform('/^"([^"]+)" catalog promotion$/')]
+    #[Transform(':catalogPromotion')]
     public function getCatalogPromotionByName(string $name): CatalogPromotionInterface
     {
         $catalogPromotion = $this->catalogPromotionRepository->findOneBy(['name' => $name]);

--- a/src/Sylius/Behat/Context/Transform/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Transform/ChannelContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -27,12 +28,10 @@ final class ChannelContext implements Context
     {
     }
 
-    /**
-     * @Transform /^channel "([^"]+)"$/
-     * @Transform /^"([^"]+)" channel/
-     * @Transform /^channel to "([^"]+)"$/
-     * @Transform :channel
-     */
+    #[Transform('/^channel "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" channel/')]
+    #[Transform('/^channel to "([^"]+)"$/')]
+    #[Transform(':channel')]
     public function getChannelByName(string $channelName)
     {
         $channels = $this->channelRepository->findByName($channelName);
@@ -47,10 +46,9 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @Transform all channels
-     *
      * @return array<ChannelInterface>
      */
+    #[Transform('all channels')]
     public function getAllChannels(): array
     {
         return $this->channelRepository->findAll();

--- a/src/Sylius/Behat/Context/Transform/CountryContext.php
+++ b/src/Sylius/Behat/Context/Transform/CountryContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -26,14 +27,12 @@ final class CountryContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^country "([^"]+)"$/
-     * @Transform /^"([^"]+)" country$/
-     * @Transform /^"([^"]+)" as shipping country$/
-     * @Transform /^"([^"]+)" as billing country$/
-     * @Transform :country
-     * @Transform :otherCountry
-     */
+    #[Transform('/^country "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" country$/')]
+    #[Transform('/^"([^"]+)" as shipping country$/')]
+    #[Transform('/^"([^"]+)" as billing country$/')]
+    #[Transform(':country')]
+    #[Transform(':otherCountry')]
     public function getCountryByName($countryName)
     {
         $countryCode = $this->countryNameConverter->convertToCode($countryName);
@@ -47,9 +46,7 @@ final class CountryContext implements Context
         return $country;
     }
 
-    /**
-     * @Transform /^"([^"]+)", "([^"]+)" and "([^"]+)" country$/
-     */
+    #[Transform('/^"([^"]+)", "([^"]+)" and "([^"]+)" country$/')]
     public function getCountriesByNames(string ...$countryNames): array
     {
         $countryCodes = $countryNames;
@@ -58,9 +55,7 @@ final class CountryContext implements Context
         return $this->countryRepository->findBy(['code' => $countryCodes]);
     }
 
-    /**
-     * @Transform :countryCode
-     */
+    #[Transform(':countryCode')]
     public function getCountryCodeByName(string $countryName): string
     {
         return $this->countryNameConverter->convertToCode($countryName);

--- a/src/Sylius/Behat/Context/Transform/CouponContext.php
+++ b/src/Sylius/Behat/Context/Transform/CouponContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class CouponContext implements Context
     {
     }
 
-    /**
-     * @Transform /^coupon "([^"]+)"$/
-     * @Transform /^"([^"]+)" coupon$/
-     * @Transform :coupon
-     */
+    #[Transform('/^coupon "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" coupon$/')]
+    #[Transform(':coupon')]
     public function getCouponByCode($couponCode)
     {
         $coupon = $this->couponRepository->findOneBy(['code' => $couponCode]);

--- a/src/Sylius/Behat/Context/Transform/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Transform/CurrencyContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Currency\Converter\CurrencyNameConverterInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -26,13 +27,11 @@ final class CurrencyContext implements Context
     ) {
     }
 
-    /**
-     * @Transform :currency
-     * @Transform :sourceCurrency
-     * @Transform :targetCurrency
-     * @Transform /^currency "([^"]+)"$/
-     * @Transform /^"([^"]+)" currency$/
-     */
+    #[Transform(':currency')]
+    #[Transform(':sourceCurrency')]
+    #[Transform(':targetCurrency')]
+    #[Transform('/^currency "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" currency$/')]
     public function getCurrencyByName($currencyName)
     {
         $currency = $this->currencyRepository->findOneBy(['code' => $this->getCurrencyCodeByName($currencyName)]);
@@ -44,11 +43,9 @@ final class CurrencyContext implements Context
         return $currency;
     }
 
-    /**
-     * @Transform :currencyCode
-     * @Transform :secondCurrencyCode
-     * @Transform :thirdCurrencyCode
-     */
+    #[Transform(':currencyCode')]
+    #[Transform(':secondCurrencyCode')]
+    #[Transform(':thirdCurrencyCode')]
     public function getCurrencyCodeByName($currencyName)
     {
         // If it's already a currency code - just return it.

--- a/src/Sylius/Behat/Context/Transform/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Transform/CustomerContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -28,10 +29,8 @@ final class CustomerContext implements Context
     ) {
     }
 
-    /**
-     * @Transform :customer
-     * @Transform /^customer "([^"]+)"$/
-     */
+    #[Transform(':customer')]
+    #[Transform('/^customer "([^"]+)"$/')]
     public function getOrCreateCustomerByEmail($email)
     {
         /** @var CustomerInterface $customer */
@@ -47,9 +46,7 @@ final class CustomerContext implements Context
         return $customer;
     }
 
-    /**
-     * @Transform /^(he|his|she|her|their|the customer of my account)$/
-     */
+    #[Transform('/^(he|his|she|her|their|the customer of my account)$/')]
     public function getLastCustomer()
     {
         return $this->sharedStorage->get('customer');

--- a/src/Sylius/Behat/Context/Transform/CustomerGroupContext.php
+++ b/src/Sylius/Behat/Context/Transform/CustomerGroupContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class CustomerGroupContext implements Context
     {
     }
 
-    /**
-     * @Transform :customerGroup
-     * @Transform /^group "([^"]+)"$/
-     * @Transform /^"([^"]+)" group$/
-     */
+    #[Transform(':customerGroup')]
+    #[Transform('/^group "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" group$/')]
     public function getCustomerGroupByName($customerGroupName)
     {
         $customerGroup = $this->customerGroupRepository->findOneBy(['name' => $customerGroupName]);

--- a/src/Sylius/Behat/Context/Transform/DateTimeContext.php
+++ b/src/Sylius/Behat/Context/Transform/DateTimeContext.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 
 final class DateTimeContext implements Context
 {
-    /**
-     * @Transform :date
-     * @Transform :startsDate
-     * @Transform :endsDate
-     * @Transform /^on "([^"]+)"$/
-     */
+    #[Transform(':date')]
+    #[Transform(':startsDate')]
+    #[Transform(':endsDate')]
+    #[Transform('/^on "([^"]+)"$/')]
     public function getDate($date)
     {
         return new \DateTime($date);

--- a/src/Sylius/Behat/Context/Transform/ExchangeRateContext.php
+++ b/src/Sylius/Behat/Context/Transform/ExchangeRateContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Currency\Converter\CurrencyNameConverterInterface;
 use Sylius\Component\Currency\Model\ExchangeRateInterface;
@@ -29,9 +30,7 @@ final class ExchangeRateContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^exchange rate between "([^"]+)" and "([^"]+)"$/
-     */
+    #[Transform('/^exchange rate between "([^"]+)" and "([^"]+)"$/')]
     public function getExchangeRateByCurrencies(
         string $sourceCurrencyName,
         string $targetCurrencyName,

--- a/src/Sylius/Behat/Context/Transform/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Transform/LocaleContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
@@ -30,28 +31,22 @@ final readonly class LocaleContext implements Context
     ) {
     }
 
-    /**
-     * @Transform :language
-     * @Transform :localeCode
-     * @Transform /^"([^"]+)" locale$/
-     * @Transform /^in the "([^"]+)" locale$/
-     */
+    #[Transform(':language')]
+    #[Transform(':localeCode')]
+    #[Transform('/^"([^"]+)" locale$/')]
+    #[Transform('/^in the "([^"]+)" locale$/')]
     public function castToLocaleCode(string $localeName): string
     {
         return $this->localeNameConverter->convertNameToCode($localeName);
     }
 
-    /**
-     * @Transform :localeNameInItsLocale
-     */
+    #[Transform(':localeNameInItsLocale')]
     public function castToItsLocaleCode(string $localeName): string
     {
         return $this->localeNameConverter->convertNameToCode($localeName);
     }
 
-    /**
-     * @Transform :localeNameInCurrentLocale
-     */
+    #[Transform(':localeNameInCurrentLocale')]
     public function castToCurrentLocale(string $localeName): string
     {
         if ($this->sharedStorage->has('current_locale_code')) {
@@ -61,9 +56,7 @@ final readonly class LocaleContext implements Context
         return $localeName;
     }
 
-    /**
-     * @Transform :locale
-     */
+    #[Transform(':locale')]
     public function getLocaleByName(string $name): LocaleInterface
     {
         $locale = $this->localeRepository->findOneBy(['code' => $this->localeNameConverter->convertNameToCode($name)]);

--- a/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Payment\Repository\PaymentMethodRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,10 +24,8 @@ final class PaymentMethodContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" payment(s)?$/
-     * @Transform :paymentMethod
-     */
+    #[Transform('/^"([^"]+)" payment(s)?$/')]
+    #[Transform(':paymentMethod')]
     public function getPaymentMethodByName($paymentMethodName)
     {
         $paymentMethods = $this->paymentMethodRepository->findByName($paymentMethodName, 'en_US');

--- a/src/Sylius/Behat/Context/Transform/ProductAssociationTypeContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductAssociationTypeContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Product\Repository\ProductAssociationTypeRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class ProductAssociationTypeContext implements Context
     {
     }
 
-    /**
-     * @Transform /^association "([^"]+)"$/
-     * @Transform /^associate as "([^"]+)"$/
-     * @Transform :productAssociationType
-     */
+    #[Transform('/^association "([^"]+)"$/')]
+    #[Transform('/^associate as "([^"]+)"$/')]
+    #[Transform(':productAssociationType')]
     public function getProductAssociationTypeByName($productAssociationTypeName)
     {
         $productAssociationTypes = $this->productAssociationTypeRepository->findByName(

--- a/src/Sylius/Behat/Context/Transform/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductAttributeContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Product\Model\ProductAttributeInterface;
 use Sylius\Component\Product\Model\ProductAttributeTranslationInterface;
@@ -25,11 +26,9 @@ final class ProductAttributeContext implements Context
     {
     }
 
-    /**
-     * @Transform :attribute
-     * @Transform :productAttribute
-     * @Transform /^"([^"]+)" product attribute$/
-     */
+    #[Transform(':attribute')]
+    #[Transform(':productAttribute')]
+    #[Transform('/^"([^"]+)" product attribute$/')]
     public function getProductAttributeByName(string $name): ProductAttributeInterface
     {
         /** @var ProductAttributeTranslationInterface[] $productAttributeTranslations */

--- a/src/Sylius/Behat/Context/Transform/ProductContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -25,14 +26,12 @@ final class ProductContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^product(?:|s) "([^"]+)"$/
-     * @Transform /^"([^"]+)" product(?:|s)$/
-     * @Transform /^(?:a|an) "([^"]+)"$/
-     * @Transform :product
-     * @Transform :firstProduct
-     * @Transform :secondProduct
-     */
+    #[Transform('/^product(?:|s) "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" product(?:|s)$/')]
+    #[Transform('/^(?:a|an) "([^"]+)"$/')]
+    #[Transform(':product')]
+    #[Transform(':firstProduct')]
+    #[Transform(':secondProduct')]
     public function getProductByName($productName)
     {
         $products = $this->productRepository->findByName($productName, $this->locale);
@@ -46,10 +45,8 @@ final class ProductContext implements Context
         return $products[0];
     }
 
-    /**
-     * @Transform /^products "([^"]+)" and "([^"]+)"$/
-     * @Transform /^products "([^"]+)", "([^"]+)" and "([^"]+)"$/
-     */
+    #[Transform('/^products "([^"]+)" and "([^"]+)"$/')]
+    #[Transform('/^products "([^"]+)", "([^"]+)" and "([^"]+)"$/')]
     public function getProductsByNames(...$productsNames)
     {
         return array_map(fn ($productName) => $this->getProductByName($productName), $productsNames);

--- a/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Product\Repository\ProductOptionRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class ProductOptionContext implements Context
     {
     }
 
-    /**
-     * @Transform /^product option "([^"]+)"$/
-     * @Transform /^"([^"]+)" option$/
-     * @Transform :productOption
-     */
+    #[Transform('/^product option "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" option$/')]
+    #[Transform(':productOption')]
     public function getProductOptionByName($productOptionName)
     {
         $productOptions = $this->productOptionRepository->findByName($productOptionName, 'en_US');

--- a/src/Sylius/Behat/Context/Transform/ProductOptionValueContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionValueContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -24,11 +25,9 @@ final class ProductOptionValueContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" option value$/
-     * @Transform :optionValue
-     * @Transform :productOptionValue
-     */
+    #[Transform('/^"([^"]+)" option value$/')]
+    #[Transform(':optionValue')]
+    #[Transform(':productOptionValue')]
     public function getProductOptionValueByCode(string $code): ProductOptionValueInterface
     {
         $productOptionValues = $this->productOptionValueRepository->findBy(['code' => $code]);

--- a/src/Sylius/Behat/Context/Transform/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductReviewContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Review\Model\ReviewInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -24,10 +25,8 @@ final class ProductReviewContext implements Context
     {
     }
 
-    /**
-     * @Transform :productReview
-     * @Transform /^"([^"]+)" product review$/
-     */
+    #[Transform(':productReview')]
+    #[Transform('/^"([^"]+)" product review$/')]
     public function getProductReviewByTitle(string $title): ReviewInterface
     {
         $productReview = $this->productReviewRepository->findOneBy(['title' => $title]);

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -30,10 +31,8 @@ final class ProductVariantContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^"([^"]+)" variant of product "([^"]+)"$/
-     * @Transform /^"([^"]+)" variant of "([^"]+)" product$/
-     */
+    #[Transform('/^"([^"]+)" variant of product "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" variant of "([^"]+)" product$/')]
     public function getProductVariantByNameAndProduct(string $variantName, string $productName): ProductVariantInterface
     {
         $products = $this->productRepository->findByName($productName, 'en_US');
@@ -53,9 +52,7 @@ final class ProductVariantContext implements Context
         return $productVariants[0];
     }
 
-    /**
-     * @Transform /^"([^"]+)" variant of this product$/
-     */
+    #[Transform('/^"([^"]+)" variant of this product$/')]
     public function getProductVariantByNameAndThisProduct(string $variantName): ProductVariantInterface
     {
         $product = $this->sharedStorage->get('product');
@@ -69,13 +66,11 @@ final class ProductVariantContext implements Context
         return $productVariants[0];
     }
 
-    /**
-     * @Transform /^"([^"]+)" product variant$/
-     * @Transform /^"([^"]+)" variant$/
-     * @Transform /^variant "([^"]+)"$/
-     * @Transform :productVariant
-     * @Transform :variant
-     */
+    #[Transform('/^"([^"]+)" product variant$/')]
+    #[Transform('/^"([^"]+)" variant$/')]
+    #[Transform('/^variant "([^"]+)"$/')]
+    #[Transform(':productVariant')]
+    #[Transform(':variant')]
     public function getProductVariantByName($name)
     {
         $productVariants = $this->productVariantRepository->findByName($name, 'en_US');
@@ -89,9 +84,7 @@ final class ProductVariantContext implements Context
         return $productVariants[0];
     }
 
-    /**
-     * @Transform /^"([^"]+)", "([^"]+)" and "([^"]+)" variants$/
-     */
+    #[Transform('/^"([^"]+)", "([^"]+)" and "([^"]+)" variants$/')]
     public function getVariantsByNames(string ...$variantNames): array
     {
         return array_map(function ($variantName) {
@@ -99,9 +92,7 @@ final class ProductVariantContext implements Context
         }, $variantNames);
     }
 
-    /**
-     * @Transform /^variant with code "([^"]+)"$/
-     */
+    #[Transform('/^variant with code "([^"]+)"$/')]
     public function getProductVariantByCode($code)
     {
         $productVariant = $this->productVariantRepository->findOneBy(['code' => $code]);
@@ -111,9 +102,7 @@ final class ProductVariantContext implements Context
         return $productVariant;
     }
 
-    /**
-     * @Transform /^"([^"]*)" (\w+) \/ "([^"]*)" (\w+) variant of product "([^"]+)"$/
-     */
+    #[Transform('/^"([^"]*)" (\w+) \/ "([^"]*)" (\w+) variant of product "([^"]+)"$/')]
     public function getVariantByOptionValuesAndProduct(
         string $value1,
         string $option1,

--- a/src/Sylius/Behat/Context/Transform/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Transform/PromotionContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 use Sylius\Component\Promotion\Repository\PromotionRepositoryInterface;
@@ -26,11 +27,9 @@ final class PromotionContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^promotion "([^"]+)"$/
-     * @Transform /^"([^"]+)" promotion$/
-     * @Transform :promotion
-     */
+    #[Transform('/^promotion "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" promotion$/')]
+    #[Transform(':promotion')]
     public function getPromotionByName($promotionName)
     {
         $promotion = $this->promotionRepository->findOneBy(['name' => $promotionName]);
@@ -43,11 +42,9 @@ final class PromotionContext implements Context
         return $promotion;
     }
 
-    /**
-     * @Transform /^coupon "([^"]+)"$/
-     * @Transform /^"([^"]+)" coupon$/
-     * @Transform :coupon
-     */
+    #[Transform('/^coupon "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" coupon$/')]
+    #[Transform(':coupon')]
     public function getPromotionCouponByCode($promotionCouponCode)
     {
         $promotionCoupon = $this->promotionCouponRepository->findOneBy(['code' => $promotionCouponCode]);

--- a/src/Sylius/Behat/Context/Transform/ProvinceContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProvinceContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -24,12 +25,10 @@ final class ProvinceContext implements Context
     {
     }
 
-    /**
-     * @Transform /^province "([^"]+)"$/
-     * @Transform /^"([^"]+)" province$/
-     * @Transform /^province as "([^"]+)"$/
-     * @Transform :province
-     */
+    #[Transform('/^province "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" province$/')]
+    #[Transform('/^province as "([^"]+)"$/')]
+    #[Transform(':province')]
     public function getProvinceByName(string $provinceName): ProvinceInterface
     {
         /** @var ProvinceInterface|null $province */
@@ -42,9 +41,7 @@ final class ProvinceContext implements Context
         return $province;
     }
 
-    /**
-     * @Transform /^"([^"]*)" and "([^"]*)" provinces$/
-     */
+    #[Transform('/^"([^"]*)" and "([^"]*)" provinces$/')]
     public function getProvincesByName(string ...$provinceNames): array
     {
         return $this->provinceRepository->findBy(['name' => $provinceNames]);

--- a/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
+++ b/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
@@ -23,17 +24,13 @@ final class SharedStorageContext implements Context
     {
     }
 
-    /**
-     * @Transform /^(it|its|theirs|them)$/
-     */
+    #[Transform('/^(it|its|theirs|them)$/')]
     public function getLatestResource()
     {
         return $this->sharedStorage->getLatestResource();
     }
 
-    /**
-     * @Transform /^(?:this|that|the) ([^"]+)$/
-     */
+    #[Transform('/^(?:this|that|the) ([^"]+)$/')]
     public function getResource($resource)
     {
         return $this->sharedStorage->get(StringInflector::nameToCode($resource));

--- a/src/Sylius/Behat/Context/Transform/ShippingCalculatorContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingCalculatorContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -24,9 +25,7 @@ final class ShippingCalculatorContext implements Context
     ) {
     }
 
-    /**
-     * @Transform :shippingCalculator
-     */
+    #[Transform(':shippingCalculator')]
     public function getShippingCalculatorByName(string $shippingCalculator): string
     {
         $flippedCalculators = array_flip(array_map(

--- a/src/Sylius/Behat/Context/Transform/ShippingCategoryContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingCategoryContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,12 +24,10 @@ class ShippingCategoryContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" shipping category/
-     * @Transform /^shipping category "([^"]+)"/
-     * @Transform /^shipping category with name "([^"]+)"$/
-     * @Transform :shippingCategory
-     */
+    #[Transform('/^"([^"]+)" shipping category/')]
+    #[Transform('/^shipping category "([^"]+)"/')]
+    #[Transform('/^shipping category with name "([^"]+)"$/')]
+    #[Transform(':shippingCategory')]
     public function getShippingCategoryByName($shippingCategoryName)
     {
         $shippingCategories = $this->shippingCategoryRepository->findBy(['name' => $shippingCategoryName]);

--- a/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Shipping\Repository\ShippingMethodRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class ShippingMethodContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" shipping method$/
-     * @Transform /^shipping method "([^"]+)"$/
-     * @Transform :shippingMethod
-     */
+    #[Transform('/^"([^"]+)" shipping method$/')]
+    #[Transform('/^shipping method "([^"]+)"$/')]
+    #[Transform(':shippingMethod')]
     public function getShippingMethodByName($shippingMethodName)
     {
         $shippingMethods = $this->shippingMethodRepository->findByName($shippingMethodName, 'en_US');

--- a/src/Sylius/Behat/Context/Transform/ShopUserContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShopUserContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
@@ -24,9 +25,7 @@ final class ShopUserContext implements Context
     {
     }
 
-    /**
-     * @Transform :shopUser
-     */
+    #[Transform(':shopUser')]
     public function getShopUserByEmail(string $email): ShopUserInterface
     {
         $shopUser = $this->shopUserRepository->findOneByEmail($email);

--- a/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Taxation\Repository\TaxCategoryRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,11 +24,9 @@ final class TaxCategoryContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" tax category$/
-     * @Transform /^tax category "([^"]+)"$/
-     * @Transform :taxCategory
-     */
+    #[Transform('/^"([^"]+)" tax category$/')]
+    #[Transform('/^tax category "([^"]+)"$/')]
+    #[Transform(':taxCategory')]
     public function getTaxCategoryByName($taxCategoryName)
     {
         $taxCategories = $this->taxCategoryRepository->findByName($taxCategoryName);

--- a/src/Sylius/Behat/Context/Transform/TaxRateContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxRateContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -23,10 +24,8 @@ final class TaxRateContext implements Context
     {
     }
 
-    /**
-     * @Transform :taxRate
-     * @Transform /^"([^"]+)" tax rate$/
-     */
+    #[Transform(':taxRate')]
+    #[Transform('/^"([^"]+)" tax rate$/')]
     public function getTaxRateByName($taxRateName)
     {
         $taxRate = $this->taxRateRepository->findOneBy(['name' => $taxRateName]);

--- a/src/Sylius/Behat/Context/Transform/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxonContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
@@ -26,19 +27,17 @@ final class TaxonContext implements Context
     ) {
     }
 
-    /**
-     * @Transform /^classified as "([^"]+)"$/
-     * @Transform /^belongs to "([^"]+)"$/
-     * @Transform /^"([^"]+)" taxon$/
-     * @Transform /^"([^"]+)" as a parent taxon$/
-     * @Transform /^"([^"]+)" parent taxon$/
-     * @Transform /^parent taxon to "([^"]+)"$/
-     * @Transform /^taxon should be "([^"]+)"$/
-     * @Transform /^taxon with "([^"]+)" name/
-     * @Transform /^taxon "([^"]+)"$/
-     * @Transform :taxon
-     * @Transform :parentTaxon
-     */
+    #[Transform('/^classified as "([^"]+)"$/')]
+    #[Transform('/^belongs to "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" taxon$/')]
+    #[Transform('/^"([^"]+)" as a parent taxon$/')]
+    #[Transform('/^"([^"]+)" parent taxon$/')]
+    #[Transform('/^parent taxon to "([^"]+)"$/')]
+    #[Transform('/^taxon should be "([^"]+)"$/')]
+    #[Transform('/^taxon with "([^"]+)" name/')]
+    #[Transform('/^taxon "([^"]+)"$/')]
+    #[Transform(':taxon')]
+    #[Transform(':parentTaxon')]
     public function getTaxonByName(string $name): TaxonInterface
     {
         $taxons = $this->taxonRepository->findByName($name, $this->locale);
@@ -52,9 +51,7 @@ final class TaxonContext implements Context
         return $taxons[0];
     }
 
-    /**
-     * @Transform /^taxon with "([^"]+)" code$/
-     */
+    #[Transform('/^taxon with "([^"]+)" code$/')]
     public function getTaxonByCode(string $code): TaxonInterface
     {
         $taxon = $this->taxonRepository->findOneBy(['code' => $code]);
@@ -63,13 +60,11 @@ final class TaxonContext implements Context
         return $taxon;
     }
 
-    /**
-     * @Transform /^classified as "([^"]+)" or "([^"]+)"$/
-     * @Transform /^configured with "([^"]+)" and "([^"]+)"$/
-     * @Transform /^"([^"]+)" and "([^"]+)" taxons$/
-     * @Transform /^belongs to "([^"]+)" and "([^"]+)"/
-     * @Transform /^"([^"]+)" and "([^"]+)" in the vertical menu$/
-     */
+    #[Transform('/^classified as "([^"]+)" or "([^"]+)"$/')]
+    #[Transform('/^configured with "([^"]+)" and "([^"]+)"$/')]
+    #[Transform('/^"([^"]+)" and "([^"]+)" taxons$/')]
+    #[Transform('/^belongs to "([^"]+)" and "([^"]+)"/')]
+    #[Transform('/^"([^"]+)" and "([^"]+)" in the vertical menu$/')]
     public function getTaxonsByNames(string ...$taxonNames): iterable
     {
         foreach ($taxonNames as $taxonName) {

--- a/src/Sylius/Behat/Context/Transform/ThemeContext.php
+++ b/src/Sylius/Behat/Context/Transform/ThemeContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
@@ -23,11 +24,9 @@ final readonly class ThemeContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" theme$/
-     * @Transform /^theme "([^"]+)"$/
-     * @Transform :theme
-     */
+    #[Transform('/^"([^"]+)" theme$/')]
+    #[Transform('/^theme "([^"]+)"$/')]
+    #[Transform(':theme')]
     public function getThemeByThemeName(string $themeName): ThemeInterface
     {
         return $this->themeRepository->findOneByName($themeName);

--- a/src/Sylius/Behat/Context/Transform/UserContext.php
+++ b/src/Sylius/Behat/Context/Transform/UserContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Service\SharedStorageInterface;
 
@@ -22,9 +23,7 @@ class UserContext implements Context
     {
     }
 
-    /**
-     * @Transform /^(I|my|he|his|she|her|"this user")$/
-     */
+    #[Transform('/^(I|my|he|his|she|her|"this user")$/')]
     public function getLoggedUser()
     {
         return $this->sharedStorage->get('user');

--- a/src/Sylius/Behat/Context/Transform/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Transform/ZoneContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Resource\Doctrine\Persistence\RepositoryInterface;
@@ -24,13 +25,11 @@ final class ZoneContext implements Context
     {
     }
 
-    /**
-     * @Transform /^"([^"]+)" zone$/
-     * @Transform /^zone "([^"]+)"$/
-     * @Transform /^zone named "([^"]+)"$/
-     * @Transform :zone
-     * @Transform :otherZone
-     */
+    #[Transform('/^"([^"]+)" zone$/')]
+    #[Transform('/^zone "([^"]+)"$/')]
+    #[Transform('/^zone named "([^"]+)"$/')]
+    #[Transform(':zone')]
+    #[Transform(':otherZone')]
     public function getZone(string $codeOrName): ZoneInterface
     {
         $zone = $this->zoneRepository->findOneBy(['code' => $codeOrName]);
@@ -47,9 +46,7 @@ final class ZoneContext implements Context
         return $zone;
     }
 
-    /**
-     * @Transform /^rest of the world$/
-     */
+    #[Transform('/^rest of the world$/')]
     public function getRestOfTheWorldZone(): ZoneInterface
     {
         $zone = $this->zoneRepository->findOneBy(['code' => 'RoW']);

--- a/src/Sylius/Behat/Context/Transform/ZoneMemberContext.php
+++ b/src/Sylius/Behat/Context/Transform/ZoneMemberContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Context\Transform;
 
+use Behat\Transformation\Transform;
 use Behat\Behat\Context\Context;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
@@ -31,9 +32,7 @@ final class ZoneMemberContext implements Context
     ) {
     }
 
-    /**
-     * @Transform the :name country member
-     */
+    #[Transform('the :name country member')]
     public function getCountryTypeZoneMemberByName($name)
     {
         $countryCode = $this->countryNameConverter->convertToCode($name);
@@ -41,10 +40,8 @@ final class ZoneMemberContext implements Context
         return $this->getZoneMemberByCode($countryCode);
     }
 
-    /**
-     * @Transform /^"([^"]+)", "([^"]+)" and "([^"]+)" country members$/
-     * @Transform /^"([^"]+)" and "([^"]+)" country members$/
-     */
+    #[Transform('/^"([^"]+)", "([^"]+)" and "([^"]+)" country members$/')]
+    #[Transform('/^"([^"]+)" and "([^"]+)" country members$/')]
     public function getCountryTypeZoneMembersByNames(string ...$names): array
     {
         $codes = $names;
@@ -53,9 +50,7 @@ final class ZoneMemberContext implements Context
         return $this->getZoneMembersByCodes($codes);
     }
 
-    /**
-     * @Transform the :name province member
-     */
+    #[Transform('the :name province member')]
     public function getProvinceTypeZoneMemberByName($name)
     {
         $provinceCode = $this->getProvinceByName($name)->getCode();
@@ -63,9 +58,7 @@ final class ZoneMemberContext implements Context
         return $this->getZoneMemberByCode($provinceCode);
     }
 
-    /**
-     * @Transform the :name zone member
-     */
+    #[Transform('the :name zone member')]
     public function getZoneTypeZoneMemberByName($name)
     {
         $zoneCode = $this->getZoneByName($name)->getCode();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18822
| License         | MIT


<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized test framework context files across the test suite by migrating to PHP 8 native attributes syntax. This update improves code consistency and aligns with modern PHP standards while maintaining all existing test functionality. No changes to test behavior or observable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->