### PR TITLE
[New routing] Refactoring shop user verification token

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/Shop/Account/RequestShopUserVerification.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/Shop/Account/RequestShopUserVerification.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Command\Shop\Account;
+
+/**
+ * @experimental
+ */
+class RequestShopUserVerification
+{
+    public function __construct(
+        public readonly mixed $shopUserId,
+        public readonly string $channelCode,
+        public readonly string $localeCode,
+    ) {
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Command/Shop/Account/SendShopUserVerificationEmail.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/Shop/Account/SendShopUserVerificationEmail.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Command\Shop\Account;
+
+/**
+ * @experimental
+ */
+class SendShopUserVerificationEmail
+{
+    public function __construct(
+        public readonly string $shopUserEmail,
+        public readonly string $localeCode,
+        public readonly string $channelCode,
+    ) {
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/CommandHandler/Shop/Account/RequestShopUserVerificationHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CommandHandler/Shop/Account/RequestShopUserVerificationHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account;
+
+use Sylius\Bundle\CoreBundle\Command\Shop\Account\RequestShopUserVerification;
+use Sylius\Bundle\CoreBundle\Command\Shop\Account\SendShopUserVerificationEmail;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Sylius\Component\User\Security\Generator\GeneratorInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+
+#[AsMessageHandler]
+final readonly class RequestShopUserVerificationHandler
+{
+    /**
+     * @param UserRepositoryInterface<ShopUserInterface> $shopUserRepository
+     */
+    public function __construct(
+        private UserRepositoryInterface $shopUserRepository,
+        private GeneratorInterface $tokenGenerator,
+        private MessageBusInterface $commandBus,
+    ) {
+    }
+
+    public function __invoke(RequestShopUserVerification $command): void
+    {
+        /** @var ShopUserInterface|null $user */
+        $user = $this->shopUserRepository->find($command->shopUserId);
+        if (null === $user) {
+            throw new \InvalidArgumentException(
+                sprintf('There is no shop user with %s id', $command->shopUserId),
+            );
+        }
+
+        $token = $this->tokenGenerator->generate();
+        $user->setEmailVerificationToken($token);
+        /** @var CustomerInterface $customer */
+        $customer = $user->getCustomer();
+
+        $this->commandBus->dispatch(new SendShopUserVerificationEmail(
+            $customer->getEmail(),
+            $command->localeCode,
+            $command->channelCode,
+        ), [new DispatchAfterCurrentBusStamp()]);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/CommandHandler/Shop/Account/SendShopUserVerificationEmailHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/CommandHandler/Shop/Account/SendShopUserVerificationEmailHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account;
+
+use Sylius\Bundle\CoreBundle\Command\Shop\Account\SendShopUserVerificationEmail;
+use Sylius\Bundle\CoreBundle\Mailer\AccountVerificationEmailManagerInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class SendShopUserVerificationEmailHandler
+{
+    /**
+     * @param UserRepositoryInterface<ShopUserInterface> $shopUserRepository
+     * @param ChannelRepositoryInterface<ChannelInterface> $channelRepository
+     */
+    public function __construct(
+        private UserRepositoryInterface $shopUserRepository,
+        private ChannelRepositoryInterface $channelRepository,
+        private AccountVerificationEmailManagerInterface $accountVerificationEmailManager,
+    ) {
+    }
+
+    public function __invoke(SendShopUserVerificationEmail $command): void
+    {
+        $shopUser = $this->shopUserRepository->findOneByEmail($command->shopUserEmail);
+        if (null === $shopUser) {
+            throw new \InvalidArgumentException(
+                sprintf('There is no shop user with %s email', $command->shopUserEmail),
+            );
+        }
+
+        $channel = $this->channelRepository->findOneByCode($command->channelCode);
+        if (null === $channel) {
+            throw new \InvalidArgumentException(
+                sprintf('Channel with code %s has not been found.', $command->channelCode),
+            );
+        }
+
+        $this->accountVerificationEmailManager->sendAccountVerificationEmail(
+            $shopUser,
+            $channel,
+            $command->localeCode,
+        );
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/command_handler.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/command_handler.php
@@ -18,7 +18,9 @@ use Sylius\Bundle\CoreBundle\CommandHandler\Admin\Account\RequestResetPasswordEm
 use Sylius\Bundle\CoreBundle\CommandHandler\Admin\Account\SendResetPasswordEmailHandler as AdminSendResetPasswordEmailHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\ResendOrderConfirmationEmailHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\ResendShipmentConfirmationEmailHandler;
+use Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account\RequestShopUserVerificationHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account\ResetPasswordHandler as ShopResetPasswordHandler;
+use Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account\SendShopUserVerificationEmailHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\Shop\ChangeShopUserPasswordHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account\RequestResetPasswordEmailHandler as ShopRequestResetPasswordEmailHandler;
 use Sylius\Bundle\CoreBundle\CommandHandler\Shop\Account\SendResetPasswordEmailHandler as ShopSendResetPasswordEmailHandler;
@@ -60,6 +62,16 @@ return static function (ContainerConfigurator $container) {
     ;
 
     $services
+        ->set('sylius.command_handler.shop.account.request_shop_user_verification', RequestShopUserVerificationHandler::class)
+        ->args([
+            service('sylius.repository.shop_user'),
+            service('sylius.shop_user.token_generator.email_verification'),
+            service('sylius.command_bus'),
+        ])
+        ->tag('messenger.message_handler', ['bus' => 'sylius.command_bus'])
+    ;
+
+    $services
         ->set('sylius.command_handler.resend_shipment_confirmation_email', ResendShipmentConfirmationEmailHandler::class)
         ->args([
             service('sylius.repository.shipment'),
@@ -85,6 +97,16 @@ return static function (ContainerConfigurator $container) {
         ->args([
             service('sylius.mailer.order_email_manager'),
             service('sylius.repository.order'),
+        ])
+        ->tag('messenger.message_handler', ['bus' => 'sylius.command_bus'])
+    ;
+
+    $services
+        ->set('sylius.command_handler.shop.account.send_shop_user_verification_email', SendShopUserVerificationEmailHandler::class)
+        ->args([
+            service('sylius.repository.shop_user'),
+            service('sylius.repository.channel'),
+            service('sylius.mailer.account_verification_email_manager'),
         ])
         ->tag('messenger.message_handler', ['bus' => 'sylius.command_bus'])
     ;

--- a/src/Sylius/Bundle/ShopBundle/Controller/RequestShopUserVerificationTokenAction.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/RequestShopUserVerificationTokenAction.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Controller;
+
+use Sylius\Bundle\CoreBundle\Command\Shop\Account\RequestShopUserVerification;
+use Sylius\Bundle\CoreBundle\Provider\FlashBagProvider;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\User\Model\UserInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @experimental
+ */
+final readonly class RequestShopUserVerificationTokenAction
+{
+    public function __construct(
+        private RouterInterface $router,
+        private TokenStorageInterface $tokenStorage,
+        private RequestStack $requestStack,
+        private ChannelContextInterface $channelContext,
+        private LocaleContextInterface $localeContext,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(Request $request, ?string $redirect): Response
+    {
+        $redirect ??= 'sylius_shop_account_dashboard';
+
+        $user = $this->getUser();
+
+        if (null === $user) {
+            $this->addWarningNotification('sylius.user.verify_no_user');
+
+            return new RedirectResponse($this->router->generate($redirect));
+        }
+
+        if (null !== $user->getVerifiedAt()) {
+            $this->addWarningNotification('sylius.user.verify_verified_email');
+
+            return new RedirectResponse($this->router->generate($redirect));
+        }
+
+        $this->messageBus->dispatch(new RequestShopUserVerification(
+            $user->getId(),
+            $this->channelContext->getChannel()->getCode(),
+            $this->localeContext->getLocaleCode(),
+        ));
+
+        FlashBagProvider::getFlashBag($this->requestStack)->add('success', 'sylius.user.verify_email_request');
+
+        return new RedirectResponse($this->router->generate($redirect));
+    }
+
+    private function addWarningNotification(string $message): void
+    {
+        FlashBagProvider::getFlashBag($this->requestStack)->add('warning', $message);
+    }
+
+    private function getUser(): ?UserInterface
+    {
+        /** @var UserInterface|null $user */
+        $user = $this->tokenStorage->getToken()?->getUser();
+
+        if (null === $user) {
+            return null;
+        }
+
+        return $user;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
@@ -4,10 +4,17 @@
 sylius_shop_user_request_verification_token:
     path: /verify
     methods: [POST]
+    condition: "context.isSyliusRoutingBcLayerEnabled('shop_request_verification_token')"
     defaults:
         _controller: sylius.controller.shop_user::requestVerificationTokenAction
         _sylius:
             redirect: sylius_shop_account_dashboard
+            
+_sylius_shop_user_request_verification_token:
+    path: /verify
+    methods: [POST]
+    condition: "not context.isSyliusRoutingBcLayerEnabled('shop_request_verification_token')"
+    controller: sylius_shop.controller.request_shop_user_verification_token
 
 sylius_shop_user_verification:
     path: /verify/{token}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.php
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.php
@@ -22,6 +22,7 @@ use Sylius\Bundle\ShopBundle\Controller\LocaleSwitchController;
 use Sylius\Bundle\ShopBundle\Controller\OrderThankYouAction;
 use Sylius\Bundle\ShopBundle\Controller\RegistrationThankYouController;
 use Sylius\Bundle\ShopBundle\Controller\RequestPasswordResetTokenAction;
+use Sylius\Bundle\ShopBundle\Controller\RequestShopUserVerificationTokenAction;
 use Sylius\Bundle\ShopBundle\Controller\ResetPasswordAction;
 
 return static function (ContainerConfigurator $container) {
@@ -115,6 +116,19 @@ return static function (ContainerConfigurator $container) {
             service('twig'),
             service('sylius.context.channel'),
             service('router.default'),
+        ])
+        ->tag('controller.service_arguments')
+    ;
+
+    $services
+        ->set('sylius_shop.controller.request_shop_user_verification_token', RequestShopUserVerificationTokenAction::class)
+        ->args([
+            service('router.default'),
+            service('security.token_storage'),
+            service('request_stack'),
+            service('sylius.context.channel'),
+            service('sylius.context.locale'),
+            service('sylius.command_bus'),
         ])
         ->tag('controller.service_arguments')
     ;


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | new-routing
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #18212
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

The commands are duplicated from 
- https://github.com/Sylius/Sylius/blob/2.3/src/Sylius/Bundle/ApiBundle/Command/Account/RequestShopUserVerification.php
- https://github.com/Sylius/Sylius/blob/2.3/src/Sylius/Bundle/ApiBundle/Command/Account/SendShopUserVerificationEmail.php


The Command handlers are duplicated from 
- https://github.com/Sylius/Sylius/blob/2.3/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/RequestShopUserVerificationHandler.php
- https://github.com/Sylius/Sylius/blob/2.3/src/Sylius/Bundle/ApiBundle/CommandHandler/Account/SendShopUserVerificationEmailHandler.php
