### PR TITLE
Remove redundant check with apip4.1.7 in matrix

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -30,8 +30,7 @@
           "symfony": "~7.4.0",
           "mariadb": "11.4.7",
           "dbal": "^3.0",
-          "state_machine_adapter": "symfony_workflow",
-          "api_platform": "~4.1.7"
+          "state_machine_adapter": "symfony_workflow"
         }
       ]
     },


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
