### PR TITLE
[Core] Remove hardcoded migrations table cleanup

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20160101084139.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20160101084139.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Migrations;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Types\Types;
 use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
 
 final class Version20160101084139 extends AbstractPostgreSQLMigration
@@ -33,11 +31,6 @@ final class Version20160101084139 extends AbstractPostgreSQLMigration
     public function getDescription(): string
     {
         return 'Regenerated Sylius migrations from 1.X';
-    }
-
-    public function postUp(Schema $schema): void
-    {
-        $this->cleanMigrationsTable();
     }
 
     public function up(Schema $schema): void
@@ -745,19 +738,4 @@ final class Version20160101084139 extends AbstractPostgreSQLMigration
         return false;
     }
 
-    private function cleanMigrationsTable(): void
-    {
-        $this->connection->executeStatement('DELETE FROM sylius_migrations WHERE version LIKE :version AND version NOT IN (:current) AND version < :new', [
-            'version' => 'Sylius\\\\Bundle\\\\CoreBundle\\\\Migrations\\\\Version%',
-            'current' => [
-                'Sylius\\Bundle\\CoreBundle\\Migrations\\Version20160101092155',
-                self::class,
-            ],
-            'new' => 'Sylius\\Bundle\\CoreBundle\\Migrations\\Version20241020131407',
-        ], [
-            'version' => Types::STRING,
-            'current' => ArrayParameterType::STRING,
-            'new' => Types::STRING,
-        ]);
-    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20160101092155.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20160101092155.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Migrations;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Types\Types;
 use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
 
 final class Version20160101092155 extends AbstractMigration
@@ -33,11 +31,6 @@ final class Version20160101092155 extends AbstractMigration
     public function getDescription(): string
     {
         return 'Regenerated Sylius migrations from 1.X';
-    }
-
-    public function postUp(Schema $schema): void
-    {
-        $this->cleanMigrationsTable();
     }
 
     public function up(Schema $schema): void
@@ -439,19 +432,4 @@ final class Version20160101092155 extends AbstractMigration
         return false;
     }
 
-    private function cleanMigrationsTable(): void
-    {
-        $this->connection->executeStatement('DELETE FROM sylius_migrations WHERE version LIKE :version AND version NOT IN (:current) AND version < :new', [
-            'version' => 'Sylius\\\\Bundle\\\\CoreBundle\\\\Migrations\\\\Version%',
-            'current' => [
-                'Sylius\\Bundle\\CoreBundle\\Migrations\\Version20160101084139',
-                self::class,
-            ],
-            'new' => 'Sylius\\Bundle\\CoreBundle\\Migrations\\Version20241020131407',
-        ], [
-            'version' => Types::STRING,
-            'current' => ArrayParameterType::STRING,
-            'new' => Types::STRING,
-        ]);
-    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #18699
| License         | MIT

Backport of #18709 to 2.0. Removes `cleanMigrationsTable()` and `postUp()` from regenerated 1.X migrations. The cleanup method used a hardcoded `sylius_migrations` table name, which fails when users configure a custom table name via `doctrine_migrations.storage.table_storage.table_name`.

When upgrading from 1.x to 2.0+, the regenerated migration runs `postUp()` which tries to delete old 1.x entries from the migrations tracking table. If the user has configured a custom table name (e.g. `migration_versions` instead of the default `sylius_migrations`), the query fails because the hardcoded table doesn't exist.

The cleanup was only cosmetic (removing old 1.x migration entries) and not critical - old entries don't cause any issues.