### PR TITLE
Handle Symfony 8+ strip region in RequestHeaderBasedLocaleContext

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
@@ -54,32 +54,28 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface, R
         $prependedAvailableLocalesCodes = array_merge([self::NO_CODE_VALID_STUB], $this->availableLocalesCodes);
 
         $bestLocaleCode = $request->getPreferredLanguage($prependedAvailableLocalesCodes);
-        if (self::NO_CODE_VALID_STUB === $bestLocaleCode) {
-            throw new LocaleNotFoundException(sprintf(
-                'None of the available locales is acceptable: "%s".',
-                implode('", "', $this->availableLocalesCodes),
-            ));
-        }
 
-        if (in_array($bestLocaleCode, $this->availableLocalesCodes, strict: true)) {
+        if (self::NO_CODE_VALID_STUB !== $bestLocaleCode && in_array($bestLocaleCode, $this->availableLocalesCodes, strict: true)) {
             return $bestLocaleCode;
         }
 
-        // Symfony 8+ strips numeric region subtags (UN M.49, e.g. "150" in "en_150"), returning only the
-        // language part. Fall back to the first available locale that starts with that language prefix.
-        $localesMatchingLanguagePrefix = array_values(array_filter(
-            $this->availableLocalesCodes,
-            static fn (string $code): bool => str_starts_with($code, $bestLocaleCode . '_')
-        ));
-
-        if ([] === $localesMatchingLanguagePrefix) {
-            throw new LocaleNotFoundException(sprintf(
-                'None of the available locales is acceptable: "%s".',
-                implode('", "', $this->availableLocalesCodes),
+        // Symfony 8+ stripped a numeric region subtag (UN M.49, e.g. "150" in "en_150") and returned only the
+        // language prefix. In both cases, fall back to prefix matching across all preferred languages.
+        foreach ($request->getLanguages() as $language) {
+            $localesMatchingLanguagePrefix = array_values(array_filter(
+                $this->availableLocalesCodes,
+                static fn (string $code): bool => str_starts_with($code, $language . '_'),
             ));
+
+            if ([] !== $localesMatchingLanguagePrefix) {
+                return $localesMatchingLanguagePrefix[0];
+            }
         }
 
-        return $localesMatchingLanguagePrefix[0];
+        throw new LocaleNotFoundException(sprintf(
+            'None of the available locales is acceptable: "%s".',
+            implode('", "', $this->availableLocalesCodes),
+        ));
     }
 
     public function reset(): void

--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
@@ -61,7 +61,26 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface, R
             ));
         }
 
-        return $bestLocaleCode;
+        if (in_array($bestLocaleCode, $this->availableLocalesCodes, strict: true)) {
+            return $bestLocaleCode;
+        }
+
+        // Symfony 8+ strips numeric region subtags (UN M.49, e.g. "150" in "en_150"), returning only the
+        // language part. Fall back to the first available locale that starts with that language prefix.
+        $localesMatchingLanguagePrefix = array_values(array_filter(
+            $this->availableLocalesCodes,
+            static fn (string $code): bool => str_starts_with($code, $bestLocaleCode . '_') ||
+                str_starts_with($code, $bestLocaleCode . '-'),
+        ));
+
+        if ([] === $localesMatchingLanguagePrefix) {
+            throw new LocaleNotFoundException(sprintf(
+                'None of the available locales is acceptable: "%s".',
+                implode('", "', $this->availableLocalesCodes),
+            ));
+        }
+
+        return $localesMatchingLanguagePrefix[0];
     }
 
     public function reset(): void

--- a/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/RequestHeaderBasedLocaleContext.php
@@ -69,8 +69,7 @@ final class RequestHeaderBasedLocaleContext implements LocaleContextInterface, R
         // language part. Fall back to the first available locale that starts with that language prefix.
         $localesMatchingLanguagePrefix = array_values(array_filter(
             $this->availableLocalesCodes,
-            static fn (string $code): bool => str_starts_with($code, $bestLocaleCode . '_') ||
-                str_starts_with($code, $bestLocaleCode . '-'),
+            static fn (string $code): bool => str_starts_with($code, $bestLocaleCode . '_')
         ));
 
         if ([] === $localesMatchingLanguagePrefix) {

--- a/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
+++ b/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
@@ -54,169 +54,113 @@ final class RequestHeaderBasedLocaleContextTest extends TestCase
         $this->requestHeaderBasedLocaleContext->getLocaleCode();
     }
 
-    public function testThrowsLocaleNotFoundExceptionIfLocaleFromMainRequestPreferredLanguageCannotBeResolved(): void
+    /**
+     * @dataProvider provideResolvingCases
+     *
+     * @param list<string> $availableLocales
+     */
+    public function testResolvesLocaleCode(string $acceptLanguage, string $default, array $availableLocales, string $expected): void
     {
         $request = new Request();
-        $request->headers->set('Accept-Language', 'fr_FR');
+        $request->headers->set('Accept-Language', $acceptLanguage);
 
         $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
 
         $this->localeProvider->expects(self::once())
             ->method('getDefaultLocaleCode')
-            ->willReturn('pl_PL');
+            ->willReturn($default);
 
         $this->localeProvider->expects(self::once())
             ->method('getAvailableLocalesCodes')
-            ->willReturn(['pl_PL', 'de_DE']);
+            ->willReturn($availableLocales);
+
+        self::assertSame($expected, $this->requestHeaderBasedLocaleContext->getLocaleCode());
+    }
+
+    /**
+     * @dataProvider provideNotFoundCases
+     *
+     * @param list<string> $availableLocales
+     */
+    public function testThrowsLocaleNotFoundExceptionForRequest(string $acceptLanguage, string $default, array $availableLocales): void
+    {
+        $request = new Request();
+        $request->headers->set('Accept-Language', $acceptLanguage);
+
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getDefaultLocaleCode')
+            ->willReturn($default);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getAvailableLocalesCodes')
+            ->willReturn($availableLocales);
 
         self::expectException(LocaleNotFoundException::class);
 
         $this->requestHeaderBasedLocaleContext->getLocaleCode();
     }
 
-    public function testThrowsLocaleNotFoundExceptionWhenLanguagePrefixHasNoMatchingLocale(): void
+    /** @return iterable<string, array{acceptLanguage: string, default: string, availableLocales: list<string>, expected: string}> */
+    public static function provideResolvingCases(): iterable
     {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'en');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('it_IT');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['it_IT']);
-
-        self::expectException(LocaleNotFoundException::class);
-
-        $this->requestHeaderBasedLocaleContext->getLocaleCode();
+        yield 'locale syntax' => [
+            'acceptLanguage' => 'de_DE',
+            'default' => 'pl_PL',
+            'availableLocales' => ['pl_PL', 'de_DE'],
+            'expected' => 'de_DE',
+        ];
+        yield 'mixed-cased language syntax' => [
+            'acceptLanguage' => 'dE-De',
+            'default' => 'pl_PL',
+            'availableLocales' => ['pl_PL', 'de_DE'],
+            'expected' => 'de_DE',
+        ];
+        yield 'upper-cased language syntax' => [
+            'acceptLanguage' => 'DE-DE',
+            'default' => 'pl_PL',
+            'availableLocales' => ['pl_PL', 'de_DE'],
+            'expected' => 'de_DE',
+        ];
+        yield 'lower-cased language syntax' => [
+            'acceptLanguage' => 'de-de',
+            'default' => 'pl_PL',
+            'availableLocales' => ['pl_PL', 'de_DE'],
+            'expected' => 'de_DE',
+        ];
+        yield 'language prefix for macro region locale' => [
+            'acceptLanguage' => 'en',
+            'default' => 'en_150',
+            'availableLocales' => ['en_150'],
+            'expected' => 'en_150',
+        ];
+        yield 'language prefix for Latin America macro region locale' => [
+            'acceptLanguage' => 'es',
+            'default' => 'es_419',
+            'availableLocales' => ['es_419'],
+            'expected' => 'es_419',
+        ];
+        yield 'first locale by language prefix when multiple macro region locales available' => [
+            'acceptLanguage' => 'en',
+            'default' => 'en_001',
+            'availableLocales' => ['en_001', 'en_150'],
+            'expected' => 'en_001',
+        ];
     }
 
-    public function testResolvesLocaleFromMainRequestPreferredLanguageInLocaleSyntax(): void
+    /** @return iterable<string, array{acceptLanguage: string, default: string, availableLocales: list<string>}> */
+    public static function provideNotFoundCases(): iterable
     {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'de_DE');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('pl_PL');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['pl_PL', 'de_DE']);
-
-        self::assertSame('de_DE', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesLocaleFromMainRequestPreferredLanguageInMixedCasedLanguageSyntax(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'dE-De');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('pl_PL');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['pl_PL', 'de_DE']);
-
-        self::assertSame('de_DE', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesLocaleFromMainRequestPreferredLanguageInUpperCasedLanguageSyntax(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'DE-DE');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('pl_PL');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['pl_PL', 'de_DE']);
-
-        self::assertSame('de_DE', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesLocaleFromMainRequestPreferredLanguageInLowerCasedLanguageSyntax(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'de-de');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('pl_PL');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['pl_PL', 'de_DE']);
-
-        self::assertSame('de_DE', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesLocaleByLanguagePrefixForMacroRegionLocale(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'en');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('en_150');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['en_150']);
-
-        self::assertSame('en_150', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesLocaleByLanguagePrefixForLatinAmericaMacroRegionLocale(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'es');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('es_419');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['es_419']);
-
-        self::assertSame('es_419', $this->requestHeaderBasedLocaleContext->getLocaleCode());
-    }
-
-    public function testResolvesFirstLocaleByLanguagePrefixWhenMultipleMacroRegionLocalesAvailable(): void
-    {
-        $request = new Request();
-        $request->headers->set('Accept-Language', 'en');
-
-        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
-
-        $this->localeProvider->expects(self::once())
-            ->method('getDefaultLocaleCode')
-            ->willReturn('en_001');
-
-        $this->localeProvider->expects(self::once())
-            ->method('getAvailableLocalesCodes')
-            ->willReturn(['en_001', 'en_150']);
-
-        self::assertSame('en_001', $this->requestHeaderBasedLocaleContext->getLocaleCode());
+        yield 'locale not available' => [
+            'acceptLanguage' => 'fr_FR',
+            'default' => 'pl_PL',
+            'availableLocales' => ['pl_PL', 'de_DE'],
+        ];
+        yield 'language prefix with no matching locale' => [
+            'acceptLanguage' => 'en',
+            'default' => 'it_IT',
+            'availableLocales' => ['it_IT'],
+        ];
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
+++ b/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
@@ -74,6 +74,26 @@ final class RequestHeaderBasedLocaleContextTest extends TestCase
         $this->requestHeaderBasedLocaleContext->getLocaleCode();
     }
 
+    public function testThrowsLocaleNotFoundExceptionWhenLanguagePrefixHasNoMatchingLocale(): void
+    {
+        $request = new Request();
+        $request->headers->set('Accept-Language', 'en');
+
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getDefaultLocaleCode')
+            ->willReturn('it_IT');
+
+        $this->localeProvider->expects(self::once())
+            ->method('getAvailableLocalesCodes')
+            ->willReturn(['it_IT']);
+
+        self::expectException(LocaleNotFoundException::class);
+
+        $this->requestHeaderBasedLocaleContext->getLocaleCode();
+    }
+
     public function testResolvesLocaleFromMainRequestPreferredLanguageInLocaleSyntax(): void
     {
         $request = new Request();
@@ -144,5 +164,59 @@ final class RequestHeaderBasedLocaleContextTest extends TestCase
             ->willReturn(['pl_PL', 'de_DE']);
 
         self::assertSame('de_DE', $this->requestHeaderBasedLocaleContext->getLocaleCode());
+    }
+
+    public function testResolvesLocaleByLanguagePrefixForMacroRegionLocale(): void
+    {
+        $request = new Request();
+        $request->headers->set('Accept-Language', 'en');
+
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getDefaultLocaleCode')
+            ->willReturn('en_150');
+
+        $this->localeProvider->expects(self::once())
+            ->method('getAvailableLocalesCodes')
+            ->willReturn(['en_150']);
+
+        self::assertSame('en_150', $this->requestHeaderBasedLocaleContext->getLocaleCode());
+    }
+
+    public function testResolvesLocaleByLanguagePrefixForLatinAmericaMacroRegionLocale(): void
+    {
+        $request = new Request();
+        $request->headers->set('Accept-Language', 'es');
+
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getDefaultLocaleCode')
+            ->willReturn('es_419');
+
+        $this->localeProvider->expects(self::once())
+            ->method('getAvailableLocalesCodes')
+            ->willReturn(['es_419']);
+
+        self::assertSame('es_419', $this->requestHeaderBasedLocaleContext->getLocaleCode());
+    }
+
+    public function testResolvesFirstLocaleByLanguagePrefixWhenMultipleMacroRegionLocalesAvailable(): void
+    {
+        $request = new Request();
+        $request->headers->set('Accept-Language', 'en');
+
+        $this->requestStack->expects(self::once())->method('getMainRequest')->willReturn($request);
+
+        $this->localeProvider->expects(self::once())
+            ->method('getDefaultLocaleCode')
+            ->willReturn('en_001');
+
+        $this->localeProvider->expects(self::once())
+            ->method('getAvailableLocalesCodes')
+            ->willReturn(['en_001', 'en_150']);
+
+        self::assertSame('en_001', $this->requestHeaderBasedLocaleContext->getLocaleCode());
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
+++ b/src/Sylius/Bundle/LocaleBundle/tests/Context/RequestHeaderBasedLocaleContextTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\Bundle\LocaleBundle\Context;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\LocaleBundle\Context\RequestHeaderBasedLocaleContext;
@@ -54,11 +55,8 @@ final class RequestHeaderBasedLocaleContextTest extends TestCase
         $this->requestHeaderBasedLocaleContext->getLocaleCode();
     }
 
-    /**
-     * @dataProvider provideResolvingCases
-     *
-     * @param list<string> $availableLocales
-     */
+    /** @param list<string> $availableLocales */
+    #[DataProvider('provideResolvingCases')]
     public function testResolvesLocaleCode(string $acceptLanguage, string $default, array $availableLocales, string $expected): void
     {
         $request = new Request();
@@ -77,11 +75,8 @@ final class RequestHeaderBasedLocaleContextTest extends TestCase
         self::assertSame($expected, $this->requestHeaderBasedLocaleContext->getLocaleCode());
     }
 
-    /**
-     * @dataProvider provideNotFoundCases
-     *
-     * @param list<string> $availableLocales
-     */
+    /** @param list<string> $availableLocales */
+    #[DataProvider('provideNotFoundCases')]
     public function testThrowsLocaleNotFoundExceptionForRequest(string $acceptLanguage, string $default, array $availableLocales): void
     {
         $request = new Request();


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18928
| License         | MIT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced locale resolution with a fallback mechanism that performs prefix matching against available locales, providing more reliable language code detection when the primary negotiation method is unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->