### PR TITLE
[BUGFIX] Use ResourceClassResolver in IriConverter to fix discriminator subclass IRi generation

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -29,6 +29,7 @@
     "ApiPlatform\\Metadata\\QueryParameter",
     "ApiPlatform\\Metadata\\Resource\\Factory\\ResourceMetadataCollectionFactoryInterface",
     "ApiPlatform\\Metadata\\Resource\\ResourceMetadataCollection",
+    "ApiPlatform\\Metadata\\ResourceClassResolverInterface",
     "ApiPlatform\\Metadata\\UriVariablesConverterInterface",
     "ApiPlatform\\Metadata\\UrlGeneratorInterface",
     "ApiPlatform\\Metadata\\Util\\ClassInfoTrait",

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Routing/IriConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Routing/IriConverter.php
@@ -31,8 +31,17 @@ final readonly class IriConverter implements IriConverterInterface
         private PathPrefixProviderInterface $pathPrefixProvider,
         private OperationResolverInterface $operationResolver,
         private RouterInterface $router,
-        private ResourceClassResolverInterface $resourceClassResolver,
+        private ?ResourceClassResolverInterface $resourceClassResolver = null,
     ) {
+        if ($this->resourceClassResolver === null) {
+            trigger_deprecation(
+                'sylius/api-bundle',
+                '2.1',
+                'Not passing a "%s" to "%s" constructor is deprecated and will be required in Sylius 3.0.',
+                ResourceClassResolverInterface::class,
+                self::class,
+            );
+        }
     }
 
     public function getResourceFromIri(string $iri, array $context = [], ?Operation $operation = null): object
@@ -52,7 +61,7 @@ final readonly class IriConverter implements IriConverterInterface
             $resourceClass = $resource;
         } else {
             $objectClass = $this->getObjectClass($resource);
-            $resourceClass = $this->resourceClassResolver->isResourceClass($objectClass)
+            $resourceClass = $this->resourceClassResolver !== null && $this->resourceClassResolver->isResourceClass($objectClass)
                 ? $this->resourceClassResolver->getResourceClass($resource)
                 : $objectClass;
         }

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Routing/IriConverter.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Routing/IriConverter.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\ApiPlatform\Routing;
 
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
 use Sylius\Bundle\ApiBundle\Provider\PathPrefixProviderInterface;
@@ -30,6 +31,7 @@ final readonly class IriConverter implements IriConverterInterface
         private PathPrefixProviderInterface $pathPrefixProvider,
         private OperationResolverInterface $operationResolver,
         private RouterInterface $router,
+        private ResourceClassResolverInterface $resourceClassResolver,
     ) {
     }
 
@@ -44,7 +46,17 @@ final readonly class IriConverter implements IriConverterInterface
         ?Operation $operation = null,
         array $context = [],
     ): ?string {
-        $resourceClass = $context['force_resource_class'] ?? (\is_string($resource) ? $resource : $this->getObjectClass($resource));
+        if (isset($context['force_resource_class'])) {
+            $resourceClass = $context['force_resource_class'];
+        } elseif (\is_string($resource)) {
+            $resourceClass = $resource;
+        } else {
+            $objectClass = $this->getObjectClass($resource);
+            $resourceClass = $this->resourceClassResolver->isResourceClass($objectClass)
+                ? $this->resourceClassResolver->getResourceClass($resource)
+                : $objectClass;
+        }
+
         $pathPrefix = $this->pathPrefixProvider->getPathPrefix($context['request_uri'] ?? $this->router->getContext()->getPathInfo());
         $operation = $this->operationResolver->resolve($resourceClass, $pathPrefix, $operation);
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_platform.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/api_platform.xml
@@ -35,6 +35,7 @@
             <argument type="service" id="sylius_api.provider.path_prefix" />
             <argument type="service" id="sylius_api.operation_resolver.path_prefix_based" />
             <argument type="service" id="api_platform.router" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
         </service>
 
         <service

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -26,6 +26,7 @@
         "php": "^8.2",
         "doctrine/dbal": "^3.9",
         "api-platform/doctrine-orm": "^4.1.7",
+        "api-platform/metadata": "^4.1.7",
         "api-platform/symfony": "^4.1.7",
         "lexik/jwt-authentication-bundle": "^3.1",
         "sylius/core-bundle": "^2.0",

--- a/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/IriConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/IriConverterTest.php
@@ -110,12 +110,64 @@ final class IriConverterTest extends TestCase
             ));
     }
 
-    public function testUsesResourceClassResolverToGetProperIriWhenConcreteClassHasNoOperations(): void
+    public function testInstantiationWithoutResourceClassResolverTriggersDeprecation(): void
+    {
+        $this->expectUserDeprecationMessageMatches('/Not passing a.*ResourceClassResolverInterface.*IriConverter.*is deprecated/');
+
+        new IriConverter(
+            $this->decoratedIriConverter,
+            $this->pathPrefixProvider,
+            $this->operationResolver,
+            $this->router,
+        );
+    }
+
+    public function testFallsBackToObjectClassWhenResourceClassResolverIsNotProvided(): void
     {
         /** @var Operation&MockObject $operation */
         $operation = $this->createMock(Operation::class);
 
         $country = new Country();
+
+        $iriConverter = new IriConverter(
+            $this->decoratedIriConverter,
+            $this->pathPrefixProvider,
+            $this->operationResolver,
+            $this->router,
+        );
+
+        $this->pathPrefixProvider->expects(self::once())
+            ->method('getPathPrefix')
+            ->with('api/v2/shop/countries')
+            ->willReturn('shop');
+
+        $this->operationResolver->expects(self::once())
+            ->method('resolve')
+            ->with(Country::class, 'shop', null)
+            ->willReturn($operation);
+
+        $this->decoratedIriConverter->expects(self::once())
+            ->method('getIriFromResource')
+            ->with(self::identicalTo($country), UrlGeneratorInterface::ABS_PATH, $operation, [
+                'request_uri' => 'api/v2/shop/countries',
+            ])
+            ->willReturn('api/v2/shop/countries/CODE');
+
+        self::assertSame('api/v2/shop/countries/CODE', $iriConverter
+            ->getIriFromResource(
+                $country,
+                UrlGeneratorInterface::ABS_PATH,
+                null,
+                ['request_uri' => 'api/v2/shop/countries'],
+            ));
+    }
+
+    public function testResolvesDiscriminatorSubclassToParentResourceClassBeforeResolvingOperation(): void
+    {
+        /** @var Operation&MockObject $shopOperation */
+        $shopOperation = $this->createMock(Operation::class);
+
+        $concreteSubclassInstance = new Country();
 
         $this->resourceClassResolver->expects(self::once())
             ->method('isResourceClass')
@@ -124,7 +176,7 @@ final class IriConverterTest extends TestCase
 
         $this->resourceClassResolver->expects(self::once())
             ->method('getResourceClass')
-            ->with($country)
+            ->with($concreteSubclassInstance)
             ->willReturn(CountryInterface::class);
 
         $this->pathPrefixProvider->expects(self::once())
@@ -135,21 +187,66 @@ final class IriConverterTest extends TestCase
         $this->operationResolver->expects(self::once())
             ->method('resolve')
             ->with(CountryInterface::class, 'shop', null)
-            ->willReturn($operation);
+            ->willReturn($shopOperation);
 
         $this->decoratedIriConverter->expects(self::once())
             ->method('getIriFromResource')
-            ->with(self::identicalTo($country), UrlGeneratorInterface::ABS_PATH, $operation, [
+            ->with(self::identicalTo($concreteSubclassInstance), UrlGeneratorInterface::ABS_PATH, $shopOperation, [
                 'request_uri' => 'api/v2/shop/countries',
             ])
             ->willReturn('api/v2/shop/countries/CODE');
 
-        self::assertSame('api/v2/shop/countries/CODE', $this->iriConverter
-            ->getIriFromResource(
-                $country,
+        self::assertSame(
+            'api/v2/shop/countries/CODE',
+            $this->iriConverter->getIriFromResource(
+                $concreteSubclassInstance,
                 UrlGeneratorInterface::ABS_PATH,
                 null,
                 ['request_uri' => 'api/v2/shop/countries'],
-            ));
+            ),
+        );
+    }
+
+    public function testUsesConcreteClassDirectlyWhenItIsNotAKnownResourceClass(): void
+    {
+        /** @var Operation&MockObject $operation */
+        $operation = $this->createMock(Operation::class);
+
+        $concreteInstance = new Country();
+
+        $this->resourceClassResolver->expects(self::once())
+            ->method('isResourceClass')
+            ->with(Country::class)
+            ->willReturn(false);
+
+        $this->resourceClassResolver->expects(self::never())
+            ->method('getResourceClass');
+
+        $this->pathPrefixProvider->expects(self::once())
+            ->method('getPathPrefix')
+            ->with('api/v2/shop/countries')
+            ->willReturn('shop');
+
+        $this->operationResolver->expects(self::once())
+            ->method('resolve')
+            ->with(Country::class, 'shop', null)
+            ->willReturn($operation);
+
+        $this->decoratedIriConverter->expects(self::once())
+            ->method('getIriFromResource')
+            ->with(self::identicalTo($concreteInstance), UrlGeneratorInterface::ABS_PATH, $operation, [
+                'request_uri' => 'api/v2/shop/countries',
+            ])
+            ->willReturn('api/v2/shop/countries/CODE');
+
+        self::assertSame(
+            'api/v2/shop/countries/CODE',
+            $this->iriConverter->getIriFromResource(
+                $concreteInstance,
+                UrlGeneratorInterface::ABS_PATH,
+                null,
+                ['request_uri' => 'api/v2/shop/countries'],
+            ),
+        );
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/IriConverterTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/ApiPlatform/Routing/IriConverterTest.php
@@ -15,6 +15,7 @@ namespace Tests\Sylius\Bundle\ApiBundle\ApiPlatform\Routing;
 
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +36,8 @@ final class IriConverterTest extends TestCase
 
     private MockObject&RouterInterface $router;
 
+    private MockObject&ResourceClassResolverInterface $resourceClassResolver;
+
     private IriConverter $iriConverter;
 
     private CountryInterface&MockObject $country;
@@ -46,11 +49,13 @@ final class IriConverterTest extends TestCase
         $this->pathPrefixProvider = $this->createMock(PathPrefixProviderInterface::class);
         $this->operationResolver = $this->createMock(OperationResolverInterface::class);
         $this->router = $this->createMock(RouterInterface::class);
+        $this->resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         $this->iriConverter = new IriConverter(
             $this->decoratedIriConverter,
             $this->pathPrefixProvider,
             $this->operationResolver,
             $this->router,
+            $this->resourceClassResolver,
         );
         $this->country = $this->createMock(CountryInterface::class);
     }
@@ -102,6 +107,49 @@ final class IriConverterTest extends TestCase
                     'request_uri' => 'api/v2/admin/countries',
                     'force_resource_class' => Country::class,
                 ],
+            ));
+    }
+
+    public function testUsesResourceClassResolverToGetProperIriWhenConcreteClassHasNoOperations(): void
+    {
+        /** @var Operation&MockObject $operation */
+        $operation = $this->createMock(Operation::class);
+
+        $country = new Country();
+
+        $this->resourceClassResolver->expects(self::once())
+            ->method('isResourceClass')
+            ->with(Country::class)
+            ->willReturn(true);
+
+        $this->resourceClassResolver->expects(self::once())
+            ->method('getResourceClass')
+            ->with($country)
+            ->willReturn(CountryInterface::class);
+
+        $this->pathPrefixProvider->expects(self::once())
+            ->method('getPathPrefix')
+            ->with('api/v2/shop/countries')
+            ->willReturn('shop');
+
+        $this->operationResolver->expects(self::once())
+            ->method('resolve')
+            ->with(CountryInterface::class, 'shop', null)
+            ->willReturn($operation);
+
+        $this->decoratedIriConverter->expects(self::once())
+            ->method('getIriFromResource')
+            ->with(self::identicalTo($country), UrlGeneratorInterface::ABS_PATH, $operation, [
+                'request_uri' => 'api/v2/shop/countries',
+            ])
+            ->willReturn('api/v2/shop/countries/CODE');
+
+        self::assertSame('api/v2/shop/countries/CODE', $this->iriConverter
+            ->getIriFromResource(
+                $country,
+                UrlGeneratorInterface::ABS_PATH,
+                null,
+                ['request_uri' => 'api/v2/shop/countries'],
             ));
     }
 }


### PR DESCRIPTION
…ss IRI generation

| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18781
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
