### PR TITLE
Remove eager customer JOIN from admin order grid query

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
@@ -6,7 +6,7 @@ sylius_grid:
                 options:
                     class: "%sylius.model.order.class%"
                     repository:
-                        method: createCriteriaAwareSearchListQueryBuilder
+                        method: createCriteriaAwareGridListQueryBuilder
                         arguments:
                             criteria: $criteria
             sorting:

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -57,6 +57,41 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         ;
     }
 
+    public function createGridListQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.state != :state')
+            ->setParameter('state', OrderInterface::STATE_CART)
+        ;
+    }
+
+    public function createCriteriaAwareGridListQueryBuilder(?array $criteria): QueryBuilder
+    {
+        if ($criteria === null) {
+            return $this->createGridListQueryBuilder();
+        }
+
+        $hasProductCriteria = '' !== ($criteria['product'] ?? '');
+        $hasVariantCriteria = '' !== ($criteria['variant'] ?? '');
+
+        $queryBuilder = $this->createGridListQueryBuilder();
+
+        if ($hasVariantCriteria || $hasProductCriteria) {
+            $queryBuilder
+                ->leftJoin('o.items', 'item')
+                ->leftJoin('item.variant', 'variant')
+            ;
+        }
+
+        if ($hasProductCriteria) {
+            $queryBuilder
+                ->leftJoin('variant.product', 'product')
+            ;
+        }
+
+        return $queryBuilder;
+    }
+
     public function createCriteriaAwareSearchListQueryBuilder(?array $criteria): QueryBuilder
     {
         if ($criteria === null) {

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -60,6 +60,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     public function createGridListQueryBuilder(): QueryBuilder
     {
         return $this->createQueryBuilder('o')
+            ->leftJoin('o.customer', 'customer')
             ->andWhere('o.state != :state')
             ->setParameter('state', OrderInterface::STATE_CART)
         ;

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -35,6 +35,13 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
      */
     public function createCriteriaAwareSearchListQueryBuilder(?array $criteria): QueryBuilder;
 
+    public function createGridListQueryBuilder(): QueryBuilder;
+
+    /**
+     * @param array<string, mixed>|null $criteria
+     */
+    public function createCriteriaAwareGridListQueryBuilder(?array $criteria): QueryBuilder;
+
     /**
      * @param array<string, mixed>|null $criteria
      */


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes # Order grid eager-joins customer, preventing optimal index usage for sorting
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.14 or 2.1 branch
 - Features and deprecations must be submitted against the 2.2 branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
