### PR TITLE
[Promotion] Add version locking to promotions and coupons

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Promotion/Modifier/AtomicOrderPromotionsUsageModifier.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Promotion/Modifier/AtomicOrderPromotionsUsageModifier.php
@@ -14,168 +14,64 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Doctrine\ORM\Promotion\Modifier;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
-use Sylius\Component\Core\Promotion\Exception\PromotionUsageLimitReachedException;
 use Sylius\Component\Core\Promotion\Modifier\OrderPromotionsUsageModifierInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Resource\Model\VersionedInterface;
+use Webmozart\Assert\Assert;
 
 final class AtomicOrderPromotionsUsageModifier implements OrderPromotionsUsageModifierInterface
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        private readonly ?Connection $connection,
+        private readonly OrderPromotionsUsageModifierInterface $decoratedModifier,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+        if (null !== $this->connection) {
+            trigger_deprecation(
+                'sylius/core-bundle',
+                '2.3',
+                'Passing a "%s" as the first constructor argument is deprecated and will be prohibited in Sylius 3.0.',
+                Connection::class,
+            );
+        }
     }
 
     public function increment(OrderInterface $order): void
     {
-        foreach ($order->getPromotions() as $promotion) {
-            $this->incrementPromotionUsage($promotion);
-        }
+        $this->lockEntities($order);
 
-        /** @var PromotionCouponInterface|null $coupon */
-        $coupon = $order->getPromotionCoupon();
-        if (null === $coupon) {
-            return;
-        }
-
-        $this->incrementCouponUsage($coupon, $order);
+        $this->decoratedModifier->increment($order);
     }
 
     public function decrement(OrderInterface $order): void
     {
+        $this->lockEntities($order);
+
+        $this->decoratedModifier->decrement($order);
+    }
+
+    private function lockEntities(OrderInterface $order): void
+    {
         foreach ($order->getPromotions() as $promotion) {
-            $this->decrementPromotionUsage($promotion);
+            $this->refreshAndLock($promotion);
         }
 
         /** @var PromotionCouponInterface|null $coupon */
         $coupon = $order->getPromotionCoupon();
-        if (null === $coupon) {
-            return;
+        if (null !== $coupon) {
+            $this->refreshAndLock($coupon);
         }
-
-        if (OrderInterface::STATE_CANCELLED === $order->getState() && !$coupon->isReusableFromCancelledOrders()) {
-            return;
-        }
-
-        $this->decrementCouponUsage($coupon);
     }
 
-    private function incrementPromotionUsage(PromotionInterface $promotion): void
+    private function refreshAndLock(PromotionCouponInterface|PromotionInterface $entity): void
     {
-        $affected = $this->connection->executeStatement(
-            'UPDATE sylius_promotion
-             SET used = used + 1
-             WHERE id = :id AND (usage_limit IS NULL OR used < usage_limit)',
-            ['id' => $promotion->getId()],
-        );
+        $this->entityManager->refresh($entity);
 
-        if (0 === $affected) {
-            throw PromotionUsageLimitReachedException::withPromotionCode((string) $promotion->getCode());
-        }
-
-        $newUsed = (int) $this->connection->fetchOne(
-            'SELECT used FROM sylius_promotion WHERE id = :id',
-            ['id' => $promotion->getId()],
-        );
-
-        $promotion->setUsed($newUsed);
-    }
-
-    private function decrementPromotionUsage(PromotionInterface $promotion): void
-    {
-        $this->connection->executeStatement(
-            'UPDATE sylius_promotion SET used = GREATEST(used - 1, 0) WHERE id = :id',
-            ['id' => $promotion->getId()],
-        );
-
-        $newUsed = (int) $this->connection->fetchOne(
-            'SELECT used FROM sylius_promotion WHERE id = :id',
-            ['id' => $promotion->getId()],
-        );
-
-        $promotion->setUsed($newUsed);
-    }
-
-    private function incrementCouponUsage(PromotionCouponInterface $coupon, OrderInterface $order): void
-    {
-        $row = $this->connection->fetchAssociative(
-            'SELECT used, usage_limit, per_customer_usage_limit FROM sylius_promotion_coupon WHERE id = :id FOR UPDATE',
-            ['id' => $coupon->getId()],
-        );
-
-        if (false === $row) {
-            throw PromotionUsageLimitReachedException::withCouponCode((string) $coupon->getCode());
-        }
-
-        if (null !== $row['usage_limit'] && (int) $row['used'] >= (int) $row['usage_limit']) {
-            throw PromotionUsageLimitReachedException::withCouponCode((string) $coupon->getCode());
-        }
-
-        if (null !== $row['per_customer_usage_limit']) {
-            $this->assertPerCustomerCouponUsageLimitNotReached(
-                $coupon,
-                $order,
-                (int) $row['per_customer_usage_limit'],
-            );
-        }
-
-        $this->connection->executeStatement(
-            'UPDATE sylius_promotion_coupon SET used = used + 1 WHERE id = :id',
-            ['id' => $coupon->getId()],
-        );
-
-        $coupon->setUsed((int) $row['used'] + 1);
-    }
-
-    private function assertPerCustomerCouponUsageLimitNotReached(
-        PromotionCouponInterface $coupon,
-        OrderInterface $order,
-        int $perCustomerUsageLimit,
-    ): void {
-        $customer = $order->getCustomer();
-        if (null === $customer || null === $customer->getId()) {
-            return;
-        }
-
-        $sql = 'SELECT o.id FROM sylius_order o
-                WHERE o.customer_id = :customerId
-                AND o.promotion_coupon_id = :couponId
-                AND o.state != :stateCart';
-        $params = [
-            'customerId' => $customer->getId(),
-            'couponId' => $coupon->getId(),
-            'stateCart' => OrderInterface::STATE_CART,
-        ];
-
-        if ($coupon->isReusableFromCancelledOrders()) {
-            $sql .= ' AND o.state != :stateCancelled';
-            $params['stateCancelled'] = OrderInterface::STATE_CANCELLED;
-        }
-
-        $sql .= ' FOR UPDATE';
-
-        $count = count($this->connection->fetchAllAssociative($sql, $params));
-
-        if ($count >= $perCustomerUsageLimit) {
-            throw PromotionUsageLimitReachedException::withCouponCode((string) $coupon->getCode());
-        }
-    }
-
-    private function decrementCouponUsage(PromotionCouponInterface $coupon): void
-    {
-        $this->connection->executeStatement(
-            'UPDATE sylius_promotion_coupon SET used = GREATEST(used - 1, 0) WHERE id = :id',
-            ['id' => $coupon->getId()],
-        );
-
-        $newUsed = (int) $this->connection->fetchOne(
-            'SELECT used FROM sylius_promotion_coupon WHERE id = :id',
-            ['id' => $coupon->getId()],
-        );
-
-        $coupon->setUsed($newUsed);
+        Assert::isInstanceOf($entity, VersionedInterface::class);
+        $this->entityManager->lock($entity, LockMode::OPTIMISTIC, $entity->getVersion());
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20260216120000.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20260216120000.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
+
+final class Version20260216120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add version column to sylius_promotion and sylius_promotion_coupon tables for optimistic locking.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_promotion ADD version INT DEFAULT 1 NOT NULL');
+        $this->addSql('ALTER TABLE sylius_promotion_coupon ADD version INT DEFAULT 1 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_promotion DROP version');
+        $this->addSql('ALTER TABLE sylius_promotion_coupon DROP version');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20260216120001.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20260216120001.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
+final class Version20260216120001 extends AbstractPostgreSQLMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add version column to sylius_promotion and sylius_promotion_coupon tables for optimistic locking (PostgreSQL).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_promotion ADD version INT DEFAULT 1 NOT NULL');
+        $this->addSql('ALTER TABLE sylius_promotion_coupon ADD version INT DEFAULT 1 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_promotion DROP version');
+        $this->addSql('ALTER TABLE sylius_promotion_coupon DROP version');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Promotion.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Promotion.orm.xml
@@ -18,6 +18,8 @@
                   >
 
     <mapped-superclass name="Sylius\Component\Core\Model\Promotion" table="sylius_promotion">
+        <field name="version" type="integer" version="true" />
+
         <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
             <order-by>
                 <order-by-field name="id" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/PromotionCoupon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/PromotionCoupon.orm.xml
@@ -17,6 +17,8 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\PromotionCoupon" table="sylius_promotion_coupon">
+        <field name="version" type="integer" version="true" />
+
         <field type="integer" name="perCustomerUsageLimit" column="per_customer_usage_limit" nullable="true" />
         <field name="reusableFromCancelledOrders" column="reusable_from_cancelled_orders" type="boolean">
             <options>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.php
@@ -199,7 +199,6 @@ return static function (ContainerConfigurator $container) {
 
     $services
         ->set('sylius.modifier.promotion.order_usage', OrderPromotionsUsageModifier::class)
-        ->args([service('sylius.manager.promotion')])
         ->public()
     ;
     $services->alias(OrderPromotionsUsageModifierInterface::class, 'sylius.modifier.promotion.order_usage')->public();
@@ -207,7 +206,11 @@ return static function (ContainerConfigurator $container) {
     $services
         ->set('sylius.modifier.promotion.order_usage.atomic', AtomicOrderPromotionsUsageModifier::class)
         ->decorate('sylius.modifier.promotion.order_usage')
-        ->args([service('doctrine.dbal.default_connection')])
+        ->args([
+            null,
+            service('.inner'),
+            service('doctrine.orm.entity_manager'),
+        ])
     ;
 
     $services

--- a/src/Sylius/Bundle/CoreBundle/tests/Doctrine/ORM/Promotion/Modifier/AtomicOrderPromotionsUsageModifierTest.php
+++ b/src/Sylius/Bundle/CoreBundle/tests/Doctrine/ORM/Promotion/Modifier/AtomicOrderPromotionsUsageModifierTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\Bundle\CoreBundle\Doctrine\ORM\Promotion\Modifier;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\CoreBundle\Doctrine\ORM\Promotion\Modifier\AtomicOrderPromotionsUsageModifier;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PromotionCouponInterface;
+use Sylius\Component\Core\Model\PromotionInterface;
+use Sylius\Component\Core\Promotion\Modifier\OrderPromotionsUsageModifierInterface;
+
+final class AtomicOrderPromotionsUsageModifierTest extends TestCase
+{
+    private MockObject&OrderPromotionsUsageModifierInterface $decoratedModifier;
+
+    private EntityManagerInterface&MockObject $entityManager;
+
+    private AtomicOrderPromotionsUsageModifier $atomicModifier;
+
+    protected function setUp(): void
+    {
+        $this->decoratedModifier = $this->createMock(OrderPromotionsUsageModifierInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->atomicModifier = new AtomicOrderPromotionsUsageModifier(
+            null,
+            $this->decoratedModifier,
+            $this->entityManager,
+        );
+    }
+
+    public function testLocksPromotionsAndCouponDuringIncrement(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $promotion = $this->createMock(PromotionInterface::class);
+        $coupon = $this->createMock(PromotionCouponInterface::class);
+
+        $order->method('getPromotions')->willReturn(new ArrayCollection([$promotion]));
+        $order->method('getPromotionCoupon')->willReturn($coupon);
+
+        $promotion->method('getVersion')->willReturn(3);
+        $coupon->method('getVersion')->willReturn(5);
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('refresh')
+            ->willReturnCallback(function (object $entity) use ($promotion, $coupon): void {
+                $this->assertTrue($entity === $promotion || $entity === $coupon);
+            })
+        ;
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('lock')
+            ->willReturnCallback(function (object $entity, int $lockMode, mixed $version) use ($promotion, $coupon): void {
+                $this->assertSame(LockMode::OPTIMISTIC, $lockMode);
+
+                if ($entity === $promotion) {
+                    $this->assertSame(3, $version);
+                } elseif ($entity === $coupon) {
+                    $this->assertSame(5, $version);
+                } else {
+                    $this->fail('Unexpected entity locked');
+                }
+            })
+        ;
+
+        $this->decoratedModifier->expects($this->once())->method('increment')->with($order);
+
+        $this->atomicModifier->increment($order);
+    }
+
+    public function testLocksPromotionsDuringIncrementWithoutCoupon(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $promotion = $this->createMock(PromotionInterface::class);
+
+        $order->method('getPromotions')->willReturn(new ArrayCollection([$promotion]));
+        $order->method('getPromotionCoupon')->willReturn(null);
+
+        $promotion->method('getVersion')->willReturn(1);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('refresh')
+            ->with($promotion)
+        ;
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('lock')
+            ->with($promotion, LockMode::OPTIMISTIC, 1)
+        ;
+
+        $this->decoratedModifier->expects($this->once())->method('increment')->with($order);
+
+        $this->atomicModifier->increment($order);
+    }
+
+    public function testLocksPromotionsAndCouponDuringDecrement(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $promotion = $this->createMock(PromotionInterface::class);
+        $coupon = $this->createMock(PromotionCouponInterface::class);
+
+        $order->method('getPromotions')->willReturn(new ArrayCollection([$promotion]));
+        $order->method('getPromotionCoupon')->willReturn($coupon);
+
+        $promotion->method('getVersion')->willReturn(3);
+        $coupon->method('getVersion')->willReturn(5);
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('refresh')
+            ->willReturnCallback(function (object $entity) use ($promotion, $coupon): void {
+                $this->assertTrue($entity === $promotion || $entity === $coupon);
+            })
+        ;
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('lock')
+            ->willReturnCallback(function (object $entity, int $lockMode, mixed $version) use ($promotion, $coupon): void {
+                $this->assertSame(LockMode::OPTIMISTIC, $lockMode);
+
+                if ($entity === $promotion) {
+                    $this->assertSame(3, $version);
+                } elseif ($entity === $coupon) {
+                    $this->assertSame(5, $version);
+                } else {
+                    $this->fail('Unexpected entity locked');
+                }
+            })
+        ;
+
+        $this->decoratedModifier->expects($this->once())->method('decrement')->with($order);
+
+        $this->atomicModifier->decrement($order);
+    }
+
+    public function testLocksPromotionsDuringDecrementWithoutCoupon(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $promotion = $this->createMock(PromotionInterface::class);
+
+        $order->method('getPromotions')->willReturn(new ArrayCollection([$promotion]));
+        $order->method('getPromotionCoupon')->willReturn(null);
+
+        $promotion->method('getVersion')->willReturn(1);
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('refresh')
+            ->with($promotion)
+        ;
+
+        $this->entityManager
+            ->expects($this->once())
+            ->method('lock')
+            ->with($promotion, LockMode::OPTIMISTIC, 1)
+        ;
+
+        $this->decoratedModifier->expects($this->once())->method('decrement')->with($order);
+
+        $this->atomicModifier->decrement($order);
+    }
+
+    public function testLocksMultiplePromotionsDuringIncrement(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $firstPromotion = $this->createMock(PromotionInterface::class);
+        $secondPromotion = $this->createMock(PromotionInterface::class);
+
+        $order->method('getPromotions')->willReturn(new ArrayCollection([$firstPromotion, $secondPromotion]));
+        $order->method('getPromotionCoupon')->willReturn(null);
+
+        $firstPromotion->method('getVersion')->willReturn(2);
+        $secondPromotion->method('getVersion')->willReturn(4);
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('refresh')
+            ->willReturnCallback(function (object $entity) use ($firstPromotion, $secondPromotion): void {
+                $this->assertTrue($entity === $firstPromotion || $entity === $secondPromotion);
+            })
+        ;
+
+        $this->entityManager
+            ->expects($this->exactly(2))
+            ->method('lock')
+            ->willReturnCallback(function (object $entity, int $lockMode, mixed $version) use ($firstPromotion, $secondPromotion): void {
+                $this->assertSame(LockMode::OPTIMISTIC, $lockMode);
+
+                if ($entity === $firstPromotion) {
+                    $this->assertSame(2, $version);
+                } elseif ($entity === $secondPromotion) {
+                    $this->assertSame(4, $version);
+                } else {
+                    $this->fail('Unexpected entity locked');
+                }
+            })
+        ;
+
+        $this->decoratedModifier->expects($this->once())->method('increment')->with($order);
+
+        $this->atomicModifier->increment($order);
+    }
+}

--- a/src/Sylius/Component/Core/Model/Promotion.php
+++ b/src/Sylius/Component/Core/Model/Promotion.php
@@ -21,6 +21,9 @@ use Webmozart\Assert\Assert;
 
 class Promotion extends BasePromotion implements PromotionInterface
 {
+    /** @var int */
+    protected $version = 1;
+
     /** @var Collection<array-key, ChannelInterface> */
     protected $channels;
 
@@ -55,5 +58,15 @@ class Promotion extends BasePromotion implements PromotionInterface
     public function hasChannel(BaseChannelInterface $channel): bool
     {
         return $this->channels->contains($channel);
+    }
+
+    public function getVersion(): ?int
+    {
+        return $this->version;
+    }
+
+    public function setVersion(?int $version): void
+    {
+        $this->version = $version;
     }
 }

--- a/src/Sylius/Component/Core/Model/PromotionCoupon.php
+++ b/src/Sylius/Component/Core/Model/PromotionCoupon.php
@@ -17,6 +17,9 @@ use Sylius\Component\Promotion\Model\PromotionCoupon as BasePromotionCoupon;
 
 class PromotionCoupon extends BasePromotionCoupon implements PromotionCouponInterface
 {
+    /** @var int */
+    protected $version = 1;
+
     /** @var int|null */
     protected $perCustomerUsageLimit;
 
@@ -41,5 +44,15 @@ class PromotionCoupon extends BasePromotionCoupon implements PromotionCouponInte
     public function setReusableFromCancelledOrders(bool $reusableFromCancelledOrders): void
     {
         $this->reusableFromCancelledOrders = $reusableFromCancelledOrders;
+    }
+
+    public function getVersion(): ?int
+    {
+        return $this->version;
+    }
+
+    public function setVersion(?int $version): void
+    {
+        $this->version = $version;
     }
 }

--- a/src/Sylius/Component/Core/Model/PromotionCouponInterface.php
+++ b/src/Sylius/Component/Core/Model/PromotionCouponInterface.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Promotion\Model\PromotionCouponInterface as BasePromotionCouponInterface;
+use Sylius\Resource\Model\VersionedInterface;
 
-interface PromotionCouponInterface extends BasePromotionCouponInterface
+interface PromotionCouponInterface extends BasePromotionCouponInterface, VersionedInterface
 {
     public function getPerCustomerUsageLimit(): ?int;
 

--- a/src/Sylius/Component/Core/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Core/Model/PromotionInterface.php
@@ -15,7 +15,8 @@ namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Channel\Model\ChannelsAwareInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface as BasePromotionInterface;
+use Sylius\Resource\Model\VersionedInterface;
 
-interface PromotionInterface extends BasePromotionInterface, ChannelsAwareInterface
+interface PromotionInterface extends BasePromotionInterface, ChannelsAwareInterface, VersionedInterface
 {
 }

--- a/src/Sylius/Component/Core/tests/Model/PromotionCouponTest.php
+++ b/src/Sylius/Component/Core/tests/Model/PromotionCouponTest.php
@@ -16,6 +16,7 @@ namespace Tests\Sylius\Component\Core\Model;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\PromotionCoupon;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
+use Sylius\Resource\Model\VersionedInterface;
 
 final class PromotionCouponTest extends TestCase
 {
@@ -53,5 +54,15 @@ final class PromotionCouponTest extends TestCase
         $this->promotionCoupon->setReusableFromCancelledOrders(false);
 
         $this->assertFalse($this->promotionCoupon->isReusableFromCancelledOrders());
+    }
+
+    public function testShouldImplementVersionedInterface(): void
+    {
+        $this->assertInstanceOf(VersionedInterface::class, $this->promotionCoupon);
+    }
+
+    public function testShouldHaveVersionOneByDefault(): void
+    {
+        $this->assertSame(1, $this->promotionCoupon->getVersion());
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.3
| Bug fix?        | kinda
| New feature?    | kinda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimistic locking added for promotions and promotion coupons to reduce concurrent update conflicts.

* **Refactor**
  * Promotion usage handling rewritten to use a locked-refresh-and-delegate approach for safer, atomic updates.

* **Database**
  * Migrations and model version fields introduced to support optimistic locking.

* **Tests**
  * Added tests covering locking and delegation behavior for promotion usage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->