### PR TITLE
Fix non-unique Faker values in fixture factories causing SQL exceptions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -31,6 +31,16 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
 
     protected OptionsResolver $optionsResolver;
 
+    /** @var array<string, true> */
+    private array $usedEmails = [];
+
+    private int $emailCounter = 0;
+
+    /** @var array<string, true> */
+    private array $usedUsernames = [];
+
+    private int $usernameCounter = 0;
+
     /**
      * @param FactoryInterface<AdminUserInterface> $userFactory
      * @param FactoryInterface<ImageInterface> $avatarImageFactory
@@ -82,8 +92,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->email)
-            ->setDefault('username', fn (Options $options): string => $this->faker->firstName . ' ' . $this->faker->lastName)
+            ->setDefault('email', fn (Options $options): string => $this->generateUniqueEmail())
+            ->setDefault('username', fn (Options $options): string => $this->generateUniqueUsername())
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('password', 'password123')
@@ -94,6 +104,38 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
             ->setDefault('avatar', '')
             ->setAllowedTypes('avatar', 'string')
         ;
+    }
+
+    private function generateUniqueEmail(): string
+    {
+        $email = $this->faker->email;
+
+        if (!isset($this->usedEmails[$email])) {
+            $this->usedEmails[$email] = true;
+
+            return $email;
+        }
+
+        $email = preg_replace('/@/', ++$this->emailCounter . '@', $email, 1);
+        $this->usedEmails[$email] = true;
+
+        return $email;
+    }
+
+    private function generateUniqueUsername(): string
+    {
+        $username = $this->faker->firstName . ' ' . $this->faker->lastName;
+
+        if (!isset($this->usedUsernames[$username])) {
+            $this->usedUsernames[$username] = true;
+
+            return $username;
+        }
+
+        $username .= ++$this->usernameCounter;
+        $this->usedUsernames[$username] = true;
+
+        return $username;
     }
 
     /** @param array<string, mixed> $options */

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -82,8 +82,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->unique()->email)
-            ->setDefault('username', fn (Options $options): string => $this->faker->unique()->firstName . ' ' . $this->faker->unique()->lastName)
+            ->setDefault('email', fn (Options $options): string => $this->faker->email)
+            ->setDefault('username', fn (Options $options): string => $this->faker->firstName . ' ' . $this->faker->lastName)
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('password', 'password123')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AdminUserExampleFactory.php
@@ -82,8 +82,8 @@ class AdminUserExampleFactory extends AbstractExampleFactory implements ExampleF
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->email)
-            ->setDefault('username', fn (Options $options): string => $this->faker->firstName . ' ' . $this->faker->lastName)
+            ->setDefault('email', fn (Options $options): string => $this->faker->unique()->email)
+            ->setDefault('username', fn (Options $options): string => $this->faker->unique()->firstName . ' ' . $this->faker->unique()->lastName)
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('password', 'password123')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -75,7 +75,7 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->email)
+            ->setDefault('email', fn (Options $options): string => $this->faker->unique()->email)
             ->setDefault('first_name', fn (Options $options): string => $this->faker->firstName)
             ->setDefault('last_name', fn (Options $options): string => $this->faker->lastName)
             ->setDefault('enabled', true)

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -32,6 +32,11 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
 
     protected OptionsResolver $optionsResolver;
 
+    /** @var array<string, true> */
+    private array $usedEmails = [];
+
+    private int $emailCounter = 0;
+
     /**
      * @param FactoryInterface<ShopUserInterface> $shopUserFactory
      * @param FactoryInterface<CustomerInterface> $customerFactory
@@ -75,7 +80,7 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->email)
+            ->setDefault('email', fn (Options $options): string => $this->generateUniqueEmail())
             ->setDefault('first_name', fn (Options $options): string => $this->faker->firstName)
             ->setDefault('last_name', fn (Options $options): string => $this->faker->lastName)
             ->setDefault('enabled', true)
@@ -103,5 +108,21 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
                 },
             )
         ;
+    }
+
+    private function generateUniqueEmail(): string
+    {
+        $email = $this->faker->email;
+
+        if (!isset($this->usedEmails[$email])) {
+            $this->usedEmails[$email] = true;
+
+            return $email;
+        }
+
+        $email = preg_replace('/@/', ++$this->emailCounter . '@', $email, 1);
+        $this->usedEmails[$email] = true;
+
+        return $email;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -75,7 +75,7 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
     protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
-            ->setDefault('email', fn (Options $options): string => $this->faker->unique()->email)
+            ->setDefault('email', fn (Options $options): string => $this->faker->email)
             ->setDefault('first_name', fn (Options $options): string => $this->faker->firstName)
             ->setDefault('last_name', fn (Options $options): string => $this->faker->lastName)
             ->setDefault('enabled', true)


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/18950
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
