### PR TITLE
Fix IriToIdentifierConverter::isIdentifier to catch all exceptions thrown during route matching

### DIFF
--- a/features/product/adding_product_reviews/adding_product_review_with_multiline_comment.feature
+++ b/features/product/adding_product_reviews/adding_product_review_with_multiline_comment.feature
@@ -1,0 +1,19 @@
+@adding_product_review
+Feature: Adding product review with multiline comment
+    In order to share my detailed opinion about product with other customers
+    As a Customer
+    I want to be able to add product review with a detailed multiline comment
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Necronomicon"
+
+    @ui @api
+    Scenario: Adding product reviews as a logged in customer
+        Given I am a logged in customer
+        When I want to review product "Necronomicon"
+        And I leave a comment "Great book for every advanced sorcerer.\nWarning: may summon demons. Five stars anyway.", titled "Scary but astonishing"
+        And I rate it with 5 points
+        And I add it
+        Then I should be notified that my review is waiting for the acceptation
+        And the "Scary but astonishing" product review of "Necronomicon" product should not be visible for customers

--- a/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductReviewContext.php
@@ -21,6 +21,7 @@ use Sylius\Behat\Context\Api\Resources;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
 final class ProductReviewContext implements Context
@@ -132,7 +133,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatMyReviewIsWaitingForTheAcceptation(): void
     {
-        // Intentionally left blank
+        Assert::same($this->client->getLastResponse()->getStatusCode(), Response::HTTP_CREATED);
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Converter/IriToIdentifierConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/Converter/IriToIdentifierConverter.php
@@ -75,7 +75,7 @@ final class IriToIdentifierConverter implements IriToIdentifierConverterInterfac
 
         try {
             $parameters = $this->router->match($fieldValue);
-        } catch (RoutingExceptionInterface) {
+        } catch (\Throwable) {
             return false;
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Tests/Converter/IriToIdentifierConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/Converter/IriToIdentifierConverterTest.php
@@ -81,6 +81,14 @@ final class IriToIdentifierConverterTest extends TestCase
     }
 
     /** @test */
+    public function it_treats_strings_that_cannot_be_matched_on_routes_because_of_exception_as_not_identifiers(): void
+    {
+        $this->router->match('test')->willThrow(new \Exception());
+
+        $this->assertFalse($this->converter->isIdentifier('test'));
+    }
+
+    /** @test */
     public function it_throws_invalid_argument_exception_if_no_route_matches(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | >=1.14
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/17727
| License         | MIT

It appears that the issue linked in the related tickets has not been fully resolved. It was fixed in Sylius 2.0 only, but since it is related to the security advisory [GHSA-mrqx-rp3w-jpjp](https://github.com/advisories/GHSA-mrqx-rp3w-jpjp), I think it should be fixed in 1.14 as well.

Additionally, the currently implemented fix using FILTER_SANITIZE_URL (see [this line](https://github.com/Sylius/Sylius/pull/17728/changes#diff-f3cf2e1df698bb3ec2c33a5048e302ce001ba9275e292c6ebadfc329140719b7R96)) is not sufficient as the issue still persists. I've prepared a Behat scenario that will fail without the fix proposed here.

I believe the best approach is to catch all exceptions in the `IriToIdentifierConverter::isIdentifier` and return false if any exception occurs.