### PR TITLE
[Admin] Fix product taxon grid `enabled` field always showing `true`

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_taxon.yml
@@ -44,7 +44,7 @@ sylius_grid:
                 enabled:
                     type: twig
                     label: sylius.ui.enabled
-                    path: product
+                    path: product.enabled
                     options:
                         template: "@SyliusAdmin/shared/grid/field/boolean.html.twig"
                 position:


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #18633
| License         | MIT

The `enabled` column in the product taxon grid always displays `true` regardless of the product's actual enabled status.

The grid's root entity is `ProductTaxon`, not `Product`. The `enabled` field had `path: product`, which passes the entire `Product` object to the boolean Twig template. The template does `{% if true == data %}` - any non-null object is truthy in Twig, so it always evaluates to `true`.

Changed `path: product` to `path: product.enabled` to pass the actual boolean value.