### PR TITLE
[BUGFIX] Include child taxons when checking total price of items from taxon pr…

### DIFF
--- a/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_total_of_items_from_specific_taxon.feature
+++ b/features/shop/promotion/applying_promotion_rules/receiving_discount_based_on_total_of_items_from_specific_taxon.feature
@@ -56,3 +56,37 @@ Feature: Receiving discount based on total of items from specific taxon
         When I check the details of my cart
         Then my cart total should be "$125.00"
         And my discount should be "-$15.00"
+
+    @api @ui
+    Scenario: Receiving discount on order while buying product from child taxon of promoted taxon
+        Given the "T-Shirts" taxon has child taxon "Polo T-Shirts"
+        And the store has a product "Polo T-Shirt" priced at "$100.00"
+        And it belongs to "Polo T-Shirts"
+        And the promotion gives "$20.00" off if order contains products classified as "T-Shirts" with a minimum value of "$50.00"
+        And I added product "Polo T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$80.00"
+        And my discount should be "-$20.00"
+
+    @api @ui
+    Scenario: Receiving no discount on order while buying product from child taxon of promoted taxon which not fits price criteria
+        Given the "T-Shirts" taxon has child taxon "Polo T-Shirts"
+        And the store has a product "Polo T-Shirt" priced at "$30.00"
+        And it belongs to "Polo T-Shirts"
+        And the promotion gives "$20.00" off if order contains products classified as "T-Shirts" with a minimum value of "$50.00"
+        And I added product "Polo T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$30.00"
+        And there should be no discount applied
+
+    @api @ui
+    Scenario: Receiving discount on order while buying products from both parent and child taxon which fit price criteria
+        Given the "T-Shirts" taxon has child taxon "Polo T-Shirts"
+        And the store has a product "Polo T-Shirt" priced at "$60.00"
+        And it belongs to "Polo T-Shirts"
+        And the promotion gives "$10.00" off if order contains products classified as "T-Shirts" with a minimum value of "$50.00"
+        And I added product "PHP T-Shirt" to the cart
+        And I added product "Polo T-Shirt" to the cart
+        When I check the details of my cart
+        Then my cart total should be "$150.00"
+        And my discount should be "-$10.00"

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Promotion\Checker\Rule;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
 use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
@@ -60,11 +61,26 @@ final class TotalOfItemsFromTaxonRuleChecker implements RuleCheckerInterface
 
         /** @var OrderItemInterface $item */
         foreach ($subject->getItems() as $item) {
-            if ($item->getProduct()->hasTaxon($targetTaxon)) {
+            if ($this->productBelongsToTaxonOrDescendant($item->getProduct(), $targetTaxon)) {
                 $itemsWithTaxonTotal += $item->getTotal();
             }
         }
 
         return $itemsWithTaxonTotal >= $configuration['amount'];
+    }
+
+    private function productBelongsToTaxonOrDescendant(?ProductInterface $product, TaxonInterface $targetTaxon): bool
+    {
+        if ($product === null) {
+            return false;
+        }
+
+        foreach ($product->getTaxons() as $taxon) {
+            if ($taxon === $targetTaxon || $taxon->getAncestors()->contains($targetTaxon)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerTest.php
+++ b/src/Sylius/Component/Core/tests/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleCheckerTest.php
@@ -85,12 +85,12 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->with(['code' => 'bows'])
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
-        $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->compositeBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
         $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
         $this->longswordItem->expects($this->once())->method('getProduct')->willReturn($this->longsword);
-        $this->longsword->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(false);
+        $this->longsword->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([]));
         $this->reflexBowItem->expects($this->once())->method('getProduct')->willReturn($this->reflexBow);
-        $this->reflexBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->reflexBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
         $this->reflexBowItem->expects($this->once())->method('getTotal')->willReturn(9000);
 
         $this->assertTrue(
@@ -112,11 +112,42 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->with(['code' => 'bows'])
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
-        $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->compositeBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
         $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
         $this->reflexBowItem->expects($this->once())->method('getProduct')->willReturn($this->reflexBow);
-        $this->reflexBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->reflexBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
         $this->reflexBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+
+        $this->assertTrue(
+            $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),
+        );
+    }
+
+    public function testShouldRecognizeSubjectAsEligibleIfItHasItemsFromChildTaxonOfConfiguredTaxon(): void
+    {
+        $recurveBows = $this->createMock(TaxonInterface::class);
+        $recurveBows->method('getAncestors')->willReturn(new ArrayCollection([$this->bows]));
+
+        $recurveBowItem = $this->createMock(OrderItemInterface::class);
+        $recurveBow = $this->createMock(ProductInterface::class);
+
+        $this->order->expects($this->once())->method('getChannel')->willReturn($this->channel);
+        $this->channel->expects($this->once())->method('getCode')->willReturn('WEB_US');
+        $this->order->expects($this->once())->method('getItems')->willReturn(new ArrayCollection([
+            $this->compositeBowItem,
+            $recurveBowItem,
+        ]));
+        $this->taxonRepository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with(['code' => 'bows'])
+            ->willReturn($this->bows);
+        $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
+        $this->compositeBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
+        $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
+        $recurveBowItem->expects($this->once())->method('getProduct')->willReturn($recurveBow);
+        $recurveBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$recurveBows]));
+        $recurveBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
 
         $this->assertTrue(
             $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),
@@ -137,10 +168,10 @@ final class TotalOfItemsFromTaxonRuleCheckerTest extends TestCase
             ->with(['code' => 'bows'])
             ->willReturn($this->bows);
         $this->compositeBowItem->expects($this->once())->method('getProduct')->willReturn($this->compositeBow);
-        $this->compositeBow->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(true);
+        $this->compositeBow->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([$this->bows]));
         $this->compositeBowItem->expects($this->once())->method('getTotal')->willReturn(5000);
         $this->longswordItem->expects($this->once())->method('getProduct')->willReturn($this->longsword);
-        $this->longsword->expects($this->once())->method('hasTaxon')->with($this->bows)->willReturn(false);
+        $this->longsword->expects($this->once())->method('getTaxons')->willReturn(new ArrayCollection([]));
 
         $this->assertFalse(
             $this->ruleChecker->isEligible($this->order, ['WEB_US' => ['taxon' => 'bows', 'amount' => 10000]]),


### PR DESCRIPTION
…omotion rule

| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18862
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
