### PR TITLE
Fix migration Version20240315112656 for large datasets

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20240315112656.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20240315112656.php
@@ -53,7 +53,7 @@ final class Version20240315112656 extends AbstractMigration
         }
 
         $connection = $this->connection;
-        $rows = $connection->fetchAllAssociative(sprintf('SELECT %s, %s FROM %s', 'id', $dataColumn, $table));
+        $rows = $connection->iterateAssociative(sprintf('SELECT %s, %s FROM %s', 'id', $dataColumn, $table));
 
         foreach ($rows as $row) {
             $id = $row['id'];
@@ -75,7 +75,7 @@ final class Version20240315112656 extends AbstractMigration
     private function serializeEncodedData(string $table, string $dataColumn): void
     {
         $connection = $this->connection;
-        $rows = $connection->fetchAllAssociative(sprintf('SELECT %s, %s FROM %s', 'id', $dataColumn, $table));
+        $rows = $connection->iterateAssociative(sprintf('SELECT %s, %s FROM %s', 'id', $dataColumn, $table));
 
         foreach ($rows as $row) {
             $id = $row['id'];


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.14
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

address log is having >2mil records in production, using the drop-in replacement method will buffer the results row per row for a much more memory efficient migration