### PR TITLE
fix: add default filter to breadcrumbs configuration title to prevent ScalarDataBag exception

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/header/breadcrumbs.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/templates/shared/crud/index/content/header/breadcrumbs.html.twig
@@ -6,7 +6,7 @@
 {% if title_from_context is not null or resource_metadata is not null %}
     {% set title = title_from_context|default(resource_metadata.applicationName~'.ui.'~resource_metadata.pluralName) %}
 {% else %}
-    {% set title = hookable_metadata.configuration.title %}
+    {% set title = hookable_metadata.configuration.title|default('') %}
 {% endif %}
 
 {{ breadcrumbs([


### PR DESCRIPTION

| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes Sylius/Stack#354
| License         | MIT

## Description

When the `configuration.title` is not set in the hookable metadata, accessing it directly on a `ScalarDataBag` throws an exception. Adding `|default('')` prevents the crash.