### PR TITLE
[BUGFIX] make checkout resolver pattern support empty locale URL prefix

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -10,7 +10,7 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/grids/product.yml" }
 
 parameters:
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)([^/]+/)?"
 
 webpack_encore:
     builds:
@@ -29,7 +29,7 @@ sylius_grid:
 
 sylius_shop:
     checkout_resolver:
-        pattern: "%sylius.security.shop_regex%/checkout/.+"
+        pattern: "^/([^/]+/)?checkout/.+"
         route_map:
             empty_order:
                 route: sylius_shop_cart_summary

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -10,7 +10,7 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/grids/product.yml" }
 
 parameters:
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)([^/]+/)?"
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
 
 webpack_encore:
     builds:

--- a/src/Sylius/Bundle/ShopBundle/tests/DependencyInjection/CheckoutResolverPatternTest.php
+++ b/src/Sylius/Bundle/ShopBundle/tests/DependencyInjection/CheckoutResolverPatternTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\ShopBundle\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
+
+final class CheckoutResolverPatternTest extends TestCase
+{
+    private const CHECKOUT_PATTERN = '^/([^/]+/)?checkout/.+';
+
+    #[Test]
+    #[DataProvider('matchingPathsProvider')]
+    public function it_matches_checkout_paths(string $path): void
+    {
+        $matcher = new PathRequestMatcher(self::CHECKOUT_PATTERN);
+        $request = Request::create($path);
+
+        $this->assertTrue($matcher->matches($request));
+    }
+
+    #[Test]
+    #[DataProvider('nonMatchingPathsProvider')]
+    public function it_does_not_match_non_checkout_paths(string $path): void
+    {
+        $matcher = new PathRequestMatcher(self::CHECKOUT_PATTERN);
+        $request = Request::create($path);
+
+        $this->assertFalse($matcher->matches($request));
+    }
+
+    public static function matchingPathsProvider(): iterable
+    {
+        yield 'default locale without prefix — address step' => ['/checkout/address'];
+        yield 'default locale without prefix — shipping step' => ['/checkout/select-shipping'];
+        yield 'default locale without prefix — payment step' => ['/checkout/select-payment'];
+        yield 'default locale without prefix — complete step' => ['/checkout/complete'];
+        yield 'non-default locale with prefix' => ['/nl/checkout/address'];
+        yield 'locale with underscore' => ['/en_US/checkout/address'];
+    }
+
+    public static function nonMatchingPathsProvider(): iterable
+    {
+        yield 'cart summary' => ['/cart'];
+        yield 'homepage' => ['/'];
+        yield 'product page' => ['/nl/products/t-shirt'];
+        yield 'admin path' => ['/admin/orders'];
+        yield 'checkout without trailing segment' => ['/checkout'];
+        yield 'checkout without trailing slash and segment' => ['/nl/checkout'];
+    }
+}


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18789
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
