### PR TITLE
[BUGFIX] remove redundant `object` from PHPDoc union types

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -93,7 +93,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      */
     private function createUserByOAuthUserResponse(UserResponseInterface $response): SyliusUserInterface
     {
-        /** @var SyliusUserInterface|object $user */
+        /** @var SyliusUserInterface $user */
         $user = $this->userFactory->createNew();
         Assert::isInstanceOf($user, SyliusUserInterface::class);
 

--- a/src/Sylius/Bundle/PayumBundle/Storage/DoctrineStorage.php
+++ b/src/Sylius/Bundle/PayumBundle/Storage/DoctrineStorage.php
@@ -20,7 +20,7 @@ class DoctrineStorage extends BaseDoctrineStorage
 {
     protected function doFind($id): ?object
     {
-        /** @var object|GatewayConfigInterface|null $resource */
+        /** @var object|null $resource */
         $resource = parent::doFind($id);
 
         if (null === $resource) {
@@ -37,7 +37,7 @@ class DoctrineStorage extends BaseDoctrineStorage
     /** @param array<mixed> $criteria */
     public function findBy(array $criteria): array
     {
-        /** @var object[]|GatewayConfigInterface[] $resources */
+        /** @var array<object> $resources */
         $resources = parent::findBy($criteria);
 
         return array_filter($resources, static function ($resource) {


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18878
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
