### PR TITLE
[API] Make API Platform resource command classes overridable via container parameters

### DIFF
--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -66,5 +66,5 @@ To override a class, define the parameter in your configuration:
 
 ```yaml
 parameters:
-    sylius_api.command.account.reset_password.class: App\Command\CustomResetPassword
+    sylius_api.command.account.reset_password.class: App\Api\Command\CustomResetPassword
 ```

--- a/UPGRADE-API-2.2.md
+++ b/UPGRADE-API-2.2.md
@@ -49,3 +49,22 @@ Additionally, the redundant `code` field has been removed from the error respons
 - If your API client reads `response.data.code`, use `response.status` (HTTP header) instead
 
 **References:** RFC 9110 (400 = syntactic errors, 422 = semantic/validation errors)
+
+
+## API Platform resource classes as container parameters
+
+The following API Platform resource classes are now defined as container parameters, allowing you to override them:
+
+| Parameter | Default class |
+|---|---|
+| `sylius_api.command.account.reset_password.class` | `Sylius\Bundle\ApiBundle\Command\Account\ResetPassword` |
+| `sylius_api.command.account.verify_shop_user.class` | `Sylius\Bundle\ApiBundle\Command\Account\VerifyShopUser` |
+| `sylius_api.command.admin.account.reset_password.class` | `Sylius\Bundle\ApiBundle\Command\Admin\Account\ResetPassword` |
+| `sylius_api.command.send_contact_request.class` | `Sylius\Bundle\ApiBundle\Command\SendContactRequest` |
+
+To override a class, define the parameter in your configuration:
+
+```yaml
+parameters:
+    sylius_api.command.account.reset_password.class: App\Command\CustomResetPassword
+```

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUserPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/admin/AdminUserPassword.xml
@@ -17,7 +17,7 @@
     xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0 https://api-platform.com/schema/metadata/resources-3.0.xsd"
 >
     <resource
-        class="Sylius\Bundle\ApiBundle\Command\Admin\Account\ResetPassword"
+        class="%sylius_api.command.admin.account.reset_password.class%"
         shortName="Administrator"
         messenger="input"
         output="false"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Contact.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/Contact.xml
@@ -17,7 +17,7 @@
     xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0 https://api-platform.com/schema/metadata/resources-3.0.xsd"
 >
     <resource
-        class="Sylius\Bundle\ApiBundle\Command\SendContactRequest"
+        class="%sylius_api.command.send_contact_request.class%"
         shortName="Contact"
         routePrefix="shop"
         messenger="input"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerPassword.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerPassword.xml
@@ -17,7 +17,7 @@
     xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0 https://api-platform.com/schema/metadata/resources-3.0.xsd"
 >
     <resource
-        class="Sylius\Bundle\ApiBundle\Command\Account\ResetPassword"
+        class="%sylius_api.command.account.reset_password.class%"
         messenger="input"
         shortName="Customer"
     >

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerVerification.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_platform/resources/shop/CustomerVerification.xml
@@ -16,7 +16,7 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0 https://api-platform.com/schema/metadata/resources-3.0.xsd"
 >
     <resource
-        class="Sylius\Bundle\ApiBundle\Command\Account\VerifyShopUser"
+        class="%sylius_api.command.account.verify_shop_user.class%"
         shortName="Customer"
         messenger="input"
         output="false"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -22,6 +22,10 @@
 
     <parameters>
         <parameter key="sylius.model.address.interface">Sylius\Component\Addressing\Model\AddressInterface</parameter>
+        <parameter key="sylius_api.command.account.reset_password.class">Sylius\Bundle\ApiBundle\Command\Account\ResetPassword</parameter>
+        <parameter key="sylius_api.command.account.verify_shop_user.class">Sylius\Bundle\ApiBundle\Command\Account\VerifyShopUser</parameter>
+        <parameter key="sylius_api.command.send_contact_request.class">Sylius\Bundle\ApiBundle\Command\SendContactRequest</parameter>
+        <parameter key="sylius_api.command.admin.account.reset_password.class">Sylius\Bundle\ApiBundle\Command\Admin\Account\ResetPassword</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

## Summary

Some API Platform resource definitions use command classes directly as the `class` attribute of the `<resource>` tag. Unlike entity-based resources (e.g. `%sylius.model.product.class%`), these command classes were hardcoded, making them impossible to override without replacing the entire XML file.

This PR introduces container parameters for these classes, following the same convention already used for Sylius model classes.

## Changes

**New parameters** defined in `src/Sylius/Bundle/ApiBundle/Resources/config/services.xml`:

| Parameter | Default class |
|---|---|
| `sylius_api.command.account.reset_password.class` | `Sylius\Bundle\ApiBundle\Command\Account\ResetPassword` |
| `sylius_api.command.account.verify_shop_user.class` | `Sylius\Bundle\ApiBundle\Command\Account\VerifyShopUser` |
| `sylius_api.command.admin.account.reset_password.class` | `Sylius\Bundle\ApiBundle\Command\Admin\Account\ResetPassword` |
| `sylius_api.command.send_contact_request.class` | `Sylius\Bundle\ApiBundle\Command\SendContactRequest` |

**Updated resource files:**
- `resources/shop/CustomerPassword.xml`
- `resources/shop/CustomerVerification.xml`
- `resources/shop/Contact.xml`
- `resources/admin/AdminUserPassword.xml`

Only the `class` attribute of `<resource>` tags has been parameterized. The `input` attributes on `<operation>` tags remain unchanged.
