### PR TITLE
[BUGFIX] Allow updating provinceName when provinceCode is null in API

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Mapper/AddressMapper.php
+++ b/src/Sylius/Bundle/ApiBundle/Mapper/AddressMapper.php
@@ -28,8 +28,10 @@ final readonly class AddressMapper implements AddressMapperInterface
         $currentAddress->setPostcode($targetAddress->getPostcode());
         $currentAddress->setPhoneNumber($targetAddress->getPhoneNumber());
 
-        $currentAddress->setProvinceCode($targetAddress->getProvinceCode());
-        $currentAddress->setProvinceName($targetAddress->getProvinceName());
+        if (null !== $targetAddress->getProvinceCode() || null !== $targetAddress->getProvinceName()) {
+            $currentAddress->setProvinceCode($targetAddress->getProvinceCode());
+            $currentAddress->setProvinceName($targetAddress->getProvinceName());
+        }
 
         return $currentAddress;
     }

--- a/src/Sylius/Bundle/ApiBundle/Mapper/AddressMapper.php
+++ b/src/Sylius/Bundle/ApiBundle/Mapper/AddressMapper.php
@@ -28,10 +28,8 @@ final readonly class AddressMapper implements AddressMapperInterface
         $currentAddress->setPostcode($targetAddress->getPostcode());
         $currentAddress->setPhoneNumber($targetAddress->getPhoneNumber());
 
-        if (null !== $targetAddress->getProvinceCode()) {
-            $currentAddress->setProvinceCode($targetAddress->getProvinceCode());
-            $currentAddress->setProvinceName($targetAddress->getProvinceName());
-        }
+        $currentAddress->setProvinceCode($targetAddress->getProvinceCode());
+        $currentAddress->setProvinceName($targetAddress->getProvinceName());
 
         return $currentAddress;
     }

--- a/src/Sylius/Bundle/ApiBundle/tests/Mapper/AddressMapperTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Mapper/AddressMapperTest.php
@@ -84,8 +84,8 @@ final class AddressMapperTest extends TestCase
         $currentAddressMock->expects(self::once())->method('setCity')->with('New York');
         $currentAddressMock->expects(self::once())->method('setPostcode')->with('00000');
         $currentAddressMock->expects(self::once())->method('setPhoneNumber')->with('123456789');
-        $currentAddressMock->expects(self::once())->method('setProvinceCode')->with(null);
-        $currentAddressMock->expects(self::once())->method('setProvinceName')->with(null);
+        $currentAddressMock->expects(self::never())->method('setProvinceCode');
+        $currentAddressMock->expects(self::never())->method('setProvinceName');
 
         self::assertSame($currentAddressMock, $this->addressMapper->mapExisting($currentAddressMock, $targetAddressMock));
     }
@@ -105,8 +105,8 @@ final class AddressMapperTest extends TestCase
         $targetAddressMock->expects(self::once())->method('getCity')->willReturn('New York');
         $targetAddressMock->expects(self::once())->method('getPostcode')->willReturn('00000');
         $targetAddressMock->expects(self::once())->method('getPhoneNumber')->willReturn('123456789');
-        $targetAddressMock->expects(self::once())->method('getProvinceCode')->willReturn(null);
-        $targetAddressMock->expects(self::once())->method('getProvinceName')->willReturn('East');
+        $targetAddressMock->expects(self::atLeastOnce())->method('getProvinceCode')->willReturn(null);
+        $targetAddressMock->expects(self::atLeastOnce())->method('getProvinceName')->willReturn('East');
         $currentAddressMock->expects(self::once())->method('setFirstName')->with('John');
         $currentAddressMock->expects(self::once())->method('setLastName')->with('Doe');
         $currentAddressMock->expects(self::once())->method('setCompany')->with('CocaCola');

--- a/src/Sylius/Bundle/ApiBundle/tests/Mapper/AddressMapperTest.php
+++ b/src/Sylius/Bundle/ApiBundle/tests/Mapper/AddressMapperTest.php
@@ -75,7 +75,7 @@ final class AddressMapperTest extends TestCase
         $targetAddressMock->expects(self::once())->method('getPostcode')->willReturn('00000');
         $targetAddressMock->expects(self::once())->method('getPhoneNumber')->willReturn('123456789');
         $targetAddressMock->expects(self::once())->method('getProvinceCode')->willReturn(null);
-        $targetAddressMock->expects(self::never())->method('getProvinceName')->willReturn('east');
+        $targetAddressMock->expects(self::once())->method('getProvinceName')->willReturn(null);
         $currentAddressMock->expects(self::once())->method('setFirstName')->with('John');
         $currentAddressMock->expects(self::once())->method('setLastName')->with('Doe');
         $currentAddressMock->expects(self::once())->method('setCompany')->with('CocaCola');
@@ -84,8 +84,39 @@ final class AddressMapperTest extends TestCase
         $currentAddressMock->expects(self::once())->method('setCity')->with('New York');
         $currentAddressMock->expects(self::once())->method('setPostcode')->with('00000');
         $currentAddressMock->expects(self::once())->method('setPhoneNumber')->with('123456789');
-        $currentAddressMock->expects(self::never())->method('setProvinceCode')->with('999');
-        $currentAddressMock->expects(self::never())->method('setProvinceName')->with('east');
+        $currentAddressMock->expects(self::once())->method('setProvinceCode')->with(null);
+        $currentAddressMock->expects(self::once())->method('setProvinceName')->with(null);
+
+        self::assertSame($currentAddressMock, $this->addressMapper->mapExisting($currentAddressMock, $targetAddressMock));
+    }
+
+    public function testUpdatesAnAddressWithProvinceNameOnly(): void
+    {
+        /** @var AddressInterface|MockObject $currentAddressMock */
+        $currentAddressMock = $this->createMock(AddressInterface::class);
+        /** @var AddressInterface|MockObject $targetAddressMock */
+        $targetAddressMock = $this->createMock(AddressInterface::class);
+
+        $targetAddressMock->expects(self::once())->method('getFirstName')->willReturn('John');
+        $targetAddressMock->expects(self::once())->method('getLastName')->willReturn('Doe');
+        $targetAddressMock->expects(self::once())->method('getCompany')->willReturn('CocaCola');
+        $targetAddressMock->expects(self::once())->method('getStreet')->willReturn('Green Avenue');
+        $targetAddressMock->expects(self::once())->method('getCountryCode')->willReturn('US');
+        $targetAddressMock->expects(self::once())->method('getCity')->willReturn('New York');
+        $targetAddressMock->expects(self::once())->method('getPostcode')->willReturn('00000');
+        $targetAddressMock->expects(self::once())->method('getPhoneNumber')->willReturn('123456789');
+        $targetAddressMock->expects(self::once())->method('getProvinceCode')->willReturn(null);
+        $targetAddressMock->expects(self::once())->method('getProvinceName')->willReturn('East');
+        $currentAddressMock->expects(self::once())->method('setFirstName')->with('John');
+        $currentAddressMock->expects(self::once())->method('setLastName')->with('Doe');
+        $currentAddressMock->expects(self::once())->method('setCompany')->with('CocaCola');
+        $currentAddressMock->expects(self::once())->method('setStreet')->with('Green Avenue');
+        $currentAddressMock->expects(self::once())->method('setCountryCode')->with('US');
+        $currentAddressMock->expects(self::once())->method('setCity')->with('New York');
+        $currentAddressMock->expects(self::once())->method('setPostcode')->with('00000');
+        $currentAddressMock->expects(self::once())->method('setPhoneNumber')->with('123456789');
+        $currentAddressMock->expects(self::once())->method('setProvinceCode')->with(null);
+        $currentAddressMock->expects(self::once())->method('setProvinceName')->with('East');
 
         self::assertSame($currentAddressMock, $this->addressMapper->mapExisting($currentAddressMock, $targetAddressMock));
     }

--- a/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
+++ b/tests/Api/Responses/shop/checkout/cart/update_cart_with_province_name_only.json
@@ -1,0 +1,91 @@
+{
+    "@context": "\/api\/v2\/contexts\/Order",
+    "@id": "\/api\/v2\/shop\/orders\/token",
+    "@type": "Order",
+    "channel": "\/api\/v2\/shop\/channels\/WEB",
+    "customer": {
+        "@id": "\/api\/v2\/shop\/customers\/@integer@",
+        "@type": "Customer",
+        "email": "changed@email.com"
+    },
+    "shippingAddress": {
+        "@id": "\/api\/v2\/shop\/addresses\/@integer@",
+        "@type": "Address",
+        "firstName": "Updated: Jane",
+        "lastName": "Updated: Doe",
+        "phoneNumber": "123456789",
+        "company": null,
+        "countryCode": "DE",
+        "provinceCode": null,
+        "provinceName": "Bavaria",
+        "street": "Updated: Top secret",
+        "city": "Updated: Munich",
+        "postcode": "80331"
+    },
+    "billingAddress": {
+        "@id": "\/api\/v2\/shop\/addresses\/@integer@",
+        "@type": "Address",
+        "firstName": "Updated: Jane",
+        "lastName": "Updated: Doe",
+        "phoneNumber": "123456789",
+        "company": null,
+        "countryCode": "DE",
+        "provinceCode": null,
+        "provinceName": "Bavaria",
+        "street": "Updated: Top secret",
+        "city": "Updated: Munich",
+        "postcode": "80331"
+    },
+    "payments": [
+        {
+            "@id": "\/api\/v2\/shop\/orders\/token\/payments\/@integer@",
+            "@type": "Payment",
+            "id": "@integer@",
+            "method": "\/api\/v2\/shop\/payment-methods\/CASH_ON_DELIVERY"
+        }
+    ],
+    "shipments": [
+        {
+            "@id": "\/api\/v2\/shop\/orders\/token\/shipments\/@integer@",
+            "@type": "Shipment",
+            "id": "@integer@",
+            "method": "\/api\/v2\/shop\/shipping-methods\/UPS"
+        }
+    ],
+    "currencyCode": "USD",
+    "localeCode": "en_US",
+    "promotionCoupon": null,
+    "checkoutState": "addressed",
+    "paymentState": "cart",
+    "shippingState": "cart",
+    "tokenValue": "token",
+    "checkoutCompletedAt": null,
+    "number": null,
+    "items": [
+        {
+            "@id": "\/api\/v2\/shop\/orders\/token\/items\/@integer@",
+            "@type": "OrderItem",
+            "variant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+            "productName": "Mug",
+            "variantName": "Blue Mug",
+            "id": "@integer@",
+            "quantity": 3,
+            "unitPrice": 2000,
+            "originalUnitPrice": 2000,
+            "total": 6000,
+            "discountedUnitPrice": 2000,
+            "subtotal": 6000
+        }
+    ],
+    "itemsTotal": 6000,
+    "total": 6500,
+    "state": "cart",
+    "itemsSubtotal": 6000,
+    "taxTotal": 0,
+    "shippingTaxTotal": 500,
+    "taxExcludedTotal": 0,
+    "taxIncludedTotal": 0,
+    "shippingTotal": 500,
+    "orderPromotionTotal": 0,
+    "shippingPromotionTotal": 0
+}

--- a/tests/Api/Shop/Checkout/CartTest.php
+++ b/tests/Api/Shop/Checkout/CartTest.php
@@ -422,6 +422,52 @@ final class CartTest extends JsonApiTestCase
     }
 
     #[Test]
+    public function it_updates_cart_with_province_name_only_in_address(): void
+    {
+        $this->setUpDefaultPutHeaders();
+
+        $this->loadFixturesFromFiles([
+            'channel/channel.yaml',
+            'cart.yaml',
+            'country.yaml',
+            'shipping_method.yaml',
+            'payment_method.yaml',
+        ]);
+
+        $tokenValue = $this->pickUpCart();
+        $this->addItemToCart('MUG_BLUE', 3, $tokenValue);
+
+        $this->requestPut(
+            uri: sprintf('/api/v2/shop/orders/%s', $tokenValue),
+            body: [
+                'email' => 'changed@email.com',
+                'billingAddress' => [
+                    'firstName' => 'Updated: Jane',
+                    'lastName' => 'Updated: Doe',
+                    'phoneNumber' => '123456789',
+                    'countryCode' => 'DE',
+                    'provinceName' => 'Bavaria',
+                    'city' => 'Updated: Munich',
+                    'street' => 'Updated: Top secret',
+                    'postcode' => '80331',
+                ],
+                'shippingAddress' => [
+                    'firstName' => 'Updated: Jane',
+                    'lastName' => 'Updated: Doe',
+                    'phoneNumber' => '123456789',
+                    'countryCode' => 'DE',
+                    'provinceName' => 'Bavaria',
+                    'city' => 'Updated: Munich',
+                    'street' => 'Updated: Top secret',
+                    'postcode' => '80331',
+                ],
+            ],
+        );
+
+        $this->assertResponseSuccessful('shop/checkout/cart/update_cart_with_province_name_only');
+    }
+
+    #[Test]
     public function it_does_not_allow_to_change_email_as_a_shop_user(): void
     {
         $this->setUpDefaultPutHeaders();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/17751
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
